### PR TITLE
[AMP-Stories] Improve block navigation, transitions, and background media

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -493,6 +493,100 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 		margin-right: 5px;
 	}
 
+	:root {
+		--block-settings-sidebar-width: 280px;
+		--admin-menu-expanded-sidebar-width: 160px;
+		--admin-menu-collapsed-sidebar-width: 36px;
+		--amp-story-content-width: 338px;
+		--block-editor-horizontal-margin: 40px;
+		--scrollbar-width: 20px;
+		--block-navigation-right-margin: 20px;
+	}
+
+	/* Navigator in the context of the open sidebar, settings hidden. */
+	.post-type-amp_story:not(.folded) .edit-post-layout #amp-root-navigation {
+		max-width: calc(
+			calc(
+				100vw
+				-
+				var(--admin-menu-expanded-sidebar-width)
+				-
+				var(--amp-story-content-width)
+				-
+				calc( var(--block-editor-horizontal-margin) * 2 )
+				-
+				var( --scrollbar-width )
+			) / 2
+			-
+			var(--block-navigation-right-margin)
+		);
+	}
+
+	.post-type-amp_story.folded .edit-post-layout #amp-root-navigation {
+		max-width: calc(
+			calc(
+				100vw
+				-
+				var(--admin-menu-collapsed-sidebar-width)
+				-
+				var(--amp-story-content-width)
+				-
+				calc( var(--block-editor-horizontal-margin) * 2 )
+				-
+				var( --scrollbar-width )
+			) / 2
+			-
+			var(--block-navigation-right-margin)
+		);
+	}
+
+	/* Navigator in the context of minimum available space - open sidebar, settings shown. */
+	.post-type-amp_story .edit-post-layout.is-sidebar-opened #amp-root-navigation {
+		max-width: calc(
+			calc(
+				100vw
+				-
+				var(--admin-menu-expanded-sidebar-width)
+				-
+				var(--block-settings-sidebar-width)
+				-
+				var(--amp-story-content-width)
+				-
+				calc( var(--block-editor-horizontal-margin) * 2 )
+				-
+				var( --scrollbar-width )
+			) / 2
+			-
+			var(--block-navigation-right-margin)
+		);
+	}
+
+	/* Navigator in the context of folded sidebar, settings hidden. */
+	.post-type-amp_story.folded #amp-root-navigation {
+		max-width: calc( 100vw - var(--admin-menu-collapsed-sidebar-width) - var(--amp-story-content-width) );
+	}
+
+	/* Navigator in the context of folded sidebar, settings shown. */
+	.post-type-amp_story.folded .edit-post-layout.is-sidebar-opened #amp-root-navigation {
+		max-width: calc(
+			calc(
+				100vw
+				-
+				var(--admin-menu-collapsed-sidebar-width)
+				-
+				var(--block-settings-sidebar-width)
+				-
+				var(--amp-story-content-width)
+				-
+				calc( var(--block-editor-horizontal-margin) * 2 )
+				-
+				var( --scrollbar-width )
+			) / 2
+			-
+			var(--block-navigation-right-margin)
+		);
+	}
+
 	.editor-block-navigation__container {
 		background: #fff;
 		border: 1px solid #eee;

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -260,7 +260,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 		display: flex;
 		align-items: center;
 		transform: none;
-		transition: transform 300ms linear;
+		transition: transform 300ms ease-in-out;
 	}
 
 	.editor-block-list__layout div[data-type="amp/amp-story-page"] {

--- a/assets/src/blocks/amp-story/edit.js
+++ b/assets/src/blocks/amp-story/edit.js
@@ -126,7 +126,7 @@ class EditPage extends Component {
 										value={ mediaId }
 										render={ ( { open } ) => (
 											<Button isDefault isLarge onClick={ open } className="editor-amp-story-page-background">
-												{ mediaUrl ? __( 'Edit Media', 'amp' ) : __( 'Upload Media', 'amp' ) }
+												{ mediaUrl ? __( 'Edit Media', 'amp' ) : __( 'Select Media', 'amp' ) }
 											</Button>
 										) }
 									/>


### PR DESCRIPTION
* Restore block navigation max-width styles inadvertently removed in 0545a43.
* Use `ease-in-out` transition timing function instead of `linear` for page navigation.
* Use 'Select Media' instead of 'Upload Media' for empty background media button.