### PR TITLE
Fix JS console errors when unregistering blocks that aren't registered

### DIFF
--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -96,7 +96,7 @@ const ampEditorBlocks = ( function() {
 			ampPanelLabel: __( 'AMP Settings', 'amp' ),
 		},
 		hasThemeSupport: true,
-		isCanonical: false,
+		isNativeAMP: false,
 	};
 
 	/**
@@ -922,11 +922,16 @@ const ampEditorBlocks = ( function() {
 			'amp-timeago',
 		];
 
-		if ( ! component.data.isNativeAMP ) {
-			ampDependentBlocks.forEach( function( block ) {
-				wp.blocks.unregisterBlockType( 'amp/' + block );
-			} );
+		if ( component.data.isNativeAMP ) {
+			return;
 		}
+
+		ampDependentBlocks.forEach( function( block ) {
+			const blockName = 'amp/' + block;
+			if ( wp.blocks.getBlockType( blockName ) ) {
+				wp.blocks.unregisterBlockType( blockName );
+			}
+		} );
 	};
 
 	return component;


### PR DESCRIPTION
As @westonruter found, there are console errors from calling`unregisterBlockType()`

**Steps To Reproduce**

1. Check out the [amp-stories-redux](https://github.com/ampproject/amp-wp/tree/amp-stories-redux) branch
2. Select "Paired" mode
3. Go to an AMP Story editor
4. Open the console
5. Expected: there are no errors
6. Actual: there are console errors like:
>Block "amp/amp-brid-player" is not registered.

<img width="1051" alt="amp-story-editor" src="https://user-images.githubusercontent.com/4063887/54249792-289d5d00-4507-11e9-98cb-2b6846e54dd5.png">

* These errors are from calling `unregisterBlockType()` on a block that wasn't registered
* This PR checks that they're registered before unregistering them