### PR TITLE
Ensure Schema.org meta data has correct date

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -870,7 +870,7 @@ function amp_get_schemaorg_metadata() {
 				'@type'            => is_page() ? 'WebPage' : 'BlogPosting',
 				'mainEntityOfPage' => get_permalink(),
 				'headline'         => get_the_title(),
-				'datePublished'    => date( 'c', intval( get_the_date( 'U', $post->ID ) ) ),
+				'datePublished'    => mysql2date( 'c', $post->post_date_gmt, false ),
 				'dateModified'     => mysql2date( 'c', $post->post_modified_gmt, false ),
 			)
 		);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -870,8 +870,8 @@ function amp_get_schemaorg_metadata() {
 				'@type'            => is_page() ? 'WebPage' : 'BlogPosting',
 				'mainEntityOfPage' => get_permalink(),
 				'headline'         => get_the_title(),
-				'datePublished'    => date( 'c', get_the_date( 'U', $post->ID ) ),
-				'dateModified'     => date( 'c', get_the_date( 'U', $post->ID ) ),
+				'datePublished'    => date( 'c', intval( get_the_date( 'U', $post->ID ) ) ),
+				'dateModified'     => date( 'c', intval( get_the_date( 'U', $post->ID ) ) ),
 			)
 		);
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -871,7 +871,7 @@ function amp_get_schemaorg_metadata() {
 				'mainEntityOfPage' => get_permalink(),
 				'headline'         => get_the_title(),
 				'datePublished'    => date( 'c', intval( get_the_date( 'U', $post->ID ) ) ),
-				'dateModified'     => date( 'c', intval( get_the_date( 'U', $post->ID ) ) ),
+				'dateModified'     => mysql2date( 'c', $post->post_modified_gmt, false ),
 			)
 		);
 


### PR DESCRIPTION
Thanks to [Fernando Tellado](https://wordpress.org/support/users/fernandot/) for raising this in:
https://wordpress.org/support/topic/warning-date-expects-parameter-2-to-be-integer-after-1-0-0/

The [documentation of date()](https://secure.php.net/manual/en/function.date.php) requires its 2nd argument to be an `int`.

And the [documentation of get_the_date()](https://developer.wordpress.org/reference/functions/get_the_date/) says it returns a string. 

But locally, using PHP 7.2, it looked like `get_the_date()` returns an int.

I couldn't reproduce this, but it'll probably be good to ensure this is an int. Edge cases might need more thought, like if `get_the_date()` somehow returns `''` or `false`, and `intval()` returns `0` for it.