### PR TITLE
Fall-back to HTTP request whenever stylesheet is not found locally or a dynamic resource

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -542,7 +542,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			);
 		} while ( 0 !== $count );
 
-		if ( false !== strpos( $path, './' ) ) {
+		if ( preg_match( '#(^|/)\.+/#', $path ) ) {
 			/* translators: %s is the path with the remaining relative segments. */
 			return new WP_Error( 'remaining_relativity', sprintf( __( 'There are remaining relative path segments: %s', 'amp' ), $path ) );
 		}

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1264,7 +1264,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'amp_file_path_illegal_linux' => array(
 				content_url( '../../../../../../../../../../../../../../../bad.css' ),
 				null,
-				'file_path_not_allowed',
+				'remaining_relativity',
 			),
 			'amp_file_path_illegal_windows' => array(
 				content_url( '..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\bad.css' ),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1223,6 +1223,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				$theme->get_stylesheet_directory_uri() . '/foo/./bar/baz/../../../style.css',
 				$theme->get_stylesheet_directory() . '/style.css',
 			),
+			'theme_stylesheet_with_trailing_dot' => array(
+				$theme->get_stylesheet_directory_uri() . '/foo./bar.css',
+				null,
+				'file_path_not_found',
+			),
 			'dashicons_without_host' => array(
 				'/wp-includes/css/dashicons.css',
 				ABSPATH . WPINC . '/css/dashicons.css',


### PR DESCRIPTION
When referencing an external stylesheet, the plugin currently is over-eager to fail the reference when it doesn't look like a CSS resource. In particular, if the URL doesn't have a `.css` extension. For such cases, it's important to fall-back to fetching the stylesheet over HTTP. So this is now implemented here. Additionally, it will very that the fetched URL is actually `text/css`.

This PR also improves handling of relative URLs in stylesheets, both for the stylesheet URLs themselves and for resources linked to in the stylesheets (e.g. background images and fonts).b

The converting of relative paths to absolute ones was not very robust. For example, a path like `foo/./bar/baz/../../../style.css` would fail to be converted `style.css`. So this is now fixed.

This should fix the following two issues, but it needs testing.

Fixes #1849.
Fixes #1797.