### PR TITLE
Fix composer vendor name and use stable version of CSS parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.3.6 || ^7.0",
-        "sabberworm/php-css-parser": "dev-master"
+        "sabberworm/php-css-parser": "^8"
     },
     "require-dev": {
         "wp-coding-standards/wpcs": "^0.14.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "automattic/amp-wp",
+    "name": "ampproject/amp-wp",
     "description": "WordPress plugin for adding AMP support.",
-    "homepage": "https://github.com/Automattic/amp-wp",
+    "homepage": "https://github.com/ampproject/amp-wp",
     "type": "wordpress-plugin",
     "license": "GPL-2.0",
     "repositories": [


### PR DESCRIPTION
While the repo has been moved to the AMP Project organization, `composer.json` still has the old references.

Also, we shouldn't be using a possibly unstable version of a dependency for a stable release, the CSS parser however is currently used as that. In this PR I change it to use the latest stable version of it >= 8 < 9 (8.2 is the latest release of that package).