### PR TITLE
Fix warning triggered when filtering kses allowed attributes

### DIFF
--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -77,6 +77,9 @@ class AMP_Editor_Blocks {
 		}
 
 		foreach ( $tags as &$tag ) {
+			if ( ! is_array( $tag ) ) {
+				continue;
+			}
 			$tag['data-amp-layout']              = true;
 			$tag['data-amp-noloading']           = true;
 			$tag['data-amp-lightbox']            = true;


### PR DESCRIPTION
This commit is to fix #1975 by considering tags could not be an array.