### PR TITLE
Second argument of the_title filter is an Int not WP_Post.

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1889,8 +1889,8 @@ class AMP_Validated_URL_Post_Type {
 	/**
 	 * Strip host name from AMP validated URL being printed.
 	 *
-	 * @param string  $title Title.
-	 * @param int     $id  Post ID.
+	 * @param string $title Title.
+	 * @param int    $id Post ID.
 	 *
 	 * @return string Title.
 	 */

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1890,12 +1890,12 @@ class AMP_Validated_URL_Post_Type {
 	 * Strip host name from AMP validated URL being printed.
 	 *
 	 * @param string  $title Title.
-	 * @param WP_Post $post  Post.
+	 * @param int     $id  Post ID.
 	 *
 	 * @return string Title.
 	 */
-	public static function filter_the_title_in_post_list_table( $title, $post = null ) {
-		if ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->base === 'edit' && get_current_screen()->post_type === self::POST_TYPE_SLUG && self::POST_TYPE_SLUG === get_post_type( $post ) ) {
+	public static function filter_the_title_in_post_list_table( $title, $id = null ) {
+		if ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->base === 'edit' && get_current_screen()->post_type === self::POST_TYPE_SLUG && self::POST_TYPE_SLUG === get_post_type( $id ) ) {
 			$title = preg_replace( '#^(\w+:)?//[^/]+#', '', $title );
 		}
 		return $title;

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -1365,7 +1365,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 		set_current_screen( 'front' );
 
 		// The first conditional isn't true yet, so $title should be unchanged.
-		$this->assertEquals( $title, AMP_Validated_URL_Post_Type::filter_the_title_in_post_list_table( $title, $post ) );
+		$this->assertEquals( $title, AMP_Validated_URL_Post_Type::filter_the_title_in_post_list_table( $title, $post->ID ) );
 
 		/*
 		 * The first conditional still isn't true yet, as the $post->post_type isn't correct.
@@ -1373,7 +1373,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 		 */
 		set_current_screen( 'edit.php' );
 		$current_screen->post_type = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
-		$this->assertEquals( $title, AMP_Validated_URL_Post_Type::filter_the_title_in_post_list_table( $title, $post ) );
+		$this->assertEquals( $title, AMP_Validated_URL_Post_Type::filter_the_title_in_post_list_table( $title, $post->ID ) );
 
 		// The conditional should be true, and this should return the filtered $title.
 		$post_correct_post_type = $this->factory()->post->create_and_get( array(


### PR DESCRIPTION
The `the_title` applies this filter `filter_the_title_in_post_list_table` with two arguments. The second argument is wrong. It is an Int, not a WP_Post object. See https://codex.wordpress.org/Plugin_API/Filter_Reference/the_title