### PR TITLE
Embed fallbacks

### DIFF
--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -64,22 +64,12 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			// Otherwise, just remove the node.
 			if ( 0 === $new_node->childNodes->length && empty( $new_attributes['src'] ) ) {
 				if ( ! empty( $orig_src ) ) {
-					$fallback_node = AMP_DOM_Utils::create_node(
-						$this->dom,
-						'blockquote',
-						array(
-							'class' => 'amp-wp-fallback amp-wp-audio-fallback'
-						)
-					);
-
-					$fallback_content = $this->dom->createDocumentFragment();
-					$fallback_content->appendXML( sprintf(
+					$fallback_node = $this->create_fallback_node(
+						sprintf(
 							wp_kses( __( 'Could not load <a href="%s">audio</a>.', 'amp' ), array( 'a' => array( 'href' => true ) ) ),
 							esc_url( array_shift( $orig_src ) )
 						)
 					);
-
-					$fallback_node->appendChild( $fallback_content );
 
 					$node->parentNode->replaceChild( $fallback_node, $node );
 				} else {

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -39,6 +39,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Only append source tags with a valid src attribute
 				if ( ! empty( $new_child_attributes['src'] ) && 'source' === $new_child_node->tagName ) {
+					AMP_DOM_Utils::add_attributes_to_node( $new_child_node, $new_child_attributes );
 					$new_node->appendChild( $new_child_node );
 				}
 			}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -106,9 +106,22 @@ abstract class AMP_Base_Sanitizer {
 		$protocol = strtok( $src, ':' );
 
 		if ( $protocol === $src && ( $https_required || $force_https ) ) {
-			// src has relative protocol, ie //example.com/asdf, so add https.
-			$src = set_url_scheme( $src, 'https' );
-		} else if ( 'https' !== $protocol ) {
+			if ( 0 === strpos( $src, '//' ) ) {
+				// src has relative protocol, ie //example.com/asdf, so add https
+				$src = set_url_scheme( $src, 'https' );
+			} else if ( 0 === strpos( $src, '/' ) ) {
+				// src is URL relative to the site root
+				$src = home_url( $src );
+			} else {
+				// src is URL relative to current URI
+				global $wp;
+				$src = home_url( trailingslashit( $wp->request ) . $src );
+			}
+
+			$protocol = strtok( $src, ':' );
+		}
+
+		if ( 'https' !== $protocol ) {
 			// Check if https is required
 			if ( $https_required ) {
 				// Remove the src. Let the implementing class decide what do from here.

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -121,4 +121,25 @@ abstract class AMP_Base_Sanitizer {
 
 		return $src;
 	}
+
+	protected function create_fallback_node( $content, $container_el = 'blockquote', $attributes = array() ) {
+		$defaults = array(
+			'class' => 'amp-wp-fallback',
+		);
+		$attributes = wp_parse_args( $attributes, $defaults );
+
+		$fallback_node = AMP_DOM_Utils::create_node(
+			$this->dom,
+			$container_el,
+			$attributes
+		);
+
+		if ( $content ) {
+			$fallback_content = $this->dom->createDocumentFragment();
+			$fallback_content->appendXML( $content );
+			$fallback_node->appendChild( $fallback_content );
+		}
+
+		return $fallback_node;
+	}
 }

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -102,14 +102,18 @@ abstract class AMP_Base_Sanitizer {
 	 * @return string
 	 */
 	public function maybe_enforce_https_src( $src, $force_https = false ) {
+		$https_required = isset( $this->args['require_https_src'] ) && true === $this->args['require_https_src'];
 		$protocol = strtok( $src, ':' );
-		if ( 'https' !== $protocol ) {
+
+		if ( $protocol === $src && ( $https_required || $force_https ) ) {
+			// src has relative protocol, ie //example.com/asdf, so add https.
+			$src = set_url_scheme( $src, 'https' );
+		} else if ( 'https' !== $protocol ) {
 			// Check if https is required
-			if ( isset( $this->args['require_https_src'] ) && true === $this->args['require_https_src'] ) {
+			if ( $https_required ) {
 				// Remove the src. Let the implementing class decide what do from here.
 				$src = '';
-			} elseif ( ( ! isset( $this->args['require_https_src'] ) || false === $this->args['require_https_src'] )
-				&& true === $force_https ) {
+			} elseif ( ! $https_required && true === $force_https ) {
 				// Don't remove the src, but force https instead
 				$src = set_url_scheme( $src, 'https' );
 			}

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -49,22 +49,12 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			// Otherwise remove the node.
 			if ( empty( $new_attributes['src'] ) ) {
 				if ( ! empty( $orig_src ) ) {
-					$fallback_node = AMP_DOM_Utils::create_node(
-						$this->dom,
-						'blockquote',
-						array(
-							'class' => 'amp-wp-fallback amp-wp-iframe-fallback'
-						)
-					);
-
-					$fallback_content = $this->dom->createDocumentFragment();
-					$fallback_content->appendXML( sprintf(
+					$fallback_node = $this->create_fallback_node(
+						sprintf(
 							wp_kses( __( 'Could not load <a href="%s">iframe</a>.', 'amp' ), array( 'a' => array( 'href' => true ) ) ),
 							esc_url( $orig_src )
 						)
 					);
-
-					$fallback_node->appendChild( $fallback_content );
 
 					$node->parentNode->replaceChild( $fallback_node, $node );
 				} else {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -61,22 +61,12 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			// Otherwise, just remove the node.
 			if ( 0 === $new_node->childNodes->length && empty( $new_attributes['src'] ) ) {
 				if ( ! empty( $orig_src ) ) {
-					$fallback_node = AMP_DOM_Utils::create_node(
-						$this->dom,
-						'blockquote',
-						array(
-							'class' => 'amp-wp-fallback amp-wp-video-fallback'
-						)
-					);
-
-					$fallback_content = $this->dom->createDocumentFragment();
-					$fallback_content->appendXML( sprintf(
+					$fallback_node = $this->create_fallback_node(
+						sprintf(
 							wp_kses( __( 'Could not load <a href="%s">video</a>.', 'amp' ), array( 'a' => array( 'href' => true ) ) ),
 							esc_url( array_shift( $orig_src ) )
 						)
 					);
-
-					$fallback_node->appendChild( $fallback_content );
 
 					$node->parentNode->replaceChild( $fallback_node, $node );
 				} else {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -10,6 +10,10 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 	public static $tag = 'video';
 
+	protected $DEFAULT_ARGS = array(
+		'require_https_src' => true,
+	);
+
 	public function sanitize() {
 		$nodes = $this->dom->getElementsByTagName( self::$tag );
 		$num_nodes = $nodes->length;
@@ -18,8 +22,14 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			$orig_src = array();
+
 			$node = $nodes->item( $i );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
+
+			if ( isset( $old_attributes['src'] ) ) {
+				$orig_src[] = $old_attributes['src'];
+			}
 
 			$new_attributes = $this->filter_attributes( $old_attributes );
 
@@ -32,6 +42,11 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $node->childNodes as $child_node ) {
 				$new_child_node = $child_node->cloneNode( true );
 				$old_child_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $new_child_node );
+
+				if ( isset( $old_child_attributes['src'] ) ) {
+					$orig_src[] = $old_child_attributes['src'];
+				}
+
 				$new_child_attributes = $this->filter_attributes( $old_child_attributes );
 
 				// Only append source tags with a valid src attribute
@@ -42,12 +57,31 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// If the node has at least one valid source, replace the old node with it.
+			// If the node has no valid sources, but at least one invalid (http) one, add a fallback element.
 			// Otherwise, just remove the node.
-			//
-			// TODO: Add a fallback handler.
-			// See: https://github.com/ampproject/amphtml/issues/2261
 			if ( 0 === $new_node->childNodes->length && empty( $new_attributes['src'] ) ) {
-				$node->parentNode->removeChild( $node );
+				if ( ! empty( $orig_src ) ) {
+					$fallback_node = AMP_DOM_Utils::create_node(
+						$this->dom,
+						'blockquote',
+						array(
+							'class' => 'amp-wp-fallback amp-wp-video-fallback'
+						)
+					);
+
+					$fallback_content = $this->dom->createDocumentFragment();
+					$fallback_content->appendXML( sprintf(
+							wp_kses( __( 'Could not load <a href="%s">video</a>.', 'amp' ), array( 'a' => array( 'href' => true ) ) ),
+							esc_url( array_shift( $orig_src ) )
+						)
+					);
+
+					$fallback_node->appendChild( $fallback_content );
+
+					$node->parentNode->replaceChild( $fallback_node, $node );
+				} else {
+					$node->parentNode->removeChild( $node );
+				}
 			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 			}

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -36,6 +36,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Only append source tags with a valid src attribute
 				if ( ! empty( $new_child_attributes['src'] ) && 'source' === $new_child_node->tagName ) {
+					AMP_DOM_Utils::add_attributes_to_node( $new_child_node, $new_child_attributes );
 					$new_node->appendChild( $new_child_node );
 				}
 			}

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -70,9 +70,16 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"/></amp-audio><amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio><amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"/></amp-audio>'
 			),
 
+			/*
 			'https_not_required' => array(
 				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
 				'<amp-audio width="400" height="300" src="http://example.com/audio/file.ogg"></amp-audio>',
+			),
+			*/
+
+			'https_required' => array(
+				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
+				'<blockquote class="amp-wp-fallback amp-wp-audio-fallback">Could not load <a href="http://example.com/audio/file.ogg">audio</a>.</blockquote>',
 			),
 		);
 	}
@@ -90,7 +97,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 	public function test__https_required() {
 		$source = '<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>';
-		$expected = '';
+		$expected = '<blockquote class="amp-wp-fallback amp-wp-audio-fallback">Could not load <a href="http://example.com/audio/file.ogg">audio</a>.</blockquote>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom, array(

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -79,7 +79,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 			'https_required' => array(
 				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
-				'<blockquote class="amp-wp-fallback amp-wp-audio-fallback">Could not load <a href="http://example.com/audio/file.ogg">audio</a>.</blockquote>',
+				'<blockquote class="amp-wp-fallback">Could not load <a href="http://example.com/audio/file.ogg">audio</a>.</blockquote>',
 			),
 		);
 	}
@@ -97,7 +97,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 	public function test__https_required() {
 		$source = '<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>';
-		$expected = '<blockquote class="amp-wp-fallback amp-wp-audio-fallback">Could not load <a href="http://example.com/audio/file.ogg">audio</a>.</blockquote>';
+		$expected = '<blockquote class="amp-wp-fallback">Could not load <a href="http://example.com/audio/file.ogg">audio</a>.</blockquote>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom, array(

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -15,7 +15,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 			'force_https' => array(
 				'<iframe src="http://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
-				'<blockquote class="amp-wp-fallback amp-wp-iframe-fallback">Could not load <a href="http://example.com/embed/132886713">iframe</a>.</blockquote>',
+				'<blockquote class="amp-wp-fallback">Could not load <a href="http://example.com/embed/132886713">iframe</a>.</blockquote>',
 			),
 
 			'iframe_without_dimensions' => array(
@@ -116,7 +116,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 	public function test__https_required() {
 		$source = '<iframe src="http://example.com/embed/132886713"></iframe>';
-		$expected = '<blockquote class="amp-wp-fallback amp-wp-iframe-fallback">Could not load <a href="http://example.com/embed/132886713">iframe</a>.</blockquote>';
+		$expected = '<blockquote class="amp-wp-fallback">Could not load <a href="http://example.com/embed/132886713">iframe</a>.</blockquote>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom, array(

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -15,7 +15,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 			'force_https' => array(
 				'<iframe src="http://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" sizes="(min-width: 500px) 500px, 100vw"></amp-iframe>',
+				'<blockquote class="amp-wp-fallback amp-wp-iframe-fallback">Could not load <a href="http://example.com/embed/132886713">iframe</a>.</blockquote>',
 			),
 
 			'iframe_without_dimensions' => array(
@@ -116,7 +116,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 	public function test__https_required() {
 		$source = '<iframe src="http://example.com/embed/132886713"></iframe>';
-		$expected = '';
+		$expected = '<blockquote class="amp-wp-fallback amp-wp-iframe-fallback">Could not load <a href="http://example.com/embed/132886713">iframe</a>.</blockquote>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom, array(

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -71,10 +71,17 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 				'<amp-video src="https://example.com/video1.mp4" width="480" height="300" sizes="(min-width: 480px) 480px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://example.com/video2.ogv" width="300" height="480" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video><amp-video src="https://example.com/video3.webm" height="100" width="200" sizes="(min-width: 200px) 200px, 100vw" class="amp-wp-enforced-sizes"></amp-video>'
 			),
 
+			/*
 			'https_not_required' => array(
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
 				'<amp-video width="300" height="300" src="http://example.com/video.mp4" sizes="(min-width: 300px) 300px, 100vw" class="amp-wp-enforced-sizes"></amp-video>',
-			)
+			),
+			*/
+
+			'https_required' => array(
+				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
+				'<blockquote class="amp-wp-fallback amp-wp-video-fallback">Could not load <a href="http://example.com/video.mp4">video</a>.</blockquote>',
+			),
 		);
 	}
 
@@ -91,7 +98,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 	public function test__https_required() {
 		$source = '<video width="300" height="300" src="http://example.com/video.mp4"></video>';
-		$expected = '';
+		$expected = '<blockquote class="amp-wp-fallback amp-wp-video-fallback">Could not load <a href="http://example.com/video.mp4">video</a>.</blockquote>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom, array(

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -80,7 +80,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'https_required' => array(
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
-				'<blockquote class="amp-wp-fallback amp-wp-video-fallback">Could not load <a href="http://example.com/video.mp4">video</a>.</blockquote>',
+				'<blockquote class="amp-wp-fallback">Could not load <a href="http://example.com/video.mp4">video</a>.</blockquote>',
 			),
 		);
 	}
@@ -98,7 +98,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 	public function test__https_required() {
 		$source = '<video width="300" height="300" src="http://example.com/video.mp4"></video>';
-		$expected = '<blockquote class="amp-wp-fallback amp-wp-video-fallback">Could not load <a href="http://example.com/video.mp4">video</a>.</blockquote>';
+		$expected = '<blockquote class="amp-wp-fallback">Could not load <a href="http://example.com/video.mp4">video</a>.</blockquote>';
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom, array(


### PR DESCRIPTION
This is a response to #354. Other related issues are #130, #288, #316, and #350.

The goal of this is to provide a consistent user experience when embedded media can't load because it's not from an https source. A few different options were discussed to make this happen, but this is what we settled on:

> Remove the (embedded) element completely, and replace it with a blockquote or some other block-level element containing the source URL and perhaps a message like “Could not load.”

Here are the types of embeds that should be covered:
- [x] Audio
- [x] Video
- [x] iFrame
