### PR TITLE
Remove Powered by WordPress in classic footer template

### DIFF
--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -16,6 +16,7 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_post_template_add_boilerplate_css' );
 	add_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
+	add_action( 'amp_post_template_head', 'wp_generator' );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );

--- a/templates/footer.php
+++ b/templates/footer.php
@@ -14,14 +14,6 @@
 <footer class="amp-wp-footer">
 	<div>
 		<h2><?php echo esc_html( wptexturize( $this->get( 'blog_name' ) ) ); ?></h2>
-		<p>
-			<a href="<?php echo esc_url( esc_html__( 'https://wordpress.org/', 'amp' ) ); ?>">
-				<?php
-				// translators: %s is WordPress.
-				echo esc_html( sprintf( __( 'Powered by %s', 'amp' ), 'WordPress' ) );
-				?>
-			</a>
-		</p>
 		<a href="#top" class="back-to-top"><?php esc_html_e( 'Back to top', 'amp' ); ?></a>
 	</div>
 </footer>


### PR DESCRIPTION
Fixes #1749, per https://github.com/ampproject/amp-wp/issues/1749#issuecomment-456415841:

> I'm wary of providing any _option_ to disable the footer credits. Either the template should have the credits or it should be removed entirely. [Decisions not options](https://wordpress.org/about/philosophy/#decisions), and all. Since the AMP plugin isn't part of WordPress.com, I'm inclined to just removed it entirely, and on WordPress.com a mu-plugin can be added which re-adds the footer credits as required according to the policies there.
> 
> In the end, the footer credits only applies to the Classic mode. When using Native/Paired modes, the active theme's templates are used along with whatever they put in the footer, so this question becomes irrelevant. In any case, I'll also open a PR to remove the footer credits from the plugin for a future release.

Also adds missing `wp_generator()` to classic post template.