### PR TITLE
Instruct wp-dev-lib to check all files not just those in patch

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -4,6 +4,7 @@ PROJECT_SLUG=amp
 SKIP_ECHO_PATHS_SCOPE=1
 README_MD_TITLE="AMP Plugin for WordPress"
 DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
+CHECK_SCOPE=all
 
 function after_wp_install {
     echo "Installing plugins..."


### PR DESCRIPTION
After #1810 we no longer need to limit PHPCS to report issues on the lines that were changes in a given PR, which is [the default behavior of wp-dev-lib](https://github.com/xwp/wp-dev-lib/blob/38dbb83cd63d2e537ccd4ddcc2866ab8cd57cbd9/readme.md#limiting-scope-of-checks). This was needed because the repo did not adhere to the standards, and so the patch scope limitation allowed us to make incremental improvements over time. This is no longer needed, and the patch scope limitation is going to cause us problems going forward such as when versions of WPCS are updated by Renovate (e.g. #1814), since the `composer.json` change wouldn't trigger `phpcs` by default.