### PR TITLE
Fix tree shaking for dynamically-added class names

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -375,7 +375,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$dynamic_class_names = array(
 
 			/*
-			 * See >https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
+			 * See <https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
 			 * Note that amp-referrer-* class names are handled in has_used_class_name() below.
 			 */
 			'amp-viewer',

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -371,16 +371,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 * Note that amp-referrer-* class names are handled in has_used_class_name() below.
 			 */
 			'amp-viewer',
-
-			// See <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
-			'amp-form-initial',
-			'amp-form-verify',
-			'amp-form-verify-error',
-			'amp-form-submitting',
-			'amp-form-submit-success',
-			'amp-form-submit-error',
-			'user-valid',
-			'user-invalid',
 		);
 
 		$classes = ' ';
@@ -425,7 +415,18 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// See <https://www.ampproject.org/docs/reference/components/amp-carousel#styling>.
 			if ( 'amp-carousel-' === substr( $class_name, 0, 13 ) ) {
-				return $this->has_used_tag_names( array( 'amp-carousel' ) );
+				if ( ! $this->has_used_tag_names( array( 'amp-carousel' ) ) ) {
+					return false;
+				}
+				continue;
+			}
+
+			// See <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
+			if ( 'amp-form-' === substr( $class_name, 0, 9 ) || 'user-valid' === $class_name || 'user-invalid' === $class_name ) {
+				if ( ! $this->has_used_tag_names( array( 'form' ) ) ) {
+					return false;
+				}
+				continue;
 			}
 
 			if ( ! isset( $this->used_class_names[ $class_name ] ) ) {

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -399,6 +399,54 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
+			'dynamic_classes_preserved' => array(
+				'
+					<html amp><head>
+					<style>
+					.amp-viewer { color: blue; }
+					.amp-referrer-www-google-com { color: red; }
+					.amp-form-submit-success { color: green; }
+					.amp-carousel-slide { outline: solid 1px red; }
+					.non-existent { color: black; }
+					</style>
+					</head><body><p>Hello!</p></body></html>
+				',
+				array(
+					implode(
+						'',
+						array(
+							'.amp-viewer{color:blue}',
+							'.amp-referrer-www-google-com{color:red}',
+							'.amp-form-submit-success{color:green}',
+							'', // Because there is no <amp-carousel> in the document.
+							'', // Because non-existent class is not used.
+						)
+					),
+				),
+				array(),
+			),
+			'dynamic_classes_preserved_carousel' => array(
+				'
+					<html amp><head>
+					<style>
+					.amp-viewer { color: blue; }
+					.amp-carousel-slide { outline: solid 1px red; }
+					</style>
+					</head>
+					<body><amp-carousel type="slides" width="450" height="300" controls loop autoplay delay="3000" data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide"> <amp-img src="images/image1.jpg" width="450" height="300"></amp-img> <amp-img src="images/image2.jpg" width="450" height="300"></amp-img> <amp-img src="images/image3.jpg" width="450" height="300"></amp-img> </amp-carousel></body>
+					</html>
+				',
+				array(
+					implode(
+						'',
+						array(
+							'.amp-viewer{color:blue}',
+							'.amp-carousel-slide{outline:solid 1px red}',
+						)
+					),
+				),
+				array(),
+			),
 		);
 	}
 

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -399,56 +399,72 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
-			'dynamic_classes_preserved' => array(
+			'dynamic_classes_preserved_always' => array(
 				'
 					<html amp><head>
-					<style>
-					.amp-viewer { color: blue; }
-					.amp-referrer-www-google-com { color: red; }
-					.amp-form-submit-success { color: green; }
-					.amp-carousel-slide { outline: solid 1px red; }
-					.non-existent { color: black; }
-					</style>
+					<style> .amp-viewer { color: blue; } </style>
+					<style> .amp-referrer-www-google-com { color: red; } </style>
+					<style> .amp-active { color: green } </style>
+					<style> .amp-carousel-slide { outline: solid 1px red; } </style>
+					<style> .amp-form-submit-success { color: green; } </style>
+					<style> .amp-access-laterpay-container { color: purple} </style>
+					<style> .amp-image-lightbox-caption { color: brown} </style>
+					<style> .amp-live-list-item-new { color: lime} </style>
+					<style> .amp-sidebar-toolbar-target-hidden { color: lavender} </style>
+					<style> .amp-sticky-ad-close-button { color: aliceblue} </style>
+					<style> .amp-docked-video-shadow { color: azure} </style>
+					<style> .non-existent { color: black; } </style>
 					</head><body><p>Hello!</p></body></html>
 				',
 				array(
-					implode(
-						'',
-						array(
-							'.amp-viewer{color:blue}',
-							'.amp-referrer-www-google-com{color:red}',
-							'', // Because there is no form.
-							'', // Because there is no <amp-carousel> in the document.
-							'', // Because non-existent class is not used.
-						)
-					),
+					'.amp-viewer{color:blue}',
+					'.amp-referrer-www-google-com{color:red}',
+					'', // Because there is no <form>, <amp-carousel>, and no non-existent.
 				),
 				array(),
 			),
-			'dynamic_classes_preserved_carousel_form' => array(
+			'dynamic_classes_preserved_conditionally' => array(
 				'
 					<html amp><head>
-					<style>
-					.amp-viewer { color: blue; }
-					.amp-carousel-slide { outline: solid 1px red; }
-					.amp-form-submit-success{color:green}
-					</style>
+					<style> .amp-viewer { color: blue; } </style>
+					<style> .amp-referrer-www-google-com { color: red; } </style>
+					<style> .amp-active { color: green } </style>
+					<style> .amp-carousel-slide { outline: solid 1px red; } </style>
+					<style> .amp-form-submit-success { color: green; } </style>
+					<style> .amp-access-laterpay-container { color: purple} </style>
+					<style> .amp-image-lightbox-caption { color: brown} </style>
+					<style> .amp-live-list-item-new { color: lime} </style>
+					<style> .amp-sidebar-toolbar-target-hidden { color: lavender} </style>
+					<style> .amp-sticky-ad-close-button { color: aliceblue} </style>
+					<style> .amp-docked-video-shadow { color: azure} </style>
+					<style> .non-existent { color: black; } </style>
 					</head>
 					<body>
+						<amp-user-notification  layout="nodisplay"  id="amp-user-notification1"  data-show-if-href="https://foo.com/api/show-api?timestamp=TIMESTAMP"  data-dismiss-href="https://foo.com/api/dismissed">  This  site  uses  cookies  to  personalize  content.  <a  href="">Learn  more.</a>  <button  on="tap:amp-user-notification1.dismiss">I  accept</button>  </amp-user-notification>
 						<amp-carousel type="slides" width="450" height="300" controls loop autoplay delay="3000" data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide"> <amp-img src="images/image1.jpg" width="450" height="300"></amp-img> <amp-img src="images/image2.jpg" width="450" height="300"></amp-img> <amp-img src="images/image3.jpg" width="450" height="300"></amp-img></amp-carousel>
 						<form action="https://example.com/" target="_top" method="get"><input name="search" type="search" required></form>
+						<section amp-access="NOT error AND NOT access" amp-access-hide><div id="amp-access-laterpay-dialog" class="amp-access-laterpay"></div></section>
+						<amp-image-lightbox id="lightbox1" layout="nodisplay"></amp-image-lightbox>
+						<amp-live-list id="my-live-list" data-poll-interval="15000" data-max-items-per-page="20"> <div update class="outer-container"> <div class="inner-container"> <button class="btn" on="tap:my-live-list.update">Click me!</button> </div> </div> <div items></div> </amp-live-list>
+						<amp-sidebar id="sidebar1" layout="nodisplay" side="right"><nav toolbar="(max-width: 767px)" toolbar-target="target-element"><ul><li></li></ul></nav></amp-sidebar>
+						<amp-sticky-ad layout="nodisplay"><amp-ad width="320" height="50" type="doubleclick" data-slot="/35096353/amptesting/formats/sticky"></amp-ad></amp-sticky-ad>
+						<amp-video dock width="720" height="305" layout="responsive" src="https://yourhost.com/videos/myvideo.mp4" poster="https://yourhost.com/posters/poster.png" artwork="https://yourhost.com/artworks/artwork.png" title="Awesome video" artist="Awesome artist" album="Amazing album"></amp-video>
 					</body>
 					</html>
 				',
 				array(
-					implode(
-						'',
-						array(
-							'.amp-viewer{color:blue}',
-							'.amp-carousel-slide{outline:solid 1px red}',
-							'.amp-form-submit-success{color:green}',
-						)
-					),
+					'.amp-viewer{color:blue}',
+					'.amp-referrer-www-google-com{color:red}',
+					'.amp-active{color:green}',
+					'.amp-carousel-slide{outline:solid 1px red}',
+					'.amp-form-submit-success{color:green}',
+					'.amp-access-laterpay-container{color:purple}',
+					'.amp-image-lightbox-caption{color:brown}',
+					'.amp-live-list-item-new{color:lime}',
+					'.amp-sidebar-toolbar-target-hidden{color:lavender}',
+					'.amp-sticky-ad-close-button{color:aliceblue}',
+					'.amp-docked-video-shadow{color:azure}',
+					'', // Because no non-existent.
 				),
 				array(),
 			),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -417,7 +417,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						array(
 							'.amp-viewer{color:blue}',
 							'.amp-referrer-www-google-com{color:red}',
-							'.amp-form-submit-success{color:green}',
+							'', // Because there is no form.
 							'', // Because there is no <amp-carousel> in the document.
 							'', // Because non-existent class is not used.
 						)
@@ -425,15 +425,19 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				),
 				array(),
 			),
-			'dynamic_classes_preserved_carousel' => array(
+			'dynamic_classes_preserved_carousel_form' => array(
 				'
 					<html amp><head>
 					<style>
 					.amp-viewer { color: blue; }
 					.amp-carousel-slide { outline: solid 1px red; }
+					.amp-form-submit-success{color:green}
 					</style>
 					</head>
-					<body><amp-carousel type="slides" width="450" height="300" controls loop autoplay delay="3000" data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide"> <amp-img src="images/image1.jpg" width="450" height="300"></amp-img> <amp-img src="images/image2.jpg" width="450" height="300"></amp-img> <amp-img src="images/image3.jpg" width="450" height="300"></amp-img> </amp-carousel></body>
+					<body>
+						<amp-carousel type="slides" width="450" height="300" controls loop autoplay delay="3000" data-next-button-aria-label="Go to next slide" data-previous-button-aria-label="Go to previous slide"> <amp-img src="images/image1.jpg" width="450" height="300"></amp-img> <amp-img src="images/image2.jpg" width="450" height="300"></amp-img> <amp-img src="images/image3.jpg" width="450" height="300"></amp-img></amp-carousel>
+						<form action="https://example.com/" target="_top" method="get"><input name="search" type="search" required></form>
+					</body>
 					</html>
 				',
 				array(
@@ -442,6 +446,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						array(
 							'.amp-viewer{color:blue}',
 							'.amp-carousel-slide{outline:solid 1px red}',
+							'.amp-form-submit-success{color:green}',
 						)
 					),
 				),


### PR DESCRIPTION
Prevent tree shaking CSS rules that use class names which are dynamically added, including those for:

* [`amp-dynamic-css-classes`](https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes) (naturally)
* [`amp-carousel`](https://www.ampproject.org/docs/reference/components/amp-carousel#styling)
* [`amp-form`](https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks)
* [`amp-user-notification`](https://www.ampproject.org/docs/reference/components/amp-user-notification#styling)
* [`amp-access`](https://www.ampproject.org/docs/reference/components/amp-access)/[`amp-access-laterpay`](https://www.ampproject.org/docs/reference/components/amp-access-laterpay#styling)
* [`amp-image-lightbox`](https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling)
* [`amp-live-list`](https://www.ampproject.org/docs/reference/components/amp-live-list#styling)
* [`amp-sidebar`](https://www.ampproject.org/docs/reference/components/amp-sidebar#styling-toolbar)
* [`amp-sticky-ad`](https://www.ampproject.org/docs/reference/components/amp-sticky-ad#styling)
* [`amp-video-docking`](https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md#styling)

Fixes #1946.
Fixes #1490.

----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/2962979/amp.zip) (1.1-alpha-20190313T180459Z-d5495203)