### PR TITLE
Consolidate translator comments for forgotten URLs string

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2196,7 +2196,7 @@ class AMP_Validated_URL_Post_Type {
 			$messages['post'] = array_merge(
 				$messages['post'],
 				array(
-					/* translators: %s is the number of posts permanently forgotten */
+					/* translators: %s is the number of posts forgotten */
 					'deleted'   => _n(
 						'%s validated URL forgotten.',
 						'%s validated URLs forgotten.',


### PR DESCRIPTION
The string `%s validated URL forgotten.` has 2 different translator comments, which leads to a weird experience for translators on translate.wordpress.org.

![screenshot 2019-01-16 at 14 37 11](https://user-images.githubusercontent.com/841956/51252518-54371780-199c-11e9-89e1-752f9a0e4346.png)
