### PR TITLE
[AMP Stories] Add maybe flushing rewrite rules.

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -148,6 +148,8 @@ class AMP_Story_Post_Type {
 				'render_callback' => array( __CLASS__, 'render_text_block' ),
 			)
 		);
+
+		self::maybe_flush_rewrite_rules();
 	}
 
 	/**
@@ -900,6 +902,24 @@ class AMP_Story_Post_Type {
 		}
 
 		return ob_get_clean();
+	}
+
+	/**
+	 * Flushes rewrite rules if it hasn't been done yet after having AMP Stories Post type.
+	 */
+	public static function maybe_flush_rewrite_rules() {
+		$current_rules = get_option( 'rewrite_rules' );
+
+		// Check if the rewrite rule for showing preview exists for different permalink settings.
+		$story_rules = array_filter(
+			array_keys( $current_rules ),
+			function( $rule ) {
+				return 0 === strpos( $rule, self::REWRITE_SLUG ) || false !== strpos( $rule, '/' . self::REWRITE_SLUG . '/' );
+			}
+		);
+		if ( empty( $story_rules ) ) {
+			flush_rewrite_rules();
+		}
 	}
 
 	/**

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -910,6 +910,11 @@ class AMP_Story_Post_Type {
 	public static function maybe_flush_rewrite_rules() {
 		$current_rules = get_option( 'rewrite_rules' );
 
+		// If we're not using permalinks.
+		if ( empty( $current_rules ) ) {
+			return;
+		}
+
 		// Check if the rewrite rule for showing preview exists for different permalink settings.
 		$story_rules = array_filter(
 			array_keys( $current_rules ),


### PR DESCRIPTION
Fixes #1978.

Adds `maybe_flush_rewrite_rules` after registering the AMP Stories CPT which checks if rewrite rules for stories are already registered and if not, flushes the rewrite rules.