### PR TITLE
Travis test matrix no longer requires PHP 5.2 and 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 # Tell Travis CI we're using PHP
 language: php
 
-# Newer versions like trusty don't have PHP 5.2 or 5.3
-# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
-dist: precise
-
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Use the latest Travis environment to speed up tests since we no longer need PHP 5.2 and 5.3.

https://github.com/ampproject/amp-wp/blob/7c0dba862bb32b43c5b45b04c89b9b290070bdb9/.travis.yml#L36-L52