### PR TITLE
Update AMP spec from v1811202257200 to v1902072121410

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -640,6 +640,12 @@ def GetValues(attr_spec):
 			value_url_dict[value_url_key.name] = value_url_val_val
 		value_dict['value_url'] = value_url_dict
 
+	if hasattr(attr_spec, 'requires_extension') and len( attr_spec.requires_extension ) != 0:
+		requires_extension_list = []
+		for requires_extension in attr_spec.requires_extension:
+			requires_extension_list.append(requires_extension)
+		value_dict['requires_extension'] = requires_extension_list
+
 	logging.info('... done')
 	return value_dict
 

--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,15 @@
       "type": "package",
       "package": {
         "name": "ampproject/amphtml",
-        "version": "1811202257200",
+        "version": "1902072121410",
         "dist": {
-          "url": "https://github.com/ampproject/amphtml/archive/1811202257200.zip",
+          "url": "https://github.com/ampproject/amphtml/archive/1902072121410.zip",
           "type": "zip"
         },
         "source": {
           "url": "git@github.com:ampproject/amphtml.git",
           "type": "git",
-          "reference": "tags/1811202257200"
+          "reference": "tags/1902072121410"
         }
       }
     },
@@ -37,7 +37,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "0.4.4",
     "phpcompatibility/php-compatibility": "9.1.1",
     "xwp/wp-dev-lib": "1.0.1",
-    "ampproject/amphtml": "1811202257200"
+    "ampproject/amphtml": "1902072121410"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c06613407aa3d9876191540de84b935",
+    "content-hash": "12cdc1dc25592200a29a0812b99f19ba",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -203,15 +203,15 @@
     "packages-dev": [
         {
             "name": "ampproject/amphtml",
-            "version": "1811202257200",
+            "version": "1902072121410",
             "source": {
                 "type": "git",
                 "url": "git@github.com:ampproject/amphtml.git",
-                "reference": "tags/1811202257200"
+                "reference": "tags/1902072121410"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://github.com/ampproject/amphtml/archive/1811202257200.zip",
+                "url": "https://github.com/ampproject/amphtml/archive/1902072121410.zip",
                 "reference": null,
                 "shasum": null
             },

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,8 +13,8 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 767;
-	private static $minimum_validator_revision_required = 348;
+	private static $spec_file_revision = 811;
+	private static $minimum_validator_revision_required = 364;
 
 	private static $descendant_tag_lists = array(
 		'amp-story-bookend-allowed-descendants' => array(
@@ -25,6 +25,7 @@ class AMP_Allowed_Tags_Generated {
 			'abbr',
 			'address',
 			'amp-call-tracking',
+			'amp-date-countdown',
 			'amp-fit-text',
 			'amp-font',
 			'amp-img',
@@ -92,6 +93,7 @@ class AMP_Allowed_Tags_Generated {
 			'address',
 			'amp-analytics',
 			'amp-audio',
+			'amp-date-countdown',
 			'amp-experiment',
 			'amp-fit-text',
 			'amp-font',
@@ -103,6 +105,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-list',
 			'amp-live-list',
 			'amp-pixel',
+			'amp-timeago',
 			'amp-video',
 			'article',
 			'aside',
@@ -197,6 +200,7 @@ class AMP_Allowed_Tags_Generated {
 								'maps',
 								'bip',
 								'bbmi',
+								'fb-me',
 								'fb-messenger',
 								'intent',
 								'line',
@@ -210,6 +214,7 @@ class AMP_Allowed_Tags_Generated {
 								'viber',
 								'webcal',
 								'web+mastodon',
+								'wh',
 								'whatsapp',
 							),
 						),
@@ -1103,6 +1108,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-account' => array(
 						'mandatory' => true,
 					),
+					'dock' => array(),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -1240,7 +1246,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'value' => array(
 							'slides',
-							'carousel',
 						),
 					),
 				),
@@ -1259,6 +1264,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-carousel',
 					),
+					'spec_name' => 'AMP-CAROUSEL [type=slides]',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
 				),
 			),
@@ -1271,9 +1277,60 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'autoplay' => array(
+						'value_regex' => '(|[0-9]+)',
+					),
+					'controls' => array(),
+					'delay' => array(
+						'value_regex' => '[0-9]+',
+					),
+					'dots' => array(
 						'value' => array(
 							'',
 						),
+					),
+					'loop' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value' => array(
+							'carousel',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+							1,
+						),
+					),
+					'requires_extension' => array(
+						'amp-carousel',
+					),
+					'spec_name' => 'AMP-CAROUSEL [type=carousel]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[slide]' => array(),
+					'arrows' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'autoplay' => array(
+						'value_regex' => '(|[0-9]+)',
 					),
 					'controls' => array(),
 					'delay' => array(
@@ -1301,7 +1358,6 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'value' => array(
 							'slides',
-							'carousel',
 						),
 					),
 				),
@@ -1331,7 +1387,74 @@ class AMP_Allowed_Tags_Generated {
 						'amp-carousel',
 						'amp-lightbox-gallery',
 					),
-					'spec_name' => 'AMP-CAROUSEL [lightbox]',
+					'spec_name' => 'AMP-CAROUSEL [lightbox] [type=slides]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[slide]' => array(),
+					'arrows' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'autoplay' => array(
+						'value_regex' => '(|[0-9]+)',
+					),
+					'controls' => array(),
+					'delay' => array(
+						'value_regex' => '[0-9]+',
+					),
+					'dots' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'lightbox' => array(
+						'mandatory' => true,
+					),
+					'loop' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value' => array(
+							'carousel',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+							1,
+						),
+					),
+					'reference_points' => array(
+						'AMP-CAROUSEL lightbox [child]' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-CAROUSEL lightbox [lightbox-exclude]' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
+					'requires_extension' => array(
+						'amp-carousel',
+						'amp-lightbox-gallery',
+					),
+					'spec_name' => 'AMP-CAROUSEL [lightbox] [type=carousel]',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
 				),
 			),
@@ -1355,6 +1478,31 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-consent',
 					),
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'type' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'requires_extension' => array(
+						'amp-consent',
+					),
+					'spec_name' => 'amp-consent [type]',
 					'unique' => true,
 				),
 			),
@@ -1504,11 +1652,57 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-date-display' => array(
+			array(
+				'attr_spec_list' => array(
+					'datetime' => array(
+						'value_regex' => 'now|(\\d{4}-[01]\\d-[0-3]\\d(T[0-2]\\d:[0-5]\\d(:[0-6]\\d(\\.\\d\\d?\\d?)?)?(Z|[+-][0-1]\\d:[0-5]\\d)?)?)',
+					),
+					'display-in' => array(
+						'value_casei' => array(
+							'utc',
+						),
+					),
+					'locale' => array(),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'offset-seconds' => array(
+						'value_regex' => '-?\\d+',
+					),
+					'timestamp-ms' => array(
+						'value_regex' => '\\d+',
+					),
+					'timestamp-seconds' => array(
+						'value_regex' => '\\d+',
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-date-display',
+					),
+				),
+			),
+		),
 		'amp-date-picker' => array(
 			array(
 				'attr_spec_list' => array(
 					'[max]' => array(),
 					'[min]' => array(),
+					'[src]' => array(),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -1596,6 +1790,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'[max]' => array(),
 					'[min]' => array(),
+					'[src]' => array(),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -1679,6 +1874,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'[max]' => array(),
 					'[min]' => array(),
+					'[src]' => array(),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -1702,6 +1898,9 @@ class AMP_Allowed_Tags_Generated {
 					'highlighted' => array(),
 					'locale' => array(),
 					'max' => array(),
+					'maximum-nights' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'media' => array(),
 					'min' => array(),
 					'minimum-nights' => array(
@@ -1772,6 +1971,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'[max]' => array(),
 					'[min]' => array(),
+					'[src]' => array(),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -1790,6 +1990,9 @@ class AMP_Allowed_Tags_Generated {
 					'highlighted' => array(),
 					'locale' => array(),
 					'max' => array(),
+					'maximum-nights' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'media' => array(),
 					'min' => array(),
 					'minimum-nights' => array(
@@ -2939,6 +3142,7 @@ class AMP_Allowed_Tags_Generated {
 		'amp-list' => array(
 			array(
 				'attr_spec_list' => array(
+					'[is-layout-container]' => array(),
 					'[src]' => array(),
 					'[state]' => array(),
 					'auto-resize' => array(
@@ -2955,6 +3159,13 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'credentials' => array(),
 					'items' => array(),
+					'load-more' => array(
+						'value' => array(
+							'auto',
+							'manual',
+						),
+					),
+					'load-more-bookmark' => array(),
 					'max-items' => array(),
 					'media' => array(),
 					'noloading' => array(
@@ -2992,6 +3203,38 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'requires_extension' => array(
+						'amp-list',
+					),
+				),
+			),
+		),
+		'amp-list-load-more' => array(
+			array(
+				'attr_spec_list' => array(
+					'load-more-button' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'load-more-end' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'load-more-failed' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'load-more-loading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-list',
 					'requires_extension' => array(
 						'amp-list',
 					),
@@ -3612,6 +3855,33 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-recaptcha-input' => array(
+			array(
+				'attr_spec_list' => array(
+					'data-action' => array(
+						'mandatory' => true,
+					),
+					'data-sitekey' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'mandatory_ancestor' => 'form',
+					'requires_extension' => array(
+						'amp-form',
+						'amp-recaptcha-input',
+					),
+				),
+			),
+		),
 		'amp-reddit' => array(
 			array(
 				'attr_spec_list' => array(
@@ -3773,10 +4043,30 @@ class AMP_Allowed_Tags_Generated {
 							1,
 						),
 					),
+					'disallowed_ancestor' => array(
+						'amp-story',
+					),
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-sidebar',
+				),
+			),
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'mandatory_parent' => 'amp-story',
+					'requires_extension' => array(
+						'amp-sidebar',
+					),
+					'spec_name' => 'amp-story >> amp-sidebar',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-sidebar',
 				),
 			),
 		),
@@ -3830,6 +4120,7 @@ class AMP_Allowed_Tags_Generated {
 								'https',
 								'mailto',
 								'bbmi',
+								'fb-me',
 								'fb-messenger',
 								'intent',
 								'line',
@@ -3840,6 +4131,7 @@ class AMP_Allowed_Tags_Generated {
 								'tg',
 								'threema',
 								'viber',
+								'wh',
 								'whatsapp',
 							),
 						),
@@ -4088,6 +4380,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'supports-landscape' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'title' => array(
 						'mandatory' => true,
 					),
@@ -4099,6 +4396,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp-consent',
 							'amp-geo',
 							'amp-pixel',
+							'amp-sidebar',
 							'amp-story-access',
 							'amp-story-auto-ads',
 							'amp-story-bookend',
@@ -4627,6 +4925,155 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-video-iframe' => array(
+			array(
+				'attr_spec_list' => array(
+					'[src]' => array(),
+					'album' => array(),
+					'alt' => array(),
+					'artist' => array(),
+					'artwork' => array(),
+					'attribution' => array(),
+					'autoplay' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'dock' => array(),
+					'implements-media-session' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'implements-rotate-to-fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'lightbox' => array(),
+					'lightbox-thumbnail-id' => array(
+						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'poster' => array(
+						'mandatory' => true,
+					),
+					'referrerpolicy' => array(),
+					'rotate-to-fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
+						'value_url' => array(
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-video-iframe',
+					),
+					'spec_name' => 'AMP-VIDEO-IFRAME[poster]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video-iframe',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[src]' => array(),
+					'album' => array(),
+					'alt' => array(),
+					'artist' => array(),
+					'artwork' => array(),
+					'attribution' => array(),
+					'autoplay' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'dock' => array(),
+					'implements-media-session' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'implements-rotate-to-fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'lightbox' => array(),
+					'lightbox-thumbnail-id' => array(
+						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'referrerpolicy' => array(),
+					'rotate-to-fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
+						'value_url' => array(
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
+					'reference_points' => array(
+						'AMP-VIDEO-IFRAME > [placeholder]' => array(
+							'mandatory' => true,
+							'unique' => true,
+						),
+					),
+					'requires_extension' => array(
+						'amp-video-iframe',
+					),
+					'spec_name' => 'AMP-VIDEO-IFRAME with [placeholder]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video-iframe',
+				),
+			),
+		),
 		'amp-vimeo' => array(
 			array(
 				'attr_spec_list' => array(
@@ -4926,6 +5373,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-videoid' => array(
 						'value_regex' => '[^=/?:]+',
 					),
+					'dock' => array(),
 					'lightbox' => array(),
 					'lightbox-thumbnail-id' => array(
 						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
@@ -5464,6 +5912,19 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'svg',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
 				),
+			),
+		),
+		'details' => array(
+			array(
+				'attr_spec_list' => array(
+					'[open]' => array(),
+					'open' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(),
 			),
 		),
 		'dfn' => array(
@@ -7341,6 +7802,7 @@ class AMP_Allowed_Tags_Generated {
 					'inputmode' => array(),
 					'list' => array(),
 					'mask' => array(
+						'blacklisted_value_regex' => '(payment-card|date-dd-mm-yyyy|date-mm-dd-yyyy|date-mm-yy|date-yyyy-mm-dd)',
 						'dispatch_key' => 1,
 						'mandatory' => true,
 					),
@@ -7376,7 +7838,392 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-inputmask',
 					),
-					'spec_name' => 'input [mask]',
+					'spec_name' => 'input [mask] (custom mask)',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[accept]' => array(),
+					'[accesskey]' => array(),
+					'[autocomplete]' => array(),
+					'[checked]' => array(),
+					'[disabled]' => array(),
+					'[height]' => array(),
+					'[inputmode]' => array(),
+					'[max]' => array(),
+					'[maxlength]' => array(),
+					'[min]' => array(),
+					'[minlength]' => array(),
+					'[multiple]' => array(),
+					'[pattern]' => array(),
+					'[placeholder]' => array(),
+					'[readonly]' => array(),
+					'[required]' => array(),
+					'[selectiondirection]' => array(),
+					'[size]' => array(),
+					'[spellcheck]' => array(),
+					'[step]' => array(),
+					'[type]' => array(),
+					'[value]' => array(),
+					'[width]' => array(),
+					'accept' => array(),
+					'accesskey' => array(),
+					'autocomplete' => array(),
+					'autofocus' => array(),
+					'checked' => array(),
+					'disabled' => array(),
+					'height' => array(),
+					'inputmode' => array(),
+					'list' => array(),
+					'mask' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'payment-card',
+						),
+					),
+					'mask-output' => array(),
+					'max' => array(),
+					'maxlength' => array(),
+					'min' => array(),
+					'minlength' => array(),
+					'multiple' => array(),
+					'name' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
+					'pattern' => array(),
+					'placeholder' => array(),
+					'readonly' => array(),
+					'required' => array(),
+					'selectiondirection' => array(),
+					'size' => array(),
+					'spellcheck' => array(),
+					'step' => array(),
+					'tabindex' => array(),
+					'type' => array(
+						'value' => array(
+							'text',
+							'tel',
+							'search',
+						),
+					),
+					'value' => array(),
+					'width' => array(),
+				),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-inputmask',
+					),
+					'spec_name' => 'input [mask=payment-card]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[accept]' => array(),
+					'[accesskey]' => array(),
+					'[autocomplete]' => array(),
+					'[checked]' => array(),
+					'[disabled]' => array(),
+					'[height]' => array(),
+					'[inputmode]' => array(),
+					'[max]' => array(),
+					'[maxlength]' => array(),
+					'[min]' => array(),
+					'[minlength]' => array(),
+					'[multiple]' => array(),
+					'[pattern]' => array(),
+					'[placeholder]' => array(),
+					'[readonly]' => array(),
+					'[required]' => array(),
+					'[selectiondirection]' => array(),
+					'[size]' => array(),
+					'[spellcheck]' => array(),
+					'[step]' => array(),
+					'[type]' => array(),
+					'[value]' => array(),
+					'[width]' => array(),
+					'accept' => array(),
+					'accesskey' => array(),
+					'autocomplete' => array(),
+					'autofocus' => array(),
+					'checked' => array(),
+					'disabled' => array(),
+					'height' => array(),
+					'inputmode' => array(),
+					'list' => array(),
+					'mask' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'date-dd-mm-yyyy',
+						),
+					),
+					'mask-output' => array(),
+					'max' => array(),
+					'maxlength' => array(),
+					'min' => array(),
+					'minlength' => array(),
+					'multiple' => array(),
+					'name' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
+					'pattern' => array(),
+					'placeholder' => array(),
+					'readonly' => array(),
+					'required' => array(),
+					'selectiondirection' => array(),
+					'size' => array(),
+					'spellcheck' => array(),
+					'step' => array(),
+					'tabindex' => array(),
+					'type' => array(
+						'value' => array(
+							'text',
+							'tel',
+							'search',
+						),
+					),
+					'value' => array(),
+					'width' => array(),
+				),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-inputmask',
+					),
+					'spec_name' => 'input [mask=date-dd-mm-yyyy]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[accept]' => array(),
+					'[accesskey]' => array(),
+					'[autocomplete]' => array(),
+					'[checked]' => array(),
+					'[disabled]' => array(),
+					'[height]' => array(),
+					'[inputmode]' => array(),
+					'[max]' => array(),
+					'[maxlength]' => array(),
+					'[min]' => array(),
+					'[minlength]' => array(),
+					'[multiple]' => array(),
+					'[pattern]' => array(),
+					'[placeholder]' => array(),
+					'[readonly]' => array(),
+					'[required]' => array(),
+					'[selectiondirection]' => array(),
+					'[size]' => array(),
+					'[spellcheck]' => array(),
+					'[step]' => array(),
+					'[type]' => array(),
+					'[value]' => array(),
+					'[width]' => array(),
+					'accept' => array(),
+					'accesskey' => array(),
+					'autocomplete' => array(),
+					'autofocus' => array(),
+					'checked' => array(),
+					'disabled' => array(),
+					'height' => array(),
+					'inputmode' => array(),
+					'list' => array(),
+					'mask' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'date-mm-dd-yyyy',
+						),
+					),
+					'mask-output' => array(),
+					'max' => array(),
+					'maxlength' => array(),
+					'min' => array(),
+					'minlength' => array(),
+					'multiple' => array(),
+					'name' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
+					'pattern' => array(),
+					'placeholder' => array(),
+					'readonly' => array(),
+					'required' => array(),
+					'selectiondirection' => array(),
+					'size' => array(),
+					'spellcheck' => array(),
+					'step' => array(),
+					'tabindex' => array(),
+					'type' => array(
+						'value' => array(
+							'text',
+							'tel',
+							'search',
+						),
+					),
+					'value' => array(),
+					'width' => array(),
+				),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-inputmask',
+					),
+					'spec_name' => 'input [mask=date-mm-dd-yyyy]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[accept]' => array(),
+					'[accesskey]' => array(),
+					'[autocomplete]' => array(),
+					'[checked]' => array(),
+					'[disabled]' => array(),
+					'[height]' => array(),
+					'[inputmode]' => array(),
+					'[max]' => array(),
+					'[maxlength]' => array(),
+					'[min]' => array(),
+					'[minlength]' => array(),
+					'[multiple]' => array(),
+					'[pattern]' => array(),
+					'[placeholder]' => array(),
+					'[readonly]' => array(),
+					'[required]' => array(),
+					'[selectiondirection]' => array(),
+					'[size]' => array(),
+					'[spellcheck]' => array(),
+					'[step]' => array(),
+					'[type]' => array(),
+					'[value]' => array(),
+					'[width]' => array(),
+					'accept' => array(),
+					'accesskey' => array(),
+					'autocomplete' => array(),
+					'autofocus' => array(),
+					'checked' => array(),
+					'disabled' => array(),
+					'height' => array(),
+					'inputmode' => array(),
+					'list' => array(),
+					'mask' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'date-mm-yy',
+						),
+					),
+					'mask-output' => array(),
+					'max' => array(),
+					'maxlength' => array(),
+					'min' => array(),
+					'minlength' => array(),
+					'multiple' => array(),
+					'name' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
+					'pattern' => array(),
+					'placeholder' => array(),
+					'readonly' => array(),
+					'required' => array(),
+					'selectiondirection' => array(),
+					'size' => array(),
+					'spellcheck' => array(),
+					'step' => array(),
+					'tabindex' => array(),
+					'type' => array(
+						'value' => array(
+							'text',
+							'tel',
+							'search',
+						),
+					),
+					'value' => array(),
+					'width' => array(),
+				),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-inputmask',
+					),
+					'spec_name' => 'input [mask=date-mm-yy]',
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[accept]' => array(),
+					'[accesskey]' => array(),
+					'[autocomplete]' => array(),
+					'[checked]' => array(),
+					'[disabled]' => array(),
+					'[height]' => array(),
+					'[inputmode]' => array(),
+					'[max]' => array(),
+					'[maxlength]' => array(),
+					'[min]' => array(),
+					'[minlength]' => array(),
+					'[multiple]' => array(),
+					'[pattern]' => array(),
+					'[placeholder]' => array(),
+					'[readonly]' => array(),
+					'[required]' => array(),
+					'[selectiondirection]' => array(),
+					'[size]' => array(),
+					'[spellcheck]' => array(),
+					'[step]' => array(),
+					'[type]' => array(),
+					'[value]' => array(),
+					'[width]' => array(),
+					'accept' => array(),
+					'accesskey' => array(),
+					'autocomplete' => array(),
+					'autofocus' => array(),
+					'checked' => array(),
+					'disabled' => array(),
+					'height' => array(),
+					'inputmode' => array(),
+					'list' => array(),
+					'mask' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'date-yyyy-mm-dd',
+						),
+					),
+					'mask-output' => array(),
+					'max' => array(),
+					'maxlength' => array(),
+					'min' => array(),
+					'minlength' => array(),
+					'multiple' => array(),
+					'name' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
+					'pattern' => array(),
+					'placeholder' => array(),
+					'readonly' => array(),
+					'required' => array(),
+					'selectiondirection' => array(),
+					'size' => array(),
+					'spellcheck' => array(),
+					'step' => array(),
+					'tabindex' => array(),
+					'type' => array(
+						'value' => array(
+							'text',
+							'tel',
+							'search',
+						),
+					),
+					'value' => array(),
+					'width' => array(),
+				),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-inputmask',
+					),
+					'spec_name' => 'input [mask=date-yyyy-mm-dd]',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
 				),
 			),
@@ -8207,6 +9054,25 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-3p-iframe-src',
 					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value_casei' => array(
+							'amp-consent-blocking',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-consent-blocking',
+					'unique' => true,
 				),
 			),
 			array(
@@ -9534,6 +10400,35 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-access-poool',
+						'requires_usage' => 3,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+					'requires_extension' => array(
+						'amp-access',
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-access-scroll',
 						'requires_usage' => 3,
 						'version' => array(
@@ -10252,6 +11147,31 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'name' => 'amp-date-countdown',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-date-display',
 						'version' => array(
 							'0.1',
 							'latest',
@@ -11281,6 +12201,44 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'nonce' => array(),
+					'template' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'amp-mustache',
+						),
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'text/plain',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
+				'tag_spec' => array(
+					'disallowed_ancestor' => array(
+						'template',
+						'amp-date-picker',
+						'form div [submit-success][template]',
+						'form div [submit-error][template]',
+						'form div [submitting][template]',
+						'form div [verify-error][template]',
+					),
+					'requires_extension' => array(
+						'amp-mustache',
+					),
+					'spec_name' => 'SCRIPT type=text/plain',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
 						'value' => array(
@@ -11572,6 +12530,31 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-reach-player',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-recaptcha-input',
 						'version' => array(
 							'0.1',
 							'latest',
@@ -12101,6 +13084,57 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-user-notification',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-video-docking',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+					'spec_name' => 'amp-video-docking',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-video-iframe',
 						'version' => array(
 							'0.1',
 							'latest',
@@ -12755,21 +13789,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'nonce' => array(),
-				),
-				'cdata' => array(
-					'cdata_regex' => 'body ?{opacity: ?0}',
-				),
-				'tag_spec' => array(
-					'mandatory_alternatives' => 'head > style[amp-boilerplate]',
-					'mandatory_parent' => 'head',
-					'spec_name' => 'head > style[amp-boilerplate] - old variant',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
-					'unique' => true,
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'amp-boilerplate' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
@@ -12783,7 +13802,7 @@ class AMP_Allowed_Tags_Generated {
 					'cdata_regex' => '\\s*body\\s*{\\s*-webkit-animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-moz-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*-ms-animation:\\s*-amp-start\\s+8s\\s+steps\\s*\\(1\\s*,\\s*end\\s*\\)\\s+0s\\s+1\\s+normal\\s+both;\\s*animation:\\s*-amp-start\\s+8s\\s+steps\\(1,\\s*end\\)\\s+0s\\s+1\\s+normal\\s+both;?\\s*}\\s*@-webkit-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-moz-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-ms-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@-o-keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*@keyframes\\s+-amp-start\\s*{\\s*from\\s*{\\s*visibility:\\s*hidden;?\\s*}\\s*to\\s*{\\s*visibility:\\s*visible;?\\s*}\\s*}\\s*',
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'head > style[amp-boilerplate]',
+					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'head > style[amp-boilerplate]',
 					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
@@ -12805,7 +13824,7 @@ class AMP_Allowed_Tags_Generated {
 					'cdata_regex' => '\\s*body\\s*{\\s*-webkit-animation:\\s*none;\\s*-moz-animation:\\s*none;\\s*-ms-animation:\\s*none;\\s*animation:\\s*none;?\\s*}\\s*',
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'noscript > style[amp-boilerplate]',
+					'mandatory' => true,
 					'mandatory_ancestor' => 'head',
 					'mandatory_parent' => 'noscript',
 					'spec_name' => 'noscript > style[amp-boilerplate]',
@@ -12855,6 +13874,14 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
+			),
+		),
+		'summary' => array(
+			array(
+				'attr_spec_list' => array(),
+				'tag_spec' => array(
+					'mandatory_parent' => 'details',
+				),
 			),
 		),
 		'sup' => array(
@@ -13362,6 +14389,7 @@ class AMP_Allowed_Tags_Generated {
 					'[disabled]' => array(),
 					'[maxlength]' => array(),
 					'[minlength]' => array(),
+					'[pattern]' => array(),
 					'[placeholder]' => array(),
 					'[readonly]' => array(),
 					'[required]' => array(),
@@ -13385,6 +14413,7 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'pattern' => array(),
 					'placeholder' => array(),
 					'readonly' => array(),
 					'required' => array(),
@@ -14807,6 +15836,17 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'spec_name' => 'AMP-STORY-GRID-LAYER default',
 				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+			),
+		),
+		'AMP-VIDEO-IFRAME > [placeholder]' => array(
+			'attr_spec_list' => array(
+				'placeholder' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-VIDEO-IFRAME > [placeholder]',
+				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video-iframe',
 			),
 		),
 	);

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1108,7 +1108,11 @@ class AMP_Allowed_Tags_Generated {
 					'data-account' => array(
 						'mandatory' => true,
 					),
-					'dock' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -4749,7 +4753,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'dock' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
 					'lightbox' => array(),
 					'lightbox-thumbnail-id' => array(
 						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
@@ -4856,7 +4864,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'dock' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
 					'loop' => array(
 						'value' => array(
 							'',
@@ -4939,7 +4951,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'dock' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
 					'implements-media-session' => array(
 						'value' => array(
 							'',
@@ -5011,7 +5027,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'dock' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
 					'implements-media-session' => array(
 						'value' => array(
 							'',
@@ -5373,7 +5393,11 @@ class AMP_Allowed_Tags_Generated {
 					'data-videoid' => array(
 						'value_regex' => '[^=/?:]+',
 					),
-					'dock' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
 					'lightbox' => array(),
 					'lightbox-thumbnail-id' => array(
 						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
@@ -15386,6 +15410,9 @@ class AMP_Allowed_Tags_Generated {
 		'amp-access-style' => array(),
 		'amp-access-template' => array(),
 		'amp-fx' => array(
+			'requires_extension' => array(
+				'amp-fx-collection',
+			),
 			'value_regex_casei' => '(fade-in|fade-in-scroll|fly-in-bottom|fly-in-left|fly-in-right|fly-in-top|parallax)(\\s|fade-in|fade-in-scroll|fly-in-bottom|fly-in-left|fly-in-right|fly-in-top|parallax)*',
 		),
 		'aria-activedescendant' => array(),
@@ -15470,20 +15497,41 @@ class AMP_Allowed_Tags_Generated {
 		'style' => array(
 			'blacklisted_value_regex' => '(!important|<!--)',
 		),
-		'subscriptions-action' => array(),
+		'subscriptions-action' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
+		),
 		'subscriptions-actions' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
 			'value' => array(
 				'',
 			),
 		),
-		'subscriptions-decorate' => array(),
+		'subscriptions-decorate' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
+		),
 		'subscriptions-dialog' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
 			'value' => array(
 				'',
 			),
 		),
-		'subscriptions-display' => array(),
+		'subscriptions-display' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
+		),
 		'subscriptions-section' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
 			'value_casei' => array(
 				'actions',
 				'content',
@@ -15491,7 +15539,11 @@ class AMP_Allowed_Tags_Generated {
 				'loading',
 			),
 		),
-		'subscriptions-service' => array(),
+		'subscriptions-service' => array(
+			'requires_extension' => array(
+				'amp-subscriptions',
+			),
+		),
 		'tabindex' => array(),
 		'title' => array(),
 		'translate' => array(),

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -549,12 +549,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				$this->script_components = array_merge( $this->script_components, $tag_spec['requires_extension'] );
 			}
 
+			// Add required AMP components for attributes.
+			foreach ( $node->attributes as $attribute ) {
+				if ( isset( $merged_attr_spec_list[ $attribute->nodeName ]['requires_extension'] ) ) {
+					$this->script_components = array_merge( $this->script_components, $merged_attr_spec_list[ $attribute->nodeName ]['requires_extension'] );
+				}
+			}
+
 			// Manually add components for attributes; this is hard-coded because attributes do not have requires_extension like tags do. See <https://github.com/ampproject/amp-wp/issues/1808>.
 			if ( $node->hasAttribute( 'lightbox' ) ) {
 				$this->script_components[] = 'amp-lightbox-gallery';
-			}
-			if ( $node->hasAttribute( 'amp-fx' ) ) {
-				$this->script_components[] = 'amp-fx-collection';
 			}
 
 			// Check if element needs amp-bind component.

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -270,7 +270,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						array( "\n", "\t" ),
 						'',
 						'
-						<amp-story standalone title="My Story" publisher="The AMP Team" publisher-logo-src="https://example.com/logo/1x1.png" poster-portrait-src="https://example.com/my-story/poster/3x4.jpg" poster-square-src="https://example.com/my-story/poster/1x1.jpg" poster-landscape-src="https://example.com/my-story/poster/4x3.jpg" background-audio="my.mp3">
+						<amp-story standalone supports-landscape title="My Story" publisher="The AMP Team" publisher-logo-src="https://example.com/logo/1x1.png" poster-portrait-src="https://example.com/my-story/poster/3x4.jpg" poster-square-src="https://example.com/my-story/poster/1x1.jpg" poster-landscape-src="https://example.com/my-story/poster/4x3.jpg" background-audio="my.mp3">
 							<i>bad</i>
 							<amp-story-page id="my-first-page">
 								<i>bad</i>
@@ -963,7 +963,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp_date_picker_range' => array(
-				'<amp-date-picker type="range" minimum-nights="2" mode="overlay" id="range-date-picker" on=" select: AMP.setState({ dates: event.dates, startDate: event.start, endDate: event.end })" format="YYYY-MM-DD" open-after-select min="2017-10-26" start-input-selector="#range-start" end-input-selector="#range-end" class="example-picker space-between"><div class="ampstart-input"><input class="border-none p0" id="range-start" placeholder="Start date"></div><div class="ampstart-input"><input class="border-none p0" id="range-end" placeholder="End date"></div><button class="ampstart-btn caps" on="tap:range-date-picker.clear">Clear</button><template type="amp-mustache" info-template><span [text]="(startDate &amp;&amp; endDate ? \'You picked \' + startDate.date + \' as start date and \' + endDate.date + \' as end date.\' : \'You will see your chosen dates here.\')"> You will see your chosen dates here.</span></template></amp-date-picker>',
+				'<amp-date-picker type="range" minimum-nights="2" maximum-nights="4" mode="overlay" id="range-date-picker" on=" select: AMP.setState({ dates: event.dates, startDate: event.start, endDate: event.end })" format="YYYY-MM-DD" open-after-select min="2017-10-26" start-input-selector="#range-start" end-input-selector="#range-end" class="example-picker space-between"><div class="ampstart-input"><input class="border-none p0" id="range-start" placeholder="Start date"></div><div class="ampstart-input"><input class="border-none p0" id="range-end" placeholder="End date"></div><button class="ampstart-btn caps" on="tap:range-date-picker.clear">Clear</button><template type="amp-mustache" info-template><span [text]="(startDate &amp;&amp; endDate ? \'You picked \' + startDate.date + \' as start date and \' + endDate.date + \' as end date.\' : \'You will see your chosen dates here.\')"> You will see your chosen dates here.</span></template></amp-date-picker>',
 				null, // No change.
 				array( 'amp-date-picker', 'amp-bind', 'amp-mustache' ),
 			),
@@ -1115,6 +1115,77 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<h1 amp-fx="parallax" data-parallax-factor="1.5">A title that moves faster than other content.</h1>',
 				null,
 				array( 'amp-fx-collection' ),
+			),
+
+			'amp-date-display' => array(
+				'<amp-date-display datetime="2017-08-02T15:05:05.000" layout="fixed" width="360" height="20"><template type="amp-mustache"><div>{{dayName}} {{day}} {{monthName}} {{year}} {{hourTwoDigit}}:{{minuteTwoDigit}}:{{secondTwoDigit}}</div></template></amp-date-display>',
+				null,
+				array( 'amp-date-display', 'amp-mustache' ),
+			),
+
+			'amp-list' => array(
+				'<amp-list credentials="include" src="https://example.com/json/product.json?clientId=CLIENT_ID(myCookieId)"><template type="amp-mustache">Your personal offer: ${{price}}</template></amp-list>',
+				null,
+				array( 'amp-list', 'amp-mustache' ),
+			),
+
+			'amp-list-load-more' => array(
+				str_replace(
+					array( "\n", "\t" ),
+					'',
+					'
+						<amp-list load-more="auto" src="https://www.load.more.example.com/" width="400" height="800">
+							<amp-list-load-more load-more-button>
+								<template type="amp-mustache">
+									Showing {{#count}} out of {{#total}} items
+									<button>Click here to see more!</button>
+								</template>
+							</amp-list-load-more>
+							<amp-list-load-more load-more-loading>
+								<svg>...</svg>
+							</amp-list-load-more>
+							<amp-list-load-more load-more-failed>
+								<button>Unable to Load More</button>
+							</amp-list-load-more>
+							<amp-list-load-more load-more-end>
+								Congratulations! You reached the end.
+							</amp-list-load-more>
+						</amp-list>
+					'
+				),
+				null,
+				array( 'amp-list', 'amp-mustache' ),
+			),
+
+			'amp-recaptcha-input' => array(
+				'<form action-xhr="/" target="_top" method="post"><amp-recaptcha-input layout="nodisplay" name="reCAPTCHA_body_key" data-sitekey="reCAPTCHA_site_key" data-action="reCAPTCHA_example_action"></amp-recaptcha-input></form>',
+				null,
+				array( 'amp-form', 'amp-recaptcha-input' ),
+			),
+
+			// @todo The poster should not be allowed if there is a placeholder.
+			'amp-video-iframe' => array(
+				'<amp-video-iframe src="https://example.com/video/" width="500" height="500" poster="https://example.com/poster.jpg" autoplay dock implements-media-session implements-rotate-to-fullscreen referrerpolicy></amp-video-iframe>',
+				null,
+				array( 'amp-video-iframe', 'amp-video-docking' ),
+			),
+
+			'amp-youtube' => array(
+				'<amp-youtube id="myLiveChannel" data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q" width="358" height="204" layout="responsive" dock><amp-img src="https://i.ytimg.com/vi/Wm1fWz-7nLQ/hqdefault_live.jpg" placeholder layout="fill"></amp-img></amp-youtube>',
+				null,
+				array( 'amp-youtube', 'amp-video-docking' ),
+			),
+
+			'details' => array(
+				'<details open [open]="foo.state"><summary>Learn more</summary><p>You are educated</p></details>',
+				null,
+				array( 'amp-bind' ),
+			),
+
+			'amp-plain-text-script-template' => array(
+				'<script type="text/plain" template="amp-mustache">Hello {{world}}!</script>',
+				null,
+				array( 'amp-mustache' ),
 			),
 		);
 	}


### PR DESCRIPTION
* Update the AMP spec to [1902072121410](https://github.com/ampproject/amphtml/releases/tag/1902072121410) from [1811202257200](https://github.com/ampproject/amphtml/releases/tag/1811202257200).
* Add support for requiring components based on attributes being present.
* Allow `amp-date-countdown` and `amp-timeago` in both `amp-story-cta-layer` and `amp-story-grid-layer`.
* Add `fb-me` and `wh` to allowed link schemes.
* Give specific specific layouts to `carousel` type from `amp-carousel` vs the `slides` type.
* Add `dock` attribute to `amp-brightcove`.
* Add `amp-consent [type]` tag spec.
* Add `amp-date-display`.
* Add `[src]` to `amp-date-picker`.
* Add `maximum-nights` to `amp-date-picker`.
* Add `amp-list-load-more`.
* Add `amp-recaptcha-input`.
* Add `supports-landscape` to `amp-story`.
* Allow `amp-consent` in `amp-story`.
* Add `amp-video-iframe`.
* Add `dock` attribute.
* Add `details` element.
* Add attributes to `input` elements.
* Add `input [mask] (custom mask)`.
* Add `input [mask=payment-card]`.
* Add `input [mask=date-dd-mm-yyyy]`
* Add `mask` and `mask-output` to `input [mask=date-mm-yy]`.
* Add `meta name=amp-consent-blocking`.
* Add `amp-access-poool`.
* Add `SCRIPT type=text/plain` alternative to `template` for Mustache.