### PR TITLE
Prevent serving AMP for post embeds

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -252,7 +252,7 @@ function post_supports_amp( $post ) {
 function is_amp_endpoint() {
 	global $pagenow, $wp_query;
 
-	if ( is_admin() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ), true ) ) {
+	if ( is_admin() || is_embed() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ), true ) ) {
 		return false;
 	}
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -385,6 +385,26 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test is_amp_endpoint() function for post embeds and feeds.
+	 *
+	 * @covers \is_amp_endpoint()
+	 * global WP_Query $wp_the_query
+	 */
+	public function test_is_amp_endpoint_for_post_embeds_and_feeds() {
+		add_theme_support( AMP_Theme_Support::SLUG );
+		$post_id = $this->factory()->post->create_and_get()->ID;
+
+		$this->go_to( home_url( "?p=$post_id" ) );
+		$this->assertTrue( is_amp_endpoint() );
+
+		$this->go_to( home_url( "?p=$post_id&embed=1" ) );
+		$this->assertFalse( is_amp_endpoint() );
+
+		$this->go_to( home_url( '?feed=rss' ) );
+		$this->assertFalse( is_amp_endpoint() );
+	}
+
+	/**
 	 * Test is_amp_endpoint() function before the parse_query action happens.
 	 *
 	 * @covers \is_amp_endpoint()
@@ -401,6 +421,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 *
 	 * @covers \is_amp_endpoint()
 	 * @expectedIncorrectUsage is_feed
+	 * @expectedIncorrectUsage is_embed
 	 * @expectedIncorrectUsage is_amp_endpoint
 	 */
 	public function test_is_amp_endpoint_when_no_wp_query() {


### PR DESCRIPTION
I was testing post embeds from my native AMP site and I noticed them appearing unexpectedly in Gutenberg as:

> ![screen shot 2019-03-06 at 10 31 56](https://user-images.githubusercontent.com/134745/53905253-ece12f80-3ffc-11e9-8047-1af28b8cc544.png)

And when I accessed the post embed endpoint I saw it was unexpectedly an AMP page, and an [invalid one](https://gist.github.com/westonruter/503c6c8d359ce10994f306dab01c93e3) at that:

![screen shot 2019-03-06 at 10 30 13](https://user-images.githubusercontent.com/134745/53905264-f8ccf180-3ffc-11e9-8c2b-7ee6ca6a370f.png)

Even though it would actually be useful to allow post embeds to be AMP documents, since we could safely embed them via the AMP Shadow API, for now we should just preserve the normal behavior and fix embedding.

With the changes in this PR, the post embed in Gutenberg now looks as expected:

> ![screen shot 2019-03-06 at 10 32 10](https://user-images.githubusercontent.com/134745/53905370-3df12380-3ffd-11e9-958e-701362792bb4.png)

And the individual embed endpoint is no longer an invalid AMP page, and it now renders properly:

> ![screen shot 2019-03-06 at 10 30 24](https://user-images.githubusercontent.com/134745/53905408-5bbe8880-3ffd-11e9-9179-08516aea5ead.png)
