### PR TITLE
[WIP] Fix reading of small SVG images to determine dimensions

### DIFF
--- a/third_party/fasterimage/ImageParser.php
+++ b/third_party/fasterimage/ImageParser.php
@@ -136,7 +136,7 @@ class ImageParser
                     return $this->type = 'tiff';
                 default:
                     $this->stream->resetPointer();
-                    $markup = $this->stream->read( 1024 );
+                    $markup = $this->stream->read( 1024, false );
                     if ( false !== strpos( $markup, '<svg' ) ) {
                         $this->type = 'svg';
                     } else {
@@ -361,7 +361,7 @@ class ImageParser
     protected function parseSizeForSvg()
     {
         $this->stream->resetPointer();
-        $markup = $this->stream->read( 1024 );
+        $markup = $this->stream->read( 1024, false );
         if ( ! preg_match( '#<svg.*?>#s', $markup, $matches ) ) {
             return null;
         }

--- a/third_party/fasterimage/Stream/Stream.php
+++ b/third_party/fasterimage/Stream/Stream.php
@@ -25,14 +25,15 @@ class Stream implements StreamableInterface
     /**
      * Get characters from the string but don't move the pointer
      *
-     * @param $characters
+     * @param int $characters Number of characters to read.
+     * @param bool $check_length Throw exception if there are not enough bytes left in the stream.
      *
      * @return string
      * @throws StreamBufferTooSmallException
      */
-    public function peek($characters)
+    public function peek($characters, $check_length=true)
     {
-        if ( strlen($this->stream_string) < $this->strpos + $characters ) {
+        if ( $check_length && strlen($this->stream_string) < $this->strpos + $characters ) {
             throw new StreamBufferTooSmallException('Not enough of the stream available.');
         }
 
@@ -42,16 +43,22 @@ class Stream implements StreamableInterface
     /**
      * Get Characters from the string
      *
-     * @param $characters
+     * @param int  $characters   Number of characters to read.
+     * @param bool $check_length Throw exception if there are not enough bytes left in the stream.
      *
      * @return string
      * @throws StreamBufferTooSmallException
      */
-    public function read($characters)
+    public function read($characters, $check_length=true)
     {
-        $result = $this->peek($characters);
+        $size   = strlen($this->stream_string);
+        $result = $this->peek($characters, $check_length);
 
-        $this->strpos += $characters;
+        if ( strlen( $result ) + $characters > $size ) {
+            $this->strpos = $size;
+        } else {
+            $this->strpos += $characters;
+        }
 
         return $result;
     }

--- a/third_party/fasterimage/Stream/StreamableInterface.php
+++ b/third_party/fasterimage/Stream/StreamableInterface.php
@@ -17,18 +17,20 @@ interface StreamableInterface {
     /**
      * Get Characters from the string
      *
-     * @param $characters
+     * @param int $characters Number of characters to read.
+     * @param bool $check_length Throw exception if there are not enough bytes left in the stream.
      */
-    public function read($characters);
+    public function read($characters, $check_length=false);
 
     /**
      * Get characters from the string but don't move the pointer
      *
-     * @param $characters
+     * @param int $characters Number of characters to read.
+     * @param bool $check_length Throw exception if there are not enough bytes left in the stream.
      *
      * @return mixed
      */
-    public function peek($characters);
+    public function peek($characters, $check_length=false);
 
     /**
      * Resets the pointer to the 0 position


### PR DESCRIPTION
This issue came up via this support topic: https://wordpress.org/support/topic/how-to-show-emoji-show-share-button-and-hide-powered-by-on-amp-page/

With this raw post content:

```html
<p>Image: <img class="emoji loaded" draggable="false" src="https://s.w.org/images/core/emoji/11/svg/1f642.svg" alt="🙂"></p>

<p>Character: 🙂</p>
```

In HTML non-AMP this gets rendered as:

![image](https://user-images.githubusercontent.com/134745/51062744-e611df80-15ac-11e9-9429-877374084195.png)

Note that the emoji character is being converted into an image by WordPress's emoji handling. In AMP this is disabled, so the character passes through as a character but the image is incorrectly rendered in AMP:

![image](https://user-images.githubusercontent.com/134745/51062759-f1fda180-15ac-11e9-908a-d1140ec3c7e8.png)

The underlying HTML is:

```html
<p>Image: <amp-img class="emoji loaded amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" draggable="false" src="https://s.w.org/images/core/emoji/11/svg/1f642.svg" alt="🙂" width="525" height="400" layout="intrinsic"></amp-img></p>

<p>Character: 🙂</p>
```

The problem turns out to be an issue with `FasterImage` and how it was modified in https://github.com/ampproject/amp-wp/pull/1150 to allow extracting pixel dimensions from SVG images. The problem is that it is attempting to read 1024 bytes of data from the image, but the [above SVG](https://s.w.org/images/core/emoji/11/svg/1f642.svg) is only 525 bytes long. This results in a `WillWashburn\Stream\StreamBufferTooSmallException` exception being thrown, and the image size failing to be obtained, and thus the fallback image size is being used (which is obviously too big).

So this PR fixes that problem by allowing small SVG images to be read without throwing an error.

# Work Outstanding

## Before

![image](https://user-images.githubusercontent.com/134745/51063167-aa781500-15ae-11e9-88c6-fc29d262946a.png)

## After

![image](https://user-images.githubusercontent.com/134745/51063184-b663d700-15ae-11e9-8b8e-a77ff08286d8.png)

While this is way better, it is still not perfect. The SVG image has a viewbox of 36x36 so that is what is assigned as the `width` & `height` of the `amp-img`. Nevertheless, the emojis are supposed to be 16x16. Or rather, they are [supposed to be `1em` by `1em`](https://github.com/WordPress/wordpress-develop/blob/33caf61b8ba988da73c2e210309566f9fdb039be/src/wp-includes/formatting.php#L5350-L5351), so it should look like this:

![image](https://user-images.githubusercontent.com/134745/51063318-57529200-15af-11e9-9f5a-cda38d56cd89.png)

So to full fix the case of inline SVG emojis we potentially need to either replace the `img.emoji` back with the underlying character (which is found in the `alt` attribute). This would not be ideal because we'd miss out on the improvements that WordPress's emoji handling was introduced for.

A full fix seems to be two-fold:

* Make emoji SVG images get sizes at `1em` somehow. This is a challenge because `amp-img` doesn't allow `em` units.
* Make an AMP-compatible version of WordPress's emoji handling, by adding a sanitizer that does in PHP what core does in JS. In the AMP plugin we disable the emoji handling in AMP:

https://github.com/ampproject/amp-wp/blob/c92e129333a8518088a37d47594079b537121d70/includes/class-amp-theme-support.php#L766-L767

These may be out of scope for this PR.

Other outstanding work:

- [ ] Fix unit test.
- [ ] Replace cURL with WP HTTP API (which would also help with mocking the uint tests).

Fixes #204.