### PR TITLE
Use more permanent redirects for AMP URLs

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -310,7 +310,11 @@ function amp_maybe_add_actions() {
 	$post = get_queried_object();
 	if ( ! post_supports_amp( $post ) ) {
 		if ( $is_amp_endpoint ) {
-			wp_safe_redirect( get_permalink( $post->ID ), 302 ); // Temporary redirect because AMP may be supported in future.
+			/*
+			 * Temporary redirect is used for admin users because classic mode and AMP support can be enabled by user at any time,
+			 * so they will be able to make AMP available for this URL and see the change without wrestling with the redirect cache.
+			 */
+			wp_safe_redirect( get_permalink( $post->ID ), current_user_can( 'manage_options' ) ? 302 : 301 );
 			exit;
 		}
 		return;


### PR DESCRIPTION
The AMP plugin does frontend redirects in several scenarios:

1. Redirect from an AMP URL to non-AMP URL when AMP is not available for a given URL because it has been disabled at the post level (relevant to both classic and paired modes).
2. Redirect from an AMP URL to non-AMP URL when AMP is not available for a given URL because the template support has not been enabled (relevant to paired mode).
3. Redirect from an AMP URL to non-AMP URL when AMP is not available for a given URL because of rejected validation errors, including when auto-accepting sanitization is disabled and there are newly-encountered validation errors (relevant to paired mode only).
4. Redirect from AMP URL to non-AMP URL when a site is AMP-first/canonical native mode is enabled (as there is no separate AMP version).
5. Redirect from  `/amp/` to `?amp` when it has been switched from Classic mode to Paired mode.

This pull request makes it so that all of these scenarios, except for 3, will do a `301` permanent redirect instead of a `302` redirect, unless an admin user is logged-in. By not redirecting for admin users, they will be allowed to make changes to the template mode and validation error statuses and then be able to see the changes reflected without wrestling with the browser's redirect cache. Naturally search engines are never logged-in, so they would always see the `301` redirects.

The scenario 3 continues to use a `302` redirect because that scenario indicates an exception where AMP is blocked due to unaccepted validation errors. Since these could be fixed at any time, it makes sense to me to not do a `301` redirect in this case.

The rationale for switching to `301` redirects instead of `302` temporary redirects is to satisfy some SEO concerns (which may or may not be valid anymore). 