### PR TITLE
[AMP Stories] Background media for story pages

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -16,6 +16,7 @@
 		6.1 Ghosted page inserter
 	7. Block navigator
 	8. Block mover
+	9. General block editor components
 	100. Shame
 		100.1 Gutenberg - Warning div not clickable
 
@@ -436,6 +437,18 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 
 .post-type-amp_story .is-selected .editor-block-mover.is-visible {
 	opacity: 1;
+}
+
+/*
+ * 9. General block editor components
+ */
+
+.editor-amp-story-page-background {
+	display: block;
+}
+
+.editor-amp-story-page-background + .is-destructive {
+	margin-top: 1em;
 }
 
 /*

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -451,6 +451,20 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	margin-top: 1em;
 }
 
+.editor-amp-story-page-wrap {
+	position: relative;
+}
+
+.editor-amp-story-page-video {
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	min-width: 100%;
+	min-height: 100%;
+}
+
 /*
  * 100. Shame
  */

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -453,6 +453,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 
 .editor-amp-story-page-wrap {
 	position: relative;
+	overflow: hidden;
 }
 
 .editor-amp-story-page-video {
@@ -463,6 +464,8 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	bottom: 0;
 	min-width: 100%;
 	min-height: 100%;
+	object-fit: cover;
+	pointer-events: none;
 }
 
 /*

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -468,6 +468,10 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	pointer-events: none;
 }
 
+#editor-amp-story-page-poster__help {
+	margin-top: 0;
+}
+
 /*
  * 100. Shame
  */

--- a/assets/src/blocks/amp-story/constants.js
+++ b/assets/src/blocks/amp-story/constants.js
@@ -1,4 +1,5 @@
 
-export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
 export const IMAGE_BACKGROUND_TYPE = 'image';
 export const VIDEO_BACKGROUND_TYPE = 'video';
+export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+export const POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];

--- a/assets/src/blocks/amp-story/constants.js
+++ b/assets/src/blocks/amp-story/constants.js
@@ -1,0 +1,4 @@
+
+export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+export const IMAGE_BACKGROUND_TYPE = 'image';
+export const VIDEO_BACKGROUND_TYPE = 'video';

--- a/assets/src/blocks/amp-story/edit.js
+++ b/assets/src/blocks/amp-story/edit.js
@@ -174,7 +174,9 @@ class EditPage extends Component {
 							{ VIDEO_BACKGROUND_TYPE === mediaType && (
 								<MediaUploadCheck>
 									<BaseControl
-										label={ __( 'Poster Image', 'amp' ) }
+										id="editor-amp-story-page-poster"
+										label={ __( 'Poster Image (required)', 'amp' ) }
+										help={ __( 'The recommended dimensions for a poster image are: 720p (720w x 1280h)', 'amp' ) }
 									>
 										<MediaUpload
 											title={ __( 'Select Poster Image', 'amp' ) }

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -70,7 +70,7 @@ export const settings = {
 								<amp-img layout="fill" src={ mediaUrl } />
 							) }
 							{ VIDEO_BACKGROUND_TYPE === mediaType && (
-								<amp-video layout="fill" src={ mediaUrl } poster="background.png" muted autoplay loop />
+								<amp-video layout="fill" src={ mediaUrl } muted autoplay loop />
 							) }
 						</amp-story-grid-layer>
 					)

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -10,6 +10,7 @@ import { InnerBlocks } from '@wordpress/editor';
  */
 import { BLOCK_ICONS } from '../../helpers';
 import EditPage from './edit';
+import { IMAGE_BACKGROUND_TYPE, VIDEO_BACKGROUND_TYPE } from './constants';
 
 export const name = 'amp/amp-story-page';
 
@@ -25,6 +26,21 @@ export const settings = {
 		},
 		backgroundColor: {
 			default: '#ffffff',
+		},
+		mediaId: {
+			type: 'number',
+		},
+		mediaUrl: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'amp-story-grid-layer[template="fill"] > amp-img, amp-story-grid-layer[template="fill"] > amp-video',
+			attribute: 'src',
+		},
+		mediaType: {
+			type: 'string',
+		},
+		focalPoint: {
+			type: 'object',
 		},
 	},
 
@@ -43,9 +59,22 @@ export const settings = {
 	edit: EditPage,
 
 	save( { attributes } ) {
+		const { id, backgroundColor, mediaUrl, mediaType } = attributes;
+
 		return (
-			<amp-story-page style={ { backgroundColor: attributes.backgroundColor } } id={ attributes.id }>
-				{ /* @todo Add fill layer for image/video */ }
+			<amp-story-page style={ { backgroundColor: backgroundColor } } id={ id }>
+				{
+					mediaUrl && (
+						<amp-story-grid-layer template="fill">
+							{ IMAGE_BACKGROUND_TYPE === mediaType && (
+								<amp-img layout="fill" src={ mediaUrl } />
+							) }
+							{ VIDEO_BACKGROUND_TYPE === mediaType && (
+								<amp-video layout="fill" src={ mediaUrl } poster="background.png" muted autoplay />
+							) }
+						</amp-story-grid-layer>
+					)
+				}
 				<amp-story-grid-layer template="vertical">
 					<InnerBlocks.Content />
 				</amp-story-grid-layer>

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -39,6 +39,9 @@ export const settings = {
 		mediaType: {
 			type: 'string',
 		},
+		poster: {
+			type: 'string',
+		},
 		focalPoint: {
 			type: 'object',
 		},
@@ -59,7 +62,7 @@ export const settings = {
 	edit: EditPage,
 
 	save( { attributes } ) {
-		const { id, backgroundColor, mediaUrl, mediaType } = attributes;
+		const { id, backgroundColor, mediaUrl, mediaType, poster } = attributes;
 
 		return (
 			<amp-story-page style={ { backgroundColor: backgroundColor } } id={ id }>
@@ -70,7 +73,7 @@ export const settings = {
 								<amp-img layout="fill" src={ mediaUrl } />
 							) }
 							{ VIDEO_BACKGROUND_TYPE === mediaType && (
-								<amp-video layout="fill" src={ mediaUrl } muted autoplay loop />
+								<amp-video layout="fill" src={ mediaUrl } poster={ poster } muted autoplay loop />
 							) }
 						</amp-story-grid-layer>
 					)

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -70,7 +70,7 @@ export const settings = {
 								<amp-img layout="fill" src={ mediaUrl } />
 							) }
 							{ VIDEO_BACKGROUND_TYPE === mediaType && (
-								<amp-video layout="fill" src={ mediaUrl } poster="background.png" muted autoplay />
+								<amp-video layout="fill" src={ mediaUrl } poster="background.png" muted autoplay loop />
 							) }
 						</amp-story-grid-layer>
 					)


### PR DESCRIPTION
To do:

* [x] Add possibility to select custom poster image for videos.  
  WordPress doesn't really create poster images for videos automatically.
  For reference, in the Gutenberg video block they added a separate `<MediaUpload>` component just for this.  
  
  Thinking further, we might want to auto-generate a poster image, but this might turn out to be a bit more complex. Plus, the poster image is not required anyway.
* [x] Use poster image for the preview in the editor instead of an actual running `<video>`
* [ ] ~Improve/fix editor styling~
  **Edit:** Editor layout will be changed drastically anyway, so no need to worry about the styling of the page block for this.
* [ ] ~Actually crop background images appropriately.~
  **Edit:** As per discussion on #1879, cropping will be tackled in a separate issue.
* [ ] ~Consider using server-side rendering instead of `save()`ing the page block's HTML.~
  This way we avoid having to deal with deprecations every time the markup changes.  
  Needs some testing to see if this works when using `InnerBlocks`.
  
  **Edit:** Something that can be discussed in a separate issue.

See #1879.