### PR TITLE
Add tree shaking for :lang() selectors

### DIFF
--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -357,10 +357,31 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
-			'unamerican_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
+			'unamerican_lang_attribute_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
 				'<html amp><head><meta charset="utf-8"><style>html[lang=en-US] {color:red} html[lang="en-US"] {color:white} html[lang^=en] {color:blue} html[lang="en-CA"] {color:red}  html[lang^=ar] { color:green; } html[lang="es-MX"] { color:green; }</style></head><body><span>Test</span></body></html>',
 				array(
 					'html[lang=en-US]{color:red}html[lang="en-US"]{color:white}html[lang^=en]{color:blue}',
+				),
+				array(),
+			),
+			'unamerican_lang_selector_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
+				'
+					<html amp><head><meta charset="utf-8">
+					<style>
+						html:lang(en-US) { color:red; }
+						body span:lang(en-US) { color:red; }
+						html:lang(en) {color:white; }
+						.test:lang(en-us, en-CA) {color:white; }
+						html span.test:lang(en-US) { color: blue;}
+						html:lang("en-US") span.test { color: blue;}
+						html:lang(en-CA) {color:red; }
+						html:lang(ar) { color:green; }
+						html:lang(es-MX) { color:green; }
+						</style>
+					</head><body><span class="test">Test</span></body></html>
+				',
+				array(
+					'html:lang(en-US){color:red}body span:lang(en-US){color:red}html:lang(en){color:white}.test:lang(en-us, en-CA){color:white}html span.test:lang(en-US){color:blue}html:lang("en-US") span.test{color:blue}',
 				),
 				array(),
 			),


### PR DESCRIPTION
Twenty Nineteen's `style.css` went from 112KB in v1.2 to an eye-dropping 208K in v1.3: almost doubling the size. When AMP has a budget of 50KB this is especially bad. As noted in #1900, the increase in size is almost all due to `:lang()` selectors being added for the various languages. This being the case, if we just tree-shake any such selectors that for all languages other than the current one, then we can recover from this large increase.

Before this PR, the tree-shaker and minifier was brought the `style.css` down to 72KB. After this PR, the total is brought down to 37KB.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/2903178/amp.zip) (v1.1-alpha-20190226T001832Z-bc77bcb5).

Fixes #1900.