### PR TITLE
Make IDs unique in cloned elements for sticky nav menu

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -852,6 +852,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		 * Elements.
 		 *
 		 * @var DOMElement $link
+		 * @var DOMElement $element
 		 * @var DOMElement $navigation_top
 		 * @var DOMElement $navigation_top_fixed
 		 */
@@ -869,6 +870,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$navigation_top->parentNode->insertBefore( $navigation_top_fixed, $navigation_top->nextSibling );
+		foreach ( $this->xpath->query( './/*[ @id ]', $navigation_top_fixed ) as $element ) {
+			$element->setAttribute( 'id', $element->getAttribute( 'id' ) . '-fixed' );
+		}
 
 		$attributes = array(
 			'layout'              => 'nodisplay',


### PR DESCRIPTION
The stick nav menu in Twenty Seventeen depends on cloning the original nav menu to then display as the fixed nav menu when scrolling down in the page. This works fine, but it turns out that the the cloned element has elements with IDs in it, and Lighthouse is flagging this in its Accessibility audit:

![image](https://user-images.githubusercontent.com/134745/54775625-9f072280-4bcb-11e9-8e8e-7b38d73a8f89.png)

So this PR simply amends `-fixed` to the `id` of every cloned element.