### PR TITLE
Prevent tree-shaking class names for amp-geo when component on page

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -461,6 +461,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
+			if ( 'amp-geo-' === substr( $class_name, 0, 8 ) || 'amp-iso-country-' === substr( $class_name, 0, 16 ) ) {
+				if ( ! $this->has_used_tag_names( array( 'amp-geo' ) ) ) {
+					return false;
+				}
+				continue;
+			}
+
 			// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
 			if ( 'amp-image-lightbox-caption' === $class_name ) {
 				if ( ! $this->has_used_tag_names( array( 'amp-image-lightbox' ) ) ) {

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -413,6 +413,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .amp-sidebar-toolbar-target-hidden { color: lavender} </style>
 					<style> .amp-sticky-ad-close-button { color: aliceblue} </style>
 					<style> .amp-docked-video-shadow { color: azure} </style>
+					<style> .amp-geo-pending { color: saddlebrown; } </style>
+					<style> .amp-geo-no-group { color: ghostwhite; } </style>
+					<style> .amp-geo-group-foo { color: peru; } </style>
+					<style> .amp-iso-country-us { color: oldlace; } </style>
 					<style> .non-existent { color: black; } </style>
 					</head><body><p>Hello!</p></body></html>
 				',
@@ -437,6 +441,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .amp-sidebar-toolbar-target-hidden { color: lavender} </style>
 					<style> .amp-sticky-ad-close-button { color: aliceblue} </style>
 					<style> .amp-docked-video-shadow { color: azure} </style>
+					<style> .amp-geo-pending { color: saddlebrown; } </style>
+					<style> .amp-geo-no-group { color: ghostwhite; } </style>
+					<style> .amp-geo-group-foo { color: peru; } </style>
+					<style> .amp-iso-country-us { color: oldlace; } </style>
 					<style> .non-existent { color: black; } </style>
 					</head>
 					<body>
@@ -449,6 +457,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						<amp-sidebar id="sidebar1" layout="nodisplay" side="right"><nav toolbar="(max-width: 767px)" toolbar-target="target-element"><ul><li></li></ul></nav></amp-sidebar>
 						<amp-sticky-ad layout="nodisplay"><amp-ad width="320" height="50" type="doubleclick" data-slot="/35096353/amptesting/formats/sticky"></amp-ad></amp-sticky-ad>
 						<amp-video dock width="720" height="305" layout="responsive" src="https://yourhost.com/videos/myvideo.mp4" poster="https://yourhost.com/posters/poster.png" artwork="https://yourhost.com/artworks/artwork.png" title="Awesome video" artist="Awesome artist" album="Amazing album"></amp-video>
+						<amp-geo layout="nodisplay"><script type="application/json">{"ISOCountryGroups": {"foo":["us"]}}</script></amp-geo>
 					</body>
 					</html>
 				',
@@ -464,6 +473,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.amp-sidebar-toolbar-target-hidden{color:lavender}',
 					'.amp-sticky-ad-close-button{color:aliceblue}',
 					'.amp-docked-video-shadow{color:azure}',
+					'.amp-geo-pending{color:saddlebrown}',
+					'.amp-geo-no-group{color:ghostwhite}',
+					'.amp-geo-group-foo{color:peru}',
+					'.amp-iso-country-us{color:oldlace}',
 					'', // Because no non-existent.
 				),
 				array(),


### PR DESCRIPTION
Conditional tree shaking for dynamic class names was added in #1959, but it missed handling class names added for `amp-geo`. See [support topic](https://wordpress.org/support/topic/filter-for-tree-shaking/).

This PR will prevent tree shaking the classes when the `amp-geo` component is used on the page:

* `amp-geo-pending`
* `amp-geo-no-group`
* `amp-geo-group-`…
* `amp-iso-country-`…

See #1490.

Build of plugin for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/2998238/amp.zip) (v1.1-alpha-20190322T203831Z-f45def68)
