### PR TITLE
[AMP Stories] Fix filtering wrapper props.

### DIFF
--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -196,14 +196,20 @@ const addWrapperProps = ( BlockListBlock ) => {
 				'amp/amp-story-page' === blockName
 			)
 		) {
-			wrapperProps = Object.assign( {}, props.wrapperProps, { 'data-amp-selected': 'parent' } );
-		} else {
-			// If we have image caption or font-family set, add these to wrapper properties.
-			wrapperProps = Object.assign( {}, props.wrapperProps, {
-				'data-amp-image-caption': ( 'core/image' === blockName && ! attributes.ampShowImageCaption ) ? 'noCaption' : undefined,
-				'data-font-family': attributes.ampFontFamily || undefined,
-			} );
+			wrapperProps = {
+				...props.wrapperProps,
+				'data-amp-selected': 'parent',
+			};
+
+			return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 		}
+
+		// If we have image caption or font-family set, add these to wrapper properties.
+		wrapperProps = {
+			...props.wrapperProps,
+			'data-amp-image-caption': ( 'core/image' === blockName && ! attributes.ampShowImageCaption ) ? 'noCaption' : undefined,
+			'data-font-family': attributes.ampFontFamily || undefined,
+		};
 
 		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 	} );

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -10,7 +10,7 @@ const { getSelectedBlockClientId } = select( 'core/editor' );
 /**
  * Internal dependencies
  */
-import { withAttributes, withParentBlock, withBlockName, withHasSelectedInnerblock, withAmpStorySettings } from './components';
+import { withAttributes, withBlockName, withHasSelectedInnerblock, withAmpStorySettings } from './components';
 import { ALLOWED_BLOCKS, BLOCK_TAG_MAPPING } from './helpers';
 
 // Ensure that the default block is page when no block is selected.
@@ -169,8 +169,7 @@ const setBlockParent = ( props ) => {
 const wrapperWithSelect = compose(
 	withAttributes,
 	withBlockName,
-	withHasSelectedInnerblock,
-	withParentBlock
+	withHasSelectedInnerblock
 );
 
 /**
@@ -179,35 +178,37 @@ const wrapperWithSelect = compose(
  * @param {Object} BlockListBlock BlockListBlock element.
  * @return {Function} Handler.
  */
-const addWrapperProps = createHigherOrderComponent(
-	( BlockListBlock ) => {
-		return wrapperWithSelect( ( props ) => {
-			const { blockName, hasSelectedInnerBlock, attributes } = props;
+const addWrapperProps = ( BlockListBlock ) => {
+	return wrapperWithSelect( ( props ) => {
+		const { blockName, hasSelectedInnerBlock, attributes } = props;
 
-			// If we have an inner block selected let's add 'data-amp-selected=parent' to the wrapper.
-			if (
-				hasSelectedInnerBlock &&
-				(
-					'amp/amp-story-page' === blockName
-				)
-			) {
-				return <BlockListBlock { ...props } data-amp-selected={ 'parent' } />;
-			}
+		// If it's not an allowed block then lets return original;
+		if ( -1 === ALLOWED_BLOCKS.indexOf( blockName ) ) {
+			return <BlockListBlock { ...props } />;
+		}
 
-			// If we got this far and it's not an allowed inner block then lets return original.
-			if ( -1 === ALLOWED_BLOCKS.indexOf( blockName ) ) {
-				return <BlockListBlock { ...props } />;
-			}
+		let wrapperProps;
 
-			return <BlockListBlock
-				{ ...props }
-				data-amp-image-caption={ ( 'core/image' === blockName && ! attributes.ampShowImageCaption ) ? 'noCaption' : undefined }
-				data-font-family={ attributes.ampFontFamily || undefined }
-			/>;
-		} );
-	},
-	'addWrapperProps'
-);
+		// If we have an inner block selected let's add 'data-amp-selected=parent' to the wrapper.
+		if (
+			hasSelectedInnerBlock &&
+			(
+				'amp/amp-story-page' === blockName
+			)
+		) {
+			wrapperProps = Object.assign( {}, props.wrapperProps, { 'data-amp-selected': 'parent' } );
+		} else {
+			// If we have image caption or font-family set, add these to wrapper properties.
+			wrapperProps = Object.assign( {}, props.wrapperProps, {
+				'data-amp-image-caption': ( 'core/image' === blockName && ! attributes.ampShowImageCaption ) ? 'noCaption' : undefined,
+				'data-font-family': attributes.ampFontFamily || undefined,
+			} );
+		}
+
+		const newProps = Object.assign( {}, props, { wrapperProps: wrapperProps } );
+		return <BlockListBlock { ...newProps } />;
+	} );
+};
 
 // These do not reliably work at domReady.
 addFilter( 'blocks.registerBlockType', 'ampStoryEditorBlocks/setBlockParent', setBlockParent );

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
-import { compose, createHigherOrderComponent } from '@wordpress/compose';
+import { compose } from '@wordpress/compose';
 import domReady from '@wordpress/dom-ready';
 import { setDefaultBlockName } from '@wordpress/blocks';
 import { select, subscribe } from '@wordpress/data';

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -205,8 +205,7 @@ const addWrapperProps = ( BlockListBlock ) => {
 			} );
 		}
 
-		const newProps = Object.assign( {}, props, { wrapperProps: wrapperProps } );
-		return <BlockListBlock { ...newProps } />;
+		return <BlockListBlock { ...props } wrapperProps={ wrapperProps } />;
 	} );
 };
 


### PR DESCRIPTION
Fixes the filter for wrapper props  (`addWrapperProps`) and restores the following features:
- Displaying font-family in the frontend;
- Adding `data-amp-selected` attribute to the selected parent;
- Displaying / hiding image caption;