### PR TITLE
Avoid infinite URL space under /amp/ endpoint in classic mode

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -319,8 +319,9 @@ function amp_maybe_add_actions() {
 	if ( $is_amp_endpoint ) {
 
 		// Prevent infinite URL space under /amp/ endpoint.
-		$endpoint = get_query_var( amp_get_slug(), false );
-		if ( ! isset( $_GET[ amp_get_slug() ] ) && false !== $endpoint && '1' !== (string) $endpoint && '' !== $endpoint ) {
+		global $wp;
+		wp_parse_str( $wp->matched_query, $path_args );
+		if ( isset( $path_args[ amp_get_slug() ] ) && '' !== $path_args[ amp_get_slug() ] ) {
 			wp_safe_redirect( amp_get_permalink( $post->ID ), 301 );
 			exit;
 		}

--- a/amp.php
+++ b/amp.php
@@ -317,6 +317,14 @@ function amp_maybe_add_actions() {
 	}
 
 	if ( $is_amp_endpoint ) {
+
+		// Prevent infinite URL space under /amp/ endpoint.
+		$endpoint = get_query_var( amp_get_slug(), false );
+		if ( ! isset( $_GET[ amp_get_slug() ] ) && false !== $endpoint && '1' !== (string) $endpoint && '' !== $endpoint ) {
+			wp_safe_redirect( amp_get_permalink( $post->ID ), 301 );
+			exit;
+		}
+
 		amp_prepare_render();
 	} else {
 		amp_add_frontend_actions();


### PR DESCRIPTION
Given an AMP page in classic mode on https://example.com/2019/01/01/example/amp/ 

When post content contains HTML such as:

```html
<a href="./amp/">Read the AMP version!</a>
```

The result is that crawlers can naively continue navigating to:

1. https://example.com/2019/01/01/example/amp/ 
1. https://example.com/2019/01/01/example/amp/amp/
1. https://example.com/2019/01/01/example/amp/amp/amp/ 
1. https://example.com/2019/01/01/example/amp/amp/amp/amp/ 
1. https://example.com/2019/01/01/example/amp/amp/amp/amp/amp/ 
1. https://example.com/2019/01/01/example/amp/amp/amp/amp/amp/amp/ 
1. https://example.com/2019/01/01/example/amp/amp/amp/amp/amp/amp/amp/ 
1. https://example.com/2019/01/01/example/amp/amp/amp/amp/amp/amp/amp/amp/...

And so on.

The path segments that appear after `amp/` are treated as the value for the `amp` query var. Normally when going to `/amp/` the value is just `1`. But in the examples above, the value can be a value like `amp/amp/amp/amp/amp/amp`. Since the `/amp/` endpoint is only used for posts, we can fix the infinite URL space problem by just getting the AMP permalink for the currently-queried post and then do a 301 redirect to that URL.

Closes #910 (replaces)