### PR TITLE
Improve validation of children of invalid elements

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -428,7 +428,7 @@ abstract class AMP_Base_Sanitizer {
 
 			$error['node_name'] = $node->nodeName;
 			if ( $node->parentNode ) {
-				$error['parent_name'] = $node->parentNode->nodeName;
+				$error['parent_name'] = property_exists( $node, 'originalParent' ) ? $node->originalParent : $node->parentNode->nodeName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
 			}
 		}
 

--- a/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
+++ b/tests/amp-tag-and-attribute-sanitizer-private-methods-tests.php
@@ -713,6 +713,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				),
 				'',
 			),
+			'nested_invalid_elements' => array(
+				array(
+					'source' => '<div><details><summary><p>Example Summary</p></summary><p>Example expanded text</p></details></div>',
+					'tag_name' => 'details',
+				),
+				'<div><summary><p>Example Summary</p></summary><p>Example expanded text</p></div>',
+			),
 			'children_multiple_empty_parents' => array(
 				array(
 					'source' => '<div><p><bad-tag>Good Data</bad-tag></p></div>',

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -214,6 +214,18 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-playbuzz' ),
 			),
 
+			'invalid_element_stripped' => array(
+				'<nonexistent><p>Foo text</p><nonexistent>',
+				'<p>Foo text</p>',
+				array(),
+			),
+
+			'nested_invalid_elements_stripped' => array(
+				'<details><summary><p>Example Summary</p></summary><p>Example expanded text</p></details>',
+				'<p>Example Summary</p><p>Example expanded text</p>',
+				array(),
+			),
+
 			// AMP-NEXT-PAGE > [separator].
 			'reference-point-amp-next-page-separator' => array(
 				'<amp-next-page src="https://example.com/config.json"><div separator><h1>Keep reading</h1></div></amp-next-page>',
@@ -1203,7 +1215,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 		);
 		$expected_errors[] = array(
 			'node_name'       => 'foo',
-			'parent_name'     => 'body',
+			'parent_name'     => 'divs',
 			'code'            => 'invalid_element',
 			'node_attributes' => array(),
 		);
@@ -1242,6 +1254,21 @@ EOB;
 		$expected_errors[] = array(
 			'node_name'       => 'lili',
 			'parent_name'     => 'ul',
+			'code'            => 'invalid_element',
+			'node_attributes' => array(),
+		);
+
+		// Both <details> and <summary> are invalid, so there should be errors for both.
+		$content[]         = '<div><details><summary><p>Example Summary</p></summary><p>Example expanded text</p></details><div>';
+		$expected_errors[] = array(
+			'node_name'       => 'details',
+			'parent_name'     => 'div',
+			'code'            => 'invalid_element',
+			'node_attributes' => array(),
+		);
+		$expected_errors[] = array(
+			'node_name'       => 'summary',
+			'parent_name'     => 'details',
 			'code'            => 'invalid_element',
 			'node_attributes' => array(),
 		);


### PR DESCRIPTION
## Before
As @amedina reported in #1493, when there is an invalid element like `<details>` and the validation error isn't accepted, its child elements are not validated. 

Copying Alberto's test markup from #1493:

```php
<details>
        <summary>Copyright 1999-2018.</summary>
        <p>- by Awesome Author. All Rights Reserved.</p>
        <p>All content and graphics on this web site are the property of the author.</p>
</details>
```

There was only an error for the `<details>`, even though the nested `<summary>` is also invalid:
<img width="941" alt="details-validation-error" src="https://user-images.githubusercontent.com/4063887/46923010-52456d00-cfd7-11e8-852e-c191f20929b1.png">

---
On accepting the `<details>` validation error, the `<summary>` is also validated. But the `parent_name` of the `<summary>` should probably be `details`, as it's nested in `<details>`:

<img width="908" alt="details-nested" src="https://user-images.githubusercontent.com/4063887/46923045-d7308680-cfd7-11e8-81f3-1cb2569b870d.png">

## After
<img width="932" alt="invalid-elements" src="https://user-images.githubusercontent.com/4063887/46923191-ea445600-cfd9-11e8-894c-dedaf14a81d8.png">

## Approach
I'm not sure this is the right solution, especially in ensuring the `parent_name` is correct.

All of the existing unit tests passed, except for one where the `parent_name` is the original parent. Which I think is the expected result.

But adding the `->originalParent` to the `DOMElement` (or [DOMText](https://secure.php.net/manual/en/class.domtext.php)) isn't ideal, as it's [not one of its properties](https://secure.php.net/manual/en/class.domelement.php#domelement.props).

This will of course require full front-end testing in all 3 template modes, like we've done for the other releases.

Closes #1493