### PR TITLE
Prevent image with caption from overflowing its container in Classic mode

### DIFF
--- a/templates/style.php
+++ b/templates/style.php
@@ -241,6 +241,10 @@ blockquote p:last-child {
 	margin-left: 1em;
 }
 
+.amp-wp-article-content figure.wp-caption {
+	max-width: 100%;
+}
+
 .amp-wp-article-content amp-img {
 	margin: 0 auto;
 }

--- a/templates/style.php
+++ b/templates/style.php
@@ -241,7 +241,7 @@ blockquote p:last-child {
 	margin-left: 1em;
 }
 
-.amp-wp-article-content figure.wp-caption {
+.amp-wp-article-content .wp-caption {
 	max-width: 100%;
 }
 


### PR DESCRIPTION
Thanks to @lumay for raising this in:
https://wordpress.org/support/topic/amp-img-with-caption-center-problem/

# Steps To Reproduce
1. Select 'Classic' mode
2. Activate the Classic Editor plugin, assuming you're running WordPress `5.0`
3. Create a post
4. Add an image with a width of at least `1000px`, and select Full Size
5. Add a caption to the image
6. Update the post and go to its AMP URL
7. Expected: the image stays within its container
8. Actual: it overflows its container:

![image-caption-overflows-container](https://user-images.githubusercontent.com/4063887/49857757-eace5280-fdb8-11e8-9e55-33c3e28d7906.png)

# Background
This only looks to exist in the Classic editor, or when using the Classic block, or when adding a `[caption]` to a Shortcode block.

An image with a caption in the Classic editor creates a `figure.wp-caption`, which often has an inline width style value, like `<figure style="width: 1199px" ...>`

This can cause it to overflow the container.

There used to be logic in `AMP_Style_Sanitizer::filter_style()` [that converted 'width' to 'max-width'](https://github.com/ampproject/amp-wp/blob/da3a779c3ffad5c61c05bba4b83b680de274c5bd/includes/sanitizers/class-amp-style-sanitizer.php#L549).

Now that it's removed, this PR applies a simple style rule as a workaround.

This is in a stylesheet because it only applies to Classic mode.

**This issue doesn't seem to exist in Paired or Native mode**, where themes can add their own `max-width` styling.

# Before
![captions-before](https://user-images.githubusercontent.com/4063887/49858011-86f85980-fdb9-11e8-902f-e60e77e0e085.png)

# After
![captions-after](https://user-images.githubusercontent.com/4063887/49858038-9081c180-fdb9-11e8-8433-0a903a58ee42.png)

