### PR TITLE
[AMP Stories] Match FE and editor view

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -624,35 +624,6 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	}
 }
 
-#amp-root-navigation .editor-block-navigation__item:hover {
-	color: #191e23;
-	border: none;
-	box-shadow: none;
-	background: #f3f4f5;
-}
-
-#amp-root-navigation .components-button.editor-block-navigation__item-button {
-	display: flex;
-	align-items: center;
-	width: 100%;
-	padding: 6px;
-	text-align: left;
-	color: #40464d;
-	border-radius: 4px;
-}
-
-#amp-root-navigation li {
-	margin-bottom: 6px;
-}
-
-#amp-root-navigation .block-editor-block-icon {
-	margin-right: 6px;
-}
-
-#amp-root-navigation .editor-block-navigation__container {
-	padding: 7px;
-}
-
 /*
  * 8. Block mover
  * Disable the block mover at all times for page blocks.

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -39,6 +39,10 @@
 	}
 }
 
+#amp-story-editor * {
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+}
+
 /*
  * 1. Style story pages wrapper.
  * - Add thicker border around the pages
@@ -251,10 +255,6 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
  * Hides the toggler and shows the navigator by default on large screens.
  */
 
-#amp-root-navigation {
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-}
-
 @media( max-width: 960px) {
 	.editor-block-list__block-edit > div > .editor-selectors {
 		display: none;
@@ -317,7 +317,6 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 		font-size: 12px;
 		color: #666;
 		letter-spacing: 1px;
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	}
 
 	.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div {

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -34,7 +34,7 @@
 		margin: 0 auto;
 	}
 	#amp-story-editor {
-		min-width: 800px;
+		min-width: 820px;
 	}
 }
 
@@ -825,6 +825,9 @@ div[data-type="amp/amp-story-page"] .wp-block:hover .amp-story-editor-block-move
 /**
  * 11. Text Block.
  */
+.wp-block[data-type="amp/amp-story-text"] p {
+	margin: 0;
+}
 .amp-story-text__resize-container .components-resizable-box__handle-right {
 	right: -26px;
 	height: 50px;

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -97,11 +97,6 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
  * Fix the page editor size to the ratio of the stories.
  */
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"] {
-	padding: 0;
-	margin: 60px 30px 0;
-}
-
 @media (min-width: 600px) {
 	div[data-type="amp/amp-story-page"] .editor-block-list__block {
 		margin: 0;
@@ -115,6 +110,12 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
 	max-width: 338px;
 	height: 553px;
 	position: relative;
+}
+
+#amp-story-editor .wp-block[data-type="amp/amp-story-page"] {
+	padding: 0;
+	margin: 60px 30px 0;
+	height: 563px;
 }
 
 #amp-story-editor .wp-block[data-type="amp/amp-story-page"] .editor-block-list__layout > .block-list-appender {
@@ -301,7 +302,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	}
 
 	.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div {
-		height: 543px;
+		height: 553px;
 	}
 
 	.amp-story-editor-carousel-navigation {

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -251,6 +251,10 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
  * Hides the toggler and shows the navigator by default on large screens.
  */
 
+#amp-root-navigation {
+	font-family: sans-serif;
+}
+
 @media( max-width: 960px) {
 	.editor-block-list__block-edit > div > .editor-selectors {
 		display: none;
@@ -313,6 +317,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 		font-size: 12px;
 		color: #666;
 		letter-spacing: 1px;
+		font-family: sans-serif;
 	}
 
 	.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div {

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -252,7 +252,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
  */
 
 #amp-root-navigation {
-	font-family: sans-serif;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 
 @media( max-width: 960px) {
@@ -313,11 +313,11 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 		position: absolute;
 		top: -3em;
 		text-transform: uppercase;
-		font-weight: 600;
+		font-weight: 500;
 		font-size: 12px;
 		color: #666;
 		letter-spacing: 1px;
-		font-family: sans-serif;
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 	}
 
 	.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div {

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -1,6 +1,7 @@
 /*------------------------------------------------------------------
 [Table of contents]
 
+	0. General editor layout styles.
 	1. Style story pages wrapper
 	2. Selected state
 		2.1 Selected label
@@ -24,6 +25,18 @@
 
 -------------------------------------------------------------------*/
 
+/*
+ * 0. General editor layout styles.
+ */
+@media screen and (min-width: 1280px) {
+	.edit-post-visual-editor {
+		max-width: 1024px;
+		margin: 0 auto;
+	}
+	#amp-story-editor {
+		min-width: 800px;
+	}
+}
 
 /*
  * 1. Style story pages wrapper.

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -624,6 +624,35 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	}
 }
 
+#amp-root-navigation .editor-block-navigation__item:hover {
+	color: #191e23;
+	border: none;
+	box-shadow: none;
+	background: #f3f4f5;
+}
+
+#amp-root-navigation .components-button.editor-block-navigation__item-button {
+	display: flex;
+	align-items: center;
+	width: 100%;
+	padding: 6px;
+	text-align: left;
+	color: #40464d;
+	border-radius: 4px;
+}
+
+#amp-root-navigation li {
+	margin-bottom: 6px;
+}
+
+#amp-root-navigation .block-editor-block-icon {
+	margin-right: 6px;
+}
+
+#amp-root-navigation .editor-block-navigation__container {
+	padding: 7px;
+}
+
 /*
  * 8. Block mover
  * Disable the block mover at all times for page blocks.
@@ -829,6 +858,11 @@ div[data-type="amp/amp-story-page"] .wp-block:hover .amp-story-editor-block-move
 .wp-block[data-type="amp/amp-story-text"] p {
 	margin: 0;
 }
+
+.wp-block-amp-story-text .editor-rich-text__editable {
+	width: 100%;
+}
+
 .amp-story-text__resize-container .components-resizable-box__handle-right {
 	right: -26px;
 	height: 50px;

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -39,7 +39,7 @@
 	}
 }
 
-#amp-story-editor * {
+#amp-story-editor {
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -82,20 +82,25 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
  * Show label while the layer is selected
  */
 
- .editor-block-list__breadcrumb {
-	 z-index: 6;
-	 pointer-events: none;
- }
+.editor-block-list__breadcrumb {
+	z-index: 6;
+	pointer-events: none;
+}
 
- .editor-block-list__block:hover .editor-block-list__breadcrumb .components-toolbar {
-	 opacity: 1;
-	 animation: none;
- }
+.editor-block-list__block:hover .editor-block-list__breadcrumb .components-toolbar {
+	opacity: 1;
+	animation: none;
+}
 
 /*
  * 3. Story page dimensions.
  * Fix the page editor size to the ratio of the stories.
  */
+
+.editor-block-list__layout div[data-type="amp/amp-story-page"] {
+	padding: 0;
+	margin: 60px 30px 0;
+}
 
 @media (min-width: 600px) {
 	div[data-type="amp/amp-story-page"] .editor-block-list__block {
@@ -112,12 +117,6 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
 	position: relative;
 }
 
-#amp-story-editor .wp-block[data-type="amp/amp-story-page"] {
-	padding: 0;
-	margin: 60px 30px 0;
-	height: 563px;
-}
-
 #amp-story-editor .wp-block[data-type="amp/amp-story-page"] .editor-block-list__layout > .block-list-appender {
 	width: 316px;
 	margin: 0 auto;
@@ -131,6 +130,7 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
 
 .editor-block-list__layout div[data-type="amp/amp-story-page"].editor-block-list__block:first-child .editor-block-list__block-edit {
 	margin: 0;
+	max-width: 100%;
 }
 
 .editor-block-list__layout div[data-type="amp/amp-story-page"].editor-block-list__block .editor-block-list__block-edit,
@@ -188,28 +188,28 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 .amp-grid-template .editor-block-list__layout .editor-block-list__block.is-selected > .editor-block-list__block-edit .editor-rich-text,
 .amp-grid-template .editor-block-list__layout .editor-block-list__block.is-typing > .editor-block-list__block-edit .editor-rich-text {
 	text-shadow:
-		0.05em 0 rgba( 255, 255, 255, 0.8 ),
-		0 0.05em rgba( 255, 255, 255, 0.8 ),
-		-0.05em 0 rgba( 255, 255, 255, 0.8 ),
-		0 -0.05em rgba( 255, 255, 255, 0.8 ),
-		-0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
-		-0.05em 0.05em rgba( 255, 255, 255, 0.8 ),
-		0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
-		0.05em 0.05em rgba( 255, 255, 255, 0.8 );
+			0.05em 0 rgba( 255, 255, 255, 0.8 ),
+			0 0.05em rgba( 255, 255, 255, 0.8 ),
+			-0.05em 0 rgba( 255, 255, 255, 0.8 ),
+			0 -0.05em rgba( 255, 255, 255, 0.8 ),
+			-0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
+			-0.05em 0.05em rgba( 255, 255, 255, 0.8 ),
+			0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
+			0.05em 0.05em rgba( 255, 255, 255, 0.8 );
 }
 
 .amp-grid-template .editor-block-list__layout .editor-block-list__block .editor-rich-text__tinymce + .editor-rich-text__tinymce,
 .amp-grid-template .editor-block-list__layout .editor-block-list__block .editor-rich-text__tinymce + .editor-rich-text__tinymce p {
 	opacity: 0.9;
 	text-shadow:
-		0.05em 0 rgba( 255, 255, 255, 0.8 ),
-		0 0.05em rgba( 255, 255, 255, 0.8 ),
-		-0.05em 0 rgba( 255, 255, 255, 0.8 ),
-		0 -0.05em rgba( 255, 255, 255, 0.8 ),
-		-0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
-		-0.05em 0.05em rgba( 255, 255, 255, 0.8 ),
-		0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
-		0.05em 0.05em rgba( 255, 255, 255, 0.8 );
+			0.05em 0 rgba( 255, 255, 255, 0.8 ),
+			0 0.05em rgba( 255, 255, 255, 0.8 ),
+			-0.05em 0 rgba( 255, 255, 255, 0.8 ),
+			0 -0.05em rgba( 255, 255, 255, 0.8 ),
+			-0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
+			-0.05em 0.05em rgba( 255, 255, 255, 0.8 ),
+			0.05em -0.05em rgba( 255, 255, 255, 0.8 ),
+			0.05em 0.05em rgba( 255, 255, 255, 0.8 );
 }
 
 /*
@@ -302,7 +302,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	}
 
 	.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div {
-		height: 553px;
+		height: 543px;
 	}
 
 	.amp-story-editor-carousel-navigation {
@@ -508,7 +508,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	/* Navigator in the context of the open sidebar, settings hidden. */
 	.post-type-amp_story:not(.folded) .edit-post-layout #amp-root-navigation {
 		max-width: calc(
-			calc(
+				calc(
 				100vw
 				-
 				var(--admin-menu-expanded-sidebar-width)
@@ -518,15 +518,15 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 				calc( var(--block-editor-horizontal-margin) * 2 )
 				-
 				var( --scrollbar-width )
-			) / 2
-			-
-			var(--block-navigation-right-margin)
+				) / 2
+				-
+				var(--block-navigation-right-margin)
 		);
 	}
 
 	.post-type-amp_story.folded .edit-post-layout #amp-root-navigation {
 		max-width: calc(
-			calc(
+				calc(
 				100vw
 				-
 				var(--admin-menu-collapsed-sidebar-width)
@@ -536,16 +536,16 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 				calc( var(--block-editor-horizontal-margin) * 2 )
 				-
 				var( --scrollbar-width )
-			) / 2
-			-
-			var(--block-navigation-right-margin)
+				) / 2
+				-
+				var(--block-navigation-right-margin)
 		);
 	}
 
 	/* Navigator in the context of minimum available space - open sidebar, settings shown. */
 	.post-type-amp_story .edit-post-layout.is-sidebar-opened #amp-root-navigation {
 		max-width: calc(
-			calc(
+				calc(
 				100vw
 				-
 				var(--admin-menu-expanded-sidebar-width)
@@ -557,9 +557,9 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 				calc( var(--block-editor-horizontal-margin) * 2 )
 				-
 				var( --scrollbar-width )
-			) / 2
-			-
-			var(--block-navigation-right-margin)
+				) / 2
+				-
+				var(--block-navigation-right-margin)
 		);
 	}
 
@@ -571,7 +571,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 	/* Navigator in the context of folded sidebar, settings shown. */
 	.post-type-amp_story.folded .edit-post-layout.is-sidebar-opened #amp-root-navigation {
 		max-width: calc(
-			calc(
+				calc(
 				100vw
 				-
 				var(--admin-menu-collapsed-sidebar-width)
@@ -583,9 +583,9 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 				calc( var(--block-editor-horizontal-margin) * 2 )
 				-
 				var( --scrollbar-width )
-			) / 2
-			-
-			var(--block-navigation-right-margin)
+				) / 2
+				-
+				var(--block-navigation-right-margin)
 		);
 	}
 
@@ -685,6 +685,20 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
 
 #amp-story-editor .components-draggable__clone {
 	position: absolute;
+}
+
+/* Pullquote block adjustments */
+.wp-block[data-type="core/pullquote"][data-align="wide"],
+.wp-block[data-type="core/pullquote"][data-align="full"] {
+	width: 100%;
+	max-width: 100%;
+}
+.block-editor-inner-blocks .wp-block[data-type="core/pullquote"] .block-editor-block-list__block-edit {
+	display: block;
+}
+
+#amp-story-editor .block-editor-block-list__layout .block-editor-block-list__block[data-align="full"] {
+	margin: 0;
 }
 
 /*

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -28,11 +28,12 @@
 /*
  * 0. General editor layout styles.
  */
+.edit-post-visual-editor {
+	padding-left: 50px;
+	padding-right: 50px;
+}
+
 @media screen and (min-width: 1280px) {
-	.edit-post-visual-editor {
-		max-width: 1024px;
-		margin: 0 auto;
-	}
 	#amp-story-editor {
 		min-width: 820px;
 	}
@@ -476,7 +477,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__lay
 
 	#amp-root-navigation {
 		position: absolute;
-		left: 5px;
+		left: 50px;
 		top: 218px;
 		width: 300px;
 		z-index: 80;

--- a/assets/css/amp-stories-frontend.css
+++ b/assets/css/amp-stories-frontend.css
@@ -1,0 +1,74 @@
+/**
+ * Front-end styling for AMP Stories.
+ */
+
+/* Text sizes to match the editor styles. */
+body,
+p {
+    font-size: 16px;
+    line-height: 1.8;
+    font-weight: normal;
+}
+.wp-block-quote cite {
+    color: #6c7781;
+    font-size: 13px;
+    font-style: normal;
+}
+
+amp-story-grid-layer {
+    padding: 0;
+}
+
+.wp-block-quote {
+    border-left: 4px solid #000;
+    padding-left: 1em;
+}
+
+.wp-block-pullquote {
+    border-top: 4px solid #555d66;
+    border-bottom: 4px solid #555d66;
+    color: #40464d;
+}
+
+.wp-block-pullquote p {
+    font-size: 20px;
+    line-height: 1.6;
+}
+
+.wp-block-pullquote cite {
+    text-transform: uppercase;
+    font-size: 13px;
+    font-style: normal;
+}
+
+.wp-block-pullquote.alignleft {
+    text-align: left;
+    width: initial;
+}
+
+.wp-block-pullquote.alignright {
+    text-align: right;
+    width: initial;
+}
+
+.wp-block-code {
+    font-family: Menlo, Consolas, monaco, monospace;
+    font-size: 14px;
+    color: #23282d;
+    padding: 0.8em 1em;
+    border: 1px solid #e2e4e7;
+    border-radius: 4px;
+}
+
+.wp-block-table {
+    width: initial;
+    min-width: 240px;
+    border-collapse: collapse;
+}
+
+.wp-block-table td,
+.wp-block-table th {
+    padding: 0.5em;
+    border: 1px solid #000;
+    font-size: 16px;
+}

--- a/assets/css/amp-stories-frontend.css
+++ b/assets/css/amp-stories-frontend.css
@@ -8,6 +8,7 @@ p {
     font-size: 16px;
     line-height: 1.8;
     font-weight: normal;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 }
 .wp-block-quote cite {
     color: #6c7781;

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -117,11 +117,19 @@ class TextBlockEdit extends Component {
 			autoFontSize,
 			height,
 			width,
+			tagName,
 		} = attributes;
 
 		const minTextHeight = 20;
 		const minTextWidth = 30;
-		const userFontSize = fontSize.size ? fontSize.size + 'px' : undefined;
+		let userFontSize = fontSize.size ? fontSize.size + 'px' : undefined;
+		if ( undefined === userFontSize ) {
+			if ( 'h1' === tagName ) {
+				userFontSize = 2 + 'rem';
+			} else if ( 'h2' === tagName ) {
+				userFontSize = 1.5 + 'rem';
+			}
+		}
 
 		return (
 			<Fragment>
@@ -224,6 +232,7 @@ class TextBlockEdit extends Component {
 							backgroundColor: backgroundColor.color,
 							color: textColor.color,
 							fontSize: ampFitText ? autoFontSize : userFontSize,
+							fontWeight: 'h1' === tagName || 'h2' === tagName ? 700 : 'normal',
 						} }
 						className={ classnames( className, {
 							'has-text-color': textColor.color,

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -10,14 +10,16 @@ import { __ } from '@wordpress/i18n';
 import {
 	RichText,
 	getColorClassName,
+	getFontSize,
 } from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import edit from './edit';
-import { getPercentageFromPixels, getFontSizeFromSlug } from '../../helpers';
+import { getPercentageFromPixels } from '../../helpers';
 import { STORY_PAGE_INNER_WIDTH } from '../../constants';
 
 export const name = 'amp/amp-story-text';
@@ -132,7 +134,9 @@ export const settings = {
 		} );
 
 		// Calculate fontsize using vw to make it responsive.
-		const userFontSize = fontSize ? getFontSizeFromSlug( fontSize ) : customFontSize;
+		const { fontSizes } = select( 'core/block-editor' ).getSettings();
+		// Get the font size in px based on the slug with fallback to customFontSize.
+		const userFontSize = fontSize ? getFontSize( fontSizes, fontSize, customFontSize ).size : customFontSize;
 		const fontSizeResponsive = ( ( userFontSize / STORY_PAGE_INNER_WIDTH ) * 100 ).toFixed( 2 ) + 'vw';
 
 		const styles = {

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 import {
 	RichText,
 	getColorClassName,
-	getFontSizeClass,
 } from '@wordpress/editor';
 import { registerBlockType } from '@wordpress/blocks';
 
@@ -18,7 +17,8 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import edit from './edit';
-import { getPercentageFromPixels } from '../../helpers';
+import { getPercentageFromPixels, getFontSizeFromSlug } from '../../helpers';
+import { STORY_PAGE_INNER_WIDTH } from '../../constants';
 
 export const name = 'amp/amp-story-text';
 
@@ -122,23 +122,23 @@ export const settings = {
 
 		const textClass = getColorClassName( 'color', textColor );
 		const backgroundClass = getColorClassName( 'background-color', backgroundColor );
-		const fontSizeClass = getFontSizeClass( fontSize );
 
 		const className = classnames( {
 			'amp-text-content': ! ampFitText,
 			'has-text-color': textColor || customTextColor,
 			'has-background': backgroundColor || customBackgroundColor,
-			[ fontSizeClass ]: ampFitText ? undefined : fontSizeClass,
 			[ textClass ]: textClass,
 			[ backgroundClass ]: backgroundClass,
 		} );
 
-		const userFontSize = fontSizeClass ? undefined : customFontSize;
+		// Calculate fontsize using vw to make it responsive.
+		const userFontSize = fontSize ? getFontSizeFromSlug( fontSize ) : customFontSize;
+		const fontSizeResponsive = ( ( userFontSize / STORY_PAGE_INNER_WIDTH ) * 100 ).toFixed( 2 ) + 'vw';
 
 		const styles = {
 			backgroundColor: backgroundClass ? undefined : customBackgroundColor,
 			color: textClass ? undefined : customTextColor,
-			fontSize: ampFitText ? autoFontSize : userFontSize,
+			fontSize: ampFitText ? autoFontSize : fontSizeResponsive,
 			width: `${ getPercentageFromPixels( 'x', width ) }%`,
 			height: `${ getPercentageFromPixels( 'y', height ) }%`,
 		};

--- a/assets/src/components/block-navigation.js
+++ b/assets/src/components/block-navigation.js
@@ -15,19 +15,19 @@ function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock } ) {
 		 * Safari+VoiceOver won't announce the list otherwise.
 		 */
 		/* eslint-disable jsx-a11y/no-redundant-roles */
-		<ul key="navigation-list" className="editor-block-navigation__list" role="list">
+		<ul key="navigation-list" className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
 			{ blocks.map( ( block ) => {
 				const blockType = getBlockType( block.name );
 				const isSelected = block.clientId === selectedBlockClientId;
 
-				let className = 'editor-block-navigation__item-button';
+				let className = 'components-button editor-block-navigation__item-button block-editor-block-navigation__item-button';
 				if ( isSelected ) {
 					className += ' is-selected';
 				}
 
 				return (
 					<li key={ block.clientId }>
-						<div className="editor-block-navigation__item">
+						<div className="editor-block-navigation__item block-editor-block-navigation__item">
 							<Button
 								className={ className }
 								onClick={ () => selectBlock( block.clientId ) }
@@ -55,7 +55,7 @@ function BlockNavigation( { elements, selectBlock, selectedBlockClientId, isReor
 	return (
 		<NavigableMenu
 			role="presentation"
-			className="editor-block-navigation__container"
+			className="editor-block-navigation__container block-editor-block-navigation__container"
 		>
 			<p className="editor-block-navigation__label">{ __( 'Block Navigation', 'amp' ) }</p>
 			{ hasElements && (

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -431,22 +431,3 @@ export const getPercentageFromPixels = ( axis, pixelValue ) => {
 	}
 	return 0;
 };
-
-/**
- * Get font size from slug.
- *
- * @param {string} slug Font slug.
- * @return {number} Font size in pixels.
- */
-export const getFontSizeFromSlug = ( slug ) => {
-	switch ( slug ) {
-		case 'small':
-			return 19.5;
-		case 'large':
-			return 36.5;
-		case 'huge':
-			return 49.5;
-		default:
-			return 16;
-	}
-};

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -431,3 +431,22 @@ export const getPercentageFromPixels = ( axis, pixelValue ) => {
 	}
 	return 0;
 };
+
+/**
+ * Get font size from slug.
+ *
+ * @param {string} slug Font slug.
+ * @return {number} Font size in pixels.
+ */
+export const getFontSizeFromSlug = ( slug ) => {
+	switch ( slug ) {
+		case 'small':
+			return 19.5;
+		case 'large':
+			return 36.5;
+		case 'huge':
+			return 49.5;
+		default:
+			return 16;
+	}
+};

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -478,6 +478,14 @@ class AMP_Story_Post_Type {
 			return;
 		}
 
+		wp_enqueue_style(
+			'amp-stories-frontend',
+			amp_get_asset_url( 'css/amp-stories-frontend.css' ),
+			array( self::AMP_STORIES_STYLE_HANDLE ),
+			AMP__VERSION,
+			false
+		);
+
 		self::enqueue_general_styles();
 	}
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -486,6 +486,15 @@ class AMP_Story_Post_Type {
 			false
 		);
 
+		// Also enqueue this since it's possible to embed another story into a story.
+		wp_enqueue_style(
+			'amp-story-card',
+			amp_get_asset_url( 'css/amp-story-card.css' ),
+			array( self::AMP_STORIES_STYLE_HANDLE ),
+			AMP__VERSION,
+			false
+		);
+
 		self::enqueue_general_styles();
 	}
 


### PR DESCRIPTION
Fixes #1967.

This PR does the following:
- Matches the fonts of various blocks in the FE and editor.
- Adjusts styles for each block, such as the table block, pullquote, etc.
- Changes the text style in the editor for Text block when the tagName switches.
- Enqueues AMP Stories embed style in the FE as well since it's possible to embed another AMP Story in a story.

Some issues that came out from the PR:
[RESOLVED] - Audio block seems to show validation error:
![Screen Shot 2019-03-22 at 2 38 29 PM](https://user-images.githubusercontent.com/3294597/54826854-0519a580-4cb1-11e9-8c7e-bb2e67066065.png)
[RESOLVED] - Fixed font sizes are not responsible, so there are still differences in how it displays in the FE.
