### PR TITLE
[AMP Stories] Remove all blocks that aren't whitelisted

### DIFF
--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -11,7 +11,7 @@ import { select, subscribe } from '@wordpress/data';
  * Internal dependencies
  */
 import { withAttributes, withParentBlock, withBlockName, withHasSelectedInnerBlock, withAmpStorySettings, withAnimationControls } from './components';
-import { ALLOWED_BLOCKS, BLOCK_TAG_MAPPING } from './constants';
+import { ALLOWED_BLOCKS, ALLOWED_CHILD_BLOCKS, BLOCK_TAG_MAPPING } from './constants';
 import { maybeEnqueueFontStyle } from './helpers';
 
 const { getSelectedBlockClientId, getBlockOrder, getBlocksByClientId } = select( 'core/editor' );
@@ -19,6 +19,9 @@ const { getSelectedBlockClientId, getBlockOrder, getBlocksByClientId } = select(
 // Ensure that the default block is page when no block is selected.
 domReady( () => {
 	setDefaultBlockName( 'amp/amp-story-page' );
+
+	// Remove all blocks that aren't whitelisted.
+	getBlockTypes().filter( ( { name } ) => ! ALLOWED_BLOCKS.includes( name ) && 'amp/amp-story-page' ).map( ( { name } ) => unregisterBlockType( name ) );
 
 	// Load all needed fonts.
 	getBlocksByClientId( getBlockOrder() )
@@ -35,9 +38,6 @@ domReady( () => {
 subscribe( () => {
 	setDefaultBlockName( getSelectedBlockClientId() ? 'amp/amp-story-text' : 'amp/amp-story-page' );
 } );
-
-// Remove all blocks that aren't whitelisted.
-getBlockTypes().filter( ( { name } ) => ! ALLOWED_BLOCKS.includes( name ) ).map( ( { name } ) => unregisterBlockType( name ) );
 
 /**
  * Add AMP attributes to every allowed AMP Story block.

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -47,7 +47,7 @@ getBlockTypes().filter( ( { name } ) => ! ALLOWED_BLOCKS.includes( name ) ).map(
  * @return {Object} Settings.
  */
 const addAMPAttributes = ( settings, name ) => {
-	if ( -1 === ALLOWED_BLOCKS.indexOf( name ) ) {
+	if ( -1 === ALLOWED_CHILD_BLOCKS.indexOf( name ) ) {
 		return settings;
 	}
 
@@ -120,7 +120,7 @@ const addAMPAttributes = ( settings, name ) => {
 const addAMPExtraProps = ( props, blockType, attributes ) => {
 	const ampAttributes = {};
 
-	if ( -1 === ALLOWED_BLOCKS.indexOf( blockType.name ) ) {
+	if ( -1 === ALLOWED_CHILD_BLOCKS.indexOf( blockType.name ) ) {
 		return props;
 	}
 
@@ -166,7 +166,7 @@ const setBlockParent = ( props ) => {
 		};
 	}
 
-	if ( -1 === name.indexOf( 'amp/amp-story-page' ) ) {
+	if ( name !== 'amp/amp-story-page' ) {
 		// Do not allow inserting any of the blocks if they're not AMP Story blocks.
 		return {
 			...props,

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -4,7 +4,7 @@
 import { addFilter } from '@wordpress/hooks';
 import { compose } from '@wordpress/compose';
 import domReady from '@wordpress/dom-ready';
-import { setDefaultBlockName } from '@wordpress/blocks';
+import { setDefaultBlockName, getBlockTypes, unregisterBlockType } from '@wordpress/blocks';
 import { select, subscribe } from '@wordpress/data';
 
 /**
@@ -35,6 +35,9 @@ domReady( () => {
 subscribe( () => {
 	setDefaultBlockName( getSelectedBlockClientId() ? 'amp/amp-story-text' : 'amp/amp-story-page' );
 } );
+
+// Remove all blocks that aren't whitelisted.
+getBlockTypes().filter( ( { name } ) => ! ALLOWED_BLOCKS.includes( name ) ).map( ( { name } ) => unregisterBlockType( name ) );
 
 /**
  * Add AMP attributes to every allowed AMP Story block.

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -158,7 +158,7 @@ const addAMPExtraProps = ( props, blockType, attributes ) => {
  */
 const setBlockParent = ( props ) => {
 	const { name } = props;
-	if ( -1 !== ALLOWED_BLOCKS.indexOf( name ) ) {
+	if ( -1 !== ALLOWED_CHILD_BLOCKS.indexOf( name ) ) {
 		// Only amp/amp-story-page blocks can be on the top level.
 		return {
 			...props,

--- a/assets/src/blocks/amp-story/edit.js
+++ b/assets/src/blocks/amp-story/edit.js
@@ -29,7 +29,7 @@ import { withSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import BlockNavigation from './block-navigation';
-import { ALLOWED_BLOCKS } from '../../constants';
+import { ALLOWED_CHILD_BLOCKS } from '../../constants';
 import { ALLOWED_MEDIA_TYPES, IMAGE_BACKGROUND_TYPE, VIDEO_BACKGROUND_TYPE, POSTER_ALLOWED_MEDIA_TYPES } from './constants';
 
 const TEMPLATE = [
@@ -228,7 +228,7 @@ class EditPage extends Component {
 							</video>
 						</div>
 					) }
-					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED_BLOCKS } />
+					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED_CHILD_BLOCKS } />
 				</div>
 			</Fragment>
 		);

--- a/assets/src/components/with-amp-story-settings.js
+++ b/assets/src/components/with-amp-story-settings.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ALLOWED_BLOCKS } from '../constants';
+import { ALLOWED_CHILD_BLOCKS } from '../constants';
 import { withParentBlock } from './';
 
 export default createHigherOrderComponent(
@@ -18,7 +18,7 @@ export default createHigherOrderComponent(
 		return withParentBlock( ( props ) => {
 			const { attributes, name, parentBlock } = props;
 
-			if ( -1 === ALLOWED_BLOCKS.indexOf( name ) || ! parentBlock || 'amp/amp-story-page' !== parentBlock.name ) {
+			if ( -1 === ALLOWED_CHILD_BLOCKS.indexOf( name ) || ! parentBlock || 'amp/amp-story-page' !== parentBlock.name ) {
 				return <BlockEdit { ...props } />;
 			}
 

--- a/assets/src/components/with-animation-controls.js
+++ b/assets/src/components/with-animation-controls.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { ALLOWED_BLOCKS } from '../constants';
+import { ALLOWED_CHILD_BLOCKS } from '../constants';
 import { AnimationControls, withParentBlock } from './';
 
 export default createHigherOrderComponent(
@@ -18,7 +18,7 @@ export default createHigherOrderComponent(
 		return withParentBlock( ( props ) => {
 			const { attributes, setAttributes, name, parentBlock } = props;
 
-			if ( -1 === ALLOWED_BLOCKS.indexOf( name ) || ! parentBlock || 'amp/amp-story-page' !== parentBlock.name ) {
+			if ( -1 === ALLOWED_CHILD_BLOCKS.indexOf( name ) || ! parentBlock || 'amp/amp-story-page' !== parentBlock.name ) {
 				return <BlockEdit { ...props } />;
 			}
 

--- a/assets/src/constants.js
+++ b/assets/src/constants.js
@@ -27,7 +27,11 @@ import Slabo27 from '../images/font-names/slabo-27.svg';
 import SourceSansPro from '../images/font-names/source-sans-pro.svg';
 import Ubuntu from '../images/font-names/ubuntu.svg';
 
-export const ALLOWED_BLOCKS = [
+export const ALLOWED_TOP_LEVEL_BLOCKS = [
+	'amp/amp-story-pag',
+];
+
+export const ALLOWED_CHILD_BLOCKS = [
 	'core/audio',
 	'core/code',
 	'core/embed',
@@ -40,6 +44,11 @@ export const ALLOWED_BLOCKS = [
 	'core/verse',
 	'core/video',
 	'amp/amp-story-text',
+];
+
+export const ALLOWED_BLOCKS = [
+	...ALLOWED_TOP_LEVEL_BLOCKS,
+	...ALLOWED_CHILD_BLOCKS,
 ];
 
 export const BLOCK_ICONS = {

--- a/assets/src/constants.js
+++ b/assets/src/constants.js
@@ -28,7 +28,7 @@ import SourceSansPro from '../images/font-names/source-sans-pro.svg';
 import Ubuntu from '../images/font-names/ubuntu.svg';
 
 export const ALLOWED_TOP_LEVEL_BLOCKS = [
-	'amp/amp-story-pag',
+	'amp/amp-story-page',
 ];
 
 export const ALLOWED_CHILD_BLOCKS = [


### PR DESCRIPTION
Without this, it's still possible to insert paragraph blocks and other blocks that aren't meant to be used in stories.