### PR TITLE
Add double quotes around the ETag header value; recognize multiple quoted ETags in If-None-Match header

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1652,7 +1652,7 @@ class AMP_Theme_Support {
 		 * not have been set yet during the WordPress template generation is
 		 * the ETag. The AMP plugin sends a Vary header at amp_init.
 		 */
-		AMP_HTTP::send_header( 'ETag', $response_cache_key );
+		AMP_HTTP::send_header( 'ETag', '"' . $response_cache_key . '"' );
 
 		// Handle responses that are cached by the browser.
 		if ( isset( $_SERVER['HTTP_IF_NONE_MATCH'] ) && $_SERVER['HTTP_IF_NONE_MATCH'] === $response_cache_key ) {

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1355,6 +1355,20 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Test that ETag allows response to short-circuit via If-None-Match request header.
 		$_SERVER['HTTP_IF_NONE_MATCH'] = $etag;
 		$this->assertEmpty( '', $call_prepare_response() );
+
+		$_SERVER['HTTP_IF_NONE_MATCH'] = sprintf( '"%s"', $etag );
+		$this->assertEmpty( '', $call_prepare_response() );
+
+		$_SERVER['HTTP_IF_NONE_MATCH'] = sprintf( 'W/"%s"', $etag );
+		$this->assertEmpty( '', $call_prepare_response() );
+
+		$_SERVER['HTTP_IF_NONE_MATCH'] = sprintf( '"%s", W/"%s"', md5( 'foo' ), $etag );
+		$this->assertEmpty( '', $call_prepare_response() );
+
+		$_SERVER['HTTP_IF_NONE_MATCH'] = sprintf( '"%s", "%s"', $etag, md5( 'bar' ) );
+		$this->assertEmpty( '', $call_prepare_response() );
+
+		// Test not match.
 		$_SERVER['HTTP_IF_NONE_MATCH'] = strrev( $etag );
 		$this->assertNotEmpty( $call_prepare_response() );
 		$this->assertNotEmpty( $this->get_etag_header_value( AMP_HTTP::$headers_sent ) );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1355,7 +1355,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Test that ETag allows response to short-circuit via If-None-Match request header.
 		$_SERVER['HTTP_IF_NONE_MATCH'] = $etag;
 		$this->assertEmpty( '', $call_prepare_response() );
-		$_SERVER['HTTP_IF_NONE_MATCH'] = $etag . '-v2';
+		$_SERVER['HTTP_IF_NONE_MATCH'] = strrev( $etag );
 		$this->assertNotEmpty( $call_prepare_response() );
 		$this->assertNotEmpty( $this->get_etag_header_value( AMP_HTTP::$headers_sent ) );
 		unset( $_SERVER['HTTP_IF_NONE_MATCH'] );


### PR DESCRIPTION
`ETag` headers being served by the AMP plugin on Pantheon were not working. After some troubleshooting, adding double quotes around the `ETag` header value fixes the issue.

The [`ETag` spec](https://tools.ietf.org/html/rfc7232#section-2.3) explain the values as:

> An entity-tag consists of an opaque quoted string, possibly prefixed by a weakness indicator.

The examples use double quotes as well.

`ETag` might be working elsewhere where the provider has software that is more forgiving but our Nginx requires the quotes.

This should not be a breaking change as other, more forgiving, implementations should continue to work when the `ETag` header value is set according to the specification.