### PR TITLE
Add missing FasterImage and Stream vendor dependencies in builds 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,6 +98,8 @@ module.exports = function( grunt ) {
 			paths.push( 'assets/js/*-compiled.js' );
 			paths.push( 'vendor/composer/**' );
 			paths.push( 'vendor/sabberworm/php-css-parser/lib/**' );
+			paths.push( 'vendor/fasterimage/fasterimage/src/**' );
+			paths.push( 'vendor/willwashburn/stream/src/**' );
 
 			grunt.task.run( 'clean' );
 			grunt.config.set( 'copy', {


### PR DESCRIPTION
Amends #1809.

This may be obsoleted by #1836 but it should be added now so that builds are not broken.