### PR TITLE
Strip old-school CDATA and HTML comments from XHTML-compatible style elements

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1115,6 +1115,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		// Strip the dreaded UTF-8 byte order mark (BOM, \uFEFF). This should ideally get handled by PHP-CSS-Parser <https://github.com/sabberworm/PHP-CSS-Parser/issues/150>.
 		$stylesheet_string = preg_replace( '/^\xEF\xBB\xBF/', '', $stylesheet_string );
 
+		// Strip obsolete CDATA sections and HTML comments which were used for old school XHTML.
+		$stylesheet_string = preg_replace( '#^\s*<!--#', '', $stylesheet_string );
+		$stylesheet_string = preg_replace( '#^\s*<!\[CDATA\[#', '', $stylesheet_string );
+		$stylesheet_string = preg_replace( '#\]\]>\s*$#', '', $stylesheet_string );
+		$stylesheet_string = preg_replace( '#-->\s*$#', '', $stylesheet_string );
+
 		$stylesheet         = array();
 		$parsed_stylesheet  = $this->parse_stylesheet( $stylesheet_string, $options );
 		$validation_results = $parsed_stylesheet['validation_results'];


### PR DESCRIPTION
Reported at https://wordpress.org/support/topic/amp-issue-css-syntax-error-style-amp-custom-2/

Google Search Console was reporting a CSS parse error on an AMP page containing a style:

```css
<![CDATA[.mailpoet_hp_email_label{display:none}
```

The use of CDATA and HTML comments in styles is only for the sake of supporting XHTML back in the day. It is obsolete now. In any case, PHP-CSS-Parser doesn't strip it out, just as it doesn't strip out the BOM (#1611) so we need to do it ourselves.