### PR TITLE
Add noscript iframe fallbacks for amp-iframe for no-JS browsers

### DIFF
--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -46,8 +46,8 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
 
-			// Allow audio in fallbacks.
-			if ( 'noscript' === $node->parentNode->nodeName ) {
+			// Skip element if already inside of an AMP element as a noscript fallback.
+			if ( 'noscript' === $node->parentNode->nodeName && $node->parentNode->parentNode && 'amp-' === substr( $node->parentNode->parentNode->nodeName, 0, 4 ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -74,7 +74,13 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
-			$node                  = $nodes->item( $i );
+			$node = $nodes->item( $i );
+
+			// Skip element if in AMP-element fallbacks.
+			if ( 'noscript' === $node->parentNode->nodeName && $node->parentNode->parentNode && 'amp-' === substr( $node->parentNode->parentNode->nodeName, 0, 4 ) ) {
+				continue;
+			}
+
 			$normalized_attributes = $this->normalize_attributes( AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node ) );
 
 			/**

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -109,7 +109,12 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$new_node->appendChild( $placeholder_node );
 			}
 
+			// Preserve original node in noscript for no-JS environments.
+			$node->setAttribute( 'src', $normalized_attributes['src'] );
 			$node->parentNode->replaceChild( $new_node, $node );
+			$noscript = $this->dom->createElement( 'noscript' );
+			$noscript->appendChild( $node );
+			$new_node->appendChild( $noscript );
 		}
 	}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -87,6 +87,11 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			// Skip element if in AMP-element fallbacks.
+			if ( 'noscript' === $node->parentNode->nodeName && $node->parentNode->parentNode && 'amp-' === substr( $node->parentNode->parentNode->nodeName, 0, 4 ) ) {
+				continue;
+			}
+
 			if ( ! $node->hasAttribute( 'src' ) || '' === trim( $node->getAttribute( 'src' ) ) ) {
 				$this->remove_invalid_child( $node );
 				continue;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -59,8 +59,8 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
 
-			// Allow video in fallbacks.
-			if ( 'noscript' === $node->parentNode->nodeName ) {
+			// Skip element if already inside of an AMP element as a noscript fallback.
+			if ( 'noscript' === $node->parentNode->nodeName && $node->parentNode->parentNode && 'amp-' === substr( $node->parentNode->parentNode->nodeName, 0, 4 ) ) {
 				continue;
 			}
 

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -174,6 +174,22 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 				'<amp-audio src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
 				null,
 			),
+
+			'audio_with_existing_noscript_fallback'     => array(
+				'<div id="player"><noscript><audio src="https://example.com/audio/file.mp3"></audio></noscript></div>',
+				'
+					<div id="player">
+						<!--noscript-->
+						<amp-audio src="https://example.com/audio/file.mp3" width="auto">
+							<a href="https://example.com/audio/file.mp3" fallback="">https://example.com/audio/file.mp3</a>
+							<noscript>
+								<audio src="https://example.com/audio/file.mp3"></audio>
+							</noscript>
+						</amp-audio>
+						<!--/noscript-->
+					</div>
+				',
+			),
 		);
 	}
 
@@ -191,6 +207,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );
+		$sanitizer->sanitize();
+
+		$sanitizer = new AMP_Script_Sanitizer( $dom );
 		$sanitizer->sanitize();
 
 		$style_sanitizer = new AMP_Style_Sanitizer( $dom );

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -1,6 +1,24 @@
 <?php
+/**
+ * Class AMP_Iframe_Converter_Test.
+ *
+ * @package AMP
+ */
 
+// phpcs:disable WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned
+
+/**
+ * Class AMP_Iframe_Converter_Test
+ *
+ * @covers AMP_Iframe_Sanitizer
+ */
 class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array Data.
+	 */
 	public function get_data() {
 		return array(
 			'no_iframes'                                => array(
@@ -10,100 +28,231 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 
 			'simple_iframe'                             => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'force_https'                               => array(
 				'<iframe src="http://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_without_dimensions'                 => array(
 				'<iframe src="https://example.com/video/132886713"></iframe>',
-				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+						<noscript>
+							<iframe src="https://example.com/video/132886713"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_height_only'                   => array(
 				'<iframe src="https://example.com/video/132886713" height="400"></iframe>',
-				'<amp-iframe src="https://example.com/video/132886713" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/video/132886713" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height">
+						<noscript>
+							<iframe src="https://example.com/video/132886713" height="400"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_width_only'                    => array(
 				'<iframe src="https://example.com/video/132886713" width="600"></iframe>',
-				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+						<noscript>
+							<iframe src="https://example.com/video/132886713" width="600"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_invalid_frameborder'           => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="no"></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+						</noscript>					
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_1_frameborder'                 => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder=1></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'simple_iframe_with_sandbox'                => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-same-origin"></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-same-origin"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_blacklisted_attribute'         => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto"></iframe>',
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_sizes_attribute_is_overridden' => array(
 				'<iframe src="https://example.com/iframe" width="500" height="281"></iframe>',
-				'<amp-iframe src="https://example.com/iframe" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/iframe" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/iframe" width="500" height="281"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_id_attribute'                  => array(
 				'<iframe src="https://example.com/iframe" id="myIframe"></iframe>',
-				'<amp-iframe src="https://example.com/iframe" id="myIframe" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/iframe" id="myIframe" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+						<noscript>
+							<iframe src="https://example.com/iframe" id="myIframe"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'iframe_with_protocol_relative_url'         => array(
 				'<iframe src="//example.com/video/132886713"></iframe>',
-				'<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height"></amp-iframe>',
+				'
+					<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+						<noscript>
+							<iframe src="https://example.com/video/132886713"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'multiple_same_iframe'                      => array(
-				trim(
-					'
-<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
-<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
-<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
 				'
+					<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+					<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+					<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+				',
+				str_repeat(
+					'
+						<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+							<noscript>
+								<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+							</noscript>
+						</amp-iframe>
+					',
+					3
 				),
-				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
 
 			'multiple_different_iframes'                => array(
-				trim(
-					'
-<iframe src="https://example.com/embed/12345" width="500" height="281"></iframe>
-<iframe src="https://example.com/embed/67890" width="280" height="501"></iframe>
-<iframe src="https://example.com/embed/11111" width="700" height="601"></iframe>
 				'
-				),
-				'<amp-iframe src="https://example.com/embed/12345" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/67890" width="280" height="501" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/embed/11111" width="700" height="601" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+					<iframe src="https://example.com/embed/12345" width="500" height="281"></iframe>
+					<iframe src="https://example.com/embed/67890" width="280" height="501"></iframe>
+					<iframe src="https://example.com/embed/11111" width="700" height="601"></iframe>
+				',
+				'
+					<amp-iframe src="https://example.com/embed/12345" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/12345" width="500" height="281"></iframe>
+						</noscript>
+					</amp-iframe>
+					<amp-iframe src="https://example.com/embed/67890" width="280" height="501" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/67890" width="280" height="501"></iframe>
+						</noscript>
+					</amp-iframe>
+					<amp-iframe src="https://example.com/embed/11111" width="700" height="601" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com/embed/11111" width="700" height="601"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 			'iframe_in_p_tag'                           => array(
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>',
-				'<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe></p>',
+				'
+					<p>
+						<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+							<noscript>
+								<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe>
+							</noscript>
+						</amp-iframe>
+					</p>
+				',
 			),
 			'multiple_iframes_in_p_tag'                 => array(
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
-				'<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe></p>',
+				'
+					<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+							<noscript>
+								<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe>
+							</noscript>
+						</amp-iframe>
+						<amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+							<noscript>
+								<iframe src="https://example.com/video/132886714" width="500" height="281"></iframe>
+							</noscript>
+						</amp-iframe>
+					</p>
+				',
 			),
 			'multiple_iframes_and_contents_in_p_tag'    => array(
 				'<p>contents<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
-				'<p>contents<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe><amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe></p>',
+				'
+					<p>contents<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+							<noscript>
+								<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe>
+							</noscript>
+						</amp-iframe>
+						<amp-iframe src="https://example.com/video/132886714" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+							<noscript>
+								<iframe src="https://example.com/video/132886714" width="500" height="281"></iframe>
+							</noscript>
+						</amp-iframe>
+					</p>
+				',
 			),
 			'iframe_src_with_commas_and_colons'         => array(
 				'<iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&z=15&l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen=""></iframe>',
-				'<amp-iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&amp;z=15&amp;l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&amp;permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen="" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				'
+					<amp-iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&amp;z=15&amp;l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&amp;permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen="" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&amp;z=15&amp;l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&amp;permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
 			),
 
 			'amp_iframe_with_fallback'                  => array(
@@ -133,10 +282,12 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$whitelist_sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
-		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
-		$this->assertEquals( $expected, $content );
+		$this->assertEqualMarkup( $expected, $content );
 	}
 
+	/**
+	 * Test HTTPS required.
+	 */
 	public function test__https_required() {
 		$source   = '<iframe src="http://example.com/embed/132886713"></iframe>';
 		$expected = '';
@@ -155,6 +306,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $content );
 	}
 
+	/**
+	 * Test get_scripts() did not convert.
+	 */
 	public function test_get_scripts__didnt_convert() {
 		$source   = '<p>Hello World</p>';
 		$expected = array();
@@ -173,6 +327,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $scripts );
 	}
 
+	/**
+	 * Test get_scripts() did convert.
+	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>';
 		$expected = array( 'amp-iframe' => true );
@@ -191,9 +348,12 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $scripts );
 	}
 
+	/**
+	 * Test args placeholder.
+	 */
 	public function test__args__placeholder() {
 		$source   = '<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>';
-		$expected = '<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"><span placeholder="" class="amp-wp-iframe-placeholder"></span></amp-iframe></p>';
+		$expected = '<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></noscript></amp-iframe></p>';
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer(
@@ -208,4 +368,19 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $content );
 	}
 
+	/**
+	 * Assert markup is equal.
+	 *
+	 * @param string $expected Expected markup.
+	 * @param string $actual   Actual markup.
+	 */
+	public function assertEqualMarkup( $expected, $actual ) {
+		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
+
+		$this->assertEquals(
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE ) ),
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE ) )
+		);
+	}
 }

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -105,13 +105,26 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&z=15&l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen=""></iframe>',
 				'<amp-iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&amp;z=15&amp;l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&amp;permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen="" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
 			),
+
+			'amp_iframe_with_fallback'                  => array(
+				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"><noscript><iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe></noscript></amp-iframe>',
+				null,
+			),
 		);
 	}
 
 	/**
+	 * Test converter.
+	 *
 	 * @dataProvider get_data
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 */
-	public function test_converter( $source, $expected ) {
+	public function test_converter( $source, $expected = null ) {
+		if ( ! $expected ) {
+			$expected = $source;
+		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
 		$sanitizer->sanitize();

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -209,6 +209,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure class="wp-block-image is-resized"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
 				'<figure class="wp-block-image is-resized"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
+
+			'amp_img_with_noscript_fallback'           => array(
+				'<amp-img src="http://placehold.it/100x100" layout="fixed" width="100" height="100"><noscript><img src="http://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
+				null,
+			),
 		);
 	}
 
@@ -219,7 +224,10 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param string $expected Expected.
 	 * @dataProvider get_data
 	 */
-	public function test_converter( $source, $expected ) {
+	public function test_converter( $source, $expected = null ) {
+		if ( ! $expected ) {
+			$expected = $source;
+		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 		$sanitizer->sanitize();

--- a/tests/test-amp-script-sanitizer.php
+++ b/tests/test-amp-script-sanitizer.php
@@ -96,6 +96,6 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertRegExp( '/<!-- Google Tag Manager -->\s*<!-- End Google Tag Manager -->/', $content );
 		$this->assertContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
 		$this->assertContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
-		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span></amp-iframe><!--/noscript-->', $content );
+		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
 	}
 }

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -166,6 +166,11 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 				null,
 			),
+
+			'video_with_fallback' => array(
+				'<div id="player"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></div>',
+				'<div id="player"><!--noscript--><amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video><!--/noscript--></div>',
+			),
 		);
 	}
 
@@ -185,6 +190,9 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 
 		$sanitizer = new AMP_Video_Sanitizer( $dom );
+		$sanitizer->sanitize();
+
+		$sanitizer = new AMP_Script_Sanitizer( $dom );
 		$sanitizer->sanitize();
 
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );


### PR DESCRIPTION
This is a follow-up to #1861.

* When converting `iframe` to `amp-iframe`, automatically put the original `iframe` inside of a `noscript` element inside or the replacement `amp-iframe`. This ensures that browsers that have JS turned off will still get the iframe rendering. 
* Prevent converting `iframe` elements which are already inside of `amp-iframe > noscript`.
* Prevent converting `img` elements which are already inside of `amp-img > noscript`.
* Prevent converting `video` elements which are already inside of `amp-video > noscript`.
* Prevent converting `audio` elements which are already inside of `amp-audio > noscript`.
