### PR TITLE
Add check for required iconv extension

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -38,12 +38,29 @@ if ( version_compare( phpversion(), '5.3.6', '<' ) ) {
 function _amp_print_php_dom_document_notice() {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'The AMP plugin requires DOM extension in PHP. Please contact your host to install DOM extension.', 'amp' ); ?></p>
+		<p><?php esc_html_e( 'The AMP plugin requires DOM extension in PHP. Please contact your host to install this extension.', 'amp' ); ?></p>
 	</div>
 	<?php
 }
 if ( ! class_exists( 'DOMDocument' ) ) {
 	add_action( 'admin_notices', '_amp_print_php_dom_document_notice' );
+	return;
+}
+
+/**
+ * Print admin notice regarding DOM extension is not installed.
+ *
+ * @since 1.0.1
+ */
+function _amp_print_php_missing_iconv_notice() {
+	?>
+	<div class="notice notice-error">
+		<p><?php esc_html_e( 'The AMP plugin requires iconv extension in PHP. Please contact your host to install this extension.', 'amp' ); ?></p>
+	</div>
+	<?php
+}
+if ( ! function_exists( 'iconv' ) ) {
+	add_action( 'admin_notices', '_amp_print_php_missing_iconv_notice' );
 	return;
 }
 


### PR DESCRIPTION
The PHP-CSS-Parser requires `iconv`.

See https://wordpress.org/support/topic/paired-mode-causes-fatal-error/