### PR TITLE
Fix conversion of Facebook embeds

### DIFF
--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -127,6 +127,24 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 				$this->create_amp_facebook_and_replace_node( $dom, $node, $embed_type );
 			}
 		}
+
+		/*
+		 * Remove the fb-root div and the Facebook Connect JS script since irrelevant.
+		 * <div id="fb-root"></div>
+		 * <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>
+		 */
+		$fb_root = $dom->getElementById( 'fb-root' );
+		if ( $fb_root ) {
+			$xpath   = new DOMXPath( $dom );
+			$scripts = array();
+			foreach ( $xpath->query( '//script[ starts-with( @src, "https://connect.facebook.net" ) and contains( @src, "sdk.js" ) ]' ) as $script ) {
+				$scripts[] = $script;
+			}
+			foreach ( $scripts as $script ) {
+				$script->parentNode->removeChild( $script );
+			}
+			$fb_root->parentNode->removeChild( $fb_root );
+		}
 	}
 
 	/**

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -218,7 +218,20 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 			$attributes
 		);
 
+		$fallback = null;
+		foreach ( $node->childNodes as $child_node ) {
+			if ( $child_node instanceof DOMElement && false !== strpos( $child_node->getAttribute( 'class' ), 'fb-xfbml-parse-ignore' ) ) {
+				$fallback = $child_node;
+				$child_node->parentNode->removeChild( $child_node );
+				$fallback->setAttribute( 'fallback', '' );
+				break;
+			}
+		}
+
 		$node->parentNode->replaceChild( $amp_facebook_node, $node );
+		if ( $fallback ) {
+			$amp_facebook_node->appendChild( $fallback );
+		}
 
 		$this->did_convert_elements = true;
 	}

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -151,6 +151,8 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 			return 'like';
 		} elseif ( false !== strpos( $class_attr, 'fb-comments' ) ) {
 			return 'comments';
+		} elseif ( false !== strpos( $class_attr, 'fb-comment-embed' ) ) {
+			return 'comment';
 		}
 
 		return null;

--- a/tests/test-amp-facebook-embed.php
+++ b/tests/test-amp-facebook-embed.php
@@ -166,6 +166,11 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				',
 				'<amp-facebook layout="responsive" width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment"></amp-facebook>',
 			),
+
+			'remove_fb_root'        => array(
+				'<div id="fb-root"></div><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				'',
+			),
 		);
 	}
 

--- a/tests/test-amp-facebook-embed.php
+++ b/tests/test-amp-facebook-embed.php
@@ -159,6 +159,13 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				',
 				'<amp-facebook-comments layout="responsive" width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
 			),
+
+			'comment_embed'         => array(
+				'
+					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
+				',
+				'<amp-facebook layout="responsive" width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment"></amp-facebook>',
+			),
 		);
 	}
 

--- a/tests/test-amp-facebook-embed.php
+++ b/tests/test-amp-facebook-embed.php
@@ -43,7 +43,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
 				'<p><amp-facebook data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
 			),
-			'notes_url'        => array(
+			'notes_url2'       => array(
 				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
 				'<p><amp-facebook data-href="https://www.facebook.com/zuck/videos/10102509264909801/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
 			),
@@ -127,6 +127,24 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'<div class="fb-post" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"></div>',
 				'<amp-facebook layout="responsive" width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post"></amp-facebook>',
 			),
+
+			'post_with_fallbacks'   => array(
+				'
+					<div class="fb-post" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/" data-width="500" data-show-text="true">
+						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore">
+							Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on <a href="https://developers.facebook.com/20531316728/posts/10154009990506729/">Thursday, August 27, 2015</a>
+						</blockquote>
+					</div>
+				',
+				'
+					<amp-facebook layout="responsive" width="500" height="400" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/"  data-show-text="true" data-embed-as="post">
+						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore" fallback="">
+							Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on <a href="https://developers.facebook.com/20531316728/posts/10154009990506729/">Thursday, August 27, 2015</a>
+						</blockquote>
+					</amp-facebook>
+				',
+			),
+
 			'video_embed'           => array(
 				'<div class="fb-video" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false"></div>',
 				'<amp-facebook layout="responsive" width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video"></amp-facebook>',
@@ -140,7 +158,13 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 						</div>
 					</div>
 				',
-				'<amp-facebook-page layout="responsive" width="340" height="432" data-href="https://www.facebook.com/xwp.co/" data-hide-cover="true" data-show-facepile="true" data-show-posts="false"></amp-facebook-page>',
+				'
+					<amp-facebook-page layout="responsive" width="340" height="432" data-href="https://www.facebook.com/xwp.co/" data-hide-cover="true" data-show-facepile="true" data-show-posts="false">
+						<div class="fb-xfbml-parse-ignore" fallback="">
+							<blockquote cite="https://www.facebook.com/xwp.co/"><a href="https://www.facebook.com/xwp.co/">Like Us</a></blockquote>
+						</div>
+					</amp-facebook-page>
+				',
 			),
 
 			'like'                  => array(


### PR DESCRIPTION
In #1955 it was reported that the Facebook embed sanitizer was erroneously processing any element that had a `data-href` attribute, as if it should be an `amp-facebook` for a post. We were not correctly checking for all of the required values of the class name.

This PR also adds support for the automatic conversion of:

* Facebook pages
* Facebook comments
* Facebook comment embeds
* Facebook likes

If there is fallback content (noted in a child element with the`fb-xfbml-parse-ignore` class) then this will be preserved as the `fallback` content for the AMP elements.

Lastly, it automatically removes the `fb-root` div and the Facebook Connect SDK, since irrelevant. This will prevent the tag-and-attribute sanitizer from complaining later.

Fixes #1955.
Fixes #1259.

Here is a build of this branch for testing: 
[amp.zip](https://github.com/ampproject/amp-wp/files/2958939/amp.zip) (v1.1-alpha-20190312T215731Z-e070d35b)
