### PR TITLE
Make get_validated_url_file_path() better compatible with register_theme_directory()

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -543,6 +543,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$includes_url = $remove_url_scheme( includes_url( '/' ) );
 		$content_url  = $remove_url_scheme( content_url( '/' ) );
 		$admin_url    = $remove_url_scheme( get_admin_url( null, '/' ) );
+		$site_url     = $remove_url_scheme( site_url( '/' ) );
 
 		$allowed_hosts = array(
 			wp_parse_url( $includes_url, PHP_URL_HOST ),
@@ -566,8 +567,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return new WP_Error( 'external_file_url', sprintf( __( 'URL is located on an external domain: %s.', 'amp' ), $url_host ) );
 		}
 
-		$base_path = null;
-		$file_path = null;
+		$base_path  = null;
+		$file_path  = null;
+		$wp_content = 'wp-content';
 		if ( 0 === strpos( $url, $content_url ) ) {
 			$base_path = WP_CONTENT_DIR;
 			$file_path = substr( $url, strlen( $content_url ) - 1 );
@@ -577,6 +579,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		} elseif ( 0 === strpos( $url, $admin_url ) ) {
 			$base_path = ABSPATH . 'wp-admin';
 			$file_path = substr( $url, strlen( $admin_url ) - 1 );
+		} elseif ( 0 === strpos( $url, $site_url . trailingslashit( $wp_content ) ) ) {
+			// Account for loading content from original wp-content directory not WP_CONTENT_DIR which can happen via register_theme_directory().
+			$base_path = ABSPATH . $wp_content;
+			$file_path = substr( $url, strlen( $site_url ) + strlen( $wp_content ) );
 		}
 
 		if ( ! $file_path || false !== strpos( $file_path, '../' ) || false !== strpos( $file_path, '..\\' ) ) {


### PR DESCRIPTION
In the wordpressdev Lando setup, [`register_theme_directory()` is used](https://github.com/felixarntz/wordpressdev/blob/01721d8aeb010b7608615857a0a854c82f3ade6c/public/content/mu-plugins/allow-using-default-themes.php#L13) to ensure that core-bundled themes can continue to be used in addition to the themes defined in the `WP_CONTENT_DIR`. This is causing a problem for `\AMP_Style_Sanitizer::get_validated_url_file_path()`:

![image](https://user-images.githubusercontent.com/134745/50570702-f07cdf80-0d49-11e9-8676-185318db6f72.png)

In order to fix this specific problem, we need to explicitly allow `ABSPATH . 'wp-content'` as a filesystem directory that files can be referenced from.

I don't believe this is the ultimate solution for any issue that may arise from having custom directories for themes and plugins, but for the time being at least it fixes this issue in the Lando environment.