### PR TITLE
Introduce new sanitizers to streamline theme support for nav menu mobile toggle and submenu dropdowns

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -708,6 +708,7 @@ function amp_get_content_sanitizers( $post = null ) {
 			),
 			'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
 			'AMP_Nav_Menu_Toggle_Sanitizer'   => ! empty( $theme_support_args['nav_menu_toggle'] ) ? $theme_support_args['nav_menu_toggle'] : array(),
+			'AMP_Nav_Menu_Dropdown_Sanitizer' => ! empty( $theme_support_args['nav_menu_dropdown'] ) ? $theme_support_args['nav_menu_dropdown'] : array(),
 			'AMP_Script_Sanitizer'            => array(),
 			'AMP_Style_Sanitizer'             => array(),
 			'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -670,7 +670,9 @@ function amp_get_content_embed_handlers( $post = null ) {
  * @return array Embed handlers.
  */
 function amp_get_content_sanitizers( $post = null ) {
-	if ( current_theme_supports( AMP_Theme_Support::SLUG ) && $post ) {
+	$theme_support_args = AMP_Theme_Support::get_theme_support_args();
+
+	if ( is_array( $theme_support_args ) && $post ) {
 		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
 		$post = null;
 	}
@@ -702,9 +704,10 @@ function amp_get_content_sanitizers( $post = null ) {
 				'add_placeholder' => true,
 			),
 			'AMP_Gallery_Block_Sanitizer'     => array( // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
-				'carousel_required' => ! current_theme_supports( AMP_Theme_Support::SLUG ), // For back-compat.
+				'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.
 			),
 			'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
+			'AMP_Nav_Menu_Toggle_Sanitizer'   => ! empty( $theme_support_args['nav_menu_toggle'] ) ? $theme_support_args['nav_menu_toggle'] : array(),
 			'AMP_Script_Sanitizer'            => array(),
 			'AMP_Style_Sanitizer'             => array(),
 			'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -664,6 +664,7 @@ function amp_get_content_embed_handlers( $post = null ) {
  * Get content sanitizers.
  *
  * @since 0.7
+ * @since 1.1 Added AMP_Nav_Menu_Toggle_Sanitizer and AMP_Nav_Menu_Dropdown_Sanitizer.
  *
  * @param WP_Post $post Post that the content belongs to. Deprecated when theme supports AMP, as sanitizers apply
  *                      to non-post data (e.g. Text widget).
@@ -677,6 +678,39 @@ function amp_get_content_sanitizers( $post = null ) {
 		$post = null;
 	}
 
+	$sanitizers = array(
+		'AMP_Core_Theme_Sanitizer'        => array(
+			'template'   => get_template(),
+			'stylesheet' => get_stylesheet(),
+		),
+		'AMP_Img_Sanitizer'               => array(),
+		'AMP_Form_Sanitizer'              => array(),
+		'AMP_Comments_Sanitizer'          => array(),
+		'AMP_Video_Sanitizer'             => array(),
+		'AMP_O2_Player_Sanitizer'         => array(),
+		'AMP_Audio_Sanitizer'             => array(),
+		'AMP_Playbuzz_Sanitizer'          => array(),
+		'AMP_Embed_Sanitizer'             => array(),
+		'AMP_Iframe_Sanitizer'            => array(
+			'add_placeholder' => true,
+		),
+		'AMP_Gallery_Block_Sanitizer'     => array( // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
+			'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.
+		),
+		'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
+		'AMP_Script_Sanitizer'            => array(),
+		'AMP_Style_Sanitizer'             => array(),
+		'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
+	);
+
+	if ( ! empty( $theme_support_args['nav_menu_toggle'] ) ) {
+		$sanitizers['AMP_Nav_Menu_Toggle_Sanitizer'] = $theme_support_args['nav_menu_toggle'];
+	}
+
+	if ( ! empty( $theme_support_args['nav_menu_dropdown'] ) ) {
+		$sanitizers['AMP_Nav_Menu_Dropdown_Sanitizer'] = $theme_support_args['nav_menu_dropdown'];
+	}
+
 	/**
 	 * Filters the content sanitizers.
 	 *
@@ -686,35 +720,7 @@ function amp_get_content_sanitizers( $post = null ) {
 	 * @param array   $handlers Handlers.
 	 * @param WP_Post $post     Post. Deprecated.
 	 */
-	$sanitizers = apply_filters( 'amp_content_sanitizers',
-		array(
-			'AMP_Core_Theme_Sanitizer'        => array(
-				'template'   => get_template(),
-				'stylesheet' => get_stylesheet(),
-			),
-			'AMP_Img_Sanitizer'               => array(),
-			'AMP_Form_Sanitizer'              => array(),
-			'AMP_Comments_Sanitizer'          => array(),
-			'AMP_Video_Sanitizer'             => array(),
-			'AMP_O2_Player_Sanitizer'         => array(),
-			'AMP_Audio_Sanitizer'             => array(),
-			'AMP_Playbuzz_Sanitizer'          => array(),
-			'AMP_Embed_Sanitizer'             => array(),
-			'AMP_Iframe_Sanitizer'            => array(
-				'add_placeholder' => true,
-			),
-			'AMP_Gallery_Block_Sanitizer'     => array( // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
-				'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.
-			),
-			'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
-			'AMP_Nav_Menu_Toggle_Sanitizer'   => ! empty( $theme_support_args['nav_menu_toggle'] ) ? $theme_support_args['nav_menu_toggle'] : array(),
-			'AMP_Nav_Menu_Dropdown_Sanitizer' => ! empty( $theme_support_args['nav_menu_dropdown'] ) ? $theme_support_args['nav_menu_dropdown'] : array(),
-			'AMP_Script_Sanitizer'            => array(),
-			'AMP_Style_Sanitizer'             => array(),
-			'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
-		),
-		$post
-	);
+	$sanitizers = apply_filters( 'amp_content_sanitizers', $sanitizers, $post );
 
 	// Force style sanitizer and whitelist sanitizer to be at end.
 	foreach ( array( 'AMP_Style_Sanitizer', 'AMP_Tag_And_Attribute_Sanitizer' ) as $class_name ) {

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -79,6 +79,7 @@ class AMP_Autoloader {
 		'AMP_Gallery_Block_Sanitizer'                 => 'includes/sanitizers/class-amp-gallery-block-sanitizer',
 		'AMP_Iframe_Sanitizer'                        => 'includes/sanitizers/class-amp-iframe-sanitizer',
 		'AMP_Img_Sanitizer'                           => 'includes/sanitizers/class-amp-img-sanitizer',
+		'AMP_Nav_Menu_Toggle_Sanitizer'               => 'includes/sanitizers/class-amp-nav-menu-toggle-sanitizer',
 		'AMP_Comments_Sanitizer'                      => 'includes/sanitizers/class-amp-comments-sanitizer',
 		'AMP_Form_Sanitizer'                          => 'includes/sanitizers/class-amp-form-sanitizer',
 		'AMP_O2_Player_Sanitizer'                     => 'includes/sanitizers/class-amp-o2-player-sanitizer',

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -80,6 +80,7 @@ class AMP_Autoloader {
 		'AMP_Iframe_Sanitizer'                        => 'includes/sanitizers/class-amp-iframe-sanitizer',
 		'AMP_Img_Sanitizer'                           => 'includes/sanitizers/class-amp-img-sanitizer',
 		'AMP_Nav_Menu_Toggle_Sanitizer'               => 'includes/sanitizers/class-amp-nav-menu-toggle-sanitizer',
+		'AMP_Nav_Menu_Dropdown_Sanitizer'             => 'includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer',
 		'AMP_Comments_Sanitizer'                      => 'includes/sanitizers/class-amp-comments-sanitizer',
 		'AMP_Form_Sanitizer'                          => 'includes/sanitizers/class-amp-form-sanitizer',
 		'AMP_O2_Player_Sanitizer'                     => 'includes/sanitizers/class-amp-o2-player-sanitizer',

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -128,6 +128,9 @@ class AMP_Theme_Support {
 			return;
 		}
 
+		// Ensure extra theme support for core themes is in place.
+		AMP_Core_Theme_Sanitizer::extend_theme_support();
+
 		self::$init_start_time = microtime( true );
 
 		require_once AMP__DIR__ . '/includes/amp-post-template-actions.php';

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1025,73 +1025,18 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		}
 		$args = array_merge( $default_args, $args );
 
-		/**
-		 * Filter the HTML output of a nav menu item to add the AMP dropdown button to reveal the sub-menu.
-		 *
-		 * @see twentyfifteen_amp_setup_hooks()
-		 *
-		 * @param string $item_output Nav menu item HTML.
-		 * @param object $item        Nav menu item.
-		 * @return string Modified nav menu item HTML.
-		 */
-		add_filter( 'walker_nav_menu_start_el', function( $item_output, $item, $depth, $nav_menu_args ) use ( $args ) {
-			unset( $depth );
+		if ( empty( $args ) ) {
+			return;
+		}
 
-			// Skip adding buttons to nav menu widgets for now.
-			if ( empty( $nav_menu_args->theme_location ) ) {
-				return $item_output;
-			}
+		$support = AMP_Theme_Support::get_theme_support_args();
+		if ( ! is_array( $support ) ) {
+			$support = array();
+		}
 
-			if ( ! in_array( 'menu-item-has-children', $item->classes, true ) ) {
-				return $item_output;
-			}
-			static $nav_menu_item_number = 0;
-			$nav_menu_item_number++;
+		$support['nav_menu_dropdown'] = $args;
 
-			$expanded = in_array( 'current-menu-ancestor', $item->classes, true );
-
-			$expanded_state_id = 'navMenuItemExpanded' . $nav_menu_item_number;
-
-			// Create new state for managing storing the whether the sub-menu is expanded.
-			$item_output .= sprintf(
-				'<amp-state id="%s"><script type="application/json">%s</script></amp-state>',
-				esc_attr( $expanded_state_id ),
-				wp_json_encode( $expanded )
-			);
-
-			$dropdown_button  = '<button';
-			$dropdown_button .= sprintf(
-				' class="%s" [class]="%s"',
-				esc_attr( $args['sub_menu_button_class'] . ( $expanded ? ' ' . $args['sub_menu_button_toggle_class'] : '' ) ),
-				esc_attr( sprintf( "%s + ( $expanded_state_id ? %s : '' )", wp_json_encode( $args['sub_menu_button_class'] ), wp_json_encode( ' ' . $args['sub_menu_button_toggle_class'] ) ) )
-			);
-			$dropdown_button .= sprintf(
-				' aria-expanded="%s" [aria-expanded]="%s"',
-				esc_attr( wp_json_encode( $expanded ) ),
-				esc_attr( "$expanded_state_id ? 'true' : 'false'" )
-			);
-			$dropdown_button .= sprintf(
-				' on="%s"',
-				esc_attr( "tap:AMP.setState( { $expanded_state_id: ! $expanded_state_id } )" )
-			);
-			$dropdown_button .= '>';
-
-			if ( isset( $args['icon'] ) ) {
-				$dropdown_button .= $args['icon'];
-			}
-			if ( isset( $args['expand_text'] ) && isset( $args['collapse_text'] ) ) {
-				$dropdown_button .= sprintf(
-					'<span class="screen-reader-text" [text]="%s">%s</span>',
-					esc_attr( sprintf( "$expanded_state_id ? %s : %s", wp_json_encode( $args['collapse_text'] ), wp_json_encode( $args['expand_text'] ) ) ),
-					esc_html( $expanded ? $args['collapse_text'] : $args['expand_text'] )
-				);
-			}
-
-			$dropdown_button .= '</button>';
-
-			$item_output .= $dropdown_button;
-			return $item_output;
-		}, 10, 4 );
+		add_theme_support( AMP_Theme_Support::SLUG, $support );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -90,7 +90,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			'add_twentyseventeen_image_styles'    => array(),
 			'add_twentyseventeen_sticky_nav_menu' => array(),
 			'add_has_header_video_body_class'     => array(),
-			'add_nav_menu_styles'                 => array(),
+			'add_nav_menu_styles'                 => array(
+				'sub_menu_button_toggle_class' => 'toggled-on',
+			),
 			'add_smooth_scrolling'                => array(
 				'//header[@id = "masthead"]//a[ contains( @class, "menu-scroll-down" ) ]',
 			),
@@ -113,7 +115,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'twentysixteen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
 				),
 			),
-			'add_nav_menu_styles' => array(),
+			'add_nav_menu_styles' => array(
+				'sub_menu_button_toggle_class' => 'toggled-on',
+			),
 		),
 
 		// Twenty Fifteen.
@@ -129,7 +133,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'twentyfifteen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
 				),
 			),
-			'add_nav_menu_styles' => array(),
+			'add_nav_menu_styles' => array(
+				'sub_menu_button_toggle_class' => 'toggle-on',
+			),
 		),
 	);
 
@@ -880,7 +886,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array $args Args.
 	 */
 	public static function add_nav_menu_styles( $args = array() ) {
-		add_action( 'wp_enqueue_scripts', function() {
+		add_action( 'wp_enqueue_scripts', function() use ( $args ) {
 			ob_start();
 			?>
 			<style>
@@ -890,7 +896,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 
 				/* Use sibling selector and re-use class on button instead of toggling toggle-on class on ul.sub-menu */
-				.main-navigation ul .toggled-on + .sub-menu {
+				.main-navigation ul .<?php echo esc_html( $args['sub_menu_button_toggle_class'] ); ?> + .sub-menu {
 					display: block;
 				}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -91,8 +91,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			'add_twentyseventeen_sticky_nav_menu' => array(),
 			'add_has_header_video_body_class'     => array(),
 			'add_nav_menu_styles'                 => array(),
-			'add_nav_menu_toggle'                 => array(),
-			'add_nav_sub_menu_buttons'            => array(),
 			'add_smooth_scrolling'                => array(
 				'//header[@id = "masthead"]//a[ contains( @class, "menu-scroll-down" ) ]',
 			),
@@ -116,8 +114,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				),
 			),
 			'add_nav_menu_styles'      => array(),
-			'add_nav_menu_toggle'      => array(),
-			'add_nav_sub_menu_buttons' => array(),
 		),
 
 		// Twenty Fifteen.
@@ -134,8 +130,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				),
 			),
 			'add_nav_menu_styles'      => array(),
-			'add_nav_menu_toggle'      => array(),
-			'add_nav_sub_menu_buttons' => array(),
 		),
 	);
 
@@ -205,66 +199,118 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Adds extra theme support arguments on the fly.
+	 *
+	 * This method is neither a buffering hook nor a sanitization callback and is called manually by
+	 * {@see AMP_Theme_Support}. Typically themes will add theme support directly and don't need such
+	 * a method. In this case, it is a workaround for adding theme support on behalf of external themes.
+	 *
+	 * @since 1.1
+	 */
+	public static function extend_theme_support() {
+		$args = self::get_theme_support_args( get_template() );
+
+		if ( empty( $args ) ) {
+			return;
+		}
+
+		$support = AMP_Theme_Support::get_theme_support_args();
+		if ( ! is_array( $support ) ) {
+			$support = array();
+		}
+
+		add_theme_support( AMP_Theme_Support::SLUG, array_merge( $support, $args ) );
+	}
+
+	/**
+	 * Returns extra arguments to pass to `add_theme_support()`.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string $theme Theme slug.
+	 * @return array Arguments to merge with existing theme support arguments.
+	 */
+	protected static function get_theme_support_args( $theme ) {
+		// phpcs:disable WordPress.WP.I18n.TextDomainMismatch
+		switch ( $theme ) {
+			case 'twentyfifteen':
+				return array(
+					'nav_menu_toggle'   => array(
+						'nav_container_id'           => 'secondary',
+						'nav_container_toggle_class' => 'toggled-on',
+						'menu_button_xpath'          => '//header[ @id = "masthead" ]//button[ contains( @class, "secondary-toggle" ) ]',
+						'menu_button_toggle_class'   => 'toggled-on',
+					),
+					'nav_menu_dropdown' => array(
+						'sub_menu_button_class'        => 'dropdown-toggle',
+						'sub_menu_button_toggle_class' => 'toggle-on',
+						'expand_text '                 => __( 'expand child menu', 'twentyfifteen' ),
+						'collapse_text'                => __( 'collapse child menu', 'twentyfifteen' ),
+					),
+				);
+
+			case 'twentysixteen':
+				return array(
+					'nav_menu_toggle'   => array(
+						'nav_container_id'           => 'site-header-menu',
+						'nav_container_toggle_class' => 'toggled-on',
+						'menu_button_xpath'          => '//header[@id = "masthead"]//button[ @id = "menu-toggle" ]',
+						'menu_button_toggle_class'   => 'toggled-on',
+					),
+					'nav_menu_dropdown' => array(
+						'sub_menu_button_class'        => 'dropdown-toggle',
+						'sub_menu_button_toggle_class' => 'toggled-on',
+						'expand_text '                 => __( 'expand child menu', 'twentysixteen' ),
+						'collapse_text'                => __( 'collapse child menu', 'twentysixteen' ),
+					),
+				);
+
+			case 'twentyseventeen':
+				$config = array(
+					'nav_menu_toggle'   => array(
+						'nav_container_id'           => 'site-navigation',
+						'nav_container_toggle_class' => 'toggled-on',
+						'menu_button_xpath'          => '//nav[@id = "site-navigation"]//button[ contains( @class, "menu-toggle" ) ]',
+						'menu_button_toggle_class'   => 'toggled-on',
+					),
+					'nav_menu_dropdown' => array(
+						'sub_menu_button_class'        => 'dropdown-toggle',
+						'sub_menu_button_toggle_class' => 'toggled-on',
+						'expand_text '                 => __( 'expand child menu', 'twentyseventeen' ),
+						'collapse_text'                => __( 'collapse child menu', 'twentyseventeen' ),
+					),
+				);
+
+				if ( function_exists( 'twentyseventeen_get_svg' ) ) {
+					$config['nav_menu_dropdown']['icon'] = twentyseventeen_get_svg( array(
+						'icon'     => 'angle-down',
+						'fallback' => true,
+					) );
+				}
+
+				return $config;
+		}
+		// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
+
+		return array();
+	}
+
+	/**
 	 * Get theme config.
 	 *
 	 * @since 1.0
+	 * @deprecated 1.1
 	 *
 	 * @param string $theme Theme slug.
 	 * @return array Class names.
 	 */
 	protected static function get_theme_config( $theme ) {
-		// phpcs:disable WordPress.WP.I18n.TextDomainMismatch
-		$config = array(
-			'sub_menu_button_class' => 'dropdown-toggle',
-		);
-		switch ( $theme ) {
-			case 'twentyfifteen':
-				return array_merge(
-					$config,
-					array(
-						'nav_container_id'             => 'secondary',
-						'nav_container_toggle_class'   => 'toggled-on',
-						'menu_button_class'            => 'secondary-toggle',
-						'menu_button_xpath'            => '//header[ @id = "masthead" ]//button[ contains( @class, "secondary-toggle" ) ]',
-						'menu_button_toggle_class'     => 'toggled-on',
-						'sub_menu_button_toggle_class' => 'toggle-on',
-						'expand_text '                 => __( 'expand child menu', 'twentyfifteen' ),
-						'collapse_text'                => __( 'collapse child menu', 'twentyfifteen' ),
-					)
-				);
+		_deprecated_function( __METHOD__, '1.1' );
 
-			case 'twentysixteen':
-				return array_merge(
-					$config,
-					array(
-						'nav_container_id'             => 'site-header-menu',
-						'nav_container_toggle_class'   => 'toggled-on',
-						'menu_button_class'            => 'menu-toggle',
-						'menu_button_xpath'            => '//header[@id = "masthead"]//button[ @id = "menu-toggle" ]',
-						'menu_button_toggle_class'     => 'toggled-on',
-						'sub_menu_button_toggle_class' => 'toggled-on',
-						'expand_text '                 => __( 'expand child menu', 'twentysixteen' ),
-						'collapse_text'                => __( 'collapse child menu', 'twentysixteen' ),
-					)
-				);
+		$args = self::get_theme_support_args( $theme );
 
-			case 'twentyseventeen':
-			default:
-				return array_merge(
-					$config,
-					array(
-						'nav_container_id'             => 'site-navigation',
-						'nav_container_toggle_class'   => 'toggled-on',
-						'menu_button_class'            => 'menu-toggle',
-						'menu_button_xpath'            => '//nav[@id = "site-navigation"]//button[ contains( @class, "menu-toggle" ) ]',
-						'menu_button_toggle_class'     => 'toggled-on',
-						'sub_menu_button_toggle_class' => 'toggled-on',
-						'expand_text '                 => __( 'expand child menu', 'twentyseventeen' ),
-						'collapse_text'                => __( 'collapse child menu', 'twentyseventeen' ),
-					)
-				);
-		}
-		// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
+		// This returns arguments in a backward-compatible way.
+		return array_merge( $args['nav_menu_toggle'], $args['nav_menu_dropdown'] );
 	}
 
 	/**
@@ -622,14 +668,12 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @link https://github.com/WordPress/wordpress-develop/blob/1af1f65a21a1a697fb5f33027497f9e5ae638453/src/wp-content/themes/twentyseventeen/style.css#L1743
 	 */
 	public static function add_twentyseventeen_masthead_styles() {
-		$args = self::get_theme_config( get_template() );
-
 		/*
 		 * The following is necessary because the styles in the theme apply to img and video,
 		 * and the CSS parser will then convert the selectors to amp-img and amp-video respectively.
 		 * Nevertheless, object-fit does not apply on amp-img and it needs to apply on an actual img.
 		 */
-		add_action( 'wp_enqueue_scripts', function() use ( $args ) {
+		add_action( 'wp_enqueue_scripts', function() {
 			$is_front_page_layout = ( is_front_page() && 'posts' !== get_option( 'show_on_front' ) ) || ( is_home() && is_front_page() );
 			ob_start();
 			?>
@@ -836,12 +880,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array $args Args.
 	 */
 	public static function add_nav_menu_styles( $args = array() ) {
-		$args = array_merge(
-			self::get_theme_config( get_template() ),
-			$args
-		);
-
-		add_action( 'wp_enqueue_scripts', function() use ( $args ) {
+		add_action( 'wp_enqueue_scripts', function() {
 			ob_start();
 			?>
 			<style>
@@ -851,24 +890,24 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 
 				/* Use sibling selector and re-use class on button instead of toggling toggle-on class on ul.sub-menu */
-				.main-navigation ul .<?php echo esc_html( $args['sub_menu_button_toggle_class'] ); ?> + .sub-menu {
+				.main-navigation ul .toggled-on + .sub-menu {
 					display: block;
 				}
 
 				<?php if ( 'twentyseventeen' === get_template() ) : ?>
 					/* Show the button*/
-					.no-js .<?php echo esc_html( $args['menu_button_class'] ); ?> {
+					.no-js .menu-toggle {
 						display: block;
 					}
 					.no-js .main-navigation > div > ul {
 						display: none;
 					}
-					.no-js .main-navigation.<?php echo esc_html( $args['nav_container_toggle_class'] ); ?> > div > ul {
+					.no-js .main-navigation.toggled-on > div > ul {
 						display: block;
 					}
 					@media screen and (min-width: 48em) {
-						.no-js .<?php echo esc_html( $args['menu_button_class'] ); ?>,
-						.no-js .<?php echo esc_html( $args['sub_menu_button_class'] ); ?> {
+						.no-js .menu-toggle,
+						.no-js .dropdown-toggle {
 							display: none;
 						}
 						.no-js .main-navigation ul,
@@ -920,7 +959,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				<?php elseif ( 'twentysixteen' === get_template() ) : ?>
 					@media screen and (max-width: 56.875em) {
 						/* Show the button*/
-						.no-js .<?php echo esc_html( $args['menu_button_class'] ); ?> {
+						.no-js .menu-toggle {
 							display: block;
 						}
 						.no-js .site-header-menu {
@@ -973,70 +1012,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
 			wp_add_inline_style( get_template() . '-style', $styles );
 		}, 11 );
-	}
-
-	/**
-	 * Ensure that support is added for nav menu toggles that are typically JS-only.
-	 *
-	 * @since 1.0
-	 * @since 1.1 Made method static so it acts as a buffering hook for adjusting theme support instead of a post-sanitizer.
-	 *
-	 * @param array $args Args.
-	 */
-	public static function add_nav_menu_toggle( $args = array() ) {
-		$args = array_merge(
-			self::get_theme_config( get_template() ),
-			$args
-		);
-
-		if ( empty( $args ) ) {
-			return;
-		}
-
-		$support = AMP_Theme_Support::get_theme_support_args();
-		if ( ! is_array( $support ) ) {
-			$support = array();
-		}
-
-		$support['nav_menu_toggle'] = $args;
-
-		add_theme_support( AMP_Theme_Support::SLUG, $support );
-	}
-
-	/**
-	 * Add buttons for nav sub-menu items.
-	 *
-	 * @since 1.0
-	 * @link https://github.com/WordPress/wordpress-develop/blob/a26c24226c6b131a0ed22c722a836c100d3ba254/src/wp-content/themes/twentyseventeen/assets/js/navigation.js#L11-L43
-	 *
-	 * @param array $args Args.
-	 */
-	public static function add_nav_sub_menu_buttons( $args = array() ) {
-		$default_args = self::get_theme_config( get_template() );
-		switch ( get_template() ) {
-			case 'twentyseventeen':
-				if ( function_exists( 'twentyseventeen_get_svg' ) ) {
-					$default_args['icon'] = twentyseventeen_get_svg( array(
-						'icon'     => 'angle-down',
-						'fallback' => true,
-					) );
-				}
-				break;
-		}
-		$args = array_merge( $default_args, $args );
-
-		if ( empty( $args ) ) {
-			return;
-		}
-
-		$support = AMP_Theme_Support::get_theme_support_args();
-		if ( ! is_array( $support ) ) {
-			$support = array();
-		}
-
-		$support['nav_menu_dropdown'] = $args;
-
-		add_theme_support( AMP_Theme_Support::SLUG, $support );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -102,34 +102,34 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		'twentysixteen'   => array(
 			// @todo Figure out an AMP solution for onResizeARIA().
 			// @todo Try to implement belowEntryMetaClass().
-			'dequeue_scripts'          => array(
+			'dequeue_scripts'     => array(
 				'twentysixteen-script',
 				'twentysixteen-html5', // Only relevant for IE<9.
 				'twentysixteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
 				'twentysixteen-skip-link-focus-fix', // Only needed by IE11 and when admin bar is present.
 			),
-			'remove_actions'           => array(
+			'remove_actions'      => array(
 				'wp_head' => array(
 					'twentysixteen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
 				),
 			),
-			'add_nav_menu_styles'      => array(),
+			'add_nav_menu_styles' => array(),
 		),
 
 		// Twenty Fifteen.
 		'twentyfifteen'   => array(
 			// @todo Figure out an AMP solution for onResizeARIA().
-			'dequeue_scripts'          => array(
+			'dequeue_scripts'     => array(
 				'twentyfifteen-script',
 				'twentyfifteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
 				'twentyfifteen-skip-link-focus-fix', // Only needed by IE11 and when admin bar is present.
 			),
-			'remove_actions'           => array(
+			'remove_actions'      => array(
 				'wp_head' => array(
 					'twentyfifteen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
 				),
 			),
-			'add_nav_menu_styles'      => array(),
+			'add_nav_menu_styles' => array(),
 		),
 	);
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -998,12 +998,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			$support = array();
 		}
 
-		$support['nav_menu_toggle'] = array(
-			'nav_container_id'             => $args['nav_container_id'],
-			'nav_menu_button_xpath'        => $args['menu_button_xpath'],
-			'nav_container_toggle_class'   => $args['nav_container_toggle_class'],
-			'nav_menu_button_toggle_class' => $args['menu_button_toggle_class'],
-		);
+		$support['nav_menu_toggle'] = $args;
 
 		add_theme_support( AMP_Theme_Support::SLUG, $support );
 	}

--- a/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
@@ -51,11 +51,6 @@ class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array $args Args.
 	 */
 	public static function add_buffering_hooks( $args = array() ) {
-		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
-		if ( is_array( $theme_support_args ) && ! empty( $theme_support_args['nav_menu_dropdown'] ) ) {
-			$args = array_merge( $args, $theme_support_args['nav_menu_dropdown'] );
-		}
-
 		if ( empty( $args['sub_menu_button_class'] ) || empty( $args['sub_menu_button_toggle_class'] ) ) {
 			return;
 		}

--- a/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Class AMP_Nav_Menu_Dropdown_Sanitizer
+ *
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Nav_Menu_Dropdown_Sanitizer
+ *
+ * Handles state for navigation menu dropdown toggles, based on theme support.
+ *
+ * @since 1.1.0
+ */
+class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
+
+	/**
+	 * Default args.
+	 *
+	 * @since 1.1.0
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'sub_menu_button_class'        => '',
+		'sub_menu_button_toggle_class' => '',
+		'expand_text'                  => '',
+		'collapse_text'                => '',
+		'icon'                         => null, // Optional.
+		'sub_menu_item_state_id'       => 'navMenuItemExpanded',
+	);
+
+	/**
+	 * AMP_Nav_Menu_Dropdown_Sanitizer constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param DOMDocument $dom  DOM.
+	 * @param array       $args Args.
+	 */
+	public function __construct( $dom, $args = array() ) {
+		parent::__construct( $dom, $args );
+
+		$this->args = self::ensure_defaults( $this->args );
+	}
+
+	/**
+	 * Add filter to manipulate output during output buffering to add AMP-compatible dropdown toggles.
+	 *
+	 * @since 1.0
+	 *
+	 * @param array $args Args.
+	 */
+	public static function add_buffering_hooks( $args = array() ) {
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
+		if ( is_array( $theme_support_args ) && ! empty( $theme_support_args['nav_menu_dropdown'] ) ) {
+			$args = array_merge( $args, $theme_support_args['nav_menu_dropdown'] );
+		}
+
+		if ( empty( $args['sub_menu_button_class'] ) || empty( $args['sub_menu_button_toggle_class'] ) ) {
+			return;
+		}
+
+		$args = self::ensure_defaults( $args );
+
+		/**
+		 * Filter the HTML output of a nav menu item to add the AMP dropdown button to reveal the sub-menu.
+		 *
+		 * @param string $item_output Nav menu item HTML.
+		 * @param object $item        Nav menu item.
+		 * @return string Modified nav menu item HTML.
+		 */
+		add_filter( 'walker_nav_menu_start_el', function( $item_output, $item, $depth, $nav_menu_args ) use ( $args ) {
+			unset( $depth );
+
+			// Skip adding buttons to nav menu widgets for now.
+			if ( empty( $nav_menu_args->theme_location ) ) {
+				return $item_output;
+			}
+
+			if ( ! in_array( 'menu-item-has-children', $item->classes, true ) ) {
+				return $item_output;
+			}
+
+			static $nav_menu_item_number = 0;
+			$nav_menu_item_number++;
+
+			$expanded = in_array( 'current-menu-ancestor', $item->classes, true );
+
+			$expanded_state_id = $args['nav_menu_item_state_id'] . $nav_menu_item_number;
+
+			// Create new state for managing storing the whether the sub-menu is expanded.
+			$item_output .= sprintf(
+				'<amp-state id="%s"><script type="application/json">%s</script></amp-state>',
+				esc_attr( $expanded_state_id ),
+				wp_json_encode( $expanded )
+			);
+
+			$dropdown_button  = '<button';
+			$dropdown_button .= sprintf(
+				' class="%s" [class]="%s"',
+				esc_attr( $args['sub_menu_button_class'] . ( $expanded ? ' ' . $args['sub_menu_button_toggle_class'] : '' ) ),
+				esc_attr( sprintf( "%s + ( $expanded_state_id ? %s : '' )", wp_json_encode( $args['sub_menu_button_class'] ), wp_json_encode( ' ' . $args['sub_menu_button_toggle_class'] ) ) )
+			);
+			$dropdown_button .= sprintf(
+				' aria-expanded="%s" [aria-expanded]="%s"',
+				esc_attr( wp_json_encode( $expanded ) ),
+				esc_attr( "$expanded_state_id ? 'true' : 'false'" )
+			);
+			$dropdown_button .= sprintf(
+				' on="%s"',
+				esc_attr( "tap:AMP.setState( { $expanded_state_id: ! $expanded_state_id } )" )
+			);
+			$dropdown_button .= '>';
+
+			if ( isset( $args['icon'] ) ) {
+				$dropdown_button .= $args['icon'];
+			}
+			if ( isset( $args['expand_text'] ) && isset( $args['collapse_text'] ) ) {
+				$dropdown_button .= sprintf(
+					'<span class="screen-reader-text" [text]="%s">%s</span>',
+					esc_attr( sprintf( "$expanded_state_id ? %s : %s", wp_json_encode( $args['collapse_text'] ), wp_json_encode( $args['expand_text'] ) ) ),
+					esc_html( $expanded ? $args['collapse_text'] : $args['expand_text'] )
+				);
+			}
+
+			$dropdown_button .= '</button>';
+
+			$item_output .= $dropdown_button;
+			return $item_output;
+		}, 10, 4 );
+	}
+
+	/**
+	 * Method needs to be stubbed to fulfill base class requirements.
+	 *
+	 * @since 1.1.0
+	 */
+	public function sanitize() {
+		// Empty method body.
+	}
+
+	/**
+	 * Ensure that some defaults are always set as fallback.
+	 *
+	 * @param array $args Arguments to set the defaults in as necessary.
+	 * @return array Arguments with defaults filled.
+	 */
+	protected static function ensure_defaults( $args ) {
+		// Ensure accessibility labels are always set.
+		if ( empty( $args['expand_text'] ) ) {
+			$args['expand_text'] = __( 'expand child menu', 'amp' );
+		}
+		if ( empty( $args['collapse_text'] ) ) {
+			$args['collapse_text'] = __( 'collapse child menu', 'amp' );
+		}
+
+		// Ensure the state ID is always set.
+		if ( empty( $args['nav_menu_item_state_id'] ) ) {
+			$args['nav_menu_item_state_id'] = 'navMenuItemExpanded';
+		}
+
+		return $args;
+	}
+}

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -61,11 +61,6 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.1.0
 	 */
 	public function sanitize() {
-		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
-		if ( is_array( $theme_support_args ) && ! empty( $theme_support_args['nav_menu_toggle'] ) ) {
-			$this->args = array_merge( $this->args, $theme_support_args['nav_menu_toggle'] );
-		}
-
 		$this->xpath = new DOMXPath( $this->dom );
 
 		$nav_el    = $this->get_nav_container();

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -21,13 +21,13 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = array(
-		'nav_container_id'             => '',
-		'nav_container_xpath'          => '', // Alternative for 'nav_container_id', if no ID available.
-		'nav_menu_button_id'           => '',
-		'nav_menu_button_xpath'        => '', // Alternative for 'nav_menu_button_id', if no ID available.
-		'nav_container_toggle_class'   => '',
-		'nav_menu_button_toggle_class' => '', // Optional.
-		'nav_menu_toggle_state_id'     => 'navMenuToggledOn',
+		'nav_container_id'           => '',
+		'nav_container_xpath'        => '', // Alternative for 'nav_container_id', if no ID available.
+		'menu_button_id'             => '',
+		'menu_button_xpath'          => '', // Alternative for 'menu_button_id', if no ID available.
+		'nav_container_toggle_class' => '',
+		'menu_button_toggle_class'   => '', // Optional.
+		'nav_menu_toggle_state_id'   => 'navMenuToggledOn',
 	);
 
 	/**
@@ -69,7 +69,7 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 		$this->xpath = new DOMXPath( $this->dom );
 
 		$nav_el    = $this->get_nav_container();
-		$button_el = $this->get_nav_menu_button();
+		$button_el = $this->get_menu_button();
 
 		// If no navigation element or no toggle class provided, bail.
 		if ( ! $nav_el || empty( $this->args['nav_container_toggle_class'] ) ) {
@@ -109,10 +109,10 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 		$button_el->setAttribute( 'on', $button_on );
 		$button_el->setAttribute( 'aria-expanded', 'false' );
 		$button_el->setAttribute( AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'aria-expanded', "$state_id ? 'true' : 'false'" );
-		if ( ! empty( $this->args['nav_menu_button_toggle_class'] ) ) {
+		if ( ! empty( $this->args['menu_button_toggle_class'] ) ) {
 			$button_el->setAttribute(
 				AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'class',
-				sprintf( "%s + ( $state_id ? %s : '' )", wp_json_encode( $button_el->getAttribute( 'class' ) ), wp_json_encode( ' ' . $this->args['nav_menu_button_toggle_class'] ) )
+				sprintf( "%s + ( $state_id ? %s : '' )", wp_json_encode( $button_el->getAttribute( 'class' ) ), wp_json_encode( ' ' . $this->args['menu_button_toggle_class'] ) )
 			);
 		}
 	}
@@ -143,13 +143,13 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @return DOMElement|null Navigation menu button element, or null if not provided or found.
 	 */
-	protected function get_nav_menu_button() {
-		if ( ! empty( $this->args['nav_menu_button_id'] ) ) {
-			return $this->dom->getElementById( $this->args['nav_menu_button_id'] );
+	protected function get_menu_button() {
+		if ( ! empty( $this->args['menu_button_id'] ) ) {
+			return $this->dom->getElementById( $this->args['menu_button_id'] );
 		}
 
-		if ( ! empty( $this->args['nav_menu_button_xpath'] ) ) {
-			return $this->xpath->query( $this->args['nav_menu_button_xpath'] )->item( 0 );
+		if ( ! empty( $this->args['menu_button_xpath'] ) ) {
+			return $this->xpath->query( $this->args['menu_button_xpath'] )->item( 0 );
 		}
 
 		return null;

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Class AMP_Nav_Menu_Toggle_Sanitizer
+ *
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Nav_Menu_Toggle_Sanitizer
+ *
+ * Handles state for navigation menu toggles, based on theme support.
+ *
+ * @since 1.1.0
+ */
+class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
+
+	/**
+	 * Default args.
+	 *
+	 * @since 1.1.0
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'nav_container_id'             => '',
+		'nav_container_xpath'          => '', // Alternative for 'nav_container_id', if no ID available.
+		'nav_menu_button_id'           => '',
+		'nav_menu_button_xpath'        => '', // Alternative for 'nav_menu_button_id', if no ID available.
+		'nav_container_toggle_class'   => '',
+		'nav_menu_button_toggle_class' => '', // Optional.
+		'nav_menu_toggle_state_id'     => 'navMenuToggledOn',
+	);
+
+	/**
+	 * XPath.
+	 *
+	 * @since 1.1.0
+	 * @var DOMXPath
+	 */
+	protected $xpath;
+
+	/**
+	 * AMP_Nav_Menu_Toggle_Sanitizer constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param DOMDocument $dom  DOM.
+	 * @param array       $args Args.
+	 */
+	public function __construct( $dom, $args = array() ) {
+		parent::__construct( $dom, $args );
+
+		// Ensure the state ID is always set.
+		if ( empty( $this->args['nav_menu_toggle_state_id'] ) ) {
+			$this->args['nav_menu_toggle_state_id'] = $this->DEFAULT_ARGS['nav_menu_toggle_state_id'];
+		}
+	}
+
+	/**
+	 * If supported per the constructor arguments, inject `amp-state` and bind dynamic classes accordingly.
+	 *
+	 * @since 1.1.0
+	 */
+	public function sanitize() {
+		$theme_support_args = AMP_Theme_Support::get_theme_support_args();
+		if ( is_array( $theme_support_args ) && ! empty( $theme_support_args['nav_menu_toggle'] ) ) {
+			$this->args = array_merge( $this->args, $theme_support_args['nav_menu_toggle'] );
+		}
+
+		$this->xpath = new DOMXPath( $this->dom );
+
+		$nav_el    = $this->get_nav_container();
+		$button_el = $this->get_nav_menu_button();
+
+		// If no navigation element or no toggle class provided, bail.
+		if ( ! $nav_el || empty( $this->args['nav_container_toggle_class'] ) ) {
+			if ( $button_el ) {
+
+				// Remove the button since it won't be used.
+				$button_el->parentNode->removeChild( $button_el );
+			}
+			return;
+		}
+
+		if ( ! $button_el ) {
+			return;
+		}
+
+		$state_id = 'navMenuToggledOn';
+		$expanded = false;
+
+		$nav_el->setAttribute(
+			AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'class',
+			sprintf(
+				"%s + ( $state_id ? %s : '' )",
+				wp_json_encode( $nav_el->getAttribute( 'class' ) ),
+				wp_json_encode( ' ' . $this->args['nav_container_toggle_class'] )
+			)
+		);
+
+		$state_el = $this->dom->createElement( 'amp-state' );
+		$state_el->setAttribute( 'id', $state_id );
+		$script_el = $this->dom->createElement( 'script' );
+		$script_el->setAttribute( 'type', 'application/json' );
+		$script_el->appendChild( $this->dom->createTextNode( wp_json_encode( $expanded ) ) );
+		$state_el->appendChild( $script_el );
+		$nav_el->parentNode->insertBefore( $state_el, $nav_el );
+
+		$button_on = sprintf( "tap:AMP.setState({ $state_id: ! $state_id })" );
+		$button_el->setAttribute( 'on', $button_on );
+		$button_el->setAttribute( 'aria-expanded', 'false' );
+		$button_el->setAttribute( AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'aria-expanded', "$state_id ? 'true' : 'false'" );
+		if ( ! empty( $this->args['nav_menu_button_toggle_class'] ) ) {
+			$button_el->setAttribute(
+				AMP_DOM_Utils::get_amp_bind_placeholder_prefix() . 'class',
+				sprintf( "%s + ( $state_id ? %s : '' )", wp_json_encode( $button_el->getAttribute( 'class' ) ), wp_json_encode( ' ' . $this->args['nav_menu_button_toggle_class'] ) )
+			);
+		}
+	}
+
+	/**
+	 * Retrieves the navigation container element.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return DOMElement|null Navigation container element, or null if not provided or found.
+	 */
+	protected function get_nav_container() {
+		if ( ! empty( $this->args['nav_container_id'] ) ) {
+			return $this->dom->getElementById( $this->args['nav_container_id'] );
+		}
+
+		if ( ! empty( $this->args['nav_container_xpath'] ) ) {
+			return $this->xpath->query( $this->args['nav_container_xpath'] )->item( 0 );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Retrieves the navigation menu button element.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return DOMElement|null Navigation menu button element, or null if not provided or found.
+	 */
+	protected function get_nav_menu_button() {
+		if ( ! empty( $this->args['nav_menu_button_id'] ) ) {
+			return $this->dom->getElementById( $this->args['nav_menu_button_id'] );
+		}
+
+		if ( ! empty( $this->args['nav_menu_button_xpath'] ) ) {
+			return $this->xpath->query( $this->args['nav_menu_button_xpath'] )->item( 0 );
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
One of the most common things theme developers still need to get their hands dirty with today when wanting to support AMP is dealing with the common hamburger menu for the navigation.

While there has been good documentation around on how to implement this, it's still quite clunky to do so - although what needs to happen is actually quite straightforward. The AMP plugin has so far automated the implementation for core themes already, only relying on some arguments like element IDs and CSS classes to use. With this PR I propose to streamline this so that _any_ WordPress theme can opt in and thus is no longer required to do the heavy lifting manually.

This PR ensures that a theme can add a `nav_menu_toggle` key when adding theme support, with the value for that being an array with further arguments. Example:

```php
add_theme_support(
    'amp',
    array(
        'nav_menu_toggle' => array(
            'nav_container_id'           => '...',
            'nav_menu_button_id'         => '...',
            'nav_container_toggle_class' => '...',
        ),
    )
);
```

The above is the minimum required. Alternatively to both IDs this PR also supports providing an Xpath query selector (in case the respective element does not use an ID), and you can also pass an optional `nav_menu_button_toggle_class` (in case the class on the button itself should change too).

A new `AMP_Nav_Menu_Toggle_Sanitizer` class is introduced to take care of this.

The logic for taking care of injecting the necessary `amp-state` and adjusting the markup I've mostly copied from `AMP_Core_Theme_Sanitizer::add_nav_menu_toggle()`. That method is now static (so that it is used as a buffering hook early) and has been simplified to dynamically add the required theme support - the heavy lifting is now part of `AMP_Nav_Menu_Toggle_Sanitizer`.