### PR TITLE
Try: Experiment with amp-img-auto-sizes

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -617,3 +617,21 @@ function amp_redirect_old_slug_to_new_url( $link ) {
 
 	return $link;
 }
+
+/**
+ * Determine whether to run the img experiment.
+ *
+ * @private
+ * @return bool Whether running experiment.
+ */
+function _amp_is_doing_img_experiment() {
+	if ( defined( 'AMP_IMG_EXPERIMENT' ) ) {
+		return AMP_IMG_EXPERIMENT;
+	}
+
+	return (
+		( defined( 'WP_DEBUG' ) && WP_DEBUG )
+		&&
+		isset( $_GET['amp_img_experiment'] ) // phpcs:ignore
+	);
+}

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -23,3 +23,13 @@ body amp-audio:not([controls]) {
 	display: inline-block;
 	height: auto;
 }
+
+/**
+ * Prevent display:block in a theme's stylesheet from breaking the width of an image that has an intrinsic layout.
+ * See <https://github.com/ampproject/amphtml/issues/17053#issuecomment-471127486>.
+ * @todo Remove the body.amp-wp-img-experiment selector from \AMP_Theme_Support::enqueue_assets() when experiment graduates.
+ */
+body.amp-wp-img-experiment .wp-block-image:not(#_) > figure > amp-img {
+	display: inline-block;
+	vertical-align: middle;
+}

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -118,7 +118,6 @@ class AMP_HTTP {
 			'_wp_amp_action_xhr_converted',
 			'amp_latest_update_time',
 			'amp_last_check_time',
-			'amp_experiments',
 		);
 
 		// Scrub input vars.
@@ -160,22 +159,6 @@ class AMP_HTTP {
 				}
 			}
 		}
-	}
-
-	/**
-	 * Get the enabled experiments.
-	 *
-	 * @return array Enabled experiments.
-	 */
-	public static function get_enabled_experiments() {
-		$enabled_experiments = array();
-		if ( isset( self::$purged_amp_query_vars['amp_experiments'] ) ) {
-			$enabled_experiments = array_map(
-				'sanitize_key',
-				(array) self::$purged_amp_query_vars['amp_experiments']
-			);
-		}
-		return $enabled_experiments;
 	}
 
 	/**

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -118,6 +118,7 @@ class AMP_HTTP {
 			'_wp_amp_action_xhr_converted',
 			'amp_latest_update_time',
 			'amp_last_check_time',
+			'amp_experiments',
 		);
 
 		// Scrub input vars.
@@ -159,6 +160,22 @@ class AMP_HTTP {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get the enabled experiments.
+	 *
+	 * @return array Enabled experiments.
+	 */
+	public static function get_enabled_experiments() {
+		$enabled_experiments = array();
+		if ( isset( self::$purged_amp_query_vars['amp_experiments'] ) ) {
+			$enabled_experiments = array_map(
+				'sanitize_key',
+				(array) self::$purged_amp_query_vars['amp_experiments']
+			);
+		}
+		return $enabled_experiments;
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2132,6 +2132,16 @@ class AMP_Theme_Support {
 
 		// Enqueue default styles expected by sanitizer.
 		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
+
+		if ( _amp_is_doing_img_experiment() ) {
+			add_filter(
+				'body_class',
+				function( $body_classes ) {
+					$body_classes[] = 'amp-wp-img-experiment';
+					return $body_classes;
+				}
+			);
+		}
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1694,8 +1694,6 @@ class AMP_Theme_Support {
 			$stream_fragment = WP_Service_Worker_Navigation_Routing_Component::get_stream_fragment_query_var();
 		}
 
-		$enabled_experiments = AMP_HTTP::get_enabled_experiments();
-
 		$args = array_merge(
 			array(
 				'content_max_width'       => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
@@ -1711,7 +1709,7 @@ class AMP_Theme_Support {
 				),
 				'user_can_validate'       => AMP_Validation_Manager::has_cap(),
 				'stream_fragment'         => $stream_fragment,
-				'enabled_experiments'     => $enabled_experiments,
+				'doing_img_experiment'    => _amp_is_doing_img_experiment(),
 			),
 			$args
 		);
@@ -2014,14 +2012,6 @@ class AMP_Theme_Support {
 				$truncate_before_comment = $dom->createComment( 'AMP_TRUNCATE_RESPONSE_FOR_STREAM_BODY' );
 				$stream_combine_script_invoke_element->parentNode->insertBefore( $truncate_before_comment, $stream_combine_script_invoke_element );
 			}
-		}
-
-		// Add experiments meta tag.
-		if ( ! empty( $enabled_experiments ) ) {
-			$meta = $dom->createElement( 'meta' );
-			$meta->setAttribute( 'name', 'amp-experiments-opt-in' );
-			$meta->setAttribute( 'content', implode( ',', $enabled_experiments ) );
-			$head->insertBefore( $meta, $head->firstChild );
 		}
 
 		$response  = "<!DOCTYPE html>\n";

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1694,6 +1694,8 @@ class AMP_Theme_Support {
 			$stream_fragment = WP_Service_Worker_Navigation_Routing_Component::get_stream_fragment_query_var();
 		}
 
+		$enabled_experiments = AMP_HTTP::get_enabled_experiments();
+
 		$args = array_merge(
 			array(
 				'content_max_width'       => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
@@ -1709,6 +1711,7 @@ class AMP_Theme_Support {
 				),
 				'user_can_validate'       => AMP_Validation_Manager::has_cap(),
 				'stream_fragment'         => $stream_fragment,
+				'enabled_experiments'     => $enabled_experiments,
 			),
 			$args
 		);
@@ -2011,6 +2014,14 @@ class AMP_Theme_Support {
 				$truncate_before_comment = $dom->createComment( 'AMP_TRUNCATE_RESPONSE_FOR_STREAM_BODY' );
 				$stream_combine_script_invoke_element->parentNode->insertBefore( $truncate_before_comment, $stream_combine_script_invoke_element );
 			}
+		}
+
+		// Add experiments meta tag.
+		if ( ! empty( $enabled_experiments ) ) {
+			$meta = $dom->createElement( 'meta' );
+			$meta->setAttribute( 'name', 'amp-experiments-opt-in' );
+			$meta->setAttribute( 'content', implode( ',', $enabled_experiments ) );
+			$head->insertBefore( $meta, $head->firstChild );
 		}
 
 		$response  = "<!DOCTYPE html>\n";

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -413,6 +413,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0
 	 */
 	public static function remove_twentynineteen_thumbnail_image_sizes() {
+		if ( in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+			return;
+		}
 		add_filter(
 			'wp_get_attachment_image_attributes',
 			function( $attr ) {
@@ -435,37 +438,40 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @link https://github.com/WordPress/wordpress-develop/blob/ddc8f803c6e99118998191fd2ea24124feb53659/src/wp-content/themes/twentyseventeen/functions.php#L545:L554
 	 */
 	public static function add_twentyseventeen_attachment_image_attributes() {
-		add_filter(
-			'wp_get_attachment_image_attributes',
-			function ( $attr, $attachment, $size ) {
-				if (
-				isset( $attr['class'] )
-				&&
-				(
-					'custom-logo' === $attr['class']
-					||
-					false !== strpos( $attr['class'], 'attachment-twentyseventeen-featured-image' )
-				)
-				) {
-					/*
-					 * The AMP runtime sets an inline style on an <amp-img> based on the sizes attribute if it's present.
-					 * For example, <amp-img style="width:100%">.
-					 * Removing the 'sizes' attribute is only a workaround, as it looks like it's not possible to override that inline style.
-					 *
-					 * @todo: remove when this is resolved: https://github.com/ampproject/amphtml/issues/17053
-					 */
-					unset( $attr['sizes'] );
-				} elseif ( is_attachment() ) {
-					$sizes = wp_get_attachment_image_sizes( $attachment->ID, $size );
-					if ( false !== $sizes ) {
-						$attr['sizes'] = $sizes;
+		if ( ! in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+			add_filter(
+				'wp_get_attachment_image_attributes',
+				function ( $attr, $attachment, $size ) {
+					if (
+						isset( $attr['class'] )
+						&&
+						(
+							'custom-logo' === $attr['class']
+							||
+							false !== strpos( $attr['class'], 'attachment-twentyseventeen-featured-image' )
+						)
+					) {
+						/*
+						 * The AMP runtime sets an inline style on an <amp-img> based on the sizes attribute if it's present.
+						 * For example, <amp-img style="width:100%">.
+						 * Removing the 'sizes' attribute is only a workaround, as it looks like it's not possible to override that inline style.
+						 *
+						 * @todo: remove when this is resolved: https://github.com/ampproject/amphtml/issues/17053
+						 */
+						unset( $attr['sizes'] );
+					} elseif ( is_attachment() ) {
+						$sizes = wp_get_attachment_image_sizes( $attachment->ID, $size );
+						if ( false !== $sizes ) {
+							$attr['sizes'] = $sizes;
+						}
 					}
-				}
-				return $attr;
-			},
-			11,
-			3
-		);
+
+					return $attr;
+				},
+				11,
+				3
+			);
+		}
 
 		/*
 		 * The max-height of the `.custom-logo-link img` is defined as being 80px, unless

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -413,7 +413,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0
 	 */
 	public static function remove_twentynineteen_thumbnail_image_sizes() {
-		if ( in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+		if ( _amp_is_doing_img_experiment() ) {
 			return;
 		}
 		add_filter(
@@ -438,7 +438,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @link https://github.com/WordPress/wordpress-develop/blob/ddc8f803c6e99118998191fd2ea24124feb53659/src/wp-content/themes/twentyseventeen/functions.php#L545:L554
 	 */
 	public static function add_twentyseventeen_attachment_image_attributes() {
-		if ( ! in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+		if ( ! _amp_is_doing_img_experiment() ) {
 			add_filter(
 				'wp_get_attachment_image_attributes',
 				function ( $attr, $attachment, $size ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -267,7 +267,12 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->add_or_append_attribute( $new_attributes, 'class', 'amp-wp-enforced-sizes' );
 		if ( empty( $new_attributes['layout'] ) && ! empty( $new_attributes['height'] ) && ! empty( $new_attributes['width'] ) ) {
-			$new_attributes['layout'] = 'intrinsic';
+			// Use responsive images when a theme supports wide and full-bleed images.
+			if ( _amp_is_doing_img_experiment() && current_theme_supports( 'align-wide' ) && $node->parentNode && 'figure' === $node->parentNode->nodeName && preg_match( '/(^|\s)(alignwide|alignfull)(\s|$)/', $node->parentNode->getAttribute( 'class' ) ) ) {
+				$new_attributes['layout'] = 'responsive';
+			} else {
+				$new_attributes['layout'] = 'intrinsic';
+			}
 		}
 
 		if ( $this->is_gif_url( $new_attributes['src'] ) ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -167,7 +167,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		if ( in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+		if ( _amp_is_doing_img_experiment() ) {
 			unset( $out['sizes'] );
 		}
 
@@ -267,7 +267,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->add_or_append_attribute( $new_attributes, 'class', 'amp-wp-enforced-sizes' );
 		if ( empty( $new_attributes['layout'] ) && ! empty( $new_attributes['height'] ) && ! empty( $new_attributes['width'] ) ) {
-			if ( in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+			if ( _amp_is_doing_img_experiment() ) {
 				if ( $new_attributes['width'] < $this->args['content_max_width'] ) {
 					$new_attributes['layout'] = 'fixed';
 				} else {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -267,15 +267,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->add_or_append_attribute( $new_attributes, 'class', 'amp-wp-enforced-sizes' );
 		if ( empty( $new_attributes['layout'] ) && ! empty( $new_attributes['height'] ) && ! empty( $new_attributes['width'] ) ) {
-			if ( _amp_is_doing_img_experiment() ) {
-				if ( $new_attributes['width'] < $this->args['content_max_width'] ) {
-					$new_attributes['layout'] = 'fixed';
-				} else {
-					$new_attributes['layout'] = 'intrinsic';
-				}
-			} else {
-				$new_attributes['layout'] = 'intrinsic';
-			}
+			$new_attributes['layout'] = 'intrinsic';
 		}
 
 		if ( $this->is_gif_url( $new_attributes['src'] ) ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -121,7 +121,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type string $alt <img> `alt` attribute - Pass along if found
 	 *      @type string $class <img> `class` attribute - Pass along if found
 	 *      @type string $srcset <img> `srcset` attribute - Pass along if found
-	 *      @type string $sizes <img> `sizes` attribute - Pass along if found
+	 *      @type string $sizes <img> `sizes` attribute - Pass along if found, or remove if found when amp-img-auto-sizes experiment enabled, because AMP will automatically compute as of <https://github.com/ampproject/amphtml/pull/20968>.
 	 *      @type string $on <img> `on` attribute - Pass along if found
 	 *      @type string $attribution <img> `attribution` attribute - Pass along if found
 	 *      @type int $width <img> width attribute - Set to numeric value if px or %
@@ -131,6 +131,10 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function filter_attributes( $attributes ) {
 		$out = array();
+
+		if ( in_array( 'amp-img-auto-sizes', AMP_HTTP::get_enabled_experiments(), true ) ) {
+			unset( $attributes['sizes'] );
+		}
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {


### PR DESCRIPTION
We may be able to eliminate some of the headaches we have currently with the `sizes` attribute on `amp-img` by just removing it: https://github.com/ampproject/amphtml/issues/17053#issuecomment-470640689

So this experiment is intended to verify that. To text, request a URL with the query params:

`?amp&amp_img_experiment`

See #1305, #1237, #1086, #1787.

This can be tested once the next Canary of `amphtml` is released, when `amp-img-auto-sizes` will appear on https://cdn.ampproject.org/experiments.html

# Fixes Inline Images

## Editor

<img width="871" alt="Screen Shot 2019-03-08 at 10 28 47" src="https://user-images.githubusercontent.com/134745/54060366-5144f000-41b1-11e9-886f-2130fcaa7ea7.png">

## Before

<img width="836" alt="Screen Shot 2019-03-08 at 10 29 27" src="https://user-images.githubusercontent.com/134745/54060373-56a23a80-41b1-11e9-8ab1-2f051e958abb.png">

## After

<img width="869" alt="Screen Shot 2019-03-08 at 10 29 09" src="https://user-images.githubusercontent.com/134745/54060384-5f930c00-41b1-11e9-9b9c-856e6dfb1ff1.png">

# Fix Wide and Full bleed Images

## Before

![image](https://user-images.githubusercontent.com/134745/54060442-8ea97d80-41b1-11e9-8b20-1243f0eaf036.png)

## After

![image](https://user-images.githubusercontent.com/134745/54060493-c0badf80-41b1-11e9-9288-970111db36b6.png)

# Todo

## Re-sized and Centered Broken

![image](https://user-images.githubusercontent.com/134745/54060537-e8aa4300-41b1-11e9-958a-b5a1fd41d511.png)

![image](https://user-images.githubusercontent.com/134745/54060543-f19b1480-41b1-11e9-8040-e6bbea8c9b10.png)

This would be a regression.

## Wide Image also Stretches

I noticed that a wide image stretched a bit horizontally with the height unchanged as I made the browser window full width.