### PR TITLE
Account for ambiguity in matching templates by incorporating template priority order from core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@
 node_modules
 wiki
 amp.zip
-**/*-compiled.js
+assets/js/*-compiled.js
 built
 /amphtml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,9 @@ module.exports = function( grunt ) {
 
 		// Clean up the build.
 		clean: {
+			compiled: {
+				src: [ 'assets/js/*-compiled.js' ]
+			},
 			build: {
 				src: [ 'build' ]
 			}
@@ -72,6 +75,9 @@ module.exports = function( grunt ) {
 		spawnQueue = [];
 		stdout = [];
 
+		// Clear out all existing compiled files first.
+		grunt.task.run( 'clean' );
+
 		grunt.task.run( 'shell:webpack_production' );
 
 		spawnQueue.push(
@@ -101,7 +107,6 @@ module.exports = function( grunt ) {
 			paths.push( 'vendor/fasterimage/fasterimage/src/**' );
 			paths.push( 'vendor/willwashburn/stream/src/**' );
 
-			grunt.task.run( 'clean' );
 			grunt.config.set( 'copy', {
 				build: {
 					src: paths,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f35ca4870517517bac1674c2156367e8",
+    "content-hash": "b2b0f486c54a51f99f43eaf9df2d3316",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -123,6 +123,11 @@
                 "phpunit/phpunit": "~4.8"
             },
             "type": "library",
+            "extra": {
+                "patches_applied": {
+                    "PHP-CSS-Parser: Fix parsing CSS selectors which contain commas <https://github.com/sabberworm/PHP-CSS-Parser/pull/138>": "patches/php-css-parser-mods.diff"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Sabberworm\\CSS": "lib/"


### PR DESCRIPTION
This fixes a bug identified in https://wordpress.org/support/topic/amp-notice-on-woocommerce-product-search-page/

It turns out that if you have a custom post type registered (say `product`), this custom post type has an archive, and you do a search among the custom post types with a URL such as:

```
?s=foo&post_type=product
```

The resulting `WP_Query` has _both_ `is_search` and `is_custom_post_type` set. WordPress will end up serving the `search.php` template here because the `is_search()` condition comes before `is_post_type_archive()` [check in `template-loader.php`](https://github.com/WordPress/wordpress-develop/blob/5.1.0/src/wp-includes/template-loader.php#L49-L68). Nevertheless, we were not taking this logic into account but are rather just issuing a warning when more than one template is matched:

https://github.com/ampproject/amp-wp/blob/3a2064ea7a3d3e83ed7bb12c4ef16623f67dae40/includes/class-amp-theme-support.php#L577-L593

Now that we see there is a case where template conditionals can be ambiguous, we need to incorporate the priority order of template conditional checks in order to make sure we select the same matching template as WordPress core will do.

The one additional consideration that the AMP plugin has to make here is the case where a site registers a custom template type that is outside of the WordPress template hierarchy entirely. Since such a template type would not be accounted for in the `template-loader.php` conditional, in this case we just use the custom matching templates by assuming they are more specific than the ones coming from core.

This PR also fixes an issue with the build process where compiled files from other branches (e.g. `amp-stories-redux`) were not getting cleaned up and were unintentionally being included in the builds. So now those compiled files are all removed before invoking Webpack when doing a build.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/2943185/amp.zip) (v1.1-alpha-20190307T202052Z-bef18cf6)
