### PR TITLE
Add _doing_it_wrong() when calling is_amp_endpoint() before queried object is available

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -283,8 +283,15 @@ function is_amp_endpoint() {
 		return true;
 	}
 
-	$availability = AMP_Theme_Support::get_template_availability();
-	return amp_is_canonical() ? $availability['supported'] : ( $has_amp_query_var && $availability['supported'] );
+	if ( ! did_action( 'wp' ) ) {
+		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( "is_amp_endpoint() was called before the 'wp' action which means it will not have access to the queried object to determine if it is an AMP response, thus neither the amp_skip_post filter nor the AMP enabled publish metabox toggle will not be considered.", 'amp' ) ), '1.0.2' );
+		$supported = true;
+	} else {
+		$availability = AMP_Theme_Support::get_template_availability();
+		$supported    = $availability['supported'];
+	}
+
+	return amp_is_canonical() ? $supported : ( $has_amp_query_var && $supported );
 }
 
 /**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -586,10 +586,12 @@ class AMP_Theme_Support {
 			 * @var WP_Post $queried_object
 			 */
 			$queried_object = $query->get_queried_object();
-			$support_errors = AMP_Post_Type_Support::get_support_errors( $queried_object );
-			if ( ! empty( $support_errors ) ) {
-				$matching_template['errors']    = array_merge( $matching_template['errors'], $support_errors );
-				$matching_template['supported'] = false;
+			if ( $queried_object instanceof WP_Post ) {
+				$support_errors = AMP_Post_Type_Support::get_support_errors( $queried_object );
+				if ( ! empty( $support_errors ) ) {
+					$matching_template['errors']    = array_merge( $matching_template['errors'], $support_errors );
+					$matching_template['supported'] = false;
+				}
 			}
 		}
 

--- a/includes/widgets/class-amp-widget-text.php
+++ b/includes/widgets/class-amp-widget-text.php
@@ -22,6 +22,7 @@ if ( class_exists( 'WP_Widget_Text' ) ) {
 		 * @return string $html The markup, unaltered.
 		 */
 		public function inject_video_max_width_style( $matches ) {
+			wp();
 			if ( is_amp_endpoint() ) {
 				return $matches[0];
 			}

--- a/includes/widgets/class-amp-widget-text.php
+++ b/includes/widgets/class-amp-widget-text.php
@@ -22,7 +22,6 @@ if ( class_exists( 'WP_Widget_Text' ) ) {
 		 * @return string $html The markup, unaltered.
 		 */
 		public function inject_video_max_width_style( $matches ) {
-			wp();
 			if ( is_amp_endpoint() ) {
 				return $matches[0];
 			}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1388,6 +1388,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers \AMP_DOM_Utils::get_content_from_dom_node()
 	 */
 	public function test_unicode_stylesheet() {
+		wp();
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
 		AMP_Theme_Support::finish_init();

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -383,6 +383,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_validate_non_amp_theme() {
+		wp();
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
@@ -1052,6 +1053,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::finish_output_buffering()
 	 */
 	public function test_start_output_buffering() {
+		wp();
 		if ( ! function_exists( 'newrelic_disable_autorum ' ) ) {
 			/**
 			 * Define newrelic_disable_autorum to allow passing line.
@@ -1079,6 +1081,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::is_output_buffering()
 	 */
 	public function test_finish_output_buffering() {
+		wp();
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
@@ -1127,6 +1130,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::filter_customize_partial_render()
 	 */
 	public function test_filter_customize_partial_render() {
+		wp();
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
@@ -1175,6 +1179,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers \amp_render_scripts()
 	 */
 	public function test_prepare_response() {
+		wp();
 		$prepare_response_args = array(
 			'enable_response_caching' => false,
 		);
@@ -1337,6 +1342,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_prepare_response_native_mode_non_amp() {
+		wp();
 		$original_html = $this->get_original_html();
 		add_filter( 'amp_validation_error_sanitized', '__return_false' ); // For testing purpose only. This should not normally be done.
 
@@ -1351,6 +1357,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * Test post-processor cache effectiveness in AMP_Theme_Support::prepare_response().
 	 */
 	public function test_post_processor_cache_effectiveness() {
+		wp();
 		$original_html = $this->get_original_html();
 		$args          = array( 'enable_response_caching' => true );
 		wp_using_ext_object_cache( true ); // turn on external object cache flag.
@@ -1508,6 +1515,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_prepare_response_bad_html() {
+		wp();
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
@@ -1533,6 +1541,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
 	public function test_prepare_response_to_add_html5_doctype_and_amp_attribute() {
+		wp();
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();

--- a/tests/test-class-amp-widget-archives.php
+++ b/tests/test-class-amp-widget-archives.php
@@ -62,6 +62,7 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	 * @see AMP_Widget_Archives::widget().
 	 */
 	public function test_widget() {
+		wp();
 		$this->assertTrue( is_amp_endpoint() );
 		$arguments = array(
 			'before_widget' => '<div>',

--- a/tests/test-class-amp-widget-categories.php
+++ b/tests/test-class-amp-widget-categories.php
@@ -62,6 +62,7 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	 * @covers AMP_Widget_Categories::widget()
 	 */
 	public function test_widget() {
+		wp();
 		$this->assertTrue( is_amp_endpoint() );
 		$arguments = array(
 			'before_widget' => '<div>',

--- a/tests/test-class-amp-widget-text.php
+++ b/tests/test-class-amp-widget-text.php
@@ -53,6 +53,7 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 	 * @covers AMP_Widget_Text::inject_video_max_width_style()
 	 */
 	public function test_inject_video_max_width_style() {
+		wp();
 		$this->assertTrue( is_amp_endpoint() );
 		$video            = '<video src="http://example.com" height="100" width="200"></video>';
 		$video_only_width = '<video src="http://example.com/this-video" width="500">';


### PR DESCRIPTION
Ever since 0.4.2, the AMP plugin has issued a `_doing_it_wrong()` when `is_amp_endpoint()` is called before the `parse_query` action. This was needed to ensure that the `amp` query var was parsed and available for inspection. 

It turns out that this did not go far enough. As of 1.0 the `is_amp_endpoint()` needs to look at the queried object as well to determine whether AMP has been enabled/disabled for a given post on singular queries. The queried object is not available at `parse_query` since the posts have not been queried yet at this point. Rather, it is only at the `wp` action that [we can be assured](https://github.com/WordPress/wordpress-develop/blob/67e12d960b166b12f7eee511bc8abf798533a872/src/wp-includes/class-wp.php#L737-L750) that `$wp_query->post` has been populated and thus that the queried object is present for inspection.

Also make sure that only a `WP_Post` is passed into `AMP_Post_Type_Support::get_support_errors()`.

Without the changes in this PR, if you have a plugin that does:

```php
add_action( 'parse_query', function() {
	if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
		add_action( 'wp_footer', function() {
			echo "HELLO PAIRED AMP!";
		} );
		add_action( 'amp_post_template_footer', function() {
			echo "HELLO CLASSIC AMP!";
		} );
	} else {
		add_action( 'wp_footer', function() {
			echo "HELLO NOT AMP!";
		} );
	}
} );
```

You will get PHP notices when viewing a singular post in paired mode:

> Notice: Trying to get property 'post_type' of non-object in /app/public/content/plugins/amp/includes/class-amp-post-type-support.php on line 80
> Notice: Trying to get property 'ID' of non-object in /app/public/content/plugins/amp/includes/class-amp-post-type-support.php on line 101

Changing `parse_query` to `wp` fixes the issue in plugin code.

Issue discovered originally in a Jetpack PR: https://github.com/Automattic/jetpack/pull/10945#issuecomment-451299275