### PR TITLE
I18N string improvements

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -50,7 +50,7 @@ function _amp_print_php_dom_document_notice() {
 			<?php
 				printf(
 					/* translators: %s: PHP extension name */
-					__( 'The AMP plugin requires the %s extension in PHP. Please contact your host to install this extension.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+					esc_html__( 'The AMP plugin requires the %s extension in PHP. Please contact your host to install this extension.', 'amp' ),
 					'DOM'
 				);
 			?>
@@ -75,7 +75,7 @@ function _amp_print_php_missing_iconv_notice() {
 			<?php
 				printf(
 					/* translators: %s: PHP extension name */
-					__( 'The AMP plugin requires the %s extension in PHP. Please contact your host to install this extension.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+					esc_html__( 'The AMP plugin requires the %s extension in PHP. Please contact your host to install this extension.', 'amp' ),
 					'iconv'
 				);
 			?>

--- a/amp.php
+++ b/amp.php
@@ -21,7 +21,15 @@
 function _amp_print_php_version_admin_notice() {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'The AMP plugin requires PHP 5.4+. Please contact your host to update your PHP version.', 'amp' ); ?></p>
+		<p>
+			<?php
+			sprintf(
+				/* translators: %s: required PHP version */
+				esc_html_e( 'The AMP plugin requires PHP %s. Please contact your host to update your PHP version.', 'amp' ),
+				'5.4+'
+			);
+			?>
+		</p>
 	</div>
 	<?php
 }
@@ -38,7 +46,15 @@ if ( version_compare( phpversion(), '5.4', '<' ) ) {
 function _amp_print_php_dom_document_notice() {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'The AMP plugin requires DOM extension in PHP. Please contact your host to install this extension.', 'amp' ); ?></p>
+		<p>
+			<?php
+				printf(
+					/* translators: %s: PHP extension name */
+					__( 'The AMP plugin requires the %s extension in PHP. Please contact your host to install this extension.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+					'DOM'
+				);
+			?>
+		</p>
 	</div>
 	<?php
 }
@@ -55,7 +71,15 @@ if ( ! class_exists( 'DOMDocument' ) ) {
 function _amp_print_php_missing_iconv_notice() {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'The AMP plugin requires iconv extension in PHP. Please contact your host to install this extension.', 'amp' ); ?></p>
+		<p>
+			<?php
+				printf(
+					/* translators: %s: PHP extension name */
+					__( 'The AMP plugin requires the %s extension in PHP. Please contact your host to install this extension.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+					'iconv'
+				);
+			?>
+		</p>
 	</div>
 	<?php
 }
@@ -72,7 +96,15 @@ if ( ! function_exists( 'iconv' ) ) {
 function _amp_print_build_needed_notice() {
 	?>
 	<div class="notice notice-error">
-		<p><?php esc_html_e( 'You appear to be running the AMP plugin from source. Please do `composer install && npm install && npm run build` to finish installation.', 'amp' ); ?></p>
+		<p>
+			<?php
+			printf(
+				/* translators: %s: composer install && npm install && npm run build */
+				__( 'You appear to be running the AMP plugin from source. Please do %s to finish installation.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				'<code>composer install && npm install && npm run build</code>'
+			);
+			?>
+		</p>
 	</div>
 	<?php
 }

--- a/amp.php
+++ b/amp.php
@@ -25,7 +25,7 @@ function _amp_print_php_version_admin_notice() {
 			<?php
 			sprintf(
 				/* translators: %s: required PHP version */
-				esc_html_e( 'The AMP plugin requires PHP %s. Please contact your host to update your PHP version.', 'amp' ),
+				esc_html__( 'The AMP plugin requires PHP %s. Please contact your host to update your PHP version.', 'amp' ),
 				'5.4+'
 			);
 			?>

--- a/assets/js/amp-block-validation.js
+++ b/assets/js/amp-block-validation.js
@@ -195,6 +195,7 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 			module.resetWarningNotice();
 
 			noticeMessage = wp.i18n.sprintf(
+				/* translators: %s: number of issues */
 				wp.i18n._n(
 					'There is %s issue from AMP validation which needs review.',
 					'There are %s issues from AMP validation which need review.',
@@ -212,36 +213,29 @@ var ampBlockValidation = ( function() { // eslint-disable-line no-unused-vars
 				blockErrorCount = validationErrors.length - blockValidationErrors.other.length;
 				if ( blockErrorCount > 0 ) {
 					noticeMessage += ' ' + wp.i18n.sprintf(
-						/* translators: %s is the count of block errors. */
+						/* translators: %s: number of block errors. */
 						wp.i18n._n(
-							'And %s is directly due to content here.',
-							'And %s are directly due to content here.',
+							'%s issue is directly due to content here.',
+							'%s issues are directly due to content here.',
 							blockErrorCount,
 							'amp'
 						),
 						blockErrorCount
 					);
+				} else if ( validationErrors.length === 1 ) {
+					noticeMessage += ' ' + wp.i18n.__( 'The issue is not directly due to content here.', 'amp' );
 				} else {
-					noticeMessage += ' ' + wp.i18n.sprintf(
-						wp.i18n._n(
-							'But it is not directly due to content here.',
-							'But none are directly due to content here.',
-							validationErrors.length,
-							'amp'
-						),
-						validationErrors.length
-					);
+					noticeMessage += ' ' + wp.i18n.__( 'The issues are not directly due to content here.', 'amp' );
 				}
 			} catch ( e ) {
 				// Clear out block validation errors in case the block sand errors cannot be aligned.
 				module.resetBlockNotices();
 
-				noticeMessage += ' ' + wp.i18n._n(
-					'It may not be due to content here.',
-					'Some may be due to content here.',
-					validationErrors.length,
-					'amp'
-				);
+				if ( validationErrors.length === 1 ) {
+					noticeMessage += ' ' + wp.i18n.__( 'The issue may not be due to content here', 'amp' );
+				} else {
+					noticeMessage += ' ' + wp.i18n.__( 'Some issues may be due to content here.', 'amp' );
+				}
 			}
 
 			rejectedErrors = _.filter( ampValidity.results, function( result ) {

--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -628,7 +628,7 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 		var ampCarousel = props.attributes.ampCarousel,
 			el = wp.element.createElement,
 			ToggleControl = wp.components.ToggleControl,
-			label = __( 'Display as AMP carousel' );
+			label = __( 'Display as carousel' );
 
 		return el( ToggleControl, {
 			label: label,

--- a/assets/js/amp-validated-url-post-edit-screen.js
+++ b/assets/js/amp-validated-url-post-edit-screen.js
@@ -120,7 +120,7 @@ const ampValidatedUrlPostEditScreen = ( function() { // eslint-disable-line no-u
 			tr.classList.add( 'hidden' );
 		} else if ( null !== numberErrorsDisplaying ) {
 			// Update the number of errors displaying and create a 'Show all' button if it does not exist yet.
-			document.getElementById( component.idNumberErrors ).innerText = component.data.l10n.showing_number_errors.replace( '%', numberErrorsDisplaying );
+			document.getElementById( component.idNumberErrors ).innerText = component.data.l10n.showing_number_errors.replace( '%1$s', numberErrorsDisplaying );
 			document.getElementById( component.idNumberErrors ).classList.remove( 'hidden' );
 			component.conditionallyCreateShowAllButton();
 			if ( document.getElementById( component.showAllId ) ) {

--- a/includes/amp-frontend-actions.php
+++ b/includes/amp-frontend-actions.php
@@ -6,7 +6,17 @@
  * @package AMP
  */
 
-_deprecated_file( __FILE__, '1.0', null, esc_html__( 'Use amp_add_amphtml_link() function which is already included from amp-helper-functions.php', 'amp' ) );
+_deprecated_file(
+	__FILE__,
+	'1.0',
+	null,
+	sprintf(
+		/* translators: 1: amp_add_amphtml_link(). 2: amp-helper-functions.php */
+		esc_html__( 'Use %1$s function which is already included from %2$s', 'amp' ),
+		'amp_add_amphtml_link()',
+		'amp-helper-functions.php'
+	)
+);
 
 /**
  * Add amphtml link to frontend.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -202,7 +202,7 @@ function amp_add_amphtml_link() {
 			echo "<!--\n";
 			echo esc_html(
 				sprintf(
-					/* translators: %s is error count */
+					/* translators: %s: error count */
 					_n(
 						'There is %s validation error that is blocking the amphtml version from being available.',
 						'There are %s validation errors that are blocking the amphtml version from being available.',
@@ -257,7 +257,17 @@ function is_amp_endpoint() {
 	$did_parse_query = did_action( 'parse_query' );
 
 	if ( ! $did_parse_query ) {
-		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( "is_amp_endpoint() was called before the 'parse_query' hook was called. This function will always return 'false' before the 'parse_query' hook is called.", 'amp' ) ), '0.4.2' );
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: 1: is_amp_endpoint(), 2: parse_query, 3: false */
+				esc_html__( '%1$s was called before the %2$s hook was called. This function will always return %3$s before the %2$s hook is called.', 'amp' ),
+				'is_amp_endpoint()',
+				'parse_query',
+				'false'
+			),
+			'0.4.2'
+		);
 	}
 
 	$has_amp_query_var = (
@@ -286,7 +296,17 @@ function is_amp_endpoint() {
 	}
 
 	if ( ! did_action( 'wp' ) ) {
-		_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( "is_amp_endpoint() was called before the 'wp' action which means it will not have access to the queried object to determine if it is an AMP response, thus neither the amp_skip_post filter nor the AMP enabled publish metabox toggle will not be considered.", 'amp' ) ), '1.0.2' );
+		_doing_it_wrong(
+			__FUNCTION__,
+			sprintf(
+				/* translators: 1: is_amp_endpoint(). 2: wp. 3: amp_skip_post */
+				esc_html__( '%1$s was called before the %2$s action which means it will not have access to the queried object to determine if it is an AMP response, thus neither the %3$s filter nor the AMP enabled publish metabox toggle will be considered.', 'amp' ),
+				'is_amp_endpoint()',
+				'wp',
+				'amp_skip_post'
+			),
+			'1.0.2'
+		);
 		$supported = true;
 	} else {
 		$availability = AMP_Theme_Support::get_template_availability();
@@ -619,8 +639,19 @@ function amp_print_analytics( $analytics ) {
 	// Can enter multiple configs within backend.
 	foreach ( $analytics_entries as $id => $analytics_entry ) {
 		if ( ! isset( $analytics_entry['type'], $analytics_entry['attributes'], $analytics_entry['config_data'] ) ) {
-			/* translators: 1: the analytics entry ID, 2: comma-separated list of the actual entry keys. */
-			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'Analytics entry for %1$s is missing one of the following keys: `type`, `attributes`, or `config_data` (array keys: %2$s)', 'amp' ), esc_html( $id ), esc_html( implode( ', ', array_keys( $analytics_entry ) ) ) ), '0.3.2' );
+			_doing_it_wrong(
+				__FUNCTION__,
+				sprintf(
+					/* translators: 1: the analytics entry ID. 2: type. 3: attributes. 4: config_data. 5: comma-separated list of the actual entry keys. */
+					esc_html__( 'Analytics entry for %1$s is missing one of the following keys: `%2$s`, `%3$s`, or `%4$s` (array keys: %5$s)', 'amp' ),
+					esc_html( $id ),
+					'type',
+					'attributes',
+					'config_data',
+					esc_html( implode( ', ', array_keys( $analytics_entry ) ) )
+				),
+				'0.3.2'
+			);
 			continue;
 		}
 		$script_element = AMP_HTML_Utils::build_tag(
@@ -654,7 +685,15 @@ function amp_print_analytics( $analytics ) {
  */
 function amp_get_content_embed_handlers( $post = null ) {
 	if ( current_theme_supports( AMP_Theme_Support::SLUG ) && $post ) {
-		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
+		_deprecated_argument(
+			__FUNCTION__,
+			'0.7',
+			sprintf(
+				/* translators: %s: $post */
+				__( 'The %s argument is deprecated when theme supports AMP.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				'$post'
+			)
+		);
 		$post = null;
 	}
 
@@ -709,7 +748,15 @@ function amp_get_content_sanitizers( $post = null ) {
 	$theme_support_args = AMP_Theme_Support::get_theme_support_args();
 
 	if ( is_array( $theme_support_args ) && $post ) {
-		_deprecated_argument( __FUNCTION__, '0.7', esc_html__( 'The $post argument is deprecated when theme supports AMP.', 'amp' ) );
+		_deprecated_argument(
+			__FUNCTION__,
+			'0.7',
+			sprintf(
+				/* translators: %s: $post */
+				__( 'The %s argument is deprecated when theme supports AMP.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				'$post'
+			)
+		);
 		$post = null;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -690,7 +690,7 @@ function amp_get_content_embed_handlers( $post = null ) {
 			'0.7',
 			sprintf(
 				/* translators: %s: $post */
-				__( 'The %s argument is deprecated when theme supports AMP.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_html__( 'The %s argument is deprecated when theme supports AMP.', 'amp' ),
 				'$post'
 			)
 		);
@@ -753,7 +753,7 @@ function amp_get_content_sanitizers( $post = null ) {
 			'0.7',
 			sprintf(
 				/* translators: %s: $post */
-				__( 'The %s argument is deprecated when theme supports AMP.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_html__( 'The %s argument is deprecated when theme supports AMP.', 'amp' ),
 				'$post'
 			)
 		);

--- a/includes/class-amp-cli.php
+++ b/includes/class-amp-cli.php
@@ -180,8 +180,7 @@ class AMP_CLI {
 			} else {
 				WP_CLI::error(
 					sprintf(
-						/* translators: %s is the flag to force validation */
-						__( 'The current template mode is Classic, which does not allow crawling the site. Please pass the --%s flag in order to force crawling for validation.', 'amp' ),
+						'The current template mode is Classic, which does not allow crawling the site. Please pass the --%s flag in order to force crawling for validation.',
 						self::FLAG_NAME_FORCE_VALIDATION
 					)
 				);
@@ -193,35 +192,32 @@ class AMP_CLI {
 			if ( ! empty( self::$include_conditionals ) ) {
 				WP_CLI::error(
 					sprintf(
-						/* translators: %s is the command line argument to include certain templates */
-						__( 'The templates passed via the --%s argument did not match any URLs. You might try passing different templates to it.', 'amp' ),
+						'The templates passed via the --%s argument did not match any URLs. You might try passing different templates to it.',
 						self::INCLUDE_ARGUMENT
 					)
 				);
 			} else {
 				WP_CLI::error(
 					sprintf(
-						/* translators: %s is the command line argument to force validation */
-						__( 'All of your templates might be unchecked in AMP Settings > Supported Templates. You might pass --%s to this command.', 'amp' ),
+						'All of your templates might be unchecked in AMP Settings > Supported Templates. You might pass --%s to this command.',
 						self::FLAG_NAME_FORCE_VALIDATION
 					)
 				);
 			}
 		}
 
-		WP_CLI::log( __( 'Crawling the site for AMP validity.', 'amp' ) );
+		WP_CLI::log( 'Crawling the site for AMP validity.' );
 
 		self::$wp_cli_progress = WP_CLI\Utils\make_progress_bar(
-			/* translators: %d is the number of URLs */
-			sprintf( __( 'Validating %d URLs...', 'amp' ), $number_urls_to_crawl ),
+			sprintf( 'Validating %d URLs...', $number_urls_to_crawl ),
 			$number_urls_to_crawl
 		);
 		self::crawl_site();
 		self::$wp_cli_progress->finish();
 
-		$key_template_type = __( 'Template or content type', 'amp' );
-		$key_url_count     = __( 'URL Count', 'amp' );
-		$key_validity_rate = __( 'Validity Rate', 'amp' );
+		$key_template_type = 'Template or content type';
+		$key_url_count     = 'URL Count';
+		$key_validity_rate = 'Validity Rate';
 
 		$table_validation_by_type = array();
 		foreach ( self::$validity_by_type as $type_name => $validity ) {
@@ -233,14 +229,13 @@ class AMP_CLI {
 		}
 
 		if ( empty( $table_validation_by_type ) ) {
-			WP_CLI::error( __( 'No validation results were obtained from the URLs.', 'amp' ) );
+			WP_CLI::error( 'No validation results were obtained from the URLs.' );
 			return;
 		}
 
 		WP_CLI::success(
 			sprintf(
-				/* translators: $1%d is the number of URls crawled, $2%d is the number of validation issues, $3%d is the number of unaccepted issues, $4%s is the list of validation by type, $5%s is the link for more details */
-				__( '%3$d crawled URLs have unaccepted issue(s) out of %2$d total with AMP validation issue(s); %1$d URLs were crawled.', 'amp' ),
+				'%3$d crawled URLs have unaccepted issue(s) out of %2$d total with AMP validation issue(s); %1$d URLs were crawled.',
 				self::$number_crawled,
 				self::$total_errors,
 				self::$unaccepted_errors
@@ -259,8 +254,7 @@ class AMP_CLI {
 			AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
 			admin_url( 'edit.php' )
 		);
-		/* translators: %s is the URL to the admin */
-		WP_CLI::line( sprintf( __( 'For more details, please see: %s', 'amp' ), $url_more_details ) );
+		WP_CLI::line( sprintf( 'For more details, please see: %s', $url_more_details ) );
 	}
 
 	/**
@@ -293,8 +287,7 @@ class AMP_CLI {
 		$posts = new WP_CLI\Iterators\Query( $query, 10000 );
 
 		$progress = WP_CLI\Utils\make_progress_bar(
-			/* translators: %d is the number of posts */
-			sprintf( __( 'Deleting %d amp_validated_url posts...', 'amp' ), $count ),
+			sprintf( 'Deleting %d amp_validated_url posts...', $count ),
 			$count
 		);
 		while ( $posts->valid() ) {
@@ -311,8 +304,7 @@ class AMP_CLI {
 		$terms = new WP_CLI\Iterators\Query( $query, 10000 );
 
 		$progress = WP_CLI\Utils\make_progress_bar(
-			/* translators: %d is the number of terms */
-			sprintf( __( 'Deleting %d amp_taxonomy_error terms...', 'amp' ), $count ),
+			sprintf( 'Deleting %d amp_taxonomy_error terms...', $count ),
 			$count
 		);
 		while ( $terms->valid() ) {
@@ -633,8 +625,7 @@ class AMP_CLI {
 		 * One cause of an error is if the validation request results in a 404 response code.
 		 */
 		if ( is_wp_error( $validity ) ) {
-			/* translators: %1$s is error code, %2$s is error message, and %3$s is the actual URL. */
-			WP_CLI::warning( sprintf( __( 'Validate URL error (%1$s): %2$s URL: %3$s', 'amp' ), $validity->get_error_code(), $validity->get_error_message(), $url ) );
+			WP_CLI::warning( sprintf( 'Validate URL error (%1$s): %2$s URL: %3$s', $validity->get_error_code(), $validity->get_error_message(), $url ) );
 			return;
 		}
 		if ( self::$wp_cli_progress ) {

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -428,7 +428,7 @@ class AMP_HTTP {
 		if ( '1' === (string) $comment->comment_approved ) {
 			$message = __( 'Your comment has been posted.', 'amp' );
 		} else {
-			$message = __( 'Your comment is awaiting moderation.', 'default' ); // Note core string re-use.
+			$message = __( 'Your comment is awaiting moderation.', 'amp' );
 		}
 
 		/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -578,10 +578,12 @@ class AMP_Theme_Support {
 		if ( count( $matching_templates ) > 1 ) {
 			_doing_it_wrong(
 				__METHOD__,
-				sprintf(
-					/* translators: %s: amp_supportable_templates */
-					__( 'Did not expect there to be more than one matching template. Did you filter %s to not honor the template hierarchy?', 'amp' ),
-					'amp_supportable_templates'
+				esc_html(
+					sprintf(
+						/* translators: %s: amp_supportable_templates */
+						__( 'Did not expect there to be more than one matching template. Did you filter %s to not honor the template hierarchy?', 'amp' ),
+						'amp_supportable_templates'
+					)
 				),
 				'1.0'
 			);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -189,7 +189,16 @@ class AMP_Theme_Support {
 			}
 
 			if ( isset( $args['available_callback'] ) ) {
-				_doing_it_wrong( 'add_theme_support', esc_html__( 'The available_callback is deprecated when adding amp theme support in favor of declaratively setting the supported_templates.', 'amp' ), '1.0' );
+				_doing_it_wrong(
+					'add_theme_support',
+					sprintf(
+						/* translators: 1: available_callback. 2: supported_templates */
+						esc_html__( 'The %1$s is deprecated when adding amp theme support in favor of declaratively setting the %2$s.', 'amp' ),
+						'available_callback',
+						'supported_templates'
+					),
+					'1.0'
+				);
 			}
 			self::$support_added_via_option = false;
 		} elseif ( 'disabled' !== $theme_support_option ) {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -567,7 +567,15 @@ class AMP_Theme_Support {
 		 * Template conditions need to be set up properly to prevent this from happening.
 		 */
 		if ( count( $matching_templates ) > 1 ) {
-			_doing_it_wrong( __METHOD__, esc_html__( 'Did not expect there to be more than one matching template. Did you filter amp_supportable_templates to not honor the template hierarchy?', 'amp' ), '1.0' );
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: amp_supportable_templates */
+					__( 'Did not expect there to be more than one matching template. Did you filter %s to not honor the template hierarchy?', 'amp' ),
+					'amp_supportable_templates'
+				),
+				'1.0'
+			);
 		}
 
 		$matching_template = array_shift( $matching_templates );
@@ -634,7 +642,7 @@ class AMP_Theme_Support {
 			);
 			if ( AMP_Post_Meta_Box::DISABLED_STATUS === get_post_meta( get_option( 'page_on_front' ), AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) ) {
 				/* translators: %s: the URL to the edit post screen. */
-				$templates['is_front_page']['description'] = sprintf( __( 'Currently disabled at the <a href="%s" target="_blank">page level</a>.', 'amp' ), esc_url( get_edit_post_link( get_option( 'page_on_front' ) ) ) );
+				$templates['is_front_page']['description'] = sprintf( __( 'Currently disabled at the <a href="%s">page level</a>.', 'amp' ), esc_url( get_edit_post_link( get_option( 'page_on_front' ) ) ) );
 			}
 
 			// In other words, same as is_posts_page, *but* it not is_singular.
@@ -643,7 +651,7 @@ class AMP_Theme_Support {
 			);
 			if ( AMP_Post_Meta_Box::DISABLED_STATUS === get_post_meta( get_option( 'page_for_posts' ), AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) ) {
 				/* translators: %s: the URL to the edit post screen. */
-				$templates['is_home']['description'] = sprintf( __( 'Currently disabled at the <a href="%s" target="_blank">page level</a>.', 'amp' ), esc_url( get_edit_post_link( get_option( 'page_for_posts' ) ) ) );
+				$templates['is_home']['description'] = sprintf( __( 'Currently disabled at the <a href="%s">page level</a>.', 'amp' ), esc_url( get_edit_post_link( get_option( 'page_for_posts' ) ) ) );
 			}
 		} else {
 			$templates['is_home'] = array(
@@ -937,8 +945,18 @@ class AMP_Theme_Support {
 			);
 
 			if ( ! is_subclass_of( $embed_handler, 'AMP_Base_Embed_Handler' ) ) {
-				/* translators: %s is embed handler */
-				_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Embed Handler (%s) must extend `AMP_Embed_Handler`', 'amp' ), $embed_handler_class ) ), '0.1' );
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html(
+						sprintf(
+							/* translators: 1: embed handler. 2: AMP_Embed_Handler */
+							__( 'Embed Handler (%1$s) must extend `%2$s`', 'amp' ),
+							esc_html( $embed_handler_class ),
+							'AMP_Embed_Handler'
+						)
+					),
+					'0.1'
+				);
 				continue;
 			}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -410,10 +410,12 @@ class AMP_Options_Manager {
 	public static function persistent_object_caching_notice() {
 		if ( ! wp_using_ext_object_cache() && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
-				'<div class="notice notice-warning"><p>%s <a href="%s">%s</a></p></div>',
-				esc_html__( 'The AMP plugin performs at its best when persistent object cache is enabled.', 'amp' ),
-				esc_url( 'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching' ),
-				esc_html__( 'More details', 'amp' )
+				'<div class="notice notice-warning"><p>%s</p></div>',
+				sprintf(
+					/* translators: %s: Persistent object cache support URL */
+					__( 'The AMP plugin performs at its best when persistent object cache is enabled. <a href="%s">More details</a>', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+					esc_url( __( 'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching', 'amp' ) )
+				)
 			);
 		}
 	}
@@ -434,9 +436,11 @@ class AMP_Options_Manager {
 
 		printf(
 			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',
-			esc_html__( "The AMP plugin's post-processor cache disabled due to the detection of highly-variable content.", 'amp' ),
-			esc_url( 'https://github.com/ampproject/amp-wp/wiki/Post-Processor-Cache' ),
-			esc_html__( 'More details', 'amp' )
+			sprintf(
+				/* translators: %s: post-processor cache support URL */
+				__( 'The AMP plugin&lsquo;s post-processor cache was disabled due to the detection of highly-variable content. <a href="%s">More details</a>', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+				esc_url( __( 'https://github.com/ampproject/amp-wp/wiki/Post-Processor-Cache', 'amp' ) )
+			)
 		);
 	}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -435,7 +435,7 @@ class AMP_Options_Manager {
 		}
 
 		printf(
-			'<div class="notice notice-warning is-dismissible"><p>%s <a href="%s">%s</a></p></div>',
+			'<div class="notice notice-warning is-dismissible"><p>%s</p></div>',
 			sprintf(
 				/* translators: %s: post-processor cache support URL */
 				__( 'The AMP plugin&lsquo;s post-processor cache was disabled due to the detection of highly-variable content. <a href="%s">More details</a>', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -465,9 +465,9 @@ class AMP_Options_Manager {
 			printf(
 				'<div class="notice notice-warning"><p>%s</p></div>',
 				sprintf(
-					/* translators: %s is location where conflicting lib was found */
-					esc_html__( "A conflicting version of PHP-CSS-Parser appears to be installed by another plugin/theme (located in '%s'). Because of this CSS processing will be limited, and tree shaking will not be available.", 'amp' ),
-					esc_html( $source_dir )
+					/* translators: %s: path to the conflicting library */
+					__( 'A conflicting version of PHP-CSS-Parser appears to be installed by another plugin or theme (located in %s). Because of this, CSS processing will be limited, and tree shaking will not be available.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+					'<code>' . esc_html( $source_dir ) . '</code>'
 				)
 			);
 		} catch ( ReflectionException $e ) {

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -388,7 +388,13 @@ class AMP_Options_Menu {
 		<?php else : ?>
 			<div class="notice notice-warning notice-alt inline">
 				<p>
-					<?php esc_html_e( 'Your theme is using the deprecated available_callback argument for AMP theme support.', 'amp' ); ?>
+					<?php
+					printf(
+						/* translators: %s: available_callback */
+						__( 'Your theme is using the deprecated %s argument for AMP theme support.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+						'available_callback'
+					);
+					?>
 				</p>
 			</div>
 		<?php endif; ?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -391,7 +391,7 @@ class AMP_Options_Menu {
 					<?php
 					printf(
 						/* translators: %s: available_callback */
-						__( 'Your theme is using the deprecated %s argument for AMP theme support.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
+						esc_html__( 'Your theme is using the deprecated %s argument for AMP theme support.', 'amp' ),
 						'available_callback'
 					);
 					?>

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -64,7 +64,6 @@ class AMP_Analytics_Options_Submenu_Page {
 								name="<?php echo esc_attr( $id_base . '[config]' ); ?>"
 								class="amp-analytics-input"
 								placeholder="{...}"
-								title="<?php esc_attr_e( 'A JSON object begins with a &#8220;{&#8221; and ends with a &#8220;}&#8221;. Do not include any HTML tags like "<amp-analytics>" or "<script>".', 'amp' ); ?>"
 								required
 								><?php echo esc_textarea( $config ); ?></textarea>
 						</label>
@@ -101,7 +100,24 @@ class AMP_Analytics_Options_Submenu_Page {
 					<?php esc_html_e( 'Learn about analytics for AMP.', 'amp' ); ?>
 				</summary>
 				<p>
-					<?php echo wp_kses_post( __( 'For Google Analytics, please see <a href="https://developers.google.com/analytics/devguides/collection/amp-analytics/" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="https://github.com/ampproject/amp-wp/wiki/Analytics" target="_blank">Analytics wiki page</a> and the AMP project\'s <a href="https://www.ampproject.org/docs/reference/components/amp-analytics" target="_blank">amp-analytics documentation</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a &#8220;{&#8221; and end with a &#8220;}&#8221;. Do not include any HTML tags like &#8220;<code>&lt;amp-analytics&gt;</code>&#8221; or &#8220;<code>&lt;script&gt;</code>&#8221;. A common entry would have the type &#8220;<code>googleanalytics</code>&#8221; (see <a href="https://www.ampproject.org/docs/analytics/analytics-vendors" target="_blank">available vendors</a>) and a configuration that looks like the following (where <code>UA-XXXXX-Y</code> is replaced with your own site\'s account number):', 'amp' ) ); ?>
+					<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: AMP Analytics docs URL. 2: AMP for WordPress analytics docs URL. 3: AMP analytics code reference. 4: amp-analytics, 5: {. 6: }. 7: <script>, 8: googleanalytics. 9: AMP analytics vendor docs URL. 10: UA-XXXXX-Y. */
+								__( 'For Google Analytics, please see <a href="%1$s" target="_blank">Adding Analytics to your AMP pages</a>; see also the <a href="%2$s" target="_blank">Analytics wiki page</a> and the AMP project\'s <a href="%3$s" target="_blank">%4$s documentation</a>. The analytics configuration supplied below must take the form of JSON objects, which begin with a %5$s and end with a %6$s. Do not include any HTML tags like %4$s or %7$s. A common entry would have the type %8$s (see <a href="%9$s" target="_blank">available vendors</a>) and a configuration that looks like the following (where %10$s is replaced with your own site\'s account number):', 'amp' ),
+								__( 'https://developers.google.com/analytics/devguides/collection/amp-analytics/', 'amp' ),
+								__( 'https://github.com/ampproject/amp-wp/wiki/Analytics', 'amp' ),
+								__( 'https://www.ampproject.org/docs/reference/components/amp-analytics', 'amp' ),
+								'<code>amp-analytics</code>',
+								'<code>{</code>',
+								'<code>}</code>',
+								'<code>&lt;script&gt;</code>',
+								'<code>googleanalytics</code>',
+								__( 'https://www.ampproject.org/docs/analytics/analytics-vendors', 'amp' ),
+								'<code>UA-XXXXX-Y</code>'
+							)
+						);
+					?>
 
 					<pre>{
 	"vars": {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1022,6 +1022,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						/* translators: 1: @import. 2: wp_enqueue_style(). 3: font CDN URL. */
 						__( 'It is not a best practice to use %1$s to load font CDN stylesheets. Please use %2$s to enqueue %3$s as its own separate script.', 'amp' ),
 						'@import',
+						'wp_enqueue_style()',
 						$import_stylesheet_url
 					)
 				),

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1019,8 +1019,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				'wp_enqueue_style',
 				esc_html(
 					sprintf(
-						/* translators: %s is URL to font CDN */
-						__( 'It is not a best practice to use @import to load font CDN stylesheets. Please use wp_enqueue_style() to enqueue %s as its own separate script.', 'amp' ),
+						/* translators: 1: @import. 2: wp_enqueue_style(). 3: font CDN URL. */
+						__( 'It is not a best practice to use %1$s to load font CDN stylesheets. Please use %2$s to enqueue %3$s as its own separate script.', 'amp' ),
+						'@import',
 						$import_stylesheet_url
 					)
 				),
@@ -2082,7 +2083,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			$comment = '';
 			if ( $include_manifest_comment && ! empty( $included_sources ) && $included_original_size > 0 ) {
-				$comment .= esc_html__( 'The style[amp-custom] element is populated with:', 'amp' ) . "\n" . implode( "\n", $included_sources ) . "\n";
+				$comment .= sprintf(
+					/* translators: %s: style[amp-custom] */
+					esc_html__( 'The %s element is populated with:', 'amp' ),
+					'style[amp-custom]'
+				) . "\n" . implode( "\n", $included_sources ) . "\n";
 				if ( self::has_required_php_css_parser() ) {
 					$comment .= sprintf(
 						/* translators: %1$d is number of included bytes, %2$d is percentage of total CSS actually included after tree shaking, %3$d is total included size */
@@ -2105,11 +2110,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				if ( $comment ) {
 					$comment .= "\n";
 				}
-				$comment .= esc_html__( 'The following stylesheets are too large to be included in style[amp-custom]:', 'amp' ) . "\n" . implode( "\n", $excluded_sources ) . "\n";
+				$comment .= sprintf(
+					/* translators: %s: style[amp-custom] */
+					esc_html__( 'The following stylesheets are too large to be included in %s:', 'amp' ),
+					'style[amp-custom]'
+				) . "\n" . implode( "\n", $excluded_sources ) . "\n";
 
 				if ( self::has_required_php_css_parser() ) {
 					$comment .= sprintf(
-						/* translators: %1$d is number of excluded bytes, %2$d is percentage of total CSS actually excluded even after tree shaking, %3$d is total excluded size */
+						/* translators: 1: number of excluded bytes. 2: percentage of total CSS actually excluded even after tree shaking. 3: total excluded size. */
 						esc_html__( 'Total excluded size: %1$s bytes (%2$d%% of %3$s total after tree shaking)', 'amp' ),
 						number_format_i18n( $excluded_size ),
 						$excluded_size / $excluded_original_size * 100,
@@ -2117,11 +2126,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					) . "\n";
 				} else {
 					$comment .= sprintf(
-						/* translators: %1$d is number of excluded bytes */
-						esc_html__( 'Total excluded size: %1$s bytes', 'amp' ),
-						number_format_i18n( $excluded_size ),
-						$excluded_size / $excluded_original_size * 100,
-						number_format_i18n( $excluded_original_size )
+						/* translators: %s: number of excluded bytes. */
+						esc_html__( 'Total excluded size: %s bytes', 'amp' ),
+						number_format_i18n( $excluded_size )
 					) . "\n";
 				}
 
@@ -2130,7 +2137,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				if ( $total_size !== $total_original_size ) {
 					$comment .= "\n";
 					$comment .= sprintf(
-						/* translators: %1$d is total combined bytes, %2$d is percentage of CSS after tree shaking, %3$d is total before tree shaking */
+						/* translators: 1: total combined bytes. 2: is percentage of CSS after tree shaking. 3: is total before tree shaking. */
 						esc_html__( 'Total combined size: %1$s bytes (%2$d%% of %3$s total after tree shaking)', 'amp' ),
 						number_format_i18n( $total_size ),
 						( $total_size / $total_original_size ) * 100,
@@ -2140,7 +2147,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			if ( $include_manifest_comment && ! self::has_required_php_css_parser() ) {
-				$comment .= "\n" . esc_html__( '!!!WARNING!!! AMP CSS processing is limited because a conflicting version of PHP-CSS-Parser has been loaded by another plugin/theme. Tree shaking is not available.', 'amp' ) . "\n";
+				$comment .= "\n" . esc_html__( 'Warning! AMP CSS processing is limited because a conflicting version of PHP-CSS-Parser has been loaded by another plugin or theme. Tree shaking is not available.', 'amp' ) . "\n";
 			}
 
 			if ( $comment ) {

--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -87,8 +87,18 @@ class AMP_Content_Sanitizer {
 			$sanitizer = new $sanitizer_class( $dom, array_merge( $args, $sanitizer_args ) );
 
 			if ( ! is_subclass_of( $sanitizer, 'AMP_Base_Sanitizer' ) ) {
-				/* translators: %s is sanitizer class */
-				_doing_it_wrong( __METHOD__, sprintf( esc_html__( 'Sanitizer (%s) must extend `AMP_Base_Sanitizer`', 'amp' ), esc_html( $sanitizer_class ) ), '0.1' );
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html(
+						sprintf(
+							/* translators: 1: sanitizer class. 2: AMP_Base_Sanitizer */
+							__( 'Sanitizer (%1$s) must extend `%2$s`', 'amp' ),
+							esc_html( $embed_handler_class ),
+							'AMP_Base_Sanitizer'
+						)
+					),
+					'0.1'
+				);
 				continue;
 			}
 

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -180,7 +180,7 @@ class AMP_Content {
 						sprintf(
 							/* translators: 1: embed handler. 2: AMP_Embed_Handler */
 							__( 'Embed Handler (%1$s) must extend `%2$s`', 'amp' ),
-							$embed_handler_class,
+							esc_html( $embed_handler_class ),
 							'AMP_Embed_Handler'
 						)
 					),

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -174,8 +174,18 @@ class AMP_Content {
 			$embed_handler = new $embed_handler_class( array_merge( $this->args, $args ) );
 
 			if ( ! is_subclass_of( $embed_handler, 'AMP_Base_Embed_Handler' ) ) {
-				/* translators: %s is embed handler */
-				_doing_it_wrong( __METHOD__, esc_html( sprintf( __( 'Embed Handler (%s) must extend `AMP_Embed_Handler`', 'amp' ), $embed_handler_class ) ), '0.1' );
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html(
+						sprintf(
+							/* translators: 1: embed handler. 2: AMP_Embed_Handler */
+							__( 'Embed Handler (%1$s) must extend `%2$s`', 'amp' ),
+							$embed_handler_class,
+							'AMP_Embed_Handler'
+						)
+					),
+					'0.1'
+				);
 				continue;
 			}
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1628,11 +1628,17 @@ class AMP_Validated_URL_Post_Type {
 			),
 		);
 
-		// Only the %d is interpolated by PHP, as the JS file will replace %% with the errors that are displaying, based on filtering.
+		// Only the second number is interpolated by PHP, as the JS file will dynamically replace %1$s with the errors being displayed.
 		$data['l10n']['showing_number_errors'] = sprintf(
-			/* translators: %% is the errors that are displaying, %d is the total number of errors found */
-			__( 'Showing %% of %d validation errors', 'amp' ),
-			self::$total_errors_for_url
+			/* translators: 1: number of errors being displayed. 2: total number of errors found. */
+			_n(
+				'Showing %1$s of %2$s validation error',
+				'Showing %1$s of %2$s validation errors',
+				self::$total_errors_for_url,
+				'amp'
+			),
+			'%1$s',
+			number_format_i18n( self::$total_errors_for_url )
 		);
 
 		wp_add_inline_script(
@@ -1691,7 +1697,7 @@ class AMP_Validated_URL_Post_Type {
 						/* translators: %s: The date this was published */
 						wp_kses_post( __( 'Last checked: <b>%s</b>', 'amp' ) ),
 						/* translators: Meta box date format */
-						esc_html( date_i18n( __( 'M j, Y @ H:i', 'default' ), strtotime( $post->post_date ) ) )
+						esc_html( date_i18n( __( 'M j, Y @ H:i', 'amp' ), strtotime( $post->post_date ) ) )
 					);
 					?>
 					</span>
@@ -1703,7 +1709,7 @@ class AMP_Validated_URL_Post_Type {
 						</a>
 					</div>
 					<div id="preview-action">
-						<button type="button" name="action" class="preview button" id="preview_validation_errors"><?php esc_html_e( 'Preview Changes', 'default' ); ?></button>
+						<button type="button" name="action" class="preview button" id="preview_validation_errors"><?php esc_html_e( 'Preview Changes', 'amp' ); ?></button>
 					</div>
 					<div class="clear"></div>
 				</div>
@@ -1773,7 +1779,7 @@ class AMP_Validated_URL_Post_Type {
 					</a>
 				</div>
 				<div id="publishing-action">
-					<button type="submit" name="action" class="button button-primary" value="<?php echo esc_attr( self::UPDATE_POST_TERM_STATUS_ACTION ); ?>"><?php esc_html_e( 'Update', 'default' ); ?></button>
+					<button type="submit" name="action" class="button button-primary" value="<?php echo esc_attr( self::UPDATE_POST_TERM_STATUS_ACTION ); ?>"><?php esc_html_e( 'Update', 'amp' ); ?></button>
 				</div>
 				<div class="clear"></div>
 			</div>
@@ -1821,7 +1827,7 @@ class AMP_Validated_URL_Post_Type {
 		$taxonomy        = AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG;
 		$taxonomy_object = get_taxonomy( $taxonomy );
 		if ( ! $taxonomy_object ) {
-			wp_die( esc_html__( 'Invalid taxonomy.', 'default' ) );
+			wp_die( esc_html__( 'Invalid taxonomy.', 'amp' ) );
 		}
 
 		/**
@@ -2038,7 +2044,7 @@ class AMP_Validated_URL_Post_Type {
 							$query->found_posts,
 							'amp'
 						),
-						$query->found_posts
+						number_format_i18n( $query->found_posts )
 					)
 				)
 			);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1859,9 +1859,14 @@ class AMP_Validation_Error_Taxonomy {
 				} else {
 					$time_ago = sprintf(
 						'<abbr title="%s">%s</abbr>',
-						esc_attr( $created_datetime->format( __( 'Y/m/d g:i:s a', 'default' ) ) ),
-						/* translators: %s is relative time */
-						esc_html( sprintf( __( '%s ago', 'default' ), human_time_diff( $created_datetime->getTimestamp() ) ) )
+						esc_attr(
+							$created_datetime->format(
+								/* translators: localized date and time format, see http://php.net/date */
+								__( 'F j, Y g:i a', 'amp' )
+							)
+						),
+						/* translators: %s: human readable timestamp */
+						esc_html( sprintf( __( '%s ago', 'amp' ), human_time_diff( $created_datetime->getTimestamp() ) ) )
 					);
 				}
 
@@ -2257,7 +2262,11 @@ class AMP_Validation_Error_Taxonomy {
 		} elseif ( 'excessive_css' === $error_code ) {
 			$error_title = __( 'Excessive CSS', 'amp' );
 		} elseif ( 'illegal_css_at_rule' === $error_code ) {
-			$error_title = __( 'Illegal CSS @ rule', 'amp' );
+			$error_title = sprintf(
+				/* translators: %s: @ */
+				__( 'Illegal CSS %s rule', 'amp' ),
+				'@'
+			);
 		} elseif ( 'disallowed_file_extension' === $error_code ) {
 			$error_title = __( 'Disallowed file extension', 'amp' );
 		} elseif ( 'file_path_not_allowed' === $error_code ) {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1906,16 +1906,24 @@ class AMP_Validation_Manager {
 			case 'white_screen_of_death':
 				return __( 'Unable to validate URL. Encountered a white screen of death likely due to a fatal error. Please check your server\'s PHP error logs.', 'amp' );
 			case '404':
-				return __( 'The fetched URL(s) was not found. It may have been deleted. If so, you can trash this.', 'amp' );
+				return __( 'The fetched URL was not found. It may have been deleted. If so, you can trash this.', 'amp' );
 			case '500':
 				return __( 'An internal server error occurred when fetching the URL for validation.', 'amp' );
 			case 'response_comment_absent':
-				return __( 'URL validation failed to due to the absence of the expected JSON-containing AMP_VALIDATION comment after the body.', 'amp' );
+				return sprintf(
+					/* translators: %s: AMP_VALIDATION */
+					__( 'URL validation failed to due to the absence of the expected JSON-containing %s comment after the body.', 'amp' ),
+					'AMP_VALIDATION'
+				);
 			case 'malformed_json_validation_errors':
-				return __( 'URL validation failed to due to unexpected JSON in the AMP_VALIDATION comment after the body.', 'amp' );
+				return sprintf(
+					/* translators: %s: AMP_VALIDATION */
+					__( 'URL validation failed to due to unexpected JSON in the %s comment after the body.', 'amp' ),
+					'AMP_VALIDATION'
+				);
 			default:
 				/* translators: %s is error code */
-				return sprintf( __( 'Unable to validate the URL(s); error code is %s.', 'amp' ), $error_code ); // Note that $error_code has been sanitized with sanitize_key(); will be escaped below as well.
+				return sprintf( __( 'URL validation failed. Error code: %s.', 'amp' ), $error_code ); // Note that $error_code has been sanitized with sanitize_key(); will be escaped below as well.
 		};
 	}
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -46,6 +46,13 @@
 		</properties>
 	</rule>
 
+	<!-- Prevent false positives for translator comments by adjusting the threshold for commented out code. -->
+	<rule ref="Squiz.PHP.CommentedOutCode">
+		<properties>
+			<property name="maxPercentage" value="50" />
+		</properties>
+	</rule>
+
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.4-99.0"/>
 	<rule ref="PHPCompatibility">


### PR DESCRIPTION
There were a few things bugging me while I was trying to localize the plugin on WordPress.org, most commonly the lack of placeholders in translatable strings. Users should not be able to accidentally translate technical terms like HTML tags or PHP function names.

I also removed i18n functions from the CLI command class, as these don't really need to be localized. They would be hard to test for translators anyway.

These improvements should make it easier to localize the plugin into other languages. Right now, it's only fully translated into Chinese (Taiwan) and Spanish (Spain) 