### PR TITLE
[AMP Stories] Add color settings to text block

### DIFF
--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -1,1 +1,9 @@
 amp-story-grid-layer[template="fill"] .wp-block-image { margin: 0; }
+
+.has-background {
+	padding: 10px !important;
+}
+
+amp-story-grid-layer > * {
+	width: auto !important;
+}

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
-import { PanelBody, SelectControl } from '@wordpress/components';
+import { PanelBody, SelectControl, withFallbackStyles } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
 	RichText,
@@ -26,6 +26,20 @@ import {
 import { FontFamilyPicker } from '../../components';
 import { maybeEnqueueFontStyle } from '../../helpers';
 
+const { getComputedStyle } = window;
+
+const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
+	const { textColor, backgroundColor, fontSize, customFontSize } = ownProps.attributes;
+	const editableNode = node.querySelector( '[contenteditable="true"]' );
+	const computedStyles = editableNode ? getComputedStyle( editableNode ) : null;
+
+	return {
+		fallbackBackgroundColor: backgroundColor || ! computedStyles ? undefined : computedStyles.backgroundColor,
+		fallbackTextColor: textColor || ! computedStyles ? undefined : computedStyles.color,
+		fallbackFontSize: fontSize || customFontSize || ! computedStyles ? undefined : parseInt( computedStyles.fontSize ) || undefined,
+	};
+} );
+
 function TextBlock( props ) {
 	const {
 		attributes,
@@ -37,6 +51,8 @@ function TextBlock( props ) {
 		textColor,
 		setBackgroundColor,
 		setTextColor,
+		fallbackTextColor,
+		fallbackBackgroundColor,
 	} = props;
 
 	const {
@@ -93,10 +109,10 @@ function TextBlock( props ) {
 						{ ...{
 							textColor: textColor.color,
 							backgroundColor: backgroundColor.color,
-							// Todo: Calculate from page background.
-							fallbackBackgroundColor: undefined,
+							fallbackTextColor,
+							fallbackBackgroundColor,
+							fontSize: fontSize.size,
 						} }
-						fontSize={ fontSize.size }
 					/>
 				</PanelColorSettings>
 			</InspectorControls>
@@ -127,4 +143,5 @@ function TextBlock( props ) {
 export default compose(
 	withColors( 'backgroundColor', { textColor: 'color' } ),
 	withFontSizes( 'fontSize' ),
+	applyFallbackStyles
 )( TextBlock );

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -1,10 +1,24 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { PanelBody, SelectControl } from '@wordpress/components';
-import { RichText, InspectorControls, FontSizePicker, withFontSizes } from '@wordpress/editor';
+import { compose } from '@wordpress/compose';
+import {
+	RichText,
+	InspectorControls,
+	FontSizePicker,
+	withFontSizes,
+	withColors,
+	PanelColorSettings,
+	ContrastChecker,
+} from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -12,16 +26,25 @@ import { RichText, InspectorControls, FontSizePicker, withFontSizes } from '@wor
 import { FontFamilyPicker } from '../../components';
 import { maybeEnqueueFontStyle } from '../../helpers';
 
-function TextBlock( {
-	attributes,
-	setAttributes,
-	className,
-	fontSize,
-	setFontSize,
-} ) {
-	const { placeholder, content, type, ampFontFamily } = attributes;
+function TextBlock( props ) {
+	const {
+		attributes,
+		setAttributes,
+		className,
+		fontSize,
+		setFontSize,
+		backgroundColor,
+		textColor,
+		setBackgroundColor,
+		setTextColor,
+	} = props;
 
-	const fontSizeClass = fontSize.class || undefined;
+	const {
+		placeholder,
+		content,
+		type,
+		ampFontFamily,
+	} = attributes;
 
 	return (
 		<Fragment>
@@ -50,6 +73,32 @@ function TextBlock( {
 						] }
 					/>
 				</PanelBody>
+				<PanelColorSettings
+					title={ __( 'Color Settings', 'amp' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: backgroundColor.color,
+							onChange: setBackgroundColor,
+							label: __( 'Background Color', 'amp' ),
+						},
+						{
+							value: textColor.color,
+							onChange: setTextColor,
+							label: __( 'Text Color', 'amp' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
+							// Todo: Calculate from page background.
+							fallbackBackgroundColor: undefined,
+						} }
+						fontSize={ fontSize.size }
+					/>
+				</PanelColorSettings>
 			</InspectorControls>
 			<RichText
 				identifier="content"
@@ -58,13 +107,24 @@ function TextBlock( {
 				value={ content }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				style={ {
+					backgroundColor: backgroundColor.color,
+					color: textColor.color,
 					fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 				} }
-				className={ `${ className } ${ fontSizeClass }` }
+				className={ classnames( className, {
+					'has-text-color': textColor.color,
+					'has-background': backgroundColor.color,
+					[ backgroundColor.class ]: backgroundColor.class,
+					[ textColor.class ]: textColor.class,
+					[ fontSize.class ]: fontSize.class,
+				} ) }
 				placeholder={ placeholder || __( 'Write text…', 'amp' ) }
 			/>
 		</Fragment>
 	);
 }
 
-export default withFontSizes( 'fontSize' )( TextBlock );
+export default compose(
+	withColors( 'backgroundColor', { textColor: 'color' } ),
+	withFontSizes( 'fontSize' ),
+)( TextBlock );

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -1,8 +1,17 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { RichText } from '@wordpress/editor';
+import {
+	RichText,
+	getColorClassName,
+	getFontSizeClass,
+} from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -12,6 +21,48 @@ import edit from './edit';
 import getTagName from './get-tag-name';
 
 export const name = 'amp/amp-story-text';
+
+const supports = {
+	className: false,
+	anchor: true,
+};
+
+const schema = {
+	placeholder: {
+		type: 'string',
+	},
+	content: {
+		type: 'string',
+		source: 'html',
+		selector: 'p,h1,h2',
+		default: '',
+	},
+	type: {
+		type: 'string',
+		default: 'auto',
+	},
+	fontSize: {
+		type: 'string',
+	},
+	customFontSize: {
+		type: 'number',
+	},
+	ampFontFamily: {
+		type: 'string',
+	},
+	textColor: {
+		type: 'string',
+	},
+	customTextColor: {
+		type: 'string',
+	},
+	backgroundColor: {
+		type: 'string',
+	},
+	customBackgroundColor: {
+		type: 'string',
+	},
+};
 
 export const settings = {
 	title: __( 'Text', 'amp' ),
@@ -28,46 +79,40 @@ export const settings = {
 		__( 'paragraph', 'amp' ),
 	],
 
-	supports: {
-		className: false,
-		anchor: true,
-	},
+	supports,
 
-	attributes: {
-		placeholder: {
-			type: 'string',
-		},
-		content: {
-			type: 'string',
-			source: 'html',
-			selector: 'p,h1,h2',
-			default: '',
-		},
-		type: {
-			type: 'string',
-			default: 'auto',
-		},
-		fontSize: {
-			type: 'string',
-		},
-		customFontSize: {
-			type: 'number',
-		},
-		ampFontFamily: {
-			type: 'string',
-		},
-	},
+	attributes: schema,
 
 	edit,
 
 	save( { attributes } ) {
-		const { content, fontSize, customFontSize } = attributes;
+		const {
+			content,
+			fontSize,
+			customFontSize,
+			backgroundColor,
+			textColor,
+			customBackgroundColor,
+			customTextColor,
+		} = attributes;
+
+		const textClass = getColorClassName( 'color', textColor );
+		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
+		const fontSizeClass = getFontSizeClass( fontSize );
 
 		const tagName = getTagName( attributes );
-		const fontSizeClass = fontSize && `is-${ fontSize }-text`;
-		const className = fontSizeClass ? fontSizeClass : undefined;
+
+		const className = classnames( {
+			'has-text-color': textColor || customTextColor,
+			'has-background': backgroundColor || customBackgroundColor,
+			[ fontSizeClass ]: fontSizeClass,
+			[ textClass ]: textClass,
+			[ backgroundClass ]: backgroundClass,
+		} );
 
 		const styles = {
+			backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+			color: textClass ? undefined : customTextColor,
 			fontSize: fontSizeClass ? undefined : customFontSize,
 		};
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -277,12 +277,9 @@ class AMP_Story_Post_Type {
 	 * @return array Modified editor settings.
 	 */
 	public static function filter_block_editor_settings( $editor_settings, $post ) {
-		if ( self::POST_TYPE_SLUG !== $post->post_type ) {
-			return $editor_settings;
+		if ( self::POST_TYPE_SLUG === $post->post_type ) {
+			unset( $editor_settings['colors'] );
 		}
-
-		unset( $editor_settings['colors'] );
-
 		return $editor_settings;
 	}
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -216,7 +216,16 @@ class AMP_Story_Post_Type {
 					return false;
 				}
 				$dep = wp_styles()->registered[ $handle ];
-				return 'fonts.googleapis.com' === wp_parse_url( $dep->src, PHP_URL_HOST );
+
+				if ( 'fonts.googleapis.com' === wp_parse_url( $dep->src, PHP_URL_HOST ) ) {
+					return true;
+				}
+
+				if ( $handle === 'wp-block-library' ) {
+					return true;
+				}
+
+				return false;
 			}
 		);
 	}
@@ -241,7 +250,7 @@ class AMP_Story_Post_Type {
 		wp_enqueue_style(
 			'amp-editor-story-blocks-style',
 			amp_get_asset_url( 'css/amp-editor-story-blocks.css' ),
-			array(),
+			array( 'wp-edit-blocks' ),
 			AMP__VERSION
 		);
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -108,6 +108,9 @@ class AMP_Story_Post_Type {
 
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_custom_block_styles' ) );
 
+		// Remove support for custom color palettes.
+		add_filter( 'block_editor_settings', array( __CLASS__, 'filter_block_editor_settings' ), 10, 2 );
+
 		// Used for amp-story[publisher-logo-src]: The publisher's logo in square format (1x1 aspect ratio). This will be supplied by the custom logo or else site icon.
 		add_image_size( 'amp-publisher-logo', 100, 100, true );
 
@@ -261,6 +264,26 @@ class AMP_Story_Post_Type {
 				self::get_inline_font_style_rule( $font )
 			);
 		}
+	}
+
+	/**
+	 * Filters the settings to pass to the block editor.
+	 *
+	 * Used to remove support for custom color palettes for AMP stories.
+	 *
+	 * @param array   $editor_settings Default editor settings.
+	 * @param WP_Post $post            Post being edited.
+	 *
+	 * @return array Modified editor settings.
+	 */
+	public static function filter_block_editor_settings( $editor_settings, $post ) {
+		if ( self::POST_TYPE_SLUG !== $post->post_type ) {
+			return $editor_settings;
+		}
+
+		unset( $editor_settings['colors'] );
+
+		return $editor_settings;
 	}
 
 	/**

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -221,7 +221,7 @@ class AMP_Story_Post_Type {
 					return true;
 				}
 
-				if ( $handle === 'wp-block-library' ) {
+				if ( 'wp-block-library' === $handle ) {
 					return true;
 				}
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "@wordpress/i18n": "3.2.0",
     "@wordpress/plugins": "2.1.0",
     "@wordpress/wordcount": "2.1.0",
-    "classnames": "^2.2.6"
+    "classnames": "2.2.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@wordpress/hooks": "2.1.0",
     "@wordpress/i18n": "3.2.0",
     "@wordpress/plugins": "2.1.0",
-    "@wordpress/wordcount": "2.1.0"
+    "@wordpress/wordcount": "2.1.0",
+    "classnames": "^2.2.6"
   }
 }


### PR DESCRIPTION
Note that this PR includes the `classnames` npm package for easier handling of class names. We can use it in other components too. Unfortunately, Gutenberg/WordPress does not expose this globally (see https://github.com/WordPress/gutenberg/issues/8078), which is why we have to bundle it on our own. It's only ~1KB big though, so not that big of a deal.

**To do:**

* [x] If no background color is set, derive from underlying element (could be an image or the page's background media), perhaps using `window.getComputedStyle()`
* [x] Add frontend styling for color CSS classes (e.g. `has-light-green-cyan-color`)

Fixes #1961.