### PR TITLE
Add core theme support for Twenty Fourteen

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1133,6 +1133,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				?>
 				<style>
 					/* Styles for featured content */
+					.grid #featured-content .post-thumbnail,
 					.slider #featured-content .post-thumbnail {
 						padding-top: 0; /* Override responsive hack which is handled by AMP layout. */
 						overflow: visible;

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -75,7 +75,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				'twentyseventeen-global', // There are somethings not yet implemented in AMP. See todos below.
 				'jquery-scrollto', // Implemented via add_smooth_scrolling().
 				'twentyseventeen-navigation', // Handled by add_nav_menu_styles, add_nav_menu_toggle, add_nav_sub_menu_buttons.
-				'twentyseventeen-skip-link-focus-fix', // Only needed by IE11 and when admin bar is present.
+				'twentyseventeen-skip-link-focus-fix', // Unnecessary since part of the AMP runtime.
 			),
 			'remove_actions'                      => array(
 				'wp_head' => array(
@@ -106,7 +106,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				'twentysixteen-script',
 				'twentysixteen-html5', // Only relevant for IE<9.
 				'twentysixteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
-				'twentysixteen-skip-link-focus-fix', // Only needed by IE11 and when admin bar is present.
+				'twentysixteen-skip-link-focus-fix', // Unnecessary since part of the AMP runtime.
 			),
 			'remove_actions'      => array(
 				'wp_head' => array(
@@ -124,7 +124,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			'dequeue_scripts'     => array(
 				'twentyfifteen-script',
 				'twentyfifteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
-				'twentyfifteen-skip-link-focus-fix', // Only needed by IE11 and when admin bar is present.
+				'twentyfifteen-skip-link-focus-fix', // Unnecessary since part of the AMP runtime.
 			),
 			'remove_actions'      => array(
 				'wp_head' => array(
@@ -134,6 +134,20 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			'add_nav_menu_styles' => array(
 				'sub_menu_button_toggle_class' => 'toggle-on',
 			),
+		),
+
+		'twentyfourteen'  => array(
+			// @todo Figure out an AMP solution for onResizeARIA().
+			'dequeue_scripts'                    => array(
+				'twentyfourteen-script',
+				'twentyfourteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
+				'jquery-masonry', // Masonry style layout is not supportedd in AMP.
+				'twentyfourteen-slider',
+			),
+			'add_nav_menu_styles'                => array(),
+			'add_twentyfourteen_masthead_styles' => array(),
+			'add_twentyfourteen_slider_carousel' => array(),
+			'add_twentyfourteen_search'          => array(),
 		),
 	);
 
@@ -158,6 +172,24 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public static function get_acceptable_errors( $template ) {
 		switch ( $template ) {
+			case 'twentyfourteen':
+				return array(
+					'removed_unused_css_rules' => true,
+					'illegal_css_at_rule'      => array(
+						array(
+							'at_rule'         => 'viewport',
+							'node_attributes' => array(
+								'id' => 'twentyfourteen-style-css',
+							),
+						),
+						array(
+							'at_rule'         => '-ms-viewport',
+							'node_attributes' => array(
+								'id' => 'twentyfourteen-style-css',
+							),
+						),
+					),
+				);
 			case 'twentyfifteen':
 				return array(
 					'removed_unused_css_rules' => true,
@@ -237,6 +269,16 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	protected static function get_theme_support_args( $theme ) {
 		// phpcs:disable WordPress.WP.I18n.TextDomainMismatch
 		switch ( $theme ) {
+			case 'twentyfourteen':
+				return array(
+					'nav_menu_toggle' => array(
+						'nav_container_id'           => 'primary-navigation',
+						'nav_container_toggle_class' => 'toggled-on',
+						'menu_button_xpath'          => '//header[ @id = "masthead" ]//button[ contains( @class, "menu-toggle" ) ]',
+						'menu_button_toggle_class'   => '',
+					),
+				);
+
 			case 'twentyfifteen':
 				return array(
 					'nav_menu_toggle'   => array(
@@ -896,10 +938,12 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					display: none;
 				}
 
-				/* Use sibling selector and re-use class on button instead of toggling toggle-on class on ul.sub-menu */
-				.main-navigation ul .<?php echo esc_html( $args['sub_menu_button_toggle_class'] ); ?> + .sub-menu {
-					display: block;
-				}
+				<?php if ( ! empty( $args['sub_menu_button_toggle_class'] ) ) : ?>
+					/* Use sibling selector and re-use class on button instead of toggling toggle-on class on ul.sub-menu */
+					.main-navigation ul .<?php echo esc_html( $args['sub_menu_button_toggle_class'] ); ?> + .sub-menu {
+						display: block;
+					}
+				<?php endif; ?>
 
 				<?php if ( 'twentyseventeen' === get_template() ) : ?>
 					/* Show the button*/
@@ -1013,6 +1057,40 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						}
 					}
 
+				<?php elseif ( 'twentyfourteen' === get_template() ) : ?>
+					@media screen and (min-width: 783px) {
+						.primary-navigation li:focus-within > a {
+							background-color: #24890d;
+							color: #fff;
+						}
+
+						.primary-navigation ul ul li:focus-within > a {
+							background-color: #41a62a;
+						}
+
+						.primary-navigation ul li:focus-within > ul {
+							left: auto;
+						}
+
+						.primary-navigation ul ul li:focus-within > ul {
+							left: 100%;
+						}
+					}
+
+					@media screen and (min-width: 1008px) {
+						.secondary-navigation li:focus-within > a {
+							background-color: #24890d;
+							color: #fff;
+						}
+
+						.secondary-navigation ul ul li:focus-within > a {
+							background-color: #41a62a;
+						}
+
+						.secondary-navigation ul li:focus-within > ul {
+							left: 202px;
+						}
+					}
 				<?php endif; ?>
 				</style>
 				<?php
@@ -1040,5 +1118,219 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				return $attributes;
 			}
 		);
+	}
+
+	/**
+	 * Add styles for Twenty Fourteen masthead.
+	 *
+	 * @since 1.1
+	 */
+	public static function add_twentyfourteen_masthead_styles() {
+		add_action(
+			'wp_print_styles',
+			function() {
+				?>
+				<style>
+					/* Styles for featured content */
+					.slider #featured-content .post-thumbnail {
+						padding-top: 0;
+					}
+					.slider #featured-content .hentry {
+						display: block;
+					}
+
+					/*
+					 * The following are needed because clicking on the :before pseudo element does not trigger a tap event.
+					 * So instead of positioning the screen reader text off screen, we just position it to cover cover the
+					 * toggle button entirely, with a zero opacity.
+					 */
+					.search-toggle {
+						position: relative;
+					}
+					.search-toggle > a.screen-reader-text {
+						left: 0;
+						top: 0;
+						right: 0;
+						bottom: 0;
+						width: auto;
+						height: auto;
+						clip: unset;
+						opacity: 0;
+					}
+
+					/*
+					 * Styles for slider carousel.
+					 */
+					.featured-content-inner > amp-carousel {
+						position: relative;
+					}
+					body.slider amp-carousel > .amp-carousel-button {
+						-webkit-font-smoothing: antialiased;
+						background-color: black;
+						background-image: none;
+						border-radius: 0;
+						border: 0;
+						bottom: 0;
+						box-sizing: border-box;
+						cursor: pointer;
+						display: inline-block;
+						font: normal 16px/1 Genericons;
+						height: 48px;
+						left: auto;
+						opacity: 1;
+						text-align: center;
+						text-decoration: inherit;
+						top: auto;
+						transform: none;
+						width: 48px;
+					}
+					body.slider amp-carousel > .amp-carousel-button:focus {
+						outline: white thin dotted;
+					}
+					body.slider amp-carousel > .amp-carousel-button:hover {
+						background-color: #24890d;
+						outline: none;
+					}
+					body.slider amp-carousel > .amp-carousel-button-prev {
+						right: 50px;
+					}
+					body.slider amp-carousel > .amp-carousel-button-prev:before {
+						color: #fff;
+						content: "\f430";
+						font-size: 32px;
+						line-height: 46px;
+					}
+					body.slider amp-carousel > .amp-carousel-button-next {
+						right: 0;
+					}
+					body.slider amp-carousel > .amp-carousel-button-next:before {
+						color: #fff;
+						content: "\f429";
+						font-size: 32px;
+						line-height: 46px;
+					}
+				</style>
+				<?php
+			}
+		);
+	}
+
+	/**
+	 * Add amp-carousel for slider in Twenty Fourteen.
+	 *
+	 * @since 1.1
+	 */
+	public function add_twentyfourteen_slider_carousel() {
+		$featured_content = $this->dom->getElementById( 'featured-content' );
+		if ( ! $featured_content ) {
+			return;
+		}
+
+		$featured_content_inner = $this->xpath->query( './div[ @class = "featured-content-inner" ]', $featured_content )->item( 0 );
+		if ( ! $featured_content_inner ) {
+			return;
+		}
+
+		$selected_slide_default  = 0;
+		$selected_slide_state_id = 'twentyFourteenSelectedSlide';
+
+		// Create the slider state.
+		$amp_state = $this->dom->createElement( 'amp-state' );
+		$amp_state->setAttribute( 'id', $selected_slide_state_id );
+		$script = $this->dom->createElement( 'script' );
+		$script->setAttribute( 'type', 'application/json' );
+		$script->appendChild( $this->dom->createTextNode( wp_json_encode( $selected_slide_default ) ) );
+		$amp_state->appendChild( $script );
+		$featured_content->appendChild( $amp_state );
+
+		// Create the carousel slider.
+		$amp_carousel_id = 'twentyFourteenSlider';
+		$amp_carousel    = AMP_DOM_Utils::create_node(
+			$this->dom,
+			'amp-carousel',
+			array(
+				'id'                  => $amp_carousel_id,
+				'layout'              => 'responsive',
+				'on'                  => "slideChange:AMP.setState( { $selected_slide_state_id: event.index } )",
+				'width'               => '100',
+				'height'              => '55.49132947', // Value comes from <https://github.com/WordPress/wordpress-develop/blob/fc2a8f0e11316d066a686995b8578d82cd5546cf/src/wp-content/themes/twentyfourteen/style.css#L3024>.
+				'type'                => 'slides',
+				'loop'                => '',
+				'data-amp-bind-slide' => $selected_slide_state_id,
+			)
+		);
+		while ( $featured_content_inner->firstChild ) {
+			$node = $featured_content_inner->removeChild( $featured_content_inner->firstChild );
+			$amp_carousel->appendChild( $node );
+		}
+		$featured_content_inner->appendChild( $amp_carousel );
+
+		// Create the selector.
+		$amp_selector = $this->dom->createElement( 'amp-selector' );
+		$amp_selector->setAttribute( 'layout', 'container' );
+		$slider_control_nav = $this->dom->createElement( 'ol' );
+		$slider_control_nav->setAttribute( 'class', 'slider-control-nav slider-control-paging' );
+		$count = $amp_carousel->getElementsByTagName( 'article' )->length;
+		for ( $i = 0; $i < $count; $i++ ) {
+			$li = $this->dom->createElement( 'li' );
+			$a  = $this->dom->createElement( 'a' );
+			if ( $selected_slide_default === $i ) {
+				$li->setAttribute( 'selected', '' );
+				$a->setAttribute( 'class', 'slider-active' );
+			}
+			$a->setAttribute( 'data-amp-bind-class', "$selected_slide_state_id == $i ? 'slider-active' : ''" );
+			$a->setAttribute( 'role', 'button' );
+			$a->setAttribute( 'on', "tap:AMP.setState( { $selected_slide_state_id: $i } )" );
+			$li->setAttribute( 'option', (string) $i );
+			$a->appendChild( $this->dom->createTextNode( $i + 1 ) );
+			$li->appendChild( $a );
+			$slider_control_nav->appendChild( $li );
+		}
+		$amp_selector->appendChild( $slider_control_nav );
+		$featured_content->appendChild( $amp_selector );
+	}
+
+	/**
+	 * Use AMP-based solutions for toggling search bar in Twenty Fourteen.
+	 *
+	 * @link https://github.com/WordPress/wordpress-develop/blob/fc2a8f0e11316d066a686995b8578d82cd5546cf/src/wp-content/themes/twentyfourteen/js/functions.js#L69-L87
+	 */
+	public function add_twentyfourteen_search() {
+		$search_toggle_div  = $this->xpath->query( '//div[ contains( @class, "search-toggle" ) ]' )->item( 0 );
+		$search_toggle_link = $this->xpath->query( './a', $search_toggle_div )->item( 0 );
+		$search_container   = $this->dom->getElementById( 'search-container' );
+		if ( ! $search_toggle_div || ! $search_toggle_link || ! $search_container ) {
+			return;
+		}
+
+		// Create the <amp-state> element that contains whether the search bar is shown.
+		$amp_state       = $this->dom->createElement( 'amp-state' );
+		$hidden_state_id = 'twentyfourteenSearchHidden';
+		$hidden          = true;
+		$amp_state->setAttribute( 'id', $hidden_state_id );
+		$script = $this->dom->createElement( 'script' );
+		$script->setAttribute( 'type', 'application/json' );
+		$script->appendChild( $this->dom->createTextNode( wp_json_encode( $hidden ) ) );
+		$amp_state->appendChild( $script );
+		$search_container->appendChild( $amp_state );
+
+		// Update AMP state to show the search bar and focus on search input when tapping on the search button.
+		$search_input_id = 'twentyfourteen_search_input';
+		$search_input_el = $this->xpath->query( './/input[ @name = "s" ]', $search_container )->item( 0 );
+		$search_toggle_link->removeAttribute( 'href' );
+		$on = "tap:AMP.setState( { $hidden_state_id: ! $hidden_state_id } )";
+		if ( $search_input_el ) {
+			$search_input_el->setAttribute( 'id', $search_input_id );
+			$on .= ",$search_input_id.focus()";
+		}
+		$search_toggle_link->setAttribute( 'on', $on );
+		$search_toggle_link->setAttribute( 'tabindex', '0' );
+		$search_toggle_link->setAttribute( 'role', 'button' );
+
+		// Set visibility and aria-expanded based of the link based on whether the search bar is expanded.
+		$search_toggle_link->setAttribute( 'aria-expanded', wp_json_encode( $hidden ) );
+		$search_toggle_link->setAttribute( 'data-amp-bind-aria-expanded', "$hidden_state_id ? 'false' : 'true'" );
+		$search_toggle_div->setAttribute( 'data-amp-bind-class', "$hidden_state_id ? 'search-toggle' : 'search-toggle active'" );
+		$search_container->setAttribute( 'data-amp-bind-class', "$hidden_state_id ? 'search-box-wrapper hide' : 'search-box-wrapper'" );
 	}
 }

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1158,57 +1158,70 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						opacity: 0;
 					}
 
-					/*
-					 * Styles for slider carousel.
-					 */
-					.featured-content-inner > amp-carousel {
-						position: relative;
-					}
-					body.slider amp-carousel > .amp-carousel-button {
-						-webkit-font-smoothing: antialiased;
-						background-color: black;
-						background-image: none;
-						border-radius: 0;
-						border: 0;
-						bottom: 0;
-						box-sizing: border-box;
-						cursor: pointer;
-						display: inline-block;
-						font: normal 16px/1 Genericons;
-						height: 48px;
-						left: auto;
-						opacity: 1;
-						text-align: center;
-						text-decoration: inherit;
-						top: auto;
-						transform: none;
-						width: 48px;
-					}
-					body.slider amp-carousel > .amp-carousel-button:focus {
-						outline: white thin dotted;
-					}
-					body.slider amp-carousel > .amp-carousel-button:hover {
-						background-color: #24890d;
-						outline: none;
-					}
-					body.slider amp-carousel > .amp-carousel-button-prev {
-						right: 50px;
-					}
-					body.slider amp-carousel > .amp-carousel-button-prev:before {
-						color: #fff;
-						content: "\f430";
-						font-size: 32px;
-						line-height: 46px;
-					}
-					body.slider amp-carousel > .amp-carousel-button-next {
-						right: 0;
-					}
-					body.slider amp-carousel > .amp-carousel-button-next:before {
-						color: #fff;
-						content: "\f429";
-						font-size: 32px;
-						line-height: 46px;
-					}
+					<?php if ( 'slider' === get_theme_mod( 'featured_content_layout' ) ) : ?>
+
+						/*
+						 * Styles for slider carousel.
+						 */
+						.featured-content-inner > amp-carousel {
+							position: relative;
+						}
+						body.slider amp-carousel > .amp-carousel-button {
+							-webkit-font-smoothing: antialiased;
+							background-color: black;
+							background-image: none;
+							border-radius: 0;
+							border-color: #fff;
+							border-style: solid;
+							border-width: 2px 1px 0 0;
+							box-sizing: border-box;
+							cursor: pointer;
+							display: inline-block;
+							font: normal 16px/1 Genericons;
+							height: 48px;
+							left: auto;
+							opacity: 1;
+							text-align: center;
+							text-decoration: inherit;
+							top: auto;
+							width: 50%;
+							transform: none;
+						}
+						body.slider amp-carousel > .amp-carousel-button:focus {
+							outline: white thin dotted;
+						}
+						body.slider amp-carousel > .amp-carousel-button:hover {
+							background-color: #24890d;
+							outline: none;
+						}
+						body.slider amp-carousel > .amp-carousel-button-prev:before {
+							color: #fff;
+							content: "\f430";
+							font-size: 32px;
+							line-height: 46px;
+						}
+						body.slider amp-carousel > .amp-carousel-button-next:before {
+							color: #fff;
+							content: "\f429";
+							font-size: 32px;
+							line-height: 46px;
+						}
+
+						@media screen and (min-width: 673px) {
+							body.slider amp-carousel > .amp-carousel-button {
+								width: 48px;
+								border: 0;
+								bottom: 0;
+							}
+							body.slider amp-carousel > .amp-carousel-button-prev {
+								right: 50px;
+							}
+							body.slider amp-carousel > .amp-carousel-button-next {
+								right: 0;
+							}
+						}
+
+					<?php endif; ?>
 				</style>
 				<?php
 			}
@@ -1221,6 +1234,10 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.1
 	 */
 	public function add_twentyfourteen_slider_carousel() {
+		if ( 'slider' !== get_theme_mod( 'featured_content_layout' ) ) {
+			return;
+		}
+
 		$featured_content = $this->dom->getElementById( 'featured-content' );
 		if ( ! $featured_content ) {
 			return;

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1133,7 +1133,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				<style>
 					/* Styles for featured content */
 					.slider #featured-content .post-thumbnail {
-						padding-top: 0;
+						padding-top: 0; /* Override responsive hack which is handled by AMP layout. */
+						overflow: visible;
 					}
 					.slider #featured-content .hentry {
 						display: block;

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -113,7 +113,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			'amp-live-list',
 			'[submit-error]',
 			'[submit-success]',
-			'amp-carousel',
 		),
 		'should_locate_sources'     => false,
 		'parsed_cache_variant'      => null,

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -113,6 +113,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			'amp-live-list',
 			'[submit-error]',
 			'[submit-success]',
+			'amp-carousel',
 		),
 		'should_locate_sources'     => false,
 		'parsed_cache_variant'      => null,


### PR DESCRIPTION
This PR adds AMP compatibility for Twenty Fourteen. There should be no AMP validation errors reported from the theme.

In testing, note that you will likely need to disable the admin bar in AMP as there will be too much CSS otherwise.

# Header Nav

Create a nested nav menu and assign to the top primary menu _and_ the secondary menu. You should see the submenus expand when hovering _and_ they should be keyboard accessible through tabbing:

![image](https://user-images.githubusercontent.com/134745/52968256-e9b73400-33ac-11e9-8487-948aee1350df.png)

![image](https://user-images.githubusercontent.com/134745/52968300-10756a80-33ad-11e9-8cb8-b5e268ee3b2c.png)

And in a mobile viewport the hamburger menu should be tappable:

![image](https://user-images.githubusercontent.com/134745/52968485-9c879200-33ad-11e9-8d63-cb75953c2922.png)

Which reveals the nested nav menus:

![image](https://user-images.githubusercontent.com/134745/52968512-b923ca00-33ad-11e9-8a72-2830281bc483.png)

# Featured Content

## Slider

Create three posts with the `featured` tag and assign them each a featured image. Open the  “Featured Content” section in the Customizer and select the “Slider” layout. The homepage should then have a slider powered by `amp-carousel` as shown below:

![image](https://user-images.githubusercontent.com/134745/52967696-23873b00-33ab-11e9-9c0e-365348d5b0ab.png)

## Grid

Featured content in desktop in grid mode should look like:

![image](https://user-images.githubusercontent.com/134745/58294619-f23e5280-7d7f-11e9-8357-58c27b211a94.png)

And in mobile:

![image](https://user-images.githubusercontent.com/134745/58294635-15690200-7d80-11e9-9a8c-8eb6168366bf.png)

Note that some of the heights will not be exactly the same between AMP and non-AMP, but it should be relatively unnoticeable (only a few pixels difference).

# Search bar

Clicking the Search button in the header should cause the search bar to appear _and_ the search input to be focused:

![image](https://user-images.githubusercontent.com/134745/52967988-2e8e9b00-33ac-11e9-9ea7-6b89608fc75b.png)

See #1742.