### PR TITLE
Update class-amp-http.php

### DIFF
--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -205,7 +205,7 @@ class AMP_HTTP {
 			if ( function_exists( 'idn_to_utf8' ) ) {
 				if ( version_compare( PHP_VERSION, '5.4', '>=' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
 					$domain = idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.idn_to_utf8_variantFound, PHPCompatibility.Constants.NewConstants.intl_idna_variant_uts46Found
-				} elseif ( version_compare( PHP_VERSION, '7.2', '==' ) || version_compare( PHP_VERSION, '7.3', '==' ) ) {
+				} elseif ( version_compare( PHP_VERSION, '7.2', '>=' ) && version_compare( PHP_VERSION, '7.4', '<' ) ) {
 					/* In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant explicitely. This may be reverted when php 7.4 is commonly used and idn_to_utf8 can be used in its default mode without warnings. */
 					$variant = INTL_IDNA_VARIANT_UTS46;
 					$options = IDNA_DEFAULT;

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -205,8 +205,8 @@ class AMP_HTTP {
 			if ( function_exists( 'idn_to_utf8' ) ) {
 				if ( version_compare( PHP_VERSION, '5.4', '>=' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
 					$domain = idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.idn_to_utf8_variantFound, PHPCompatibility.Constants.NewConstants.intl_idna_variant_uts46Found
-				} else if( version_compare( PHP_VERSION, '7.2', '==' ) || version_compare( PHP_VERSION, '7.3', '==' ) ){
-					/* In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant explicitely */
+				} elseif ( version_compare( PHP_VERSION, '7.2', '==' ) || version_compare( PHP_VERSION, '7.3', '==' ) ) {
+					/* In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant explicitely. This may be reverted when php 7.4 is commonly used and idn_to_utf8 can be used in its default mode without warnings. */
 					$variant = INTL_IDNA_VARIANT_UTS46;
 					$options = IDNA_DEFAULT;
 					$domain = idn_to_utf8( $domain, $options, $variant );

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -205,6 +205,11 @@ class AMP_HTTP {
 			if ( function_exists( 'idn_to_utf8' ) ) {
 				if ( version_compare( PHP_VERSION, '5.4', '>=' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
 					$domain = idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.idn_to_utf8_variantFound, PHPCompatibility.Constants.NewConstants.intl_idna_variant_uts46Found
+				} else if( version_compare( PHP_VERSION, '7.2', '==' ) || version_compare( PHP_VERSION, '7.3', '==' ) ){
+					/* In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant explicitely */
+					$variant = INTL_IDNA_VARIANT_UTS46;
+					$options = IDNA_DEFAULT;
+					$domain = idn_to_utf8( $domain, $options, $variant );
 				} else {
 					$domain = idn_to_utf8( $domain );
 				}

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -209,7 +209,7 @@ class AMP_HTTP {
 					/* In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant explicitely. This may be reverted when php 7.4 is commonly used and idn_to_utf8 can be used in its default mode without warnings. */
 					$variant = INTL_IDNA_VARIANT_UTS46;
 					$options = IDNA_DEFAULT;
-					$domain = idn_to_utf8( $domain, $options, $variant );
+					$domain  = idn_to_utf8( $domain, $options, $variant );
 				} else {
 					$domain = idn_to_utf8( $domain );
 				}

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -206,7 +206,11 @@ class AMP_HTTP {
 				if ( version_compare( PHP_VERSION, '5.4', '>=' ) && defined( 'INTL_IDNA_VARIANT_UTS46' ) ) {
 					$domain = idn_to_utf8( $domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_UTS46 ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.idn_to_utf8_variantFound, PHPCompatibility.Constants.NewConstants.intl_idna_variant_uts46Found
 				} elseif ( version_compare( PHP_VERSION, '7.2', '>=' ) && version_compare( PHP_VERSION, '7.4', '<' ) ) {
-					/* In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant explicitely. This may be reverted when php 7.4 is commonly used and idn_to_utf8 can be used in its default mode without warnings. */
+					/*
+					 * In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning.
+					 * Thus we must set the variant explicitly. This may be reverted when PHP 7.4 is commonly used and
+					 * idn_to_utf8 can be used in its default mode without warnings.
+					 */
 					$variant = INTL_IDNA_VARIANT_UTS46;
 					$options = IDNA_DEFAULT;
 					$domain  = idn_to_utf8( $domain, $options, $variant );


### PR DESCRIPTION
In PHP 7.2/7.3 calling idn_to_* functions with default arguments throws a warning. Thus we must set the variant and options explicitely.
lines 208 - 212 fixed