### PR TITLE
Proposing amp_post_template_body_open hook (AMP Reader mode version of wp_body_open)

### DIFF
--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -24,4 +24,4 @@
 </head>
 
 <body class="<?php echo esc_attr( $this->get( 'body_class' ) ); ?>">
-<?php do_action( 'wp_body_open', $this ); ?>
+<?php do_action( 'amp_wp_body_open', $this ); ?>

--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -24,4 +24,4 @@
 </head>
 
 <body class="<?php echo esc_attr( $this->get( 'body_class' ) ); ?>">
-<?php do_action( 'amp_wp_body_open', $this ); ?>
+<?php do_action( 'amp_post_template_body_open', $this ); ?>

--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -24,4 +24,4 @@
 </head>
 
 <body class="<?php echo esc_attr( $this->get( 'body_class' ) ); ?>">
-<?php do_action( 'amp_post_template_body', $this ); ?>
+<?php do_action( 'wp_body_open', $this ); ?>

--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -24,3 +24,4 @@
 </head>
 
 <body class="<?php echo esc_attr( $this->get( 'body_class' ) ); ?>">
+<?php do_action( 'amp_post_template_body', $this ); ?>


### PR DESCRIPTION
Proposing a hook for post body, this will be part of an upcoming fix changes for third party analytics tracking tags and some A/B testing tools which require actions after opening body.