### PR TITLE
Integrate Composer into production build process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,7 +34,7 @@ module.exports = function( grunt ) {
 				command: 'cross-env BABEL_ENV=production webpack'
 			},
 			composer_production: {
-				command: 'rm -rf vendor && rm composer.lock && composer config platform.php 5.4 && composer install --no-dev && git checkout composer.*'
+				command: 'rm -rf vendor && composer install --no-dev'
 			},
 			composer: {
 				command: 'composer install'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,6 +33,9 @@ module.exports = function( grunt ) {
 			webpack_production: {
 				command: 'cross-env BABEL_ENV=production webpack'
 			},
+			composer_production: {
+				command: 'rm -rf vendor && rm composer.lock && composer config platform.php 5.4 && composer install --no-dev && git checkout composer.*'
+			},
 			create_build_zip: {
 				command: 'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi; if [ -e amp.zip ]; then rm amp.zip; fi; cd build; zip -r ../amp.zip .; cd ..; echo; echo "ZIP of build: $(pwd)/amp.zip"'
 			}

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,6 @@
     "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
     "phpcompatibility/php-compatibility": "9.1.1"
   },
-  "config": {
-    "platform": {
-      "php": "5.4"
-    }
-  },
   "extra": {
     "patches": {
       "fasterimage/fasterimage": {

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,17 @@
     "php": "^5.4 || ^7.0",
     "sabberworm/php-css-parser": "8.1.1",
     "fasterimage/fasterimage": "1.2.0",
-    "cweagans/composer-patches": "~1.6"
+    "cweagans/composer-patches": "1.6.5"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "1.2.1",
     "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
     "phpcompatibility/php-compatibility": "9.1.1"
+  },
+  "config": {
+    "platform": {
+      "php": "5.4"
+    }
   },
   "extra": {
     "patches": {


### PR DESCRIPTION
When running `composer install` for a production build, it needs to be ensured that all dependencies are compatible with PHP 5.4. It furthermore needs to be ensured that only the dependencies needed for production are part of the build.

This PR integrates Composer into the build process so that it no longer needs to rely on the user manually doing things right in that regard:

* First, a new `shell:composer_production` is run, which temporarily removes all local dependencies and installs only the production ones via the `--no-dev` flag. Furthermore, for that one call the PHP version is hard-set to 5.4, to ensure dependencies are compatible. This mitigates the issue noticed in #1131, where you can't use newer versions of for example the dev dependencies during development.
* Then, the previously existing `shell:webpack_production` is run.
* Then all the files necessary are copied to the `build` directory. Since `vendor` now only has the dependencies needed, we can rely on that and copy the whole vendor directory.
* Afterwards, the regular `composer install` is run again to have access to all the regular dev dependencies again.
* Finally, the markdown readme is generated. This uses the `dev-lib`, which via #1131 will be installed via Composer. Therefore it's crucial for the regular `composer install` to be run before this, as mentioned above.