### PR TITLE
Try: Use amp-mathml and amp-fit-text components in Gutenberg block edit function's React components

### DIFF
--- a/assets/css/amp-editor-blocks.css
+++ b/assets/css/amp-editor-blocks.css
@@ -2,3 +2,6 @@
 .is-amp-fit-text + .blocks-font-size > .components-font-size-picker__custom-input {
     display: none;
 }
+.edit-post-visual-editor amp-fit-text p {
+    font-size: inherit;
+}

--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -284,7 +284,8 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 			var attributes = props.attributes,
 				name = props.name,
 				ampLayout,
-				inspectorControls;
+				inspectorControls,
+				WrappedBlockEdit;
 
 			ampLayout = attributes.ampLayout;
 
@@ -324,11 +325,25 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 				];
 			}
 
+			WrappedBlockEdit = el( BlockEdit, _.extend( {
+				key: 'original'
+			}, props ) );
+
+			if ( -1 !== component.data.textBlocks.indexOf( name ) && props.attributes.ampFitText ) {
+				WrappedBlockEdit = el(
+					'amp-fit-text',
+					{
+						'min-font-size': props.attributes.minFont,
+						'max-font-size': props.attributes.maxFont,
+						height: props.attributes.height
+					},
+					WrappedBlockEdit
+				);
+			}
+
 			return [
 				inspectorControls,
-				el( BlockEdit, _.extend( {
-					key: 'original'
-				}, props ) )
+				WrappedBlockEdit
 			];
 		};
 	};

--- a/blocks/amp-mathml/index.js
+++ b/blocks/amp-mathml/index.js
@@ -33,17 +33,20 @@ export default registerBlockType(
 			}
 		},
 
-		edit( { attributes, setAttributes } ) {
+		edit( { attributes, isSelected, setAttributes } ) {
 			const { dataFormula } = attributes;
 
-			return (
-				<PlainText
-					key='formula'
-					value={ dataFormula }
-					placeholder={ __( 'Insert formula', 'amp' ) }
-					onChange={ ( value ) => setAttributes( { dataFormula: value } ) }
-				/>
-			);
+			if ( isSelected ) {
+				return (
+					<PlainText
+						key='formula'
+						value={ dataFormula }
+						placeholder={ __( 'Insert formula', 'amp' ) }
+						onChange={ ( value ) => setAttributes( { dataFormula: value } ) }
+					/>
+				);
+			}
+			return <amp-mathml layout="container" data-formula={ dataFormula }></amp-mathml>;
 		},
 
 		save( { attributes } ) {

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -138,6 +138,8 @@ class AMP_Editor_Blocks {
 				array( 'wp-blocks', 'lodash', 'wp-i18n', 'wp-element', 'wp-components' ),
 				AMP__VERSION
 			);
+
+			wp_enqueue_script( 'amp-mathml' );
 		}
 
 		wp_enqueue_script(

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -140,6 +140,7 @@ class AMP_Editor_Blocks {
 			);
 
 			wp_enqueue_script( 'amp-mathml' );
+			wp_enqueue_script( 'amp-fit-text' );
 		}
 
 		wp_enqueue_script(


### PR DESCRIPTION
In order to be able to create content using AMP components, it is important that the AMP components be able to be rendered in the editing context. For the next generation editor of WordPress, Gutenberg, this means being able to use AMP components inside of React components, and that changes to the AMP components' attributes will cause the shadow DOM to dynamically update as expected.

This does work as expected `amp-mathml` component:

![maxresdefault](https://user-images.githubusercontent.com/841956/66129742-cd40d280-e5f0-11e9-8558-280f6e633cd1.jpg)


This may be because it doesn't have much shadow DOM to speak of, other than a single `iframe` child. 

However, using the `amp-fit-text` component in React does not work as expected:

![maxresdefault (1)](https://user-images.githubusercontent.com/841956/66129756-d3cf4a00-e5f0-11e9-898d-6238124e5cf7.jpg)

Note that even though the `amp-fit-text` component's `height`, `min-font-size`, and `max-font-size` attributes are being modified, the changes to them are not getting applied to the shadow DOM.