### PR TITLE
Fix tests in environments where custom content dir is set and WP_HOME/WP_SITEURL is defined

### DIFF
--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1138,7 +1138,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	public function get_stylesheet_urls() {
 
 		// Make sure core-bundled themes are registered.
-		register_theme_directory( ABSPATH . 'wp-content/themes' );
+		if ( WP_CONTENT_DIR !== ABSPATH . 'wp-content/themes' ) {
+			register_theme_directory( ABSPATH . 'wp-content/themes' );
+		}
 
 		$theme = new WP_Theme( 'twentyseventeen', ABSPATH . 'wp-content/themes' );
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1136,14 +1136,20 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @returns array Stylesheet URL data.
 	 */
 	public function get_stylesheet_urls() {
+
+		// Make sure core-bundled themes are registered.
+		register_theme_directory( ABSPATH . 'wp-content/themes' );
+
+		$theme = new WP_Theme( 'twentyseventeen', ABSPATH . 'wp-content/themes' );
+
 		return array(
 			'theme_stylesheet_without_host' => array(
 				'/wp-content/themes/twentyseventeen/style.css',
-				WP_CONTENT_DIR . '/themes/twentyseventeen/style.css',
+				$theme->get_stylesheet_directory() . '/style.css',
 			),
 			'theme_stylesheet_with_host' => array(
-				WP_CONTENT_URL . '/themes/twentyseventeen/style.css',
-				WP_CONTENT_DIR . '/themes/twentyseventeen/style.css',
+				$theme->get_stylesheet_directory_uri() . '/style.css',
+				$theme->get_stylesheet_directory() . '/style.css',
 			),
 			'dashicons_without_host' => array(
 				'/wp-includes/css/dashicons.css',
@@ -1225,6 +1231,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$this->assertInstanceOf( 'WP_Error', $actual );
 			$this->assertEquals( $error_code, $actual->get_error_code() );
 		} else {
+			$this->assertInternalType( 'string', $actual );
 			$this->assertEquals( $expected, $actual );
 		}
 	}

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -178,8 +178,20 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	 * @covers AMP_HTTP::filter_allowed_redirect_hosts()
 	 */
 	public function test_get_amp_cache_hosts() {
-		update_option( 'home', 'https://example.com' );
-		update_option( 'siteurl', 'https://example.org' );
+
+		// Note that filters are used instead of updating option because of WP_HOME and WP_SITEURL constants.
+		add_filter(
+			'home_url',
+			function () {
+				return 'https://example.com';
+			}
+		);
+		add_filter(
+			'site_url',
+			function () {
+				return 'https://example.org';
+			}
+		);
 
 		$hosts = AMP_HTTP::get_amp_cache_hosts();
 

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -311,9 +311,22 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 		);
 
 		// Check URL scheme.
+		add_filter(
+			'home_url',
+			function ( $url ) {
+				return set_url_scheme( $url, 'http' );
+			},
+			10
+		);
 		update_option( 'home', home_url( '/', 'http' ) );
 		$this->assertEquals( 'http', wp_parse_url( AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id ), PHP_URL_SCHEME ) );
-		update_option( 'home', home_url( '/', 'https' ) );
+		add_filter(
+			'home_url',
+			function ( $url ) {
+				return set_url_scheme( $url, 'https' );
+			},
+			10
+		);
 		$this->assertEquals( 'https', wp_parse_url( AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id ), PHP_URL_SCHEME ) );
 	}
 

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -318,7 +318,6 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 			},
 			10
 		);
-		update_option( 'home', home_url( '/', 'http' ) );
 		$this->assertEquals( 'http', wp_parse_url( AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id ), PHP_URL_SCHEME ) );
 		add_filter(
 			'home_url',


### PR DESCRIPTION
Fixes tests running in the [wordpressdev Lando environment](https://github.com/felixarntz/wordpressdev):

![image](https://user-images.githubusercontent.com/134745/52155520-155dbe80-2638-11e9-9137-c78683e9a336.png)

In this environment, the `WP_HOME`/`WP_SITEURL` constants are set, and this causes problems for tests that tried changing the `home` and `siteurl` options. So to fix that problem, filters are now used instead.

Also, the environment registers a custom directory for the content, which broke tests related to theme path URLs. So now the core themes directory is explicitly referenced in the test.