### PR TITLE
Change ?amp to ?amp=1 

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -85,7 +85,7 @@ function amp_get_permalink( $post_id ) {
 	if ( current_theme_supports( 'amp' ) ) {
 		$permalink = get_permalink( $post_id );
 		if ( ! amp_is_canonical() ) {
-			$permalink = add_query_arg( 'amp', '', $permalink );
+			$permalink = add_query_arg( 'amp', '1', $permalink );
 		}
 		return $permalink;
 	}
@@ -128,7 +128,7 @@ function amp_get_permalink( $post_id ) {
 			'attachment' === get_post_type( $post_id )
 		);
 		if ( $use_query_var ) {
-			$amp_url = add_query_arg( amp_get_slug(), '', $permalink );
+			$amp_url = add_query_arg( amp_get_slug(), '1', $permalink );
 		} else {
 			$amp_url = preg_replace( '/#.*/', '', $permalink );
 			$amp_url = trailingslashit( $amp_url ) . user_trailingslashit( amp_get_slug(), 'single_amp' );
@@ -193,13 +193,13 @@ function amp_add_amphtml_link() {
 	$amp_url = null;
 	if ( current_theme_supports( 'amp' ) ) {
 		if ( AMP_Theme_Support::is_paired_available() ) {
-			$amp_url = add_query_arg( amp_get_slug(), '', $current_url );
+			$amp_url = add_query_arg( amp_get_slug(), '1', $current_url );
 		}
 	} else {
 		if ( is_singular() ) {
 			$amp_url = amp_get_permalink( get_queried_object_id() );
 		} else {
-			$amp_url = add_query_arg( amp_get_slug(), '', $current_url );
+			$amp_url = add_query_arg( amp_get_slug(), '1', $current_url );
 		}
 	}
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -246,11 +246,11 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		return array(
 			'home' => array(
 				home_url( '/' ),
-				add_query_arg( amp_get_slug(), '', home_url( '/' ) ),
+				add_query_arg( amp_get_slug(), '1', home_url( '/' ) ),
 			),
 			'404'  => array(
 				home_url( '/no-existe/' ),
-				add_query_arg( amp_get_slug(), '', home_url( '/no-existe/' ) ),
+				add_query_arg( amp_get_slug(), '1', home_url( '/no-existe/' ) ),
 			),
 			'post' => array(
 				get_permalink( $post_id ),

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -101,9 +101,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			'post_type'   => 'page',
 		) );
 
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_post ) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_page ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $published_post ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $drafted_post ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $published_page ) );
 
 		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
 		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
@@ -118,9 +118,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		// Now check with theme support added (in paired mode).
 		add_theme_support( 'amp', array( 'template_dir' => './' ) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_post ) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_page ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $published_post ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $drafted_post ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $published_page ) );
 		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
 		$this->assertNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
@@ -156,9 +156,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			'post_status' => 'publish',
 			'post_type'   => 'page',
 		) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '/amp/', amp_get_permalink( $published_post ) );
-		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_page ) );
+		$this->assertStringEndsWith( '?amp=1', amp_get_permalink( $published_page ) );
 
 		add_filter( 'post_link', $add_anchor_fragment );
 		$this->assertStringEndsWith( '/amp/#anchor', amp_get_permalink( $published_post ) );
@@ -177,9 +177,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		// Now check with theme support added (in paired mode).
 		add_theme_support( 'amp', array( 'template_dir' => './' ) );
-		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
-		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_post ) );
-		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_page ) );
+		$this->assertStringEndsWith( '&amp=1', amp_get_permalink( $drafted_post ) );
+		$this->assertStringEndsWith( '?amp=1', amp_get_permalink( $published_post ) );
+		$this->assertStringEndsWith( '?amp=1', amp_get_permalink( $published_page ) );
 		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
 		$this->assertNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
@@ -187,7 +187,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		// Make sure that if permalink has anchor that it is persists.
 		add_filter( 'post_link', $add_anchor_fragment );
-		$this->assertStringEndsWith( '/?amp#anchor', amp_get_permalink( $published_post ) );
+		$this->assertStringEndsWith( '/?amp=1#anchor', amp_get_permalink( $published_post ) );
 	}
 
 	/**
@@ -218,8 +218,8 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers \amp_remove_endpoint()
 	 */
 	public function test_amp_remove_endpoint() {
-		$this->assertEquals( 'https://example.com/foo/', amp_remove_endpoint( 'https://example.com/foo/?amp' ) );
-		$this->assertEquals( 'https://example.com/foo/?#bar', amp_remove_endpoint( 'https://example.com/foo/?amp#bar' ) );
+		$this->assertEquals( 'https://example.com/foo/', amp_remove_endpoint( 'https://example.com/foo/?amp=1' ) );
+		$this->assertEquals( 'https://example.com/foo/?#bar', amp_remove_endpoint( 'https://example.com/foo/?amp=1#bar' ) );
 		$this->assertEquals( 'https://example.com/foo/', amp_remove_endpoint( 'https://example.com/foo/amp/' ) );
 		$this->assertEquals( 'https://example.com/foo/?blaz', amp_remove_endpoint( 'https://example.com/foo/amp/?blaz' ) );
 	}


### PR DESCRIPTION
Usually the static cache configuration (nginx, static html files, proxy, etc) tells the server to bypass cache if the query string is not empty. Since 1.0 the amp URLs use ?amp and that prevents the server from caching it.

It's really easy to add a rule that tells the server to cache a page if a non-empty query arg is present but it's not easy to work with empty query args.

I've changed `amp` query var to `amp=1` to make it possible to the server or cache and CDN services detect if amp query arg is present and deliver cached content.

Fixes #1383.