### PR TITLE
Fix AMP Status toggle boolean - Issue #1011

### DIFF
--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -167,7 +167,7 @@ class AMP_Post_Meta_Box {
 		$verify = (
 			isset( $post->ID )
 			&&
-			is_post_type_viewable( $post->post_type )
+			post_type_supports( $post->post_type, amp_get_slug() )
 			&&
 			current_user_can( 'edit_post', $post->ID )
 			&&


### PR DESCRIPTION
Update boolean for adding AMP Status toggle to post_type_supports() instead of is_post_type_viewable() to fix issue #1011 since Safe Redirect Manager sets public_queryable to true in post type registration. 

Fixes #1011