### PR TITLE
Add noscript fallbacks for img, audio, and video; improve audio conversion to amp-audio; add AMP [fallback] for amp-audio/amp-video

### DIFF
--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -79,7 +79,7 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 			defaultHeight: 400,
 			mediaBlocks: [
 				'core/image',
-				'core/video',
+				'core/video'
 			],
 			textBlocks: [
 				'core/paragraph',

--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -37,7 +37,6 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 					value: 'responsive',
 					label: __( 'Responsive', 'amp' ),
 					notAvailable: [
-						'core/audio',
 						'core-embed/soundcloud'
 					]
 				},
@@ -50,7 +49,6 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 					value: 'fill',
 					label: __( 'Fill', 'amp' ),
 					notAvailable: [
-						'core/audio',
 						'core-embed/soundcloud'
 					]
 				},
@@ -58,7 +56,6 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 					value: 'flex-item',
 					label: __( 'Flex Item', 'amp' ),
 					notAvailable: [
-						'core/audio',
 						'core-embed/soundcloud'
 					]
 				},
@@ -67,7 +64,6 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 					value: 'intrinsic',
 					label: __( 'Intrinsic', 'amp' ),
 					notAvailable: [
-						'core/audio',
 						'core-embed/youtube',
 						'core-embed/facebook',
 						'core-embed/instagram',
@@ -84,7 +80,6 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 			mediaBlocks: [
 				'core/image',
 				'core/video',
-				'core/audio'
 			],
 			textBlocks: [
 				'core/paragraph',

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -800,7 +800,7 @@ class AMP_Theme_Support {
 		add_filter(
 			'get_custom_logo',
 			function( $html ) {
-				return preg_replace( '/(?<=<img\s)/', ' noloading ', $html );
+				return preg_replace( '/(?<=<img\s)/', ' data-amp-noloading="" ', $html );
 			},
 			1
 		);

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -51,6 +51,8 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			$old_node = $node->cloneNode( true );
+
 			$amp_data       = $this->get_data_amp_attributes( $node );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 			$old_attributes = $this->filter_data_amp_attributes( $old_attributes, $amp_data );
@@ -61,19 +63,20 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 
 			foreach ( $node->childNodes as $child_node ) {
 
+				if ( ! ( $child_node instanceof DOMElement ) ) {
+					continue;
+				}
+
 				/**
 				 * Child node.
 				 *
 				 * @todo: Fix when `source` has no closing tag as DOMDocument does not handle well.
 				 *
-				 * @var DOMNode $child_node
+				 * @var DOMElement $child_node
+				 * @var DOMElement $new_child_node
 				 */
 
-				$new_child_node = $child_node->cloneNode( true );
-				if ( ! $new_child_node instanceof DOMElement ) {
-					continue;
-				}
-
+				$new_child_node       = $child_node->cloneNode( true );
 				$old_child_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $new_child_node );
 				$new_child_attributes = $this->filter_attributes( $old_child_attributes );
 
@@ -113,7 +116,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 				$noscript = $this->dom->createElement( 'noscript' );
 				$new_node->appendChild( $noscript );
 				$node->parentNode->replaceChild( $new_node, $node );
-				$noscript->appendChild( $node );
+				$noscript->appendChild( $old_node );
 				$node->removeAttribute( 'height' );
 				$node->removeAttribute( 'width' );
 			}

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -44,7 +44,13 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
-			$node           = $nodes->item( $i );
+			$node = $nodes->item( $i );
+
+			// Allow video in fallbacks.
+			if ( 'noscript' === $node->parentNode->nodeName ) {
+				continue;
+			}
+
 			$amp_data       = $this->get_data_amp_attributes( $node );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 			$old_attributes = $this->filter_data_amp_attributes( $old_attributes, $amp_data );

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -54,7 +54,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
 			// For amp-audio, the default width and height are inferred from browser.
-			$sources = array();
+			$sources        = array();
 			$new_attributes = $this->filter_attributes( $old_attributes );
 			if ( ! empty( $new_attributes['src'] ) ) {
 				$sources[] = $new_attributes['src'];

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -46,7 +46,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
 
-			// Allow video in fallbacks.
+			// Allow audio in fallbacks.
 			if ( 'noscript' === $node->parentNode->nodeName ) {
 				continue;
 			}
@@ -110,7 +110,12 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 					$new_node->setAttribute( 'width', 'auto' );
 				}
 
+				$noscript = $this->dom->createElement( 'noscript' );
+				$new_node->appendChild( $noscript );
 				$node->parentNode->replaceChild( $new_node, $node );
+				$noscript->appendChild( $node );
+				$node->removeAttribute( 'height' );
+				$node->removeAttribute( 'width' );
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -229,7 +229,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Make final modifications to DOMNode
 	 *
-	 * @param DOMElement $node The DOMNode to adjust and replace.
+	 * @param DOMElement $node The img element to adjust and replace.
 	 */
 	private function adjust_and_replace_node( $node ) {
 
@@ -254,9 +254,16 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		} else {
 			$new_tag = 'amp-img';
 		}
-		$new_node = AMP_DOM_Utils::create_node( $this->dom, $new_tag, $new_attributes );
-		$new_node = $this->handle_centering( $new_node );
+
+		$img_node = AMP_DOM_Utils::create_node( $this->dom, $new_tag, $new_attributes );
+		$new_node = $this->handle_centering( $img_node );
 		$node->parentNode->replaceChild( $new_node, $node );
+
+		// Preserve original node in noscript for no-JS environments.
+		$noscript = $this->dom->createElement( 'noscript' );
+		$noscript->appendChild( $node );
+		$img_node->appendChild( $noscript );
+
 		$this->add_auto_width_to_figure( $new_node );
 	}
 

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -35,8 +35,8 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			// Skip noscript elements inside of amp-img. See \AMP_Img_Sanitizer::adjust_and_replace_node().
-			if ( 'amp-img' === $noscript->parentNode->nodeName ) {
+			// Skip noscript elements inside of amp-img or other AMP components for fallbacks. See \AMP_Img_Sanitizer::adjust_and_replace_node().
+			if ( 'amp-' === substr( $noscript->parentNode->nodeName, 0, 4 ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -35,6 +35,11 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			// Skip noscript elements inside of amp-img. See \AMP_Img_Sanitizer::adjust_and_replace_node().
+			if ( 'amp-img' === $noscript->parentNode->nodeName ) {
+				continue;
+			}
+
 			$fragment = $this->dom->createDocumentFragment();
 			$fragment->appendChild( $this->dom->createComment( 'noscript' ) );
 			while ( $noscript->firstChild ) {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -57,7 +57,13 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
-			$node           = $nodes->item( $i );
+			$node = $nodes->item( $i );
+
+			// Allow video in fallbacks.
+			if ( 'noscript' === $node->parentNode->nodeName ) {
+				continue;
+			}
+
 			$amp_data       = $this->get_data_amp_attributes( $node );
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 			$old_attributes = $this->filter_data_amp_attributes( $old_attributes, $amp_data );

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -30,73 +30,73 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 			'simple_audio' => array(
 				'<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
 			),
 
 			'autoplay_attribute' => array(
 				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay=""></amp-audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay=""><noscript><audio src="https://example.com/audio/file.ogg" autoplay></audio></noscript></amp-audio>',
 			),
 
 			'autoplay_attribute__false' => array(
 				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay="false"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg" autoplay="false"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_whitelisted_attributes__enabled' => array(
 				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="" muted=""></amp-audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="" muted=""><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_whitelisted_attributes__disabled' => array(
 				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test"></amp-audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test"><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_blacklisted_attribute' => array(
 				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" style="border-color: red;"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio>',
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg" style="border-color: red;"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_children' => array(
-				'<audio width="400" height="300">
-	<source src="https://example.com/foo.wav" type="audio/wav">
-</audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></amp-audio>',
+				'<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>',
+				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_layout_from_editor_fixed_height' => array(
 				'<figure data-amp-layout="fixed-height"><audio src="https://example.com/audio/file.ogg" width="100" height="100"></audio></figure>',
-				'<figure data-amp-layout="fixed-height"><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100" layout="fixed-height"></amp-audio></figure>',
+				'<figure data-amp-layout="fixed-height"><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100" layout="fixed-height"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio></figure>',
 			),
 
 			'multiple_same_audio' => array(
-				'<audio width="400" height="300">
-	<source src="https://example.com/foo.wav" type="audio/wav">
-</audio>
-<audio width="400" height="300">
-	<source src="https://example.com/foo.wav" type="audio/wav">
-</audio>
-<audio width="400" height="300">
-	<source src="https://example.com/foo.wav" type="audio/wav">
-</audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></amp-audio><amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></amp-audio><amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></amp-audio>',
+				'
+					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+				',
+				'
+					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+				',
 			),
 
 			'multiple_different_audio' => array(
-				'<audio width="400" height="300">
-	<source src="https://example.com/foo.wav" type="audio/wav">
-</audio>
-<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>
-<audio height="500" width="300">
-	<source src="https://example.com/foo2.wav" type="audio/wav">
-</audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></amp-audio><amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"></amp-audio><amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"></amp-audio>',
+				'
+					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>
+					<audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"></audio>
+				',
+				'
+					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>
+					<amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio></noscript></amp-audio>
+				',
 			),
 
 			'https_not_required' => array(
 				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
-				'<amp-audio width="400" height="300" src="http://example.com/audio/file.ogg"></amp-audio>',
+				'<amp-audio width="400" height="300" src="http://example.com/audio/file.ogg"><noscript><audio src="http://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_fallback' => array(
@@ -121,8 +121,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );
 		$sanitizer->sanitize();
-		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
-		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
+		$content  = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content  = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $content ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
 		$this->assertEquals( $expected, $content );
 	}
 

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -100,8 +100,8 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 			),
 
 			'audio_with_fallback' => array(
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
-				null
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
+				null,
 			),
 		);
 	}

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -10,9 +10,7 @@
 /**
  * Class AMP_Audio_Converter_Test
  *
- * This is here because PhpStorm cannot find them because of phpunit6-compat.php
- *
- * @method void assertEquals( mixed $expected, mixed $actual, string $errorMessage=null )
+ * @covers AMP_Audio_Sanitizer
  */
 class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
@@ -29,78 +27,112 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 			),
 
 			'simple_audio' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
+				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio></noscript></amp-audio>',
 			),
 
 			'autoplay_attribute' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay=""><noscript><audio src="https://example.com/audio/file.ogg" autoplay></audio></noscript></amp-audio>',
+				'<audio src="https://example.com/audio/file.ogg" autoplay></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" autoplay="" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" autoplay></audio></noscript></amp-audio>',
 			),
 
 			'autoplay_attribute__false' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" autoplay="false"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg" autoplay="false"></audio></noscript></amp-audio>',
+				'<audio src="https://example.com/audio/file.ogg" autoplay="false"></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" autoplay="false"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_whitelisted_attributes__enabled' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="" muted=""><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio></noscript></amp-audio>',
+				'<audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" class="test" loop="" muted="" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_whitelisted_attributes__disabled' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg" class="test"><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio></noscript></amp-audio>',
-			),
-
-			'audio_with_blacklisted_attribute' => array(
-				'<audio width="400" height="300" src="https://example.com/audio/file.ogg" style="border-color: red;"></audio>',
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg" style="border-color: red;"></audio></noscript></amp-audio>',
+				'<audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" class="test" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_children' => array(
-				'<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>',
-				'<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
+				'<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>',
+				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
+			),
+
+			'audio_with_http_children' => array(
+				'<audio><source src="http://example.com/foo.wav" type="audio/wav"></audio>',
+				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_layout_from_editor_fixed_height' => array(
-				'<figure data-amp-layout="fixed-height"><audio src="https://example.com/audio/file.ogg" width="100" height="100"></audio></figure>',
-				'<figure data-amp-layout="fixed-height"><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100" layout="fixed-height"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio></figure>',
+				'<figure><audio src="https://example.com/audio/file.ogg" width="100" height="100"></audio><figcaption>Caption</figcaption></figure>',
+				'<figure><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio><figcaption>Caption</figcaption></figure>',
 			),
 
 			'multiple_same_audio' => array(
 				'
-					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
-					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
-					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
 				',
 				'
-					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
-					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
-					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
 				',
 			),
 
 			'multiple_different_audio' => array(
 				'
-					<audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"></audio>
-					<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>
-					<audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"></audio>
+					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
+					<audio src="https://example.com/audio/file.ogg"></audio>
+					<audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio>
 				',
 				'
-					<amp-audio width="400" height="300"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
-					<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>
-					<amp-audio height="500" width="300"><source src="https://example.com/foo2.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio src="https://example.com/audio/file.ogg" width="auto"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo2.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio></noscript></amp-audio>
 				',
 			),
 
-			'https_not_required' => array(
-				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
-				'<amp-audio width="400" height="300" src="http://example.com/audio/file.ogg"><noscript><audio src="http://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
+			'audio_with_track_no_source_element' => array(
+				'
+					<audio src="https://example.com/audio/file.ogg">
+						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+					</audio>
+				',
+				'
+					<amp-audio src="https://example.com/audio/file.ogg" width="auto">
+						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+						<noscript>
+							<audio src="https://example.com/audio/file.ogg">
+								<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+							</audio>
+						</noscript>
+					</amp-audio>
+				',
 			),
 
-			'audio_with_fallback' => array(
-				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
+			'audio_with_track_and_source_element' => array(
+				'
+					<audio>
+						<source src="https://example.com/audio/file.ogg" type="audio/mp3">
+						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+					</audio>
+				',
+				'
+					<amp-audio width="auto">
+						<source src="https://example.com/audio/file.ogg" type="audio/mp3">
+						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+						<noscript>
+							<audio>
+								<source src="https://example.com/audio/file.ogg" type="audio/mp3">
+								<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+							</audio>
+						</noscript>
+					</amp-audio>
+				',
+			),
+
+			'amp_audio_with_existing_noscript_fallback' => array(
+				'<amp-audio src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
 				null,
 			),
 		);
@@ -121,14 +153,22 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );
 		$sanitizer->sanitize();
-		$content  = AMP_DOM_Utils::get_content_from_dom( $dom );
-		$content  = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $content ) );
-		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
-		$this->assertEquals( $expected, $content );
+
+		$style_sanitizer = new AMP_Style_Sanitizer( $dom );
+		$style_sanitizer->sanitize();
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+		$whitelist_sanitizer->sanitize();
+
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$this->assertEqualMarkup( $expected, $content );
 	}
 
+	/**
+	 * Test that HTTPS is enforced.
+	 */
 	public function test__https_required() {
-		$source   = '<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>';
+		$source   = '<audio src="http://example.com/audio/file.ogg"></audio>';
 		$expected = '';
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
@@ -144,6 +184,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $content );
 	}
 
+	/**
+	 * Test that scripts don't get picked up.
+	 */
 	public function test_get_scripts__didnt_convert() {
 		$source   = '<p>Hello World</p>';
 		$expected = array();
@@ -162,8 +205,11 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $scripts );
 	}
 
+	/**
+	 * Test that scripts get picked up.
+	 */
 	public function test_get_scripts__did_convert() {
-		$source   = '<audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio>';
+		$source   = '<audio src="https://example.com/audio/file.ogg"></audio>';
 		$expected = array( 'amp-audio' => true );
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
@@ -178,5 +224,21 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 			$whitelist_sanitizer->get_scripts()
 		);
 		$this->assertEquals( $expected, $scripts );
+	}
+
+	/**
+	 * Assert markup is equal.
+	 *
+	 * @param string $expected Expected markup.
+	 * @param string $actual   Actual markup.
+	 */
+	public function assertEqualMarkup( $expected, $actual ) {
+		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
+
+		$this->assertEquals(
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE ) ),
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE ) )
+		);
 	}
 }

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -28,42 +28,42 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 			'simple_audio' => array(
 				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
-				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio></noscript></amp-audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio></noscript></amp-audio>',
 			),
 
 			'autoplay_attribute' => array(
 				'<audio src="https://example.com/audio/file.ogg" autoplay></audio>',
-				'<amp-audio src="https://example.com/audio/file.ogg" autoplay="" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" autoplay></audio></noscript></amp-audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" autoplay="" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" autoplay></audio></noscript></amp-audio>',
 			),
 
 			'autoplay_attribute__false' => array(
 				'<audio src="https://example.com/audio/file.ogg" autoplay="false"></audio>',
-				'<amp-audio src="https://example.com/audio/file.ogg" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" autoplay="false"></audio></noscript></amp-audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" autoplay="false"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_whitelisted_attributes__enabled' => array(
 				'<audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio>',
-				'<amp-audio src="https://example.com/audio/file.ogg" class="test" loop="" muted="" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio></noscript></amp-audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" class="test" loop="" muted="" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_whitelisted_attributes__disabled' => array(
 				'<audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio>',
-				'<amp-audio src="https://example.com/audio/file.ogg" class="test" width="auto"><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio></noscript></amp-audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" class="test" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_children' => array(
 				'<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>',
-				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
+				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_http_children' => array(
 				'<audio><source src="http://example.com/foo.wav" type="audio/wav"></audio>',
-				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
+				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
 			),
 
 			'audio_with_layout_from_editor_fixed_height' => array(
 				'<figure><audio src="https://example.com/audio/file.ogg" width="100" height="100"></audio><figcaption>Caption</figcaption></figure>',
-				'<figure><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio><figcaption>Caption</figcaption></figure>',
+				'<figure><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio><figcaption>Caption</figcaption></figure>',
 			),
 
 			'multiple_same_audio' => array(
@@ -73,9 +73,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
 				',
 				'
-					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
-					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
-					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
 				',
 			),
 
@@ -86,9 +86,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 					<audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio>
 				',
 				'
-					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
-					<amp-audio src="https://example.com/audio/file.ogg" width="auto"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>
-					<amp-audio width="auto"><source src="https://example.com/foo2.wav" type="audio/wav"><noscript><audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
+					<amp-audio src="https://example.com/audio/file.ogg" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>
+					<amp-audio width="auto"><source src="https://example.com/foo2.wav" type="audio/wav"><a href="https://example.com/foo2.wav" fallback="">https://example.com/foo2.wav</a><noscript><audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio></noscript></amp-audio>
 				',
 			),
 
@@ -101,6 +101,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 				'
 					<amp-audio src="https://example.com/audio/file.ogg" width="auto">
 						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+						<a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a>
 						<noscript>
 							<audio src="https://example.com/audio/file.ogg">
 								<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
@@ -121,10 +122,48 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 					<amp-audio width="auto">
 						<source src="https://example.com/audio/file.ogg" type="audio/mp3">
 						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+						<a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a>
 						<noscript>
 							<audio>
 								<source src="https://example.com/audio/file.ogg" type="audio/mp3">
 								<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
+							</audio>
+						</noscript>
+					</amp-audio>
+				',
+			),
+
+			'audio_block_and_shortcode_output' => array(
+				'
+					<figure class="wp-block-audio">
+						<audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio>
+						<figcaption>Caption</figcaption>
+					</figure>
+
+					<!--[if lt IE 9]><script>document.createElement(\'audio\');</script><![endif]-->
+					<audio class="wp-audio-shortcode" id="audio-87-1" preload="none" style="width: 100%;" controls="controls">
+						<source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1"/>
+						<a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3</a>
+					</audio>
+				',
+				'
+					<figure class="wp-block-audio">
+						<amp-audio controls="" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3" width="auto">
+							<a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3" fallback="">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3</a>
+							<noscript>
+								<audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio>
+							</noscript>
+						</amp-audio>
+						<figcaption>Caption</figcaption>
+					</figure>
+
+					<!--[if lt IE 9]><script>document.createElement(\'audio\');</script><![endif]-->
+					<amp-audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls" width="auto">
+						<source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
+						<a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3" fallback="">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3</a>
+						<noscript>
+							<audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls">
+								<source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
 							</audio>
 						</noscript>
 					</amp-audio>

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -15,6 +15,12 @@
  * @method void assertEquals( mixed $expected, mixed $actual, string $errorMessage=null )
  */
 class AMP_Audio_Converter_Test extends WP_UnitTestCase {
+
+	/**
+	 * Get data.
+	 *
+	 * @return array
+	 */
 	public function get_data() {
 		return array(
 			'no_audios' => array(
@@ -92,13 +98,26 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 				'<audio width="400" height="300" src="http://example.com/audio/file.ogg"></audio>',
 				'<amp-audio width="400" height="300" src="http://example.com/audio/file.ogg"></amp-audio>',
 			),
+
+			'audio_with_fallback' => array(
+				'<amp-audio width="400" height="300" src="https://example.com/audio/file.ogg"><noscript><audio width="400" height="300" src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
+				null
+			),
 		);
 	}
 
 	/**
+	 * Test converter.
+	 *
 	 * @dataProvider get_data
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 */
-	public function test_converter( $source, $expected ) {
+	public function test_converter( $source, $expected = null ) {
+		if ( null === $expected ) {
+			$expected = $source;
+		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );
 		$sanitizer->sanitize();

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -67,7 +67,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_noloading_from_editor'         => array(
 				'<figure data-amp-noloading="true"><img src="http://placehold.it/300x300" height="300" width="300" /></figure>',
-				'<figure data-amp-noloading="true"><amp-img src="http://placehold.it/300x300" height="300" width="300" noloading="" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></figure>',
+				'<figure data-amp-noloading="true"><amp-img src="http://placehold.it/300x300" height="300" width="300" noloading="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
 			),
 
 			'image_with_spaces_only_src'               => array(
@@ -77,12 +77,12 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_empty_width_and_height'        => array(
 				'<p><img src="http://placehold.it/200x300" width="" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300" width="" height=""></noscript></amp-img></p>',
 			),
 
 			'image_with_undefined_width_and_height'    => array(
 				'<p><img src="http://placehold.it/200x300" /></p>',
-				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300"></noscript></amp-img></p>',
 			),
 
 			'image_with_empty_width'                   => array(
@@ -102,7 +102,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_zero_width_and_height'         => array(
 				'<p><img src="http://placehold.it/300x300" width="0" height="0" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="0" height="0" class="amp-wp-enforced-sizes"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="0" height="0" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" width="0" height="0"></noscript></amp-img></p>',
 			),
 
 			'image_with_decimal_width'                 => array(
@@ -157,52 +157,52 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'multiple_different_images'                => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/360x160" width="360" height="160" /><img src="http://placehold.it/370x170" width="370" height="170" /><img src="http://placehold.it/380x180" width="380" height="180" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/360x160" width="360" height="160"></noscript></amp-img><amp-img src="http://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/370x170" width="370" height="170"></noscript></amp-img><amp-img src="http://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/380x180" width="380" height="180"></noscript></amp-img>',
 			),
 
 			'image_center_aligned'                     => array(
 				'<img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150" />',
-				'<figure class="aligncenter" style="max-width: 350px;"><amp-img class="amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"></amp-img></figure>',
+				'<figure class="aligncenter" style="max-width: 350px;"><amp-img class="amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img></figure>',
 			),
 
 			'image_left_aligned'                       => array(
 				'<img class="alignleft" src="http://placehold.it/350x150" width="350" height="150" />',
-				'<amp-img class="alignleft amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"></amp-img>',
+				'<amp-img class="alignleft amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="alignleft" src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'image_with_caption'                       => array(
 				'<figure class="wp-caption aligncenter"><img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
-				'<figure class="wp-caption aligncenter"><amp-img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312 amp-wp-enforced-sizes" layout="intrinsic"></amp-img><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
+				'<figure class="wp-caption aligncenter"><amp-img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312 amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"></noscript></amp-img><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
 			),
 
 			'image_with_custom_lightbox_attrs'         => array(
 				'<figure data-amp-lightbox="true"><img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
-				'<figure data-amp-lightbox="true"><amp-img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure data-amp-lightbox="true"><amp-img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			),
 
 			'wide_image'                               => array(
 				'<figure class="wp-block-image"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_center_aligned'                => array(
 				'<figure class="wp-block-image aligncenter"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image aligncenter" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image aligncenter" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_left_aligned_custom_style'     => array(
 				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignleft" style="width: auto;border:solid 1px red;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image alignleft" style="width: auto;border:solid 1px red;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_right_aligned'                 => array(
 				'<figure class="wp-block-image alignright"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignright" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image alignright" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_is_resized'                    => array(
 				'<figure class="wp-block-image is-resized"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image is-resized"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"></amp-img></figure>',
+				'<figure class="wp-block-image is-resized"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 		);
 	}

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -57,12 +57,12 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_layout'                        => array(
 				'<img src="http://placehold.it/100x100" data-amp-layout="fill" width="100" height="100" />',
-				'<amp-img src="http://placehold.it/100x100" layout="fill" width="100" height="100" class="amp-wp-enforced-sizes"></amp-img>',
+				'<amp-img src="http://placehold.it/100x100" layout="fill" width="100" height="100" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/100x100" data-amp-layout="fill" width="100" height="100"></noscript></amp-img>',
 			),
 
 			'image_with_layout_from_editor'            => array(
 				'<figure data-amp-layout="fill"><img src="http://placehold.it/300x300" height="300" width="300" /></figure>',
-				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 300px;"><amp-img src="http://placehold.it/300x300" layout="fill" class="amp-wp-enforced-sizes"></amp-img></figure>',
+				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 300px;"><amp-img src="http://placehold.it/300x300" layout="fill" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
 			),
 
 			'image_with_noloading_from_editor'         => array(
@@ -77,27 +77,27 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_empty_width_and_height'        => array(
 				'<p><img src="http://placehold.it/200x300" width="" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300" width="" height=""></noscript></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_undefined_width_and_height'    => array(
 				'<p><img src="http://placehold.it/200x300" /></p>',
-				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300"></noscript></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_empty_width'                   => array(
 				'<p><img src="http://placehold.it/500x1000" width="" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/500x1000" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/500x1000" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/500x1000" width="150" height="300" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_empty_height'                  => array(
 				'<p><img src="http://placehold.it/500x1000" width="300" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/500x1000" width="300" height="600" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/500x1000" width="300" height="600" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/500x1000" width="300" height="600" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_zero_width'                    => array(
 				'<p><img src="http://placehold.it/300x300" width="0" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="0" height="300" class="amp-wp-enforced-sizes"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="0" height="300" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" width="0" height="300"></noscript></amp-img></p>',
 			),
 
 			'image_with_zero_width_and_height'         => array(
@@ -107,52 +107,52 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_decimal_width'                 => array(
 				'<p><img src="http://placehold.it/300x300" width="299.5" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="299.5" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="299.5" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" width="299.5" height="300"></noscript></amp-img></p>',
 			),
 
 			'image_with_self_closing_tag'              => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
 			),
 
 			'image_with_no_end_tag'                    => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!">',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
 			),
 
 			'image_with_end_tag'                       => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></img>',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
 			),
 
 			'image_with_on_attribute'                  => array(
 				'<img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150" />',
-				'<amp-img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'image_with_no_dimensions_is_forced'       => array(
 				'<img src="http://placehold.it/350x150" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" class=""></noscript></amp-img>',
 			),
 
 			'image_with_bad_src_url_get_fallback_dims' => array(
 				'<img src="http://example.com/404.png" />',
-				'<amp-img src="http://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height"></noscript></amp-img>',
 			),
 
 			'gif_image_conversion'                     => array(
 				'<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />',
-				'<amp-anim src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-anim>',
+				'<amp-anim src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
 			),
 
 			'gif_image_url_with_querystring'           => array(
 				'<img src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" />',
-				'<amp-anim src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-anim>',
+				'<amp-anim src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
 			),
 
 			'multiple_same_image'                      => array(
 				'<img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'multiple_different_images'                => array(

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -60,6 +60,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="http://placehold.it/100x100" layout="fill" width="100" height="100" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/100x100" data-amp-layout="fill" width="100" height="100"></noscript></amp-img>',
 			),
 
+			'image_with_noloading'                     => array(
+				'<img src="http://placehold.it/100x100" data-amp-noloading="" width="100" height="100">',
+				'<amp-img src="http://placehold.it/100x100" noloading="" width="100" height="100" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/100x100" data-amp-noloading="" width="100" height="100"></noscript></amp-img>',
+			),
+
 			'image_with_layout_from_editor'            => array(
 				'<figure data-amp-layout="fill"><img src="http://placehold.it/300x300" height="300" width="300" /></figure>',
 				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 300px;"><amp-img src="http://placehold.it/300x300" layout="fill" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -18,107 +18,138 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'simple_video' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			),
 
 			'video_without_dimensions' => array(
 				'<video src="https://example.com/file.mp4"></video>',
-				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height"></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height"><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			),
 
 			'autoplay_attribute' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay></video></noscript></amp-video>',
 			),
 
 			'autoplay_attribute__false' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video></noscript></amp-video>',
 			),
 
 			'video_with_whitelisted_attributes__enabled' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video></noscript></amp-video>',
 			),
 
 			'video_with_whitelisted_attributes__disabled' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video></noscript></amp-video>',
 			),
 
 			'video_with_custom_attribute' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video></noscript></amp-video>',
 			),
 
 			'video_with_sizes_attribute_is_overridden' => array(
 				'<video width="300" height="200" src="https://example.com/file.mp4"></video>',
-				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="responsive"><noscript><video width="300" height="200" src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			),
 
 			'video_with_children' => array(
-				'<video width="480" height="300" poster="https://example.com/video-image.gif">
-	<source src="https://example.com/video.mp4" type="video/mp4">
-	<source src="https://example.com/video.ogv" type="video/ogg">
-</video>',
-				'<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="responsive"><source src="https://example.com/video.mp4" type="video/mp4"><source src="https://example.com/video.ogv" type="video/ogg"></amp-video>',
+				'
+					<video width="480" height="300" poster="https://example.com/video-image.gif">
+						<source src="https://example.com/video.mp4" type="video/mp4">
+						<source src="https://example.com/video.ogv" type="video/ogg">
+					</video>
+				',
+				'
+					<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="responsive">
+						<source src="https://example.com/video.mp4" type="video/mp4">
+						<source src="https://example.com/video.ogv" type="video/ogg">
+						<noscript>
+							<video width="480" height="300" poster="https://example.com/video-image.gif">
+								<source src="https://example.com/video.mp4" type="video/mp4">
+								<source src="https://example.com/video.ogv" type="video/ogg">
+							</video>
+						</noscript>
+					</amp-video>
+				',
 			),
 
 			'video_with_layout_from_editor_fill' => array(
 				'<figure data-amp-layout="fill"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
-				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 100px;"><amp-video src="https://example.com/file.mp4" layout="fill"></amp-video></figure>',
+				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 100px;"><amp-video src="https://example.com/file.mp4" layout="fill"><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
 			),
 
 			'video_with_layout_from_editor_fixed' => array(
 				'<figure data-amp-layout="fixed"><video src="https://example.com/file.mp4" width="100"></video></figure>',
-				'<figure data-amp-layout="fixed"><amp-video src="https://example.com/file.mp4" width="100" layout="fixed" height="400"></amp-video></figure>',
+				'<figure data-amp-layout="fixed"><amp-video src="https://example.com/file.mp4" width="100" layout="fixed" height="400"><noscript><video src="https://example.com/file.mp4" width="100"></video></noscript></amp-video></figure>',
 			),
 
 			'video_with_noloading_from_editor' => array(
 				'<figure data-amp-noloading="true"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
-				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="responsive"></amp-video></figure>',
+				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="responsive"><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
 			),
 
 			'multiple_same_video' => array(
-				implode(
-					'',
-					array(
-						'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
-						'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
-						'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
-						'<video src="https://example.com/video.mp4" width="480" height="300"></video>',
-					)
-				),
-				'<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video><amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"></amp-video>',
+				'
+					<video src="https://example.com/video.mp4" width="480" height="300"></video>
+					<video src="https://example.com/video.mp4" width="480" height="300"></video>
+					<video src="https://example.com/video.mp4" width="480" height="300"></video>
+					<video src="https://example.com/video.mp4" width="480" height="300"></video>
+				',
+				'
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+				',
 			),
 
 			'multiple_different_videos' => array(
-				implode(
-					'',
-					array(
-						'<video src="https://example.com/video1.mp4" width="480" height="300"></video>',
-						'<video src="https://example.com/video2.ogv" width="300" height="480"></video>',
-						'<video src="https://example.com/video3.webm" height="100" width="200"></video>',
-					)
-				),
-				implode(
-					'',
-					array(
-						'<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"></amp-video>',
-						'<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"></amp-video>',
-						'<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"></amp-video>',
-					)
-				),
+				'
+					<video src="https://example.com/video1.mp4" width="480" height="300"></video>
+					<video src="https://example.com/video2.ogv" width="300" height="480"></video>
+					<video src="https://example.com/video3.webm" height="100" width="200"></video>
+				',
+				'
+					<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video1.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"><noscript><video src="https://example.com/video2.ogv" width="300" height="480"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"><noscript><video src="https://example.com/video3.webm" height="100" width="200"></video></noscript></amp-video>
+				',
 			),
 
 			'https_not_required' => array(
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			),
 
 			'http_video_with_children' => array(
-				'<video width="480" height="300" poster="https://example.com/poster.jpeg"><source src="http://example.com/video.mp4" type="video/mp4"><source src="http://example.com/video.ogv" type="video/ogg"><track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt" /><a href="http://example.com/video.mp4">http://example.com/video.mp4</a></video>',
-				'<amp-video width="480" height="300" poster="https://example.com/poster.jpeg" layout="responsive"><source src="https://example.com/video.mp4" type="video/mp4"><source src="https://example.com/video.ogv" type="video/ogg"><track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt"><a href="http://example.com/video.mp4" fallback="">http://example.com/video.mp4</a></amp-video>',
+				'
+					<video width="480" height="300" poster="https://example.com/poster.jpeg">
+						<source src="http://example.com/video.mp4" type="video/mp4">
+						<source src="http://example.com/video.ogv" type="video/ogg">
+						<track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt"/>
+						<a href="http://example.com/video.mp4">http://example.com/video.mp4</a>
+					</video>
+				',
+				'
+					<amp-video width="480" height="300" poster="https://example.com/poster.jpeg" layout="responsive">
+						<source src="https://example.com/video.mp4" type="video/mp4">
+						<source src="https://example.com/video.ogv" type="video/ogg">
+						<track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt">
+						<a href="http://example.com/video.mp4" fallback="">http://example.com/video.mp4</a>
+						<noscript>
+							<video width="480" height="300" poster="https://example.com/poster.jpeg">
+								<source src="https://example.com/video.mp4" type="video/mp4">
+								<source src="https://example.com/video.ogv" type="video/ogg">
+								<track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt">
+								<a href="http://example.com/video.mp4" fallback="">http://example.com/video.mp4</a>
+					        </video>
+						</noscript>
+					</amp-video>
+				',
 			),
 
 			'amp_video_with_fallback' => array(
@@ -140,6 +171,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
+
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );
 		$sanitizer->sanitize();
@@ -147,7 +179,9 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$whitelist_sanitizer->sanitize();
 
-		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content  = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content  = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $content ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
 		$this->assertEquals( $expected, $content );
 	}
 

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -28,42 +28,42 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'simple_video' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			),
 
 			'video_without_dimensions' => array(
 				'<video src="https://example.com/file.mp4"></video>',
-				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height"><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			),
 
 			'autoplay_attribute' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay></video></noscript></amp-video>',
 			),
 
 			'autoplay_attribute__false' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video></noscript></amp-video>',
 			),
 
 			'video_with_whitelisted_attributes__enabled' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video></noscript></amp-video>',
 			),
 
 			'video_with_whitelisted_attributes__disabled' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video></noscript></amp-video>',
 			),
 
 			'video_with_custom_attribute' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video></noscript></amp-video>',
 			),
 
 			'video_with_sizes_attribute_is_overridden' => array(
 				'<video width="300" height="200" src="https://example.com/file.mp4"></video>',
-				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="responsive"><noscript><video width="300" height="200" src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video width="300" height="200" src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			),
 
 			'video_with_children' => array(
@@ -77,6 +77,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 					<amp-video width="480" height="300" poster="https://example.com/video-image.gif" layout="responsive">
 						<source src="https://example.com/video.mp4" type="video/mp4">
 						<source src="https://example.com/video.ogv" type="video/ogg">
+						<a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a>
 						<noscript>
 							<video width="480" height="300" poster="https://example.com/video-image.gif">
 								<source src="https://example.com/video.mp4" type="video/mp4">
@@ -89,17 +90,17 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'video_with_layout_from_editor_fill' => array(
 				'<figure data-amp-layout="fill"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
-				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 100px;"><amp-video src="https://example.com/file.mp4" layout="fill"><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
+				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 100px;"><amp-video src="https://example.com/file.mp4" layout="fill"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
 			),
 
 			'video_with_layout_from_editor_fixed' => array(
 				'<figure data-amp-layout="fixed"><video src="https://example.com/file.mp4" width="100"></video></figure>',
-				'<figure data-amp-layout="fixed"><amp-video src="https://example.com/file.mp4" width="100" layout="fixed" height="400"><noscript><video src="https://example.com/file.mp4" width="100"></video></noscript></amp-video></figure>',
+				'<figure data-amp-layout="fixed"><amp-video src="https://example.com/file.mp4" width="100" layout="fixed" height="400"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" width="100"></video></noscript></amp-video></figure>',
 			),
 
 			'video_with_noloading_from_editor' => array(
 				'<figure data-amp-noloading="true"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
-				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="responsive"><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
+				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
 			),
 
 			'multiple_same_video' => array(
@@ -110,10 +111,10 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 					<video src="https://example.com/video.mp4" width="480" height="300"></video>
 				',
 				'
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
 				',
 			),
 
@@ -124,15 +125,15 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 					<video src="https://example.com/video3.webm" height="100" width="200"></video>
 				',
 				'
-					<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"><noscript><video src="https://example.com/video1.mp4" width="480" height="300"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"><noscript><video src="https://example.com/video2.ogv" width="300" height="480"></video></noscript></amp-video>
-					<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"><noscript><video src="https://example.com/video3.webm" height="100" width="200"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video1.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video1.mp4" fallback="">https://example.com/video1.mp4</a><noscript><video src="https://example.com/video1.mp4" width="480" height="300"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"><a href="https://example.com/video2.ogv" fallback="">https://example.com/video2.ogv</a><noscript><video src="https://example.com/video2.ogv" width="300" height="480"></video></noscript></amp-video>
+					<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"><a href="https://example.com/video3.webm" fallback="">https://example.com/video3.webm</a><noscript><video src="https://example.com/video3.webm" height="100" width="200"></video></noscript></amp-video>
 				',
 			),
 
 			'https_not_required' => array(
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			),
 
 			'http_video_with_children' => array(
@@ -155,7 +156,6 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 								<source src="https://example.com/video.mp4" type="video/mp4">
 								<source src="https://example.com/video.ogv" type="video/ogg">
 								<track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt">
-								<a href="http://example.com/video.mp4" fallback="">http://example.com/video.mp4</a>
 					        </video>
 						</noscript>
 					</amp-video>
@@ -215,7 +215,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$whitelist_sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
-		$this->assertEquals( $expected, $content );
+		$this->assertEqualMarkup( $expected, $content );
 	}
 
 	/**

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -3,6 +3,12 @@
 // phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
 
 class AMP_Video_Converter_Test extends WP_UnitTestCase {
+
+	/**
+	 * Get data.
+	 *
+	 * @return array
+	 */
 	public function get_data() {
 		return array(
 			'no_videos' => array(
@@ -114,13 +120,26 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 				'<video width="480" height="300" poster="https://example.com/poster.jpeg"><source src="http://example.com/video.mp4" type="video/mp4"><source src="http://example.com/video.ogv" type="video/ogg"><track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt" /><a href="http://example.com/video.mp4">http://example.com/video.mp4</a></video>',
 				'<amp-video width="480" height="300" poster="https://example.com/poster.jpeg" layout="responsive"><source src="https://example.com/video.mp4" type="video/mp4"><source src="https://example.com/video.ogv" type="video/ogg"><track srclang="en" label="English" kind="subtitles" src="https://example.com/test-en.vtt"><a href="http://example.com/video.mp4" fallback="">http://example.com/video.mp4</a></amp-video>',
 			),
+
+			'amp_video_with_fallback' => array(
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				null,
+			),
 		);
 	}
 
 	/**
+	 * Test converter.
+	 *
 	 * @dataProvider get_data
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 */
-	public function test_converter( $source, $expected ) {
+	public function test_converter( $source, $expected = null ) {
+		if ( null === $expected ) {
+			$expected = $source;
+		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );
 		$sanitizer->sanitize();

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1575,7 +1575,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		<body><!-- </body></html> -->
 		<div id="dynamic-id-0"></div>
 		<img width="100" height="100" src="https://example.com/test.png">
-		<audio width="400" height="300" src="https://example.com/audios/myaudio.mp3"></audio>
+		<audio src="https://example.com/audios/myaudio.mp3"></audio>
 		<amp-ad type="a9"
 				width="300"
 				height="250"

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1335,10 +1335,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$prev_ordered_contain = $ordered_contain;
 		}
 
-		$this->assertNotContains( '<img', $sanitized_html );
+		$this->assertContains( '<noscript><img', $sanitized_html );
 		$this->assertContains( '<amp-img', $sanitized_html );
 
-		$this->assertNotContains( '<audio', $sanitized_html );
+		$this->assertNotContains( '<audio', $sanitized_html ); // This will likely need to change if we add noscript audio fallbacks.
 		$this->assertContains( '<amp-audio', $sanitized_html );
 
 		$removed_nodes = array();

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1338,7 +1338,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<noscript><img', $sanitized_html );
 		$this->assertContains( '<amp-img', $sanitized_html );
 
-		$this->assertNotContains( '<audio', $sanitized_html ); // This will likely need to change if we add noscript audio fallbacks.
+		$this->assertContains( '<noscript><audio', $sanitized_html );
 		$this->assertContains( '<amp-audio', $sanitized_html );
 
 		$removed_nodes = array();


### PR DESCRIPTION
Appends original `img` to `amp-img` under `noscript` for no-JS browsers. This is [recommended by AMP](https://www.ampproject.org/docs/media/amp_replacements#displaying-images-when-javascript-is-disabled):

> ## Displaying images when JavaScript is disabled
> As `<amp-img>` relies on JavaScript, if the user chooses to disable scripts, images won't display. In this case, you should provide a fallback to the image using `<img>` and `<noscript>`, like so:
```html
<amp-img src="images/sunset.jpg"
  width="264"
  height="195">
  <noscript>
    <img src="images/sunset.jpg" width="264" height="195" />
  </noscript>
</amp-img>
```

So, given an `img` element:

```html
<img src="http://placehold.it/300x400" width="300" width="400">
```

Before this would be sanitized as:

```html
<amp-img src="http://placehold.it/300x400" width="300" width="400" class="amp-wp-enforced-sizes"></amp-img>
```

But after this change it would be:

```html
<amp-img src="http://placehold.it/300x400" width="300" width="400" class="amp-wp-enforced-sizes">
    <noscript>
        <img src="http://placehold.it/300x400" width="300" width="400">
    </noscript>
</amp-img>
```

This also short-circuits the `img`, `video`, and `audio` sanitizers for elements that are inside of `noscript` elements. Similarly, the AMP equivalent to `wp_mediaelement_fallback()` is implemented so that there are `fallback` links inside the `amp-audio` elements.

# Audio Improvements

## Audio non-AMP

> ![image](https://user-images.githubusercontent.com/134745/52850235-4697bd80-3113-11e9-8570-d92fde98c521.png)

```html
<figure class="wp-block-audio">
    <audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio>
    <figcaption>Caption</figcaption>
</figure>

<!--[if lt IE 9]><script>document.createElement('audio');</script><![endif]-->
<audio class="wp-audio-shortcode" id="audio-87-1" preload="none" style="width: 100%;" controls="controls">
    <source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1"/>
    <a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3</a>
</audio>
```

## AMP Audio before changes in PR

> ![image](https://user-images.githubusercontent.com/134745/52850288-6202c880-3113-11e9-8bfc-aad00a1f214c.png)

```html
<figure class="wp-block-audio">
    <amp-audio src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></amp-audio>
    <figcaption>Caption</figcaption>
</figure>

<amp-audio class="wp-audio-shortcode">
    <source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
</amp-audio>
```

## AMP Audio after changes in PR

> ![image](https://user-images.githubusercontent.com/134745/52850309-747d0200-3113-11e9-8abf-1c7f195eba88.png)

```html
<figure class="wp-block-audio">
    <amp-audio controls="" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3" width="auto">
        <a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3" fallback="">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3</a>
        <noscript>
            <audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio>
        </noscript>
    </amp-audio>
    <figcaption>Caption</figcaption>
</figure>

<amp-audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls" width="auto">
    <source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
    <a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1" fallback="">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1</a>
    <noscript>
        <audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls">
            <source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
        </audio>
    </noscript>
</amp-audio>
```

# Video Fallbacks

## Non-AMP Video

```html
<figure class="wp-block-video">
    <video controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/stamp.mp4"></video>
</figure>
```

## Before PR AMP Video

```html
<figure class="wp-block-video">
    <amp-video controls="" src="https://wordpressdev.lndo.site/content/uploads/2019/02/stamp.mp4" width="404" height="720" layout="responsive"></amp-video>
</figure>
```

## After PR AMP Video

```html
<figure class="wp-block-video">
    <amp-video controls="" src="https://wordpressdev.lndo.site/content/uploads/2019/02/stamp.mp4" width="404" height="720" layout="responsive">
        <a href="https://wordpressdev.lndo.site/content/uploads/2019/02/stamp.mp4" fallback="">https://wordpressdev.lndo.site/content/uploads/2019/02/stamp.mp4</a>
        <noscript>
            <video controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/stamp.mp4"></video>
        </noscript>
    </amp-video>
</figure>
```

Fixes #1832.