### PR TITLE
Animation order: only show valid options

### DIFF
--- a/assets/src/components/with-animation-controls.js
+++ b/assets/src/components/with-animation-controls.js
@@ -17,7 +17,7 @@ import { AnimationControls } from './';
 
 const applyWithSelect = withSelect( ( select, props ) => {
 	const { getSelectedBlockClientId, getBlockRootClientId, getBlock } = select( 'core/editor' );
-	const { getAnimationOrder } = select( 'amp/story' );
+	const { getAnimationOrder, isValidAnimationPredecessor } = select( 'amp/story' );
 
 	const currentBlock = getSelectedBlockClientId();
 	const page = getBlockRootClientId( currentBlock );
@@ -34,7 +34,7 @@ const applyWithSelect = withSelect( ( select, props ) => {
 				.filter( ( { id } ) => {
 					const block = getBlock( id );
 
-					return block && block.attributes.ampAnimationType;
+					return block && block.attributes.ampAnimationType && isValidAnimationPredecessor( page, currentBlock, id );
 				} )
 				.map( ( { id } ) => {
 					const block = getBlock( id );

--- a/assets/src/stores/amp-story/index.js
+++ b/assets/src/stores/amp-story/index.js
@@ -22,6 +22,7 @@ export default registerStore(
 		selectors,
 		actions,
 		initialState: {
+			animationOrder: {},
 			reordering: {
 				blockOrder: [],
 				isReordering: false,

--- a/assets/src/stores/amp-story/reducer.js
+++ b/assets/src/stores/amp-story/reducer.js
@@ -3,6 +3,11 @@
  */
 import { select, combineReducers } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { isValidAnimationPredecessor } from './selectors';
+
 const { getBlock, getBlockOrder } = select( 'core/editor' );
 
 /**
@@ -22,22 +27,7 @@ export function animationOrder( state = {}, action ) {
 
 	switch ( action.type ) {
 		case 'ADD_ANIMATION':
-			const hasCycle = ( a, b ) => {
-				let parent = b;
-
-				while ( parent !== undefined ) {
-					if ( parent === a ) {
-						return true;
-					}
-
-					const parentItem = pageAnimationOrder.find( ( { id } ) => id === parent );
-					parent = parentItem ? parentItem.parent : undefined;
-				}
-
-				return false;
-			};
-
-			const parent = -1 !== entryIndex( predecessor ) && ! hasCycle( item, predecessor ) ? predecessor : undefined;
+			const parent = isValidAnimationPredecessor( { animationOrder: state }, page, item, predecessor ) ? predecessor : undefined;
 
 			if ( entryIndex( item ) !== -1 ) {
 				pageAnimationOrder[ entryIndex( item ) ].parent = parent;

--- a/assets/src/stores/amp-story/selectors.js
+++ b/assets/src/stores/amp-story/selectors.js
@@ -26,6 +26,44 @@ export function getAnimationPredecessor( state, page, item ) {
 }
 
 /**
+ * Determines whether a given predecessor -> item combination is valid.
+ *
+ * Returns false if the predecessor itself is not animated or if it would result in a cycle.
+ *
+ * @param {Object} state       Editor state.
+ * @param {string} page        ID of the page the item is in.
+ * @param {string} item        ID of the animated item.
+ * @param {string} predecessor ID of the animated item's predecessor.
+ *
+ * @return {boolean} True if the animation predecessor is valid, false otherwise.
+ */
+export function isValidAnimationPredecessor( state, page, item, predecessor ) {
+	if ( undefined === predecessor ) {
+		return true;
+	}
+
+	const pageAnimationOrder = state.animationOrder[ page ] || [];
+	const predecessorEntry = pageAnimationOrder.find( ( { id } ) => id === predecessor );
+
+	const hasCycle = ( a, b ) => {
+		let parent = b;
+
+		while ( parent !== undefined ) {
+			if ( parent === a ) {
+				return true;
+			}
+
+			const parentItem = pageAnimationOrder.find( ( { id } ) => id === parent );
+			parent = parentItem ? parentItem.parent : undefined;
+		}
+
+		return false;
+	};
+
+	return predecessorEntry && ! hasCycle( item, predecessor );
+}
+
+/**
  * Returns the currently selected page.
  *
  * @param {Object} state Editor state.


### PR DESCRIPTION
Fixes #1984.

To verify:

1. Add first block (A) with animation.
2. Add second block (B) with animation, choose to begin after A.
3. Edit A, verify that you cannot select it to start after B.