### PR TITLE
Fix Fatal error due to missing arguments

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -513,6 +513,12 @@ function amp_filter_script_loader_tag( $tag, $handle ) {
  * @return string Link tag HTML.
  */
 function amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, $handle, $href = '' ) {
+
+	// In the case of concatenated CSS stylesheet links, $href is not being passed to function. Ref - <https://github.com/ampproject/amp-wp/pull/1754#issue-239925151>.
+	if ( empty( $href ) && preg_match( '#<link.+?href=[\'"](.+?)[\'"]#', $tag, $matches ) ) {
+		$href = html_entity_decode( $matches[1], ENT_QUOTES );
+	}
+
 	static $allowed_font_src_regex = null;
 	unset( $handle );
 	if ( ! $allowed_font_src_regex ) {

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -512,7 +512,7 @@ function amp_filter_script_loader_tag( $tag, $handle ) {
  * @param string $href   Link URL.
  * @return string Link tag HTML.
  */
-function amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, $handle, $href ) {
+function amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, $handle, $href = '' ) {
 	static $allowed_font_src_regex = null;
 	unset( $handle );
 	if ( ! $allowed_font_src_regex ) {


### PR DESCRIPTION
I faced Fatal Error while using latest 1.0.1 version on a news site which is hosted on WordPress.com VIP platform. 

Looks like in case of concatenated CSS files, somehow its not passing 3rd argument `$href` to the function `amp_filter_font_style_loader_tag_with_crossorigin_anonymous` here -
https://github.com/ampproject/amp-wp/blob/1.0.1/includes/amp-helper-functions.php#L515

After some debugging I found that $tag contains -  
`<link rel='stylesheet' id='all-css-0' href='https://amp-wp.test/_static/??/wp-includes/css/dashicons.css,/wp-includes/css/admin-bar.css?m=1534398924j' type='text/css' media='all' />` 
and $handle contains `h4-global`.

This was the error - 
> `Fatal error: Uncaught ArgumentCountError: Too few arguments to function amp_filter_font_style_loader_tag_with_crossorigin_anonymous(), 2 passed in /wp/wp-includes/class-wp-hook.php on line 286 and exactly 3 expected in /wp-content/plugins/amp/includes/amp-helper-functions.php:515 Stack trace: #0 /wp/wp-includes/class-wp-hook.php(286): amp_filter_font_style_loader_tag_with_crossorigin_anonymous('<link rel='styl...', 'h4-global') #1 /wp/wp-includes/plugin.php(208): WP_Hook->apply_filters('<link rel='styl...', Array) #2 /wp-content/mu-plugins/http-concat/cssconcat.php(130): apply_filters('style_loader_ta...', '<link rel='styl...', 'h4-global') #3 /wp/wp-includes/functions.wp-styles.php(64): WPcom_CSS_Concat->do_items(Array) #4 /wp/wp-includes/class-wp-hook.php(286): wp_print_styles(false) #5 /wp/wp-includes/class-wp-hook.php(310): WP_Hook->apply_filter in /wp-content/plugins/amp/includes/amp-helper-functions.php on line 515`

To fix this error, I have just set the default value to 3rd argument `$href = ''`.