### PR TITLE
Improve reliability of phpunit test runs across environments

### DIFF
--- a/tests/test-class-amp-gfycat-embed-handler.php
+++ b/tests/test-class-amp-gfycat-embed-handler.php
@@ -20,18 +20,12 @@ class AMP_Gfycat_Embed_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		// Mock the HTTP request.
-		add_filter( 'pre_http_request', function( $pre, $r, $url ) {
+		add_filter( 'pre_oembed_result', function( $pre, $url ) {
 			if ( false === strpos( $url, 'tautwhoppingcougar' ) ) {
 				return $pre;
 			}
-			return array(
-				'body'     => '{"version":"1.0","type":"video","provider_name":"https://gfycat.com","width":500,"height":281,"title":"Melanie Raccoon riding bike-side angle (reddit)","html":"<iframe src=\'https://gfycat.com/ifr/tautwhoppingcougar\' frameborder=\'0\' scrolling=\'no\' width=\'500\' height=\'281.25\'  allowfullscreen></iframe>"}',
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-			);
-		}, 10, 3 );
+			return '<iframe src=\'https://gfycat.com/ifr/tautwhoppingcougar\' frameborder=\'0\' scrolling=\'no\' width=\'500\' height=\'281.25\'  allowfullscreen></iframe>';
+		}, 10, 2 );
 
 		/*
 		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1432,6 +1432,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			return home_url( '/favicon.png' );
 		} );
 
+		// Specify file paths for stylesheets not available in src.
+		foreach ( array( 'wp-block-library', 'wp-block-library-theme' ) as $src_style_handle ) {
+			if ( wp_style_is( $src_style_handle, 'registered' ) ) {
+				wp_styles()->registered[ $src_style_handle ]->src = amp_get_asset_url( 'css/amp-default.css' ); // A dummy path.
+			}
+		}
+
 		ob_start();
 		?>
 		<!DOCTYPE html>


### PR DESCRIPTION
* Account for stylesheets in core `src` which may not be available. Since unit tests run for non-core use `src` as the `ABSPATH` the stylesheets pulled in from NPM are not available, and so we need to supply dummy paths.
* Use `pre_oembed_result` filter instead of `pre_http_request` since the former is an earlier way to short-circuit the oEmbed request. Without this, Gfycat was failing on the [`wordpressdev` environment](https://github.com/felixarntz/wordpressdev), in particular https://github.com/felixarntz/wordpressdev/pull/4.