### PR TITLE
Check filtered analytics entry for `config_data` not `config` to match docs

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -408,7 +408,7 @@ function amp_get_analytics( $analytics = array() ) {
 		$analytics[ $entry_id ] = array(
 			'type'        => $entry['type'],
 			'attributes'  => array(),
-			'config_data' => json_decode( $entry['config'] ),
+			'config_data' => json_decode( $entry['config_data'] ),
 		);
 	}
 


### PR DESCRIPTION
In the existing docs, users are recommend to filter `config_data`, but it looks like actually `config` is checked the custom key values.

Doc: https://github.com/Automattic/amp-wp/wiki/Analytics
Code: https://github.com/Automattic/amp-wp/blob/1.0/includes/amp-helper-functions.php#L568

See #1498..