### PR TITLE
Restore cursor:pointer for menu-scroll-down in Twenty Seventeen

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -687,6 +687,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					display: none;
 				}
 
+				/* This is needed by add_smooth_scrolling because it removes the [href] attribute. */
+				.menu-scroll-down {
+					cursor: pointer;
+				}
+
 				<?php if ( $is_front_page_layout && ! has_custom_header() ) : ?>
 					/* https://github.com/WordPress/wordpress-develop/blob/fd5ba80c5c3d9cf62348567073945e246285fbca/src/wp-content/themes/twentyseventeen/assets/js/global.js#L92-L94 */
 					.site-branding {


### PR DESCRIPTION
Amends #1777.

Because `add_smooth_scrolling` removes the `href` attribute on the `.menu-scroll-down` element:

![image](https://user-images.githubusercontent.com/134745/51366448-71521000-1a9a-11e9-917c-c207bf19a468.png)

The `pointer:cursor` style needs to be re-added manually.