### PR TITLE
Enqueue component scripts for attributes that require extensions (e.g. amp-lightbox-gallery for amp-img[lightbox])

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -553,6 +553,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $node->hasAttribute( 'lightbox' ) ) {
 				$this->script_components[] = 'amp-lightbox-gallery';
 			}
+			if ( $node->hasAttribute( 'amp-fx' ) ) {
+				$this->script_components[] = 'amp-fx-collection';
+			}
 
 			// Check if element needs amp-bind component.
 			if ( $node instanceof DOMElement && ! in_array( 'amp-bind', $this->script_components, true ) ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -549,6 +549,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				$this->script_components = array_merge( $this->script_components, $tag_spec['requires_extension'] );
 			}
 
+			// Manually add components for attributes; this is hard-coded because attributes do not have requires_extension like tags do. See <https://github.com/ampproject/amp-wp/issues/1808>.
+			if ( $node->hasAttribute( 'lightbox' ) ) {
+				$this->script_components[] = 'amp-lightbox-gallery';
+			}
+
 			// Check if element needs amp-bind component.
 			if ( $node instanceof DOMElement && ! in_array( 'amp-bind', $this->script_components, true ) ) {
 				foreach ( $node->attributes as $name => $value ) {

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -240,6 +240,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-lightbox-gallery' ),
 			),
 
+			'lightbox-with-amp-carousel' => array(
+				'<amp-carousel lightbox width="1600" height="900" layout="responsive" type="slides"><amp-img src="image1" width="200" height="100"></amp-img><amp-img src="image1" width="200" height="100"></amp-img><amp-img src="image1" width="200" height="100"></amp-img></amp-carousel>',
+				null,
+				array( 'amp-lightbox-gallery', 'amp-carousel' ),
+			),
+
 			'reference-points-amp-live-list' => array(
 				'<amp-live-list id="my-live-list" data-poll-interval="15000" data-max-items-per-page="20"><button update on="tap:my-live-list.update">You have updates!</button><div items></div><div pagination></div></amp-live-list>',
 				null,

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1022,6 +1022,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				null,
 				array( 'amp-image-slider' ),
 			),
+
+			'amp-fx-collection' => array(
+				'<h1 amp-fx="parallax" data-parallax-factor="1.5">A title that moves faster than other content.</h1>',
+				null,
+				array( 'amp-fx-collection' ),
+			),
 		);
 	}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -237,7 +237,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'reference-point-lightbox-thumbnail-id' => array(
 				'<amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>',
 				null,
-				array(),
+				array( 'amp-lightbox-gallery' ),
 			),
 
 			'reference-points-amp-live-list' => array(


### PR DESCRIPTION
There seems to be a bug in the tag-and-attribute sanitizer where it is not detecting the need for the `amp-lightbox-gallery` this component when an element has the `lightbox` attribute. The problem is in the following logic:

https://github.com/ampproject/amp-wp/blob/12a0627d18e5ea37abd1838b7161a21fc389913f/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L543-L566

This is likely because almost all component scripts are related to elements, not to attributes. That is why it is likely being missed. 

This is also showing up incorrectly in unit tests. In the following example:

https://github.com/ampproject/amp-wp/blob/12a0627d18e5ea37abd1838b7161a21fc389913f/tests/test-tag-and-attribute-sanitizer.php#L237-L241

The `array()` should actually be `array( 'amp-lightbox-gallery' )`.

This is also a problem for `amp-fx-collection` where it has an `amp-fx` attribute which requires the component script to be included. The problem with `amp-fx` and `lightbox` attributes is that the validator spec has no mechanism to mark such attributes as `requires_extension`, as is the case for tags. See https://github.com/ampproject/amphtml/issues/19935. Because of this, we have to hare-code the dependencies, similar to how we currently include `amp-bind` when there is a binding attribute is present.

# TODO

- [x] Confirm that there is indeed no way in the validator to determine the required extension for a given attribute.
- [x] Determine if there are any other such attributes that need hard-coded consideration.
- [x] Require the `amp-fx-collection` extension when an element has the `amp-fx` attribute.

Fixes #1808.