### PR TITLE
Fix invoking is_amp_endpoint() when there is no WP_Query

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -262,11 +262,10 @@ function is_amp_endpoint() {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				/* translators: 1: is_amp_endpoint(), 2: parse_query, 3: false */
-				esc_html__( '%1$s was called before the %2$s hook was called. This function will always return %3$s before the %2$s hook is called.', 'amp' ),
+				/* translators: 1: is_amp_endpoint(), 2: parse_query */
+				esc_html__( '%1$s was called before the %2$s hook was called.', 'amp' ),
 				'is_amp_endpoint()',
-				'parse_query',
-				'false'
+				'parse_query'
 			),
 			'0.4.2'
 		);
@@ -276,11 +275,10 @@ function is_amp_endpoint() {
 		_doing_it_wrong(
 			__FUNCTION__,
 			sprintf(
-				/* translators: 1: is_amp_endpoint(), 2: WP_Query, 3: false */
-				esc_html__( '%1$s was called before the %2$s was instantiated. This function will always return %3$s before the %2$s hook is called.', 'amp' ),
+				/* translators: 1: is_amp_endpoint(), 2: WP_Query */
+				esc_html__( '%1$s was called before the %2$s was instantiated.', 'amp' ),
 				'is_amp_endpoint()',
-				'WP_Query',
-				'false'
+				'WP_Query'
 			),
 			'1.1'
 		);

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -385,6 +385,44 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_amp_endpoint() function before the parse_query action happens.
+	 *
+	 * @covers \is_amp_endpoint()
+	 * @expectedIncorrectUsage is_amp_endpoint
+	 */
+	public function test_is_amp_endpoint_before_parse_query_action() {
+		global $wp_actions;
+		unset( $wp_actions['parse_query'] );
+		$this->assertFalse( is_amp_endpoint() );
+	}
+
+	/**
+	 * Test is_amp_endpoint() function when there is no WP_Query.
+	 *
+	 * @covers \is_amp_endpoint()
+	 * @expectedIncorrectUsage is_feed
+	 * @expectedIncorrectUsage is_amp_endpoint
+	 */
+	public function test_is_amp_endpoint_when_no_wp_query() {
+		global $wp_query;
+		$wp_query = null;
+		$this->assertFalse( is_amp_endpoint() );
+	}
+
+	/**
+	 * Test is_amp_endpoint() function before the wp action happens.
+	 *
+	 * @covers \is_amp_endpoint()
+	 * @expectedIncorrectUsage is_amp_endpoint
+	 */
+	public function test_is_amp_endpoint_before_wp_action() {
+		add_theme_support( 'amp' );
+		global $wp_actions;
+		unset( $wp_actions['wp'] );
+		$this->assertTrue( is_amp_endpoint() );
+	}
+
+	/**
 	 * Filter calls.
 	 *
 	 * @var array


### PR DESCRIPTION
* Prevent fatal error when calling `is_amp_endpoint()` and no `WP_Query` exists.
* Issue `_doing_it_wrong()` warnings when called but there is no query.
* Fix correctness of `_doing_it_wrong()` warnings where non-`false` values actually can be returned.
* Add tests for calling `is_amp_endpoint()` incorrectly.

Fixes #1905.