### PR TITLE
Switch to installing wp-dev-lib via composer instead of via submodule

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -7,10 +7,6 @@ DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
 CHECK_SCOPE=all
 
 function after_wp_install {
-	echo -n "Installing Jetpack..."
-	svn export -q https://plugins.svn.wordpress.org/jetpack/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/jetpack"
-	echo "done"
-
 	if [[ $WP_VERSION == 4.* ]]; then
 		echo -n "Installing Gutenberg..."
 		svn export -q https://plugins.svn.wordpress.org/gutenberg/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"

--- a/.dev-lib
+++ b/.dev-lib
@@ -4,7 +4,9 @@ PROJECT_SLUG=amp
 SKIP_ECHO_PATHS_SCOPE=1
 README_MD_TITLE="AMP Plugin for WordPress"
 DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
-CHECK_SCOPE=all
+if [[ ! -z $TRAVIS ]]; then
+	CHECK_SCOPE=all
+fi
 
 function after_wp_install {
 	if [[ $WP_VERSION == 4.* ]]; then

--- a/.dev-lib
+++ b/.dev-lib
@@ -4,6 +4,7 @@ PROJECT_SLUG=amp
 SKIP_ECHO_PATHS_SCOPE=1
 README_MD_TITLE="AMP Plugin for WordPress"
 DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
+CHECK_SCOPE=all
 
 function after_wp_install {
     echo "Installing plugins..."

--- a/.dev-lib
+++ b/.dev-lib
@@ -7,7 +7,13 @@ DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
 CHECK_SCOPE=all
 
 function after_wp_install {
-    echo "Installing plugins..."
-    svn export -q https://plugins.svn.wordpress.org/jetpack/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/jetpack"
-    svn export -q https://plugins.svn.wordpress.org/gutenberg/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
+	echo -n "Installing Jetpack..."
+	svn export -q https://plugins.svn.wordpress.org/jetpack/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/jetpack"
+	echo "done"
+
+	if [[ $WP_VERSION == 4.* ]]; then
+		echo -n "Installing Gutenberg..."
+		svn export -q https://plugins.svn.wordpress.org/gutenberg/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
+		echo "done"
+	fi
 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "dev-lib"]
-	path = dev-lib
-	url = https://github.com/xwp/wp-dev-lib.git
-	branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ jobs:
       php: "7.3"
       env: WP_VERSION=5.0
     - php: "5.4"
-      env: WP_VERSION=4.9    DEV_LIB_SKIP=composer,phpcs
+      env: WP_VERSION=4.9    DEV_LIB_SKIP=phpcs
     - php: "5.5"
       env: WP_VERSION=latest DEV_LIB_SKIP=phpcs
     - php: "5.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ cache:
     - $HOME/deployment-targets
 
 install:
-  - if [[ $DEV_LIB_SKIP =~ composer ]]; then composer install --no-dev; fi
   - nvm install 8.11.4 && nvm use 8.11.4
   - composer install
   - export DEV_LIB_PATH=vendor/xwp/wp-dev-lib/scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,16 @@ cache:
 install:
   - if [[ $DEV_LIB_SKIP =~ composer ]]; then composer install --no-dev; fi
   - nvm install 8.11.4 && nvm use 8.11.4
-  - export DEV_LIB_PATH=dev-lib
-  - source $DEV_LIB_PATH/travis.install.sh
+  - composer install
+  - export DEV_LIB_PATH=vendor/xwp/wp-dev-lib/scripts
+  - source "$DEV_LIB_PATH/travis.install.sh"
   - npx grunt shell:webpack_production
 
 script:
-  - source $DEV_LIB_PATH/travis.script.sh
+  - source "$DEV_LIB_PATH/travis.script.sh"
 
 after_script:
-  - source $DEV_LIB_PATH/travis.after_script.sh
+  - source "$DEV_LIB_PATH/travis.after_script.sh"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# Newer versions like trusty don't have PHP 5.2 or 5.3
-# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
-dist: precise
+# Using trusty instead of precise because we don't need PHP 5.2 or 5.3 anymore.
+dist: trusty
+
+addons:
+  apt:
+    packages:
+      # Needed for `xmllint`.
+      - libxml2-utils
 
 notifications:
   email:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function( grunt ) {
 				stderr: true
 			},
 			readme: {
-				command: './dev-lib/generate-markdown-readme' // Generate the readme.md.
+				command: './vendor/xwp/wp-dev-lib/scripts/generate-markdown-readme' // Generate the readme.md.
 			},
 			phpunit: {
 				command: 'phpunit'
@@ -92,7 +92,7 @@ module.exports = function( grunt ) {
 			versionAppend = new Date().toISOString().replace( /\.\d+/, '' ).replace( /-|:/g, '' ) + '-' + commitHash;
 
 			paths = lsOutput.trim().split( /\n/ ).filter( function( file ) {
-				return ! /^(blocks|\.|bin|([^/]+)+\.(md|json|xml)|Gruntfile\.js|tests|wp-assets|dev-lib|readme\.md|composer\..*|patches|webpack.*)/.test( file );
+				return ! /^(blocks|\.|bin|([^/]+)+\.(md|json|xml)|Gruntfile\.js|tests|wp-assets|readme\.md|composer\..*|patches|webpack.*)/.test( file );
 			} );
 			paths.push( 'vendor/autoload.php' );
 			paths.push( 'assets/js/*-compiled.js' );

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "wp-coding-standards/wpcs": "1.2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
     "phpcompatibility/php-compatibility": "9.1.1",
-    "xwp/wp-dev-lib": "dev-feature/composer-first"
+    "xwp/wp-dev-lib": "1.0.0"
   },
   "config": {
     "platform": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   "require-dev": {
     "wp-coding-standards/wpcs": "1.2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
-    "phpcompatibility/php-compatibility": "9.1.1"
+    "phpcompatibility/php-compatibility": "9.1.1",
+    "xwp/wp-dev-lib": "dev-feature/composer-first"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "733cdfdecea0d0afe37d7807da8c801d",
+    "content-hash": "2acfabf13987e7a26bf70a4fdc6ffda1",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -420,15 +420,58 @@
                 "wordpress"
             ],
             "time": "2018-12-18T09:43:51+00:00"
+        },
+        {
+            "name": "xwp/wp-dev-lib",
+            "version": "dev-feature/composer-first",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/xwp/wp-dev-lib.git",
+                "reference": "e4266005d1d81da3821cc4d77f05f1a566be955f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/e4266005d1d81da3821cc4d77f05f1a566be955f",
+                "reference": "e4266005d1d81da3821cc4d77f05f1a566be955f",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Weston Ruter",
+                    "email": "weston@xwp.co",
+                    "homepage": "https://weston.ruter.net"
+                },
+                {
+                    "name": "XWP",
+                    "email": "engage@xwp.co",
+                    "homepage": "https://xwp.co"
+                }
+            ],
+            "description": "Common code used during development of WordPress plugins and themes",
+            "homepage": "https://github.com/xwp/wp-dev-lib",
+            "keywords": [
+                "wordpress"
+            ],
+            "time": "2019-01-17T04:29:25+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "xwp/wp-dev-lib": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "^5.4 || ^7.0"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "5.4"
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2acfabf13987e7a26bf70a4fdc6ffda1",
+    "content-hash": "b5c8a0233426fe2cf20d57bd8e5ad351",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -423,16 +423,16 @@
         },
         {
             "name": "xwp/wp-dev-lib",
-            "version": "dev-feature/composer-first",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/xwp/wp-dev-lib.git",
-                "reference": "e4266005d1d81da3821cc4d77f05f1a566be955f"
+                "reference": "90574b4e61c53a9b0e7f286812fe428d13c9ba7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/e4266005d1d81da3821cc4d77f05f1a566be955f",
-                "reference": "e4266005d1d81da3821cc4d77f05f1a566be955f",
+                "url": "https://api.github.com/repos/xwp/wp-dev-lib/zipball/90574b4e61c53a9b0e7f286812fe428d13c9ba7d",
+                "reference": "90574b4e61c53a9b0e7f286812fe428d13c9ba7d",
                 "shasum": ""
             },
             "type": "library",
@@ -457,14 +457,12 @@
             "keywords": [
                 "wordpress"
             ],
-            "time": "2019-01-17T04:29:25+00:00"
+            "time": "2019-01-17T05:00:30+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "xwp/wp-dev-lib": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/contributing.md
+++ b/contributing.md
@@ -45,7 +45,20 @@ an explicit [Code of Conduct](https://github.com/ampproject/amp-wp/blob/develop/
 To start, clone this repository into your WordPress install being used for development:
 
 ```bash
-cd wp-content/plugins && git clone --recursive git@github.com:ampproject/amp-wp.git amp
+cd wp-content/plugins && git clone git@github.com:ampproject/amp-wp.git amp
+```
+
+Then install the packages:
+
+```bash
+composer install
+npm install
+```
+
+And lastly, do a build of the JavaScript:
+
+```bash
+npm run build
 ```
 
 Lastly, to get the plugin running in your WordPress install, run `composer install` and then activate the plugin via the WordPress dashboard or `wp plugin activate amp`.
@@ -63,7 +76,6 @@ To edit JavaScript code which is built/complied, run `npm run dev` to watch the 
 To create a build of the plugin for installing in WordPress as a ZIP package, do:
 
 ```bash
-git submodule update --init # (if you haven't done so yet)
 composer install # (if you haven't done so yet)
 npm install # (if you haven't done so yet)
 npm run build
@@ -136,7 +148,7 @@ When you push a commit to your PR, Travis CI will run the PHPUnit tests and snif
 
 Contributors who want to make a new release, follow these steps:
 
-0. Do `git submodule update --init --recursive && npm install && composer selfupdate && composer install`.
+0. Do `npm install && composer selfupdate && composer install`.
 1. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant). Verify via `npx grunt shell:verify_matching_versions`.
 2. Add changelog entry to readme.
 3. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.

--- a/contributing.md
+++ b/contributing.md
@@ -152,7 +152,7 @@ Contributors who want to make a new release, follow these steps:
 1. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant). Verify via `npx grunt shell:verify_matching_versions`.
 2. Add changelog entry to readme.
 3. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
-4. Do sanity check by comparing the `build` directory with the previously-deployed plugin at http://plugins.svn.wordpress.org/amp/trunk
+4. Do sanity check by comparing the `build` directory with the previously-deployed plugin on WordPress.org for example: `svn export https://plugins.svn.wordpress.org/amp/trunk /tmp/amp-trunk; diff /tmp/amp-trunk/ ./build/` (instead of straight `diff`, it's best to use a GUI like `idea diff`, `phpstorm diff`, or `opendiff`).
 5. Draft blog post about the new release.
 6. [Draft new release](https://github.com/ampproject/amp-wp/releases/new) on GitHub targeting the release branch, with the new plugin version as the tag and release title. Attaching the `amp.zip` build to the release. Include link to changelog in release tag.
 7. Run `npm run deploy` to commit the plugin to WordPress.org.

--- a/contributing.md
+++ b/contributing.md
@@ -48,11 +48,9 @@ To start, clone this repository into your WordPress install being used for devel
 cd wp-content/plugins && git clone --recursive git@github.com:ampproject/amp-wp.git amp
 ```
 
-If you happened to have cloned without `--recursive` previously, please do `git submodule update --init` to ensure the [dev-lib](https://github.com/xwp/wp-dev-lib/) submodule is available for development.
-
 Lastly, to get the plugin running in your WordPress install, run `composer install` and then activate the plugin via the WordPress dashboard or `wp plugin activate amp`.
 
-To install the `pre-commit` hook, do `bash dev-lib/install-pre-commit-hook.sh`.
+To install the `pre-commit` hook, do `bash vendor/xwp/wp-dev-lib/scripts/install-pre-commit-hook.sh`.
 
 Note that pull requests will be checked against [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) with PHPCS, and for JavaScript linting is done with ESLint and (for now) JSCS and JSHint.
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -56,7 +56,6 @@
 	<arg name="extensions" value="php"/>
 	<file>.</file>
 
-	<exclude-pattern>*/dev-lib/*</exclude-pattern>
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>includes/sanitizers/class-amp-allowed-tags-generated.php</exclude-pattern>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <phpunit
-	bootstrap="dev-lib/phpunit-plugin-bootstrap.php"
+	bootstrap="vendor/xwp/wp-dev-lib/sample-config/phpunit-plugin-bootstrap.php"
 	backupGlobals="false"
 	colors="true"
 	convertErrorsToExceptions="true"


### PR DESCRIPTION
Todo:

- [x] Switch to installing `dev-lib` via NPM (or Composer) instead of using submodule. See https://github.com/xwp/wp-dev-lib/pull/278
- [x] Make sure Travis CI does `composer install` first so that `dev-lib` is available.
- [x] Update instructions to remove references to submodules.
- [ ] ~Install WP-CLI's i18n package via Composer.~ (see https://github.com/ampproject/amp-wp/pull/1789)

Other:

- [ ] ~Automatically `composer install` when doing `npm install`.~
- [ ] ~Warn when `composer` is not installed.~
