### PR TITLE
Don't try JSON decoding if the filtered analytics config data is already an array

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -565,7 +565,7 @@ function amp_get_analytics( $analytics = array() ) {
 		$analytics[ $entry_id ] = array(
 			'type'        => $entry['type'],
 			'attributes'  => array(),
-			'config_data' => json_decode( $entry['config'] ),
+			'config_data' => is_array( $entry['config'] ) ? $entry['config'] : json_decode( $entry['config'] ),
 		);
 	}
 


### PR DESCRIPTION
The [filter docs](https://github.com/Automattic/amp-wp/wiki/Analytics) will result in the custom key-values being PHP array, but the filter still runs `json_decode`. A potential patch might be something like, `'config_data' => is_array( $entry['config'] ) ? $entry['config'] : json_decode( $entry['config'] )`.

See #1498.