### PR TITLE
Suppress style[amp-custom] manifest HTML comment when not WP_DEBUG

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -734,7 +734,9 @@ function amp_get_content_sanitizers( $post = null ) {
 		),
 		'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
 		'AMP_Script_Sanitizer'            => array(),
-		'AMP_Style_Sanitizer'             => array(),
+		'AMP_Style_Sanitizer'             => array(
+			'include_manifest_comment' => defined( 'WP_DEBUG' ) && WP_DEBUG,
+		),
 		'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
 	);
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -735,7 +735,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
 		'AMP_Script_Sanitizer'            => array(),
 		'AMP_Style_Sanitizer'             => array(
-			'include_manifest_comment' => defined( 'WP_DEBUG' ) && WP_DEBUG,
+			'include_manifest_comment' => defined( 'WP_DEBUG' ) && WP_DEBUG ? 'always' : 'when_css_excluded',
 		),
 		'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
 	);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -735,7 +735,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since it's logic is using the already sanitized content.
 		'AMP_Script_Sanitizer'            => array(),
 		'AMP_Style_Sanitizer'             => array(
-			'include_manifest_comment' => defined( 'WP_DEBUG' ) && WP_DEBUG ? 'always' : 'when_css_excluded',
+			'include_manifest_comment' => ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? 'always' : 'when_excessive',
 		),
 		'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
 	);

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -59,7 +59,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type bool     $should_locate_sources      Whether to locate the sources when reporting validation errors.
 	 *      @type string   $parsed_cache_variant       Additional value by which to vary parsed cache.
 	 *      @type bool     $accept_tree_shaking        Whether to accept tree-shaking by default and bypass a validation error.
-	 *      @type bool     $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element.
+	 *      @type string   $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element. Can be 'always', 'never', or 'when_css_excluded'.
 	 * }
 	 */
 	protected $args;
@@ -80,7 +80,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'should_locate_sources'     => false,
 		'parsed_cache_variant'      => null,
 		'accept_tree_shaking'       => false,
-		'include_manifest_comment'  => true,
+		'include_manifest_comment'  => 'always',
 	);
 
 	/**
@@ -1985,8 +1985,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 
+			$include_manifest_comment = (
+				'always' === $this->args['include_manifest_comment']
+				||
+				( $excluded_size > 0 && 'when_css_excluded' === $this->args['include_manifest_comment'] )
+			);
+
 			$comment = '';
-			if ( ! empty( $this->args['include_manifest_comment'] ) && ! empty( $included_sources ) && $included_original_size > 0 ) {
+			if ( $include_manifest_comment && ! empty( $included_sources ) && $included_original_size > 0 ) {
 				$comment .= esc_html__( 'The style[amp-custom] element is populated with:', 'amp' ) . "\n" . implode( "\n", $included_sources ) . "\n";
 				if ( self::has_required_php_css_parser() ) {
 					$comment .= sprintf(
@@ -2006,7 +2012,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					) . "\n";
 				}
 			}
-			if ( ! empty( $this->args['include_manifest_comment'] ) && ! empty( $excluded_sources ) && $excluded_original_size > 0 ) {
+			if ( $include_manifest_comment && ! empty( $excluded_sources ) && $excluded_original_size > 0 ) {
 				if ( $comment ) {
 					$comment .= "\n";
 				}
@@ -2044,7 +2050,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 
-			if ( ! empty( $this->args['include_manifest_comment'] ) && ! self::has_required_php_css_parser() ) {
+			if ( $include_manifest_comment && ! self::has_required_php_css_parser() ) {
 				$comment .= "\n" . esc_html__( '!!!WARNING!!! AMP CSS processing is limited because a conflicting version of PHP-CSS-Parser has been loaded by another plugin/theme. Tree shaking is not available.', 'amp' ) . "\n";
 			}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1985,13 +1985,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			$include_manifest_comment = (
-				'never' !== $this->args['include_manifest_comment']
-				&&
-				(
-					'always' === $this->args['include_manifest_comment']
-					||
-					( $excluded_size > 0 && 'when_excessive' === $this->args['include_manifest_comment'] )
-				)
+				'always' === $this->args['include_manifest_comment']
+				||
+				( $excluded_size > 0 && 'when_excessive' === $this->args['include_manifest_comment'] )
 			);
 
 			$comment = '';

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -59,6 +59,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type bool     $should_locate_sources      Whether to locate the sources when reporting validation errors.
 	 *      @type string   $parsed_cache_variant       Additional value by which to vary parsed cache.
 	 *      @type bool     $accept_tree_shaking        Whether to accept tree-shaking by default and bypass a validation error.
+	 *      @type bool     $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element.
 	 * }
 	 */
 	protected $args;
@@ -79,6 +80,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'should_locate_sources'     => false,
 		'parsed_cache_variant'      => null,
 		'accept_tree_shaking'       => false,
+		'include_manifest_comment'  => true,
 	);
 
 	/**
@@ -1982,8 +1984,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$excluded_original_size += $pending_stylesheet['original_size'];
 				}
 			}
+
 			$comment = '';
-			if ( ! empty( $included_sources ) && $included_original_size > 0 ) {
+			if ( ! empty( $this->args['include_manifest_comment'] ) && ! empty( $included_sources ) && $included_original_size > 0 ) {
 				$comment .= esc_html__( 'The style[amp-custom] element is populated with:', 'amp' ) . "\n" . implode( "\n", $included_sources ) . "\n";
 				if ( self::has_required_php_css_parser() ) {
 					$comment .= sprintf(
@@ -2003,7 +2006,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					) . "\n";
 				}
 			}
-			if ( ! empty( $excluded_sources ) && $excluded_original_size > 0 ) {
+			if ( ! empty( $this->args['include_manifest_comment'] ) && ! empty( $excluded_sources ) && $excluded_original_size > 0 ) {
 				if ( $comment ) {
 					$comment .= "\n";
 				}
@@ -2041,7 +2044,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 
-			if ( ! self::has_required_php_css_parser() ) {
+			if ( ! empty( $this->args['include_manifest_comment'] ) && ! self::has_required_php_css_parser() ) {
 				$comment .= "\n" . esc_html__( '!!!WARNING!!! AMP CSS processing is limited because a conflicting version of PHP-CSS-Parser has been loaded by another plugin/theme. Tree shaking is not available.', 'amp' ) . "\n";
 			}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -59,7 +59,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type bool     $should_locate_sources      Whether to locate the sources when reporting validation errors.
 	 *      @type string   $parsed_cache_variant       Additional value by which to vary parsed cache.
 	 *      @type bool     $accept_tree_shaking        Whether to accept tree-shaking by default and bypass a validation error.
-	 *      @type string   $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element. Can be 'always', 'never', or 'when_css_excluded'.
+	 *      @type string   $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element. Can be 'always', 'never', or 'when_excessive'.
 	 * }
 	 */
 	protected $args;
@@ -1855,7 +1855,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @see https://www.ampproject.org/docs/fundamentals/spec#keyframes-stylesheet
 	 */
 	private function finalize_styles() {
-
 		$stylesheet_sets = array(
 			'custom'    => array(
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-custom.css */",
@@ -1986,9 +1985,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			$include_manifest_comment = (
-				'always' === $this->args['include_manifest_comment']
-				||
-				( $excluded_size > 0 && 'when_css_excluded' === $this->args['include_manifest_comment'] )
+				'never' !== $this->args['include_manifest_comment']
+				&&
+				(
+					'always' === $this->args['include_manifest_comment']
+					||
+					( $excluded_size > 0 && 'when_excessive' === $this->args['include_manifest_comment'] )
+				)
 			);
 
 			$comment = '';

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -42,7 +42,7 @@
 	</rule>
 	<rule ref="WordPress.NamingConventions.ValidVariableName">
 		<properties>
-			<property name="customPropertiesWhitelist" value="childNodes,tagName,textContent,parentNode,nodeType,nodeName,nextSibling,firstChild,lastChild,nodeValue,DEFAULT_ARGS,documentElement,removeChild,ownerDocument,DEFAULT_WIDTH,DEFAULT_HEIGHT" />
+			<property name="customPropertiesWhitelist" value="childNodes,tagName,textContent,parentNode,nodeType,nodeName,nextSibling,previousSibling,firstChild,lastChild,nodeValue,DEFAULT_ARGS,documentElement,removeChild,ownerDocument,DEFAULT_WIDTH,DEFAULT_HEIGHT" />
 		</properties>
 	</rule>
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -759,6 +759,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
 			array(
+				'include_manifest_comment'  => AMP_Style_Sanitizer::INCLUDE_MANIFEST_COMMENT_WHEN_EXCESSIVE,
 				'use_document_element'      => true,
 				'remove_unused_rules'       => 'always',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
@@ -776,12 +777,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertContains( '.dashicons-admin-appearance:before{', $actual_stylesheets[0] );
 		$this->assertNotContains( '.dashicons-format-chat:before', $actual_stylesheets[0] );
 
+		$xpath = new DOMXPath( $dom );
+		$style = $xpath->query( '//style[ @amp-custom ]' )->item( 0 );
+		$this->assertNotInstanceOf( 'DOMComment', $style->previousSibling, 'Expected manifest comment to be excluded.' );
+
 		// Test with rule-removal not forced, since dashicons alone is not larger than 50KB.
 		$dom         = AMP_DOM_Utils::get_dom( $html );
 		$error_codes = array();
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
 			array(
+				'include_manifest_comment'  => 'never',
 				'use_document_element'      => true,
 				'remove_unused_rules'       => 'sometimes',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
@@ -797,6 +803,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertContains( '.dashicons,.dashicons-before:before{', $actual_stylesheets[0] );
 		$this->assertContains( '.dashicons-admin-appearance:before{', $actual_stylesheets[0] );
 		$this->assertContains( '.dashicons-format-chat:before', $actual_stylesheets[0] );
+
+		$xpath = new DOMXPath( $dom );
+		$style = $xpath->query( '//style[ @amp-custom ]' )->item( 0 );
+		$this->assertNotInstanceOf( 'DOMComment', $style->previousSibling, 'Expected manifest comment to be excluded because not excessive.' );
 	}
 
 	/**
@@ -836,6 +846,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
 			array(
+				'include_manifest_comment'  => 'always',
 				'use_document_element'      => true,
 				'remove_unused_rules'       => 'always',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
@@ -851,6 +862,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( '.sidebar2{visibility:hidden}', $actual_stylesheets[2] );
 		$this->assertEquals( '.sidebar2.visible{display:block}', $actual_stylesheets[3] );
 		$this->assertEmpty( $actual_stylesheets[4] );
+
+		$xpath = new DOMXPath( $dom );
+		$style = $xpath->query( '//style[ @amp-custom ]' )->item( 0 );
+		$this->assertInstanceOf( 'DOMComment', $style->previousSibling, 'Expected manifest comment to be present because always included.' );
+		$this->assertNotContains( 'The following stylesheets are too large to be included', $style->previousSibling->nodeValue );
+		$this->assertContains( 'The style[amp-custom] element is populated with', $style->previousSibling->nodeValue );
 	}
 
 	/**
@@ -906,6 +923,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element'      => true,
+				'include_manifest_comment'  => AMP_Style_Sanitizer::INCLUDE_MANIFEST_COMMENT_WHEN_EXCESSIVE,
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
@@ -948,6 +966,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			array( 'excessive_css' ),
 			$error_codes
 		);
+
+		$xpath = new DOMXPath( $dom );
+		$style = $xpath->query( '//style[ @amp-custom ]' )->item( 0 );
+		$this->assertInstanceOf( 'DOMComment', $style->previousSibling, 'Expected manifest comment to be present because excessive.' );
+		$this->assertContains( 'The style[amp-custom] element is populated with', $style->previousSibling->nodeValue );
+		$this->assertContains( 'The following stylesheets are too large to be included', $style->previousSibling->nodeValue );
 	}
 
 	/**

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -759,7 +759,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
 			array(
-				'include_manifest_comment'  => AMP_Style_Sanitizer::INCLUDE_MANIFEST_COMMENT_WHEN_EXCESSIVE,
+				'include_manifest_comment'  => 'when_excessive',
 				'use_document_element'      => true,
 				'remove_unused_rules'       => 'always',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
@@ -923,7 +923,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element'      => true,
-				'include_manifest_comment'  => AMP_Style_Sanitizer::INCLUDE_MANIFEST_COMMENT_WHEN_EXCESSIVE,
+				'include_manifest_comment'  => 'when_excessive',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},


### PR DESCRIPTION
The HTML comment that contains the manifest of what comprises the `style[amp-custom]` element can get quite large, so large in fact that Lighthouse will flag it in the performance audit. So the comment should be able to be excluded.

I suggest that we only show the comment, by default, when `WP_DEBUG` is enabled. We currently only send the `Server-Timing` headers when `WP_DEBUG` is enabled (or an admin user is logged-in).

We should still by default show the manifest when there is any CSS excluded, as this is critical for debugging in production without turning `WP_DEBUG` on. So by default we can have the manifest comment hidden unless `WP_DEBUG` is on or there is any CSS being excluded. 

So, the default value for this option is `when_css_excluded`.

If a site wants to override this and force the comment to be displayed, even when there is no excluded:

```php
add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
    $sanitizers['AMP_Style_Sanitizer']['include_manifest_comment'] = 'always';
    return $sanitizers;
} );
```

Likewise, to always hide the comment even when `WP_DEBUG` is enabled:

```php
add_filter( 'amp_content_sanitizers', function( $sanitizers ) {
    $sanitizers['AMP_Style_Sanitizer']['include_manifest_comment'] = 'never';
    return $sanitizers;
} );
```