### PR TITLE
Improve definition and filtering of sanitizer default args

### DIFF
--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -22,13 +22,16 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'audio';
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'add_noscript_fallback' => true,
-	];
+	public static function get_default_args() {
+		return [
+			'add_noscript_fallback' => true,
+		];
+	}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -32,7 +32,7 @@ abstract class AMP_Base_Sanitizer {
 	 * Placeholder for default args, to be set in child classes.
 	 *
 	 * @since 0.2
-	 *
+	 * @deprecated See get_default_args() static method.
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [];
@@ -94,6 +94,16 @@ abstract class AMP_Base_Sanitizer {
 	private $should_not_removed_nodes = [];
 
 	/**
+	 * Get default args.
+	 *
+	 * @since 1.1
+	 * @return array Default args.
+	 */
+	public static function get_default_args() {
+		return [];
+	}
+
+	/**
 	 * AMP_Base_Sanitizer constructor.
 	 *
 	 * @since 0.2
@@ -112,7 +122,7 @@ abstract class AMP_Base_Sanitizer {
 	 */
 	public function __construct( $dom, $args = [] ) {
 		$this->dom  = $dom;
-		$this->args = array_merge( $this->DEFAULT_ARGS, $args );
+		$this->args = array_merge( $this->DEFAULT_ARGS, static::get_default_args(), $args );
 
 		if ( ! empty( $this->args['use_document_element'] ) ) {
 			$this->root_element = $this->dom->documentElement;

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -13,15 +13,16 @@
 class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @since 1.1
-	 *
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'comment_live_list' => false,
-	];
+	public static function get_default_args() {
+		return [
+			'comment_live_list' => false,
+		];
+	}
 
 	/**
 	 * Pre-process the comment form and comment list for AMP.

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -29,6 +29,19 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	protected $args;
 
 	/**
+	 * Get default args.
+	 *
+	 * @since 1.3
+	 * @return array Default args.
+	 */
+	public static function get_default_args() {
+		return [
+			'template'   => get_template(),
+			'stylesheet' => get_stylesheet(),
+		];
+	}
+
+	/**
 	 * Body element.
 	 *
 	 * @since 1.0

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -59,13 +59,16 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	protected $args;
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'carousel_required' => false,
-	];
+	public static function get_default_args() {
+		return [
+			'carousel_required' => ! current_theme_supports( AMP_Theme_Support::SLUG ), // For back-compat.
+		];
+	}
 
 	/**
 	 * Sanitize the gallery block contained by <ul> element where necessary.

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -32,9 +32,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'iframe';
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @var array {
+	 * @since 1.3
+	 * @return array {
 	 *     Default args.
 	 *
 	 *     @type bool   $add_placeholder       Whether to add a placeholder element.
@@ -43,12 +44,20 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *     @type string $alias_origin          An alternative origin which can be supplied which is used when encountering same-origin iframes.
 	 * }
 	 */
-	protected $DEFAULT_ARGS = [
-		'add_placeholder'       => false,
-		'add_noscript_fallback' => true,
-		'current_origin'        => null,
-		'alias_origin'          => null,
-	];
+	public static function get_default_args() {
+		$parsed_home_url = wp_parse_url( get_home_url() );
+		$current_origin  = $parsed_home_url['scheme'] . '://' . $parsed_home_url['host'];
+		if ( isset( $parsed_home_url['port'] ) ) {
+			$current_origin .= ':' . $parsed_home_url['port'];
+		}
+
+		return [
+			'add_placeholder'       => true, // @todo Or false as originally?
+			'add_noscript_fallback' => true,
+			'current_origin'        => $current_origin,
+			'alias_origin'          => null,
+		];
+	}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -41,13 +41,16 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'img';
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'add_noscript_fallback' => true,
-	];
+	public static function get_default_args() {
+		return [
+			'add_noscript_fallback' => true,
+		];
+	}
 
 	/**
 	 * Animation extension.

--- a/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
@@ -15,32 +15,27 @@
 class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @since 1.1.0
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'sub_menu_button_class'        => '',
-		'sub_menu_button_toggle_class' => '',
-		'expand_text'                  => '',
-		'collapse_text'                => '',
-		'icon'                         => null, // Optional.
-		'sub_menu_item_state_id'       => 'navMenuItemExpanded',
-	];
+	public static function get_default_args() {
+		$args = [
+			'sub_menu_button_class'        => '',
+			'sub_menu_button_toggle_class' => '',
+			'expand_text'                  => __( 'expand child menu', 'amp' ),
+			'collapse_text'                => __( 'collapse child menu', 'amp' ),
+			'icon'                         => null, // Optional.
+			'sub_menu_item_state_id'       => 'navMenuItemExpanded',
+		];
 
-	/**
-	 * AMP_Nav_Menu_Dropdown_Sanitizer constructor.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param DOMDocument $dom  DOM.
-	 * @param array       $args Args.
-	 */
-	public function __construct( $dom, $args = [] ) {
-		parent::__construct( $dom, $args );
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
+		if ( ! empty( $theme_support_args['nav_menu_dropdown'] ) ) {
+			$args = array_merge( $args, $theme_support_args['nav_menu_dropdown'] );
+		}
 
-		$this->args = self::ensure_defaults( $this->args );
+		return $args;
 	}
 
 	/**
@@ -135,28 +130,5 @@ class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function sanitize() {
 		// Empty method body.
-	}
-
-	/**
-	 * Ensure that some defaults are always set as fallback.
-	 *
-	 * @param array $args Arguments to set the defaults in as necessary.
-	 * @return array Arguments with defaults filled.
-	 */
-	protected static function ensure_defaults( $args ) {
-		// Ensure accessibility labels are always set.
-		if ( empty( $args['expand_text'] ) ) {
-			$args['expand_text'] = __( 'expand child menu', 'amp' );
-		}
-		if ( empty( $args['collapse_text'] ) ) {
-			$args['collapse_text'] = __( 'collapse child menu', 'amp' );
-		}
-
-		// Ensure the state ID is always set.
-		if ( empty( $args['nav_menu_item_state_id'] ) ) {
-			$args['nav_menu_item_state_id'] = 'navMenuItemExpanded';
-		}
-
-		return $args;
 	}
 }

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -15,22 +15,6 @@
 class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
-	 * Default args.
-	 *
-	 * @since 1.1.0
-	 * @var array
-	 */
-	protected $DEFAULT_ARGS = [
-		'nav_container_id'           => '',
-		'nav_container_xpath'        => '', // Alternative for 'nav_container_id', if no ID available.
-		'menu_button_id'             => '',
-		'menu_button_xpath'          => '', // Alternative for 'menu_button_id', if no ID available.
-		'nav_container_toggle_class' => '',
-		'menu_button_toggle_class'   => '', // Optional.
-		'nav_menu_toggle_state_id'   => 'navMenuToggledOn',
-	];
-
-	/**
 	 * XPath.
 	 *
 	 * @since 1.1.0
@@ -39,20 +23,28 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 	protected $xpath;
 
 	/**
-	 * AMP_Nav_Menu_Toggle_Sanitizer constructor.
+	 * Get default args.
 	 *
-	 * @since 1.1.0
-	 *
-	 * @param DOMDocument $dom  DOM.
-	 * @param array       $args Args.
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	public function __construct( $dom, $args = [] ) {
-		parent::__construct( $dom, $args );
+	public static function get_default_args() {
+		$args = [
+			'nav_container_id'           => '',
+			'nav_container_xpath'        => '', // Alternative for 'nav_container_id', if no ID available.
+			'menu_button_id'             => '',
+			'menu_button_xpath'          => '', // Alternative for 'menu_button_id', if no ID available.
+			'nav_container_toggle_class' => '',
+			'menu_button_toggle_class'   => '', // Optional.
+			'nav_menu_toggle_state_id'   => 'navMenuToggledOn',
+		];
 
-		// Ensure the state ID is always set.
-		if ( empty( $this->args['nav_menu_toggle_state_id'] ) ) {
-			$this->args['nav_menu_toggle_state_id'] = $this->DEFAULT_ARGS['nav_menu_toggle_state_id'];
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
+		if ( ! empty( $theme_support_args['nav_menu_toggle'] ) ) {
+			$args = array_merge( $args, $theme_support_args['nav_menu_toggle'] );
 		}
+
+		return $args;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-story-export-sanitizer.php
+++ b/includes/sanitizers/class-amp-story-export-sanitizer.php
@@ -15,14 +15,17 @@
 class AMP_Story_Export_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'base_url'      => '',
-		'canonical_url' => '',
-	];
+	public static function get_default_args() {
+		return [
+			'base_url'      => '',
+			'canonical_url' => '',
+		];
+	}
 
 	/**
 	 * Default assets.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -93,24 +93,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	protected $args;
 
 	/**
-	 * Default args.
-	 *
-	 * @var array
-	 */
-	protected $DEFAULT_ARGS = [
-		'dynamic_element_selectors' => [
-			'amp-list',
-			'amp-live-list',
-			'[submit-error]',
-			'[submit-success]',
-			'amp-script',
-		],
-		'should_locate_sources'     => false,
-		'parsed_cache_variant'      => null,
-		'include_manifest_comment'  => 'always',
-	];
-
-	/**
 	 * List of stylesheet parts prior to selector/rule removal (tree shaking).
 	 *
 	 * Keys are MD5 hashes of stylesheets.
@@ -298,6 +280,27 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'amp-wistia-player',
 		'amp-youtube',
 	];
+
+	/**
+	 * Get default args.
+	 *
+	 * @since 1.3
+	 * @return array Default args.
+	 */
+	public static function get_default_args() {
+		return [
+			'dynamic_element_selectors' => [
+				'amp-list',
+				'amp-live-list',
+				'[submit-error]',
+				'[submit-success]',
+				'amp-script',
+			],
+			'should_locate_sources'     => false,
+			'parsed_cache_variant'      => null,
+			'include_manifest_comment'  => ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? 'always' : 'when_excessive',
+		];
+	}
 
 	/**
 	 * Get error codes that can be raised during parsing of CSS.

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -77,15 +77,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private $stack = [];
 
 	/**
-	 * Default args.
-	 *
-	 * @since 0.5
-	 *
-	 * @var array
-	 */
-	protected $DEFAULT_ARGS = [];
-
-	/**
 	 * AMP script components that are discovered being required through sanitization.
 	 *
 	 * @var string[]
@@ -100,6 +91,20 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	protected $should_not_replace_nodes = [];
 
 	/**
+	 * Get default args.
+	 *
+	 * @since 1.3
+	 * @return array Default args.
+	 */
+	public static function get_default_args() {
+		return [
+			'amp_allowed_tags'                => AMP_Allowed_Tags_Generated::get_allowed_tags(),
+			'amp_globally_allowed_attributes' => AMP_Allowed_Tags_Generated::get_allowed_attributes(),
+			'amp_layout_allowed_attributes'   => AMP_Allowed_Tags_Generated::get_layout_attributes(),
+		];
+	}
+
+	/**
 	 * AMP_Tag_And_Attribute_Sanitizer constructor.
 	 *
 	 * @since 0.5
@@ -108,12 +113,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array       $args Args.
 	 */
 	public function __construct( $dom, $args = [] ) {
-		$this->DEFAULT_ARGS = [
-			'amp_allowed_tags'                => AMP_Allowed_Tags_Generated::get_allowed_tags(),
-			'amp_globally_allowed_attributes' => AMP_Allowed_Tags_Generated::get_allowed_attributes(),
-			'amp_layout_allowed_attributes'   => AMP_Allowed_Tags_Generated::get_layout_attributes(),
-		];
-
 		parent::__construct( $dom, $args );
 
 		if ( ! empty( $this->args['allow_dirty_styles'] ) ) {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -25,13 +25,16 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'video';
 
 	/**
-	 * Default args.
+	 * Get default args.
 	 *
-	 * @var array
+	 * @since 1.3
+	 * @return array Default args.
 	 */
-	protected $DEFAULT_ARGS = [
-		'add_noscript_fallback' => true,
-	];
+	public static function get_default_args() {
+		return [
+			'add_noscript_fallback' => true,
+		];
+	}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -391,7 +391,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Iframe_Sanitizer( $dom, $args );
+		$sanitizer = new AMP_Iframe_Sanitizer( $dom, array_merge( [ 'add_placeholder' => false ], $args ) );
 		$sanitizer->sanitize();
 
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );

--- a/tests/php/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/php/test-class-amp-gallery-block-sanitizer.php
@@ -71,7 +71,10 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Gallery_Block_Sanitizer(
 			$dom,
-			[ 'content_max_width' => 600 ]
+			[
+				'content_max_width' => 600,
+				'carousel_required' => false,
+			]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );


### PR DESCRIPTION
At the moment the default args for the sanitizers are not mode available for plugins to filter. This means, for example, if a plugin wants to augment default args they have to currently copy all of them:

```php
add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
	$sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] = array_merge(
		// In case another filter already defined dynamic_element_selectors.
		! empty( $sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] ) ? $sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] : array(),
		// Duplicated from protected AMP_Style_Sanitizer::$DEFAULT_ARGS.
		array(
			'amp-list',
			'amp-live-list',
			'[submit-error]',
			'[submit-success]',
		),
		// Duplicated from protected AMP_Style_Sanitizer::$DEFAULT_ARGS.
		array(
			'#jp-relatedposts',
			'.jp-relatedposts',
			'.jp-relatedposts-items',
			'.jp-relatedposts-post',
		)
	);
	return $sanitizers;
} );
```

This is not ideal. This PR allows you to instead do:

```php
add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
	$sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'] = array_merge(
		$sanitizers['AMP_Style_Sanitizer']['dynamic_element_selectors'],
		array(
			'#jp-relatedposts',
			'.jp-relatedposts',
			'.jp-relatedposts-items',
			'.jp-relatedposts-post',
		)
	);
	return $sanitizers;
} );
```

The `AMP_Base_Sanitizer` class gets a new `get_default_args()` static method which is called up front when obtaining the list of sanitizers and their args. This then exposes the default args to the `amp_content_sanitizers` filter to customize.

This PR also deprecates the `DEFAULT_ARGS` class variable and consolidates the location of default args to be all defined in this `get_default_args()` methods.