### PR TITLE
Add required PHPUnit testsuite name

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,7 @@
 		<const name="WP_TEST_ACTIVATED_PLUGINS" value="jetpack/jetpack.php,gutenberg/gutenberg.php" />
 	</php>
 	<testsuites>
-		<testsuite>
+		<testsuite name="amp-wp">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
In newer versions of PHPUnit (>= 7.0 I believe), the `name` attribute is for the `<testsuite>` is required. Otherwise you will get a warning like this:


```
$ phpunit
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 7.5.6 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 13:
  - Element 'testsuite': The attribute 'name' is required but missing.

  Test results may not be as expected.
```