### PR TITLE
Add support for Archives widget block when displaying as dropdown

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -9,9 +9,7 @@ if [[ ! -z $TRAVIS ]]; then
 fi
 
 function after_wp_install {
-	if [[ $WP_VERSION == 4.* ]]; then
-		echo -n "Installing Gutenberg..."
-		svn export -q https://plugins.svn.wordpress.org/gutenberg/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
-		echo "done"
-	fi
+	echo -n "Installing Gutenberg..."
+	svn export -q https://plugins.svn.wordpress.org/gutenberg/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
+	echo "done"
 }

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -13,75 +13,64 @@
 class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 
 	/**
-	 * Render methods for blocks.
+	 * Methods to ampify blocks.
 	 *
 	 * @var array
 	 */
-	protected $block_render_methods = array(
-		'core/categories' => 'render_categories_block',
-		'core/archives'   => 'render_archives_block',
+	protected $block_ampify_methods = array(
+		'core/categories' => 'ampify_categories_block',
+		'core/archives'   => 'ampify_archives_block',
 	);
 
 	/**
 	 * Register embed.
 	 */
 	public function register_embed() {
-		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
-			return;
-		}
-
-		$registry = WP_Block_Type_Registry::get_instance();
-		foreach ( $this->block_render_methods as $block_name => $render_method ) {
-			$block = $registry->get_registered( $block_name );
-			if ( $block ) {
-				$block->original_render_callback = $block->render_callback;
-				$block->render_callback          = array( $this, $render_method );
-			}
-		}
+		add_filter( 'render_block', array( $this, 'filter_rendered_block' ), 0, 2 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
-			return;
-		}
-
-		$registry = WP_Block_Type_Registry::get_instance();
-		foreach ( array_keys( $this->block_render_methods ) as $block_name ) {
-			$block = $registry->get_registered( $block_name );
-			if ( $block && isset( $block->original_render_callback ) ) {
-				$block->render_callback = $block->original_render_callback;
-			}
-		}
+		remove_filter( 'render_block', array( $this, 'filter_rendered_block' ), 0 );
 	}
 
 	/**
-	 * Render categories block when displayAsDropdown.
+	 * Filters the content of a single block to make it AMP valid.
+	 *
+	 * @param string $block_content The block content about to be appended.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Filtered block content.
+	 */
+	public function filter_rendered_block( $block_content, $block ) {
+		if ( isset( $block['blockName'] ) && isset( $this->block_ampify_methods[ $block['blockName'] ] ) ) {
+			$block_content = call_user_func(
+				array( $this, $this->block_ampify_methods[ $block['blockName'] ] ),
+				$block_content
+			);
+		}
+		return $block_content;
+	}
+
+	/**
+	 * Fix rendering of categories block when displayAsDropdown.
 	 *
 	 * This excludes the disallowed JS scrips, adds <form> tags, and uses on:change for <select>.
 	 *
 	 * @see render_block_core_categories()
 	 *
-	 * @param array $attributes Attributes.
+	 * @param string $block_content Block content.
 	 * @return string Rendered.
 	 */
-	public function render_categories_block( $attributes ) {
-		$block = WP_Block_Type_Registry::get_instance()->get_registered( 'core/categories' );
-		if ( ! isset( $block->original_render_callback ) ) {
-			return '';
-		}
-
-		$rendered = call_user_func( $block->original_render_callback, $attributes );
-
+	public function ampify_categories_block( $block_content ) {
 		static $block_id = 0;
 		$block_id++;
 
 		$form_id = "wp-block-categories-dropdown-{$block_id}-form";
 
 		// Remove output of build_dropdown_script_block_core_categories().
-		$rendered = preg_replace( '#<script.+?</script>#s', '', $rendered );
+		$block_content = preg_replace( '#<script.+?</script>#s', '', $block_content );
 
 		$form = sprintf(
 			'<form action="%s" method="get" target="_top" id="%s">',
@@ -89,47 +78,41 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 			esc_attr( $form_id )
 		);
 
-		$rendered = preg_replace(
+		$block_content = preg_replace(
 			'#(<select)(.+</select>)#s',
 			$form . '$1' . sprintf( ' on="change:%1$s.submit"', esc_attr( $form_id ) ) . '$2</form>',
-			$rendered,
+			$block_content,
 			1
 		);
 
-		return $rendered;
+		return $block_content;
 	}
 
 	/**
-	 * Render archives block when displayAsDropdown.
+	 * Fix rendering of archives block when displayAsDropdown.
 	 *
 	 * This replaces disallowed script with the use of on:change for <select>.
 	 *
 	 * @see render_block_core_archives()
 	 *
-	 * @param array $attributes Attributes.
+	 * @param string $block_content Block content.
 	 * @return string Rendered.
 	 */
-	public function render_archives_block( $attributes ) {
-		$block = WP_Block_Type_Registry::get_instance()->get_registered( 'core/archives' );
-		if ( ! isset( $block->original_render_callback ) ) {
-			return '';
-		}
-
-		$rendered = call_user_func( $block->original_render_callback, $attributes );
+	public function ampify_archives_block( $block_content ) {
 
 		// Eliminate use of uniqid(). Core should be using wp_unique_id() here.
 		static $block_id = 0;
 		$block_id++;
-		$rendered = preg_replace( '/(?<="wp-block-archives-)\w+(?=")/', $block_id, $rendered );
+		$block_content = preg_replace( '/(?<="wp-block-archives-)\w+(?=")/', $block_id, $block_content );
 
 		// Replace onchange with on attribute.
-		$rendered = preg_replace(
+		$block_content = preg_replace(
 			'/onchange=".+?"/',
 			'on="change:AMP.navigateTo(url=event.value)"',
-			$rendered
+			$block_content
 		);
 
-		return $rendered;
+		return $block_content;
 	}
 
 }

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -13,30 +13,45 @@
 class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 
 	/**
-	 * Original block callback.
+	 * Upgraded blocks.
 	 *
 	 * @var array
 	 */
-	public $original_categories_callback;
+	protected $registered_blocks = array();
 
 	/**
-	 * Block name.
+	 * AMP_Core_Block_Handler constructor.
 	 *
-	 * @var string
+	 * @param array $args Args.
 	 */
-	public $block_name = 'core/categories';
+	public function __construct( array $args = array() ) {
+		parent::__construct( $args );
+
+		$this->registered_blocks = array(
+			'core/categories' => array(
+				'render_callback'      => array( $this, 'render_categories_block' ),
+				'core_render_callback' => 'render_block_core_categories',
+			),
+			'core/archives'   => array(
+				'render_callback'      => array( $this, 'render_archives_block' ),
+				'core_render_callback' => 'render_block_core_archives',
+			),
+		);
+	}
 
 	/**
 	 * Register embed.
 	 */
 	public function register_embed() {
-		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
-			$registry = WP_Block_Type_Registry::get_instance();
-			$block    = $registry->get_registered( $this->block_name );
+		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
+			return;
+		}
 
-			if ( $block ) {
-				$this->original_categories_callback = $block->render_callback;
-				$block->render_callback             = array( $this, 'render' );
+		$registry = WP_Block_Type_Registry::get_instance();
+		foreach ( $this->registered_blocks as $block_name => $args ) {
+			$block = $registry->get_registered( $block_name );
+			if ( $block && $args['core_render_callback'] === $block->render_callback ) {
+				$block->render_callback = $args['render_callback'];
 			}
 		}
 	}
@@ -45,25 +60,34 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
-			$registry = WP_Block_Type_Registry::get_instance();
-			$block    = $registry->get_registered( $this->block_name );
+		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
+			return;
+		}
 
-			if ( $block && ! empty( $this->original_categories_callback ) ) {
-				$block->render_callback             = $this->original_categories_callback;
-				$this->original_categories_callback = null;
+		$registry = WP_Block_Type_Registry::get_instance();
+		foreach ( $this->registered_blocks as $block_name => $args ) {
+			$block = $registry->get_registered( $block_name );
+			if ( $block && $args['render_callback'] === $block->render_callback ) {
+				$block->render_callback = $args['core_render_callback'];
 			}
 		}
 	}
 
 	/**
-	 * Render Gutenberg block. This is essentially the same method as the original.
-	 * Difference is excluding the disallowed JS script, adding <form> tags, and using on:change for <select>.
+	 * Render categories block when displayAsDropdown.
+	 *
+	 * This excludes the disallowed JS scrips, adds <form> tags, and uses on:change for <select>.
+	 *
+	 * @see render_block_core_categories()
 	 *
 	 * @param array $attributes Attributes.
 	 * @return string Rendered.
 	 */
-	public function render( $attributes ) {
+	public function render_categories_block( $attributes ) {
+		if ( empty( $attributes['displayAsDropdown'] ) ) {
+			return call_user_func( $this->registered_blocks['core/categories']['core_render_callback'], $attributes );
+		}
+
 		static $block_id = 0;
 		$block_id++;
 
@@ -80,26 +104,20 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 			'title_li'     => '',
 		);
 
-		if ( ! empty( $attributes['displayAsDropdown'] ) ) {
-			$id                       = 'wp-block-categories-dropdown-' . $block_id;
-			$form_id                  = $id . '-form';
-			$args['id']               = $id;
-			$args['show_option_none'] = __( 'Select Category', 'amp' );
-			$wrapper_markup           = '<div class="%1$s">%2$s</div>';
-			$items_markup             = wp_dropdown_categories( $args );
-			$type                     = 'dropdown';
+		$id                       = 'wp-block-categories-dropdown-' . $block_id;
+		$form_id                  = $id . '-form';
+		$args['id']               = $id;
+		$args['show_option_none'] = __( 'Select Category', 'amp' );
+		$wrapper_markup           = '<div class="%1$s">%2$s</div>';
+		$items_markup             = wp_dropdown_categories( $args );
+		$type                     = 'dropdown';
 
-			$items_markup = preg_replace(
-				'/(?<=<select\b)/',
-				sprintf( ' on="change:%s.submit"', esc_attr( $form_id ) ),
-				$items_markup,
-				1
-			);
-		} else {
-			$wrapper_markup = '<div class="%1$s"><ul>%2$s</ul></div>';
-			$items_markup   = wp_list_categories( $args );
-			$type           = 'list';
-		}
+		$items_markup = preg_replace(
+			'/(?<=<select\b)/',
+			sprintf( ' on="change:%s.submit"', esc_attr( $form_id ) ),
+			$items_markup,
+			1
+		);
 
 		$class = "wp-block-categories wp-block-categories-{$type} align{$align}";
 
@@ -109,9 +127,104 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 			$items_markup
 		);
 
-		if ( ! empty( $attributes['displayAsDropdown'] ) ) {
-			$block_content = sprintf( '<form action="%s" method="get" target="_top" id="%s">%s</form>', esc_url( home_url() ), esc_attr( $form_id ), $block_content );
-		}
+		$block_content = sprintf(
+			'<form action="%s" method="get" target="_top" id="%s">%s</form>',
+			esc_url( home_url() ),
+			esc_attr( $form_id ),
+			$block_content
+		);
+
 		return $block_content;
 	}
+
+	/**
+	 * Render archives block when displayAsDropdown.
+	 *
+	 * This replaces disallowed script with the use of on:change for <select>.
+	 *
+	 * @see render_block_core_archives()
+	 *
+	 * @param array $attributes Attributes.
+	 * @return string Rendered.
+	 */
+	public function render_archives_block( $attributes ) {
+		if ( empty( $attributes['displayAsDropdown'] ) ) {
+			return call_user_func( $this->registered_blocks['core/archives']['core_render_callback'], $attributes );
+		}
+
+		$show_post_count = ! empty( $attributes['showPostCounts'] );
+
+		static $block_id = 0;
+		$block_id++;
+
+		$class = 'wp-block-archives';
+
+		if ( isset( $attributes['align'] ) ) {
+			$class .= " align{$attributes['align']}";
+		}
+
+		if ( isset( $attributes['className'] ) ) {
+			$class .= " {$attributes['className']}";
+		}
+
+		$class .= ' wp-block-archives-dropdown';
+
+		$dropdown_id = 'wp-block-categories-dropdown-' . $block_id;
+		$title       = __( 'Archives' );
+
+		/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
+		$dropdown_args = apply_filters(
+			'widget_archives_dropdown_args',
+			array(
+				'type'            => 'monthly',
+				'format'          => 'option',
+				'show_post_count' => $show_post_count,
+			)
+		);
+
+		$dropdown_args['echo'] = 0;
+
+		switch ( $dropdown_args['type'] ) {
+			case 'yearly':
+				$label = __( 'Select Year' );
+				break;
+			case 'monthly':
+				$label = __( 'Select Month' );
+				break;
+			case 'daily':
+				$label = __( 'Select Day' );
+				break;
+			case 'weekly':
+				$label = __( 'Select Week' );
+				break;
+			default:
+				$label = __( 'Select Post' );
+				break;
+		}
+
+		$block_content  = sprintf(
+			'<label class="screen-reader-text" for="%s">%s</label>',
+			esc_attr( $dropdown_id ),
+			esc_html( $title )
+		);
+		$block_content .= sprintf(
+			'<select id="%s" on="change:AMP.navigateTo(url=event.value)">',
+			esc_attr( $dropdown_id )
+		);
+		$block_content .= sprintf(
+			'<option value="">%s</option>',
+			esc_html( $label )
+		);
+		$block_content .= wp_get_archives( $dropdown_args );
+		$block_content .= '</select>';
+
+		$block_content = sprintf(
+			'<div class="%1$s">%2$s</div>',
+			esc_attr( $class ),
+			$block_content
+		);
+
+		return $block_content;
+	}
+
 }

--- a/tests/test-class-amp-core-block-handler.php
+++ b/tests/test-class-amp-core-block-handler.php
@@ -27,6 +27,7 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		}
 
 		$handler = new AMP_Core_Block_Handler();
+		$handler->unregister_embed(); // Make sure we are on the initial clean state.
 
 		$registry = WP_Block_Type_Registry::get_instance();
 

--- a/tests/test-class-amp-core-block-handler.php
+++ b/tests/test-class-amp-core-block-handler.php
@@ -15,97 +15,48 @@
 class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 
 	/**
-	 * Instance of the tested class.
-	 *
-	 * @var AMP_Core_Block_Handler.
-	 */
-	public $instance;
-
-	/**
-	 * Test block name.
-	 *
-	 * @var string
-	 */
-	public $test_block = 'core/test';
-
-	/**
-	 * Teardown.
-	 */
-	public function tearDown() {
-		if ( function_exists( 'register_block_type' ) ) {
-			$this->unregister_dummy_block();
-		}
-
-		parent::tearDown();
-	}
-
-	/**
-	 * Register test block.
-	 */
-	public function register_dummy_block() {
-		$settings = array(
-			'render_callback' => '__return_true',
-		);
-		register_block_type( $this->test_block, $settings );
-	}
-
-	/**
-	 * Unregister test block.
-	 */
-	public function unregister_dummy_block() {
-		unregister_block_type( $this->test_block );
-	}
-
-	/**
 	 * Test register_embed().
+	 *
+	 * @covers AMP_Core_Block_Handler::register_embed()
+	 * @covers AMP_Core_Block_Handler::unregister_embed()
 	 */
-	public function test_register_embed() {
+	public function test_register_and_unregister_embed() {
 
 		if ( ! function_exists( 'register_block_type' ) ) {
 			$this->markTestIncomplete( 'Files needed for testing missing.' );
 		}
 
-		$this->register_dummy_block();
-
-		$this->instance             = new AMP_Core_Block_Handler();
-		$this->instance->block_name = $this->test_block;
+		$handler = new AMP_Core_Block_Handler();
 
 		$registry = WP_Block_Type_Registry::get_instance();
-		$block    = $registry->get_registered( $this->test_block );
 
-		$this->assertEquals( '__return_true', $block->render_callback );
+		$props = array( 'displayAsDropdown' => true );
 
-		$this->instance->register_embed();
+		$categories_block = $registry->get_registered( 'core/categories' );
+		$archives_block   = $registry->get_registered( 'core/archives' );
 
-		$registry = WP_Block_Type_Registry::get_instance();
-		$block    = $registry->get_registered( $this->test_block );
-
-		$this->assertTrue( is_array( $block->render_callback ) );
-
-		$this->unregister_dummy_block();
-	}
-
-	/**
-	 * Test unregister_embed().
-	 */
-	public function test_unregister_embed() {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestIncomplete( 'Files needed for testing missing.' );
+		$handler->register_embed();
+		$rendered = $categories_block->render( $props );
+		$this->assertContains( '<select', $rendered );
+		$this->assertNotContains( 'onchange', $rendered );
+		$this->assertContains( 'on="change', $rendered );
+		if ( $archives_block ) {
+			$rendered = $archives_block->render( $props );
+			$this->assertContains( '<select', $rendered );
+			$this->assertNotContains( 'onchange', $rendered );
+			$this->assertContains( 'on="change', $rendered );
 		}
 
-		$this->register_dummy_block();
-
-		$this->instance             = new AMP_Core_Block_Handler();
-		$this->instance->block_name = $this->test_block;
-
-		$this->instance->register_embed();
-		$this->instance->unregister_embed();
-
-		$registry = WP_Block_Type_Registry::get_instance();
-		$block    = $registry->get_registered( $this->test_block );
-
-		$this->assertEquals( '__return_true', $block->render_callback );
-
-		$this->unregister_dummy_block();
+		$handler->unregister_embed();
+		$rendered = $categories_block->render( $props );
+		$this->assertContains( '<select', $rendered );
+		$this->assertContains( 'onchange', $rendered );
+		$this->assertNotContains( 'on="change', $rendered );
+		if ( $archives_block ) {
+			$rendered = $archives_block->render( $props );
+			$this->assertContains( '<select', $rendered );
+			$this->assertContains( 'onchange', $rendered );
+			$this->assertNotContains( 'on="change', $rendered );
+		}
 	}
 }

--- a/tests/test-class-amp-core-block-handler.php
+++ b/tests/test-class-amp-core-block-handler.php
@@ -29,32 +29,28 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		$handler = new AMP_Core_Block_Handler();
 		$handler->unregister_embed(); // Make sure we are on the initial clean state.
 
-		$registry = WP_Block_Type_Registry::get_instance();
-
-		$props = array( 'displayAsDropdown' => true );
-
-		$categories_block = $registry->get_registered( 'core/categories' );
-		$archives_block   = $registry->get_registered( 'core/archives' );
+		$categories_block = '<!-- wp:categories {"displayAsDropdown":true,"showHierarchy":true,"showPostCounts":true} /-->';
+		$archives_block   = '<!-- wp:archives {"displayAsDropdown":true,"showPostCounts":true} /-->';
 
 		$handler->register_embed();
-		$rendered = $categories_block->render( $props );
+		$rendered = do_blocks( $categories_block );
 		$this->assertContains( '<select', $rendered );
 		$this->assertNotContains( 'onchange', $rendered );
 		$this->assertContains( 'on="change', $rendered );
-		if ( $archives_block ) {
-			$rendered = $archives_block->render( $props );
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/archives' ) ) {
+			$rendered = do_blocks( $archives_block );
 			$this->assertContains( '<select', $rendered );
 			$this->assertNotContains( 'onchange', $rendered );
 			$this->assertContains( 'on="change', $rendered );
 		}
 
 		$handler->unregister_embed();
-		$rendered = $categories_block->render( $props );
+		$rendered = do_blocks( $categories_block );
 		$this->assertContains( '<select', $rendered );
 		$this->assertContains( 'onchange', $rendered );
 		$this->assertNotContains( 'on="change', $rendered );
-		if ( $archives_block ) {
-			$rendered = $archives_block->render( $props );
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/archives' ) ) {
+			$rendered = do_blocks( $archives_block );
 			$this->assertContains( '<select', $rendered );
 			$this->assertContains( 'onchange', $rendered );
 			$this->assertNotContains( 'on="change', $rendered );


### PR DESCRIPTION
The Archives widget has joined the Categories widget as being available in blocks. These blocks both allow for the items to be displayed as a dropdown. When displayed as a dropdown, JavaScript is required to navigate once the selected option is changed. This script causes an AMP validation error and so we must use the AMP equivalent.

* Use an AMP-compatible alternative to `onchange` in the Archives widget.
* Use `render_block` filter instead of overriding the `render_callback`. 
* Eliminate duplicated code for Categories and Archives widget in favor of just applying the diff to make it valid AMP. This also fixed the alignment of the Categories block which had diverged in core.
* Always install Gutenberg during unit testing to be able to be able to test new feature plugin features. See also https://github.com/xwp/wp-dev-lib/pull/297.
* Make sure that the Archives widget does not output `uniqid()` in favor of an auto-incremented ID. See https://core.trac.wordpress.org/ticket/44883.
* Add tests for actual output of Categories and Archives widgets.

Fixes #1991.

The widget is configured like this:

> ![image](https://user-images.githubusercontent.com/134745/54872449-7759bb00-4d81-11e9-9bf7-5eab2076e204.png)

The widget is rendered like this on the frontend:

> ![image](https://user-images.githubusercontent.com/134745/54872442-5b561980-4d81-11e9-864b-86ef1b91761b.png)

# Archives Widget Before

> ![image](https://user-images.githubusercontent.com/134745/54872439-4bd6d080-4d81-11e9-979e-002c9a8e0bf1.png)

# Archives Widget After

> ![image](https://user-images.githubusercontent.com/134745/54872476-98221080-4d81-11e9-9812-0b50b31faed3.png)
