### PR TITLE
Fix content smooth scrolling in Twenty Seventeen

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -491,6 +491,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $this->xpath->query( $link_xpath ) as $link ) {
 				if ( $link instanceof DOMElement && preg_match( '/#(.+)/', $link->getAttribute( 'href' ), $matches ) ) {
 					$link->setAttribute( 'on', sprintf( 'tap:%s.scrollTo(duration=600)', $matches[1] ) );
+
+					// Prevent browser from jumping immediately to the link target.
+					$link->removeAttribute( 'href' );
+					$link->setAttribute( 'tabindex', '0' );
+					$link->setAttribute( 'role', 'button' );
 				}
 			}
 		}


### PR DESCRIPTION
In the Twenty Seventeen theme of WordPress, there is a down arrow on the homepage that upon clicking causes a smooth scroll down to the content area:

![image](https://user-images.githubusercontent.com/134745/50388201-3a1f5780-06c4-11e9-992f-0a617161c6ea.png)

This arrow appears in markup as a link:

```html
<a href="#content" class="menu-scroll-down">...</a>
```

The theme implements the smooth-scroll behavior via the jQuery scrollTo plugin, with a page navigation jump for browsers that have JS disabled. 

In the AMP version of the theme, however, we [omit that plugin](https://github.com/ampproject/amp-wp/blob/511a8b1d8f81f79ec6968a48637d22091e8ce700/includes/sanitizers/class-amp-core-theme-sanitizer.php#L78) since it is not valid AMP, and the AMP plugin then instead [adds an `on` attribute](https://github.com/ampproject/amp-wp/blob/511a8b1d8f81f79ec6968a48637d22091e8ce700/includes/sanitizers/class-amp-core-theme-sanitizer.php#L541-L549) to the element:

```html
<a href="#content" on="tap:content.scrollTo(duration=600)" class="menu-scroll-down">...</a>
```

I believe this did work at one time, but it is not working any longer. Instead of there being a smooth scroll behavior, the browser now just jumps to the `#content` element in the page. 

Since there is no way in AMP currently to call `event.preventDefault()`, I saw via https://github.com/ampproject/amphtml/issues/8810 fix seems to be to just remove the `href` while also add a `role=button` and `tabindex=0`. This ensures that the smooth scroll behavior happens for both clicks and keypresses:

```html
<a on="tap:content.scrollTo(duration=600)" role="button" tabindex="0" class="menu-scroll-down">...</a>
```

The downside here is that the link will no longer work with JS turned off, but that will be the least of the problems on the page if that is the case. It would be better if there was a `preventDefault` [action](https://www.ampproject.org/docs/interaction_dynamic/amp-actions-and-events#element-specific-actions) so you could do:

```html
<a href="#content" on="tap:content.scrollTo(duration=600),preventDefault" class="menu-scroll-down">...</a>
```

But this is not currently supported in AMP.