### PR TITLE
Definitively fix issues with images in AMP not visually matching non-AMP version

### DIFF
--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -1,6 +1,11 @@
-.amp-wp-unknown-size [src] {
-	/** Worst case scenario when we can't figure out dimensions for an image. **/
-	/** Force the image into a box of fixed dimensions and use object-fit to scale. **/
+
+/*
+ * Prevent cases of amp-img converted from img to appear with stretching by using object-fit to scale.
+ * See <https://github.com/ampproject/amphtml/issues/21371#issuecomment-475443219>.
+ * Also use object-fit:contain in worst case scenario when we can't figure out dimensions for an image.
+ */
+amp-img.amp-wp-enforced-sizes[layout=intrinsic] > img,
+.amp-wp-unknown-size > img {
 	object-fit: contain;
 }
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -783,7 +783,9 @@ function amp_get_content_sanitizers( $post = null ) {
 			'template'   => get_template(),
 			'stylesheet' => get_stylesheet(),
 		),
-		'AMP_Img_Sanitizer'               => array(),
+		'AMP_Img_Sanitizer'               => array(
+			'align_wide_support' => current_theme_supports( 'align-wide' ),
+		),
 		'AMP_Form_Sanitizer'              => array(),
 		'AMP_Comments_Sanitizer'          => array(
 			'comments_live_list' => ! empty( $theme_support_args['comments_live_list'] ),

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -913,7 +913,7 @@ class AMP_Theme_Support {
 		);
 
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ), 0 ); // Enqueue before theme's styles.
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'dequeue_customize_preview_scripts' ), 1000 );
 		add_filter( 'customize_partial_render', array( __CLASS__, 'filter_customize_partial_render' ) );
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -64,7 +64,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				),
 			),
 			'add_twentynineteen_masthead_styles' => array(),
-			'add_twentynineteen_image_styles'    => array(),
+			'adjust_twentynineteen_images'       => array(),
 		),
 
 		// Twenty Seventeen.
@@ -1024,11 +1024,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Output image styles for twentynineteen.
+	 * Adjust images in twentynineteen.
 	 *
-	 * @since 1.0
+	 * @since 1.1
 	 */
-	public static function add_twentynineteen_image_styles() {
+	public static function adjust_twentynineteen_images() {
 
 		// Make sure the featured image gets responsive layout.
 		add_filter(
@@ -1039,21 +1039,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 				return $attributes;
 			}
-		);
-
-		add_action(
-			'wp_enqueue_scripts',
-			function() {
-				ob_start();
-				?>
-				<style>
-					/* TODO: Remove? */
-				</style>
-				<?php
-				$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
-				wp_add_inline_style( get_template() . '-style', $styles );
-			},
-			11
 		);
 	}
 }

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -53,20 +53,18 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	protected static $theme_features = array(
 		// Twenty Nineteen.
 		'twentynineteen'  => array(
-			'dequeue_scripts'                             => array(
+			'dequeue_scripts'                    => array(
 				'twentynineteen-skip-link-focus-fix', // This is part of AMP. See <https://github.com/ampproject/amphtml/issues/18671>.
 				'twentynineteen-priority-menu',
 				'twentynineteen-touch-navigation', // @todo There could be an AMP implementation of this, similar to what is implemented on ampproject.org.
 			),
-			'remove_actions'                              => array(
+			'remove_actions'                     => array(
 				'wp_print_footer_scripts' => array(
 					'twentynineteen_skip_link_focus_fix', // See <https://github.com/WordPress/twentynineteen/pull/47>.
 				),
 			),
-			'add_twentynineteen_masthead_styles'          => array(),
-			'add_twentynineteen_image_styles'             => array(),
-			'remove_twentynineteen_thumbnail_image_sizes' => array(),
-
+			'add_twentynineteen_masthead_styles' => array(),
+			'add_twentynineteen_image_styles'    => array(),
 		),
 
 		// Twenty Seventeen.
@@ -403,30 +401,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Remove the sizes attribute from thumbnail images in Twenty Nineteen.
-	 *
-	 * The AMP runtime sets an inline style on an <amp-img> based on the sizes attribute if it's present.
-	 * For example, <amp-img style="width:calc(50vw)">.
-	 * Removing the 'sizes' attribute isn't ideal, but it looks like it's not possible to override that inline style.
-	 *
-	 * @todo: remove when this is resolved: https://github.com/ampproject/amphtml/issues/17053
-	 * @since 1.0
-	 */
-	public static function remove_twentynineteen_thumbnail_image_sizes() {
-		add_filter(
-			'wp_get_attachment_image_attributes',
-			function( $attr ) {
-				if ( isset( $attr['class'] ) && false !== strpos( $attr['class'], 'attachment-post-thumbnail' ) ) {
-					unset( $attr['sizes'] );
-				}
-
-				return $attr;
-			},
-			11
-		);
-	}
-
-	/**
 	 * Add filter to adjust the attachment image attributes to ensure attachment pages have a consistent <amp-img> rendering.
 	 *
 	 * This is only used in Twenty Seventeen.
@@ -435,38 +409,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @link https://github.com/WordPress/wordpress-develop/blob/ddc8f803c6e99118998191fd2ea24124feb53659/src/wp-content/themes/twentyseventeen/functions.php#L545:L554
 	 */
 	public static function add_twentyseventeen_attachment_image_attributes() {
-		add_filter(
-			'wp_get_attachment_image_attributes',
-			function ( $attr, $attachment, $size ) {
-				if (
-				isset( $attr['class'] )
-				&&
-				(
-					'custom-logo' === $attr['class']
-					||
-					false !== strpos( $attr['class'], 'attachment-twentyseventeen-featured-image' )
-				)
-				) {
-					/*
-					 * The AMP runtime sets an inline style on an <amp-img> based on the sizes attribute if it's present.
-					 * For example, <amp-img style="width:100%">.
-					 * Removing the 'sizes' attribute is only a workaround, as it looks like it's not possible to override that inline style.
-					 *
-					 * @todo: remove when this is resolved: https://github.com/ampproject/amphtml/issues/17053
-					 */
-					unset( $attr['sizes'] );
-				} elseif ( is_attachment() ) {
-					$sizes = wp_get_attachment_image_sizes( $attachment->ID, $size );
-					if ( false !== $sizes ) {
-						$attr['sizes'] = $sizes;
-					}
-				}
-				return $attr;
-			},
-			11,
-			3
-		);
-
 		/*
 		 * The max-height of the `.custom-logo-link img` is defined as being 80px, unless
 		 * there is header media in which case it is 200px. Issues related to vertically-squashed

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1084,9 +1084,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Output image styles for twentynineteen.
 	 *
-	 * When <img> tags have an 'aligncenter' class, AMP_Img_Sanitizer::handle_centering() wraps theme in <figure class="aligncenter">.
-	 * This ensures that the image inside it is centered.
-	 *
 	 * @since 1.0
 	 */
 	public static function add_twentynineteen_image_styles() {
@@ -1096,9 +1093,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				ob_start();
 				?>
 				<style>
-					figure.aligncenter {
-						text-align: center
-					}
+					/* TODO: Remove? */
 				</style>
 				<?php
 				$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1087,6 +1087,18 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0
 	 */
 	public static function add_twentynineteen_image_styles() {
+
+		// Make sure the featured image gets responsive layout.
+		add_filter(
+			'wp_get_attachment_image_attributes',
+			function( $attributes ) {
+				if ( preg_match( '/(^|\s)(attachment-post-thumbnail)(\s|$)/', $attributes['class'] ) ) {
+					$attributes['data-amp-layout'] = 'responsive';
+				}
+				return $attributes;
+			}
+		);
+
 		add_action(
 			'wp_enqueue_scripts',
 			function() {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -261,15 +261,14 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$img_node = AMP_DOM_Utils::create_node( $this->dom, $new_tag, $new_attributes );
-		$new_node = $this->handle_centering( $img_node );
-		$node->parentNode->replaceChild( $new_node, $node );
+		$node->parentNode->replaceChild( $img_node, $node );
 
 		// Preserve original node in noscript for no-JS environments.
 		$noscript = $this->dom->createElement( 'noscript' );
 		$noscript->appendChild( $node );
 		$img_node->appendChild( $noscript );
 
-		$this->add_auto_width_to_figure( $new_node );
+		$this->add_auto_width_to_figure( $img_node );
 	}
 
 	/**
@@ -312,45 +311,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$ext  = self::$anim_extension;
 		$path = wp_parse_url( $url, PHP_URL_PATH );
 		return substr( $path, -strlen( $ext ) ) === $ext;
-	}
-
-	/**
-	 * Handles an issue with the aligncenter class.
-	 *
-	 * If the <amp-img> has the class aligncenter, this strips the class and wraps it in a <figure> to center the image.
-	 * There was an issue where the aligncenter class overrode the "display: inline-block" rule of AMP's layout="intrinsic" attribute.
-	 * So this strips that class, and instead wraps the image in a <figure> to center it.
-	 *
-	 * @since 0.7
-	 * @see https://github.com/ampproject/amp-wp/issues/1104
-	 *
-	 * @param DOMElement $node The <amp-img> node.
-	 * @return DOMElement $node The <amp-img> node, possibly wrapped in a <figure>.
-	 */
-	public function handle_centering( $node ) {
-		$align_class = 'aligncenter';
-		$classes     = $node->getAttribute( 'class' );
-		$width       = $node->getAttribute( 'width' );
-
-		// If this doesn't have a width attribute, centering it in the <figure> wrapper won't work.
-		if ( empty( $width ) || ! in_array( $align_class, preg_split( '/\s+/', trim( $classes ) ), true ) ) {
-			return $node;
-		}
-
-		// Strip the class, and wrap the <amp-img> in a <figure>.
-		$classes = trim( str_replace( $align_class, '', $classes ) );
-		$node->setAttribute( 'class', $classes );
-		$figure = AMP_DOM_Utils::create_node(
-			$this->dom,
-			'figure',
-			array(
-				'class' => $align_class,
-				'style' => "max-width: {$width}px;",
-			)
-		);
-		$figure->appendChild( $node );
-
-		return $figure;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -250,7 +250,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_or_append_attribute( $new_attributes, 'class', 'amp-wp-enforced-sizes' );
 		if ( empty( $new_attributes['layout'] ) && ! empty( $new_attributes['height'] ) && ! empty( $new_attributes['width'] ) ) {
 			// Use responsive images when a theme supports wide and full-bleed images.
-			if ( _amp_is_doing_img_experiment() && current_theme_supports( 'align-wide' ) && $node->parentNode && 'figure' === $node->parentNode->nodeName && preg_match( '/(^|\s)(alignwide|alignfull)(\s|$)/', $node->parentNode->getAttribute( 'class' ) ) ) {
+			if ( ! empty( $this->args['align_wide_support'] ) && $node->parentNode && 'figure' === $node->parentNode->nodeName && preg_match( '/(^|\s)(alignwide|alignfull)(\s|$)/', $node->parentNode->getAttribute( 'class' ) ) ) {
 				$new_attributes['layout'] = 'responsive';
 			} else {
 				$new_attributes['layout'] = 'intrinsic';

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -249,7 +249,12 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->add_or_append_attribute( $new_attributes, 'class', 'amp-wp-enforced-sizes' );
 		if ( empty( $new_attributes['layout'] ) && ! empty( $new_attributes['height'] ) && ! empty( $new_attributes['width'] ) ) {
-			$new_attributes['layout'] = 'intrinsic';
+			// Use responsive images when a theme supports wide and full-bleed images.
+			if ( _amp_is_doing_img_experiment() && current_theme_supports( 'align-wide' ) && $node->parentNode && 'figure' === $node->parentNode->nodeName && preg_match( '/(^|\s)(alignwide|alignfull)(\s|$)/', $node->parentNode->getAttribute( 'class' ) ) ) {
+				$new_attributes['layout'] = 'responsive';
+			} else {
+				$new_attributes['layout'] = 'intrinsic';
+			}
 		}
 
 		if ( $this->is_gif_url( $new_attributes['src'] ) ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -107,6 +107,21 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->determine_dimensions( $need_dimensions );
 		$this->adjust_and_replace_nodes_in_array_map( $need_dimensions );
+
+		/*
+		 * Opt-in to amp-img-auto-sizes experiment.
+		 * This is needed because the sizes attribute is removed from all img elements converted to amp-img
+		 * in order to prevent the undesirable setting of the width. This $meta tag can be removed once the
+		 * experiment ends (and the feature has been fully launched).
+		 * See <https://github.com/ampproject/amphtml/issues/21371> and <https://github.com/ampproject/amp-wp/pull/2036>.
+		 */
+		$head = $this->dom->getElementsByTagName( 'head' )->item( 0 );
+		if ( $head ) {
+			$meta = $this->dom->createElement( 'meta' );
+			$meta->setAttribute( 'name', 'amp-experiments-opt-in' );
+			$meta->setAttribute( 'content', 'amp-img-auto-sizes' );
+			$head->insertBefore( $meta, $head->firstChild );
+		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -275,8 +275,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$noscript = $this->dom->createElement( 'noscript' );
 		$noscript->appendChild( $node );
 		$img_node->appendChild( $noscript );
-
-		$this->add_auto_width_to_figure( $img_node );
 	}
 
 	/**
@@ -319,38 +317,5 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$ext  = self::$anim_extension;
 		$path = wp_parse_url( $url, PHP_URL_PATH );
 		return substr( $path, -strlen( $ext ) ) === $ext;
-	}
-
-	/**
-	 * Add an inline style to set the `<figure>` element's width to `auto` instead of `fit-content`.
-	 *
-	 * @since 1.0
-	 * @see https://github.com/ampproject/amp-wp/issues/1086
-	 *
-	 * @param DOMElement $node The DOMNode to adjust and replace.
-	 */
-	protected function add_auto_width_to_figure( $node ) {
-		$figure = $node->parentNode;
-		if ( ! ( $figure instanceof DOMElement ) || 'figure' !== $figure->tagName ) {
-			return;
-		}
-
-		$class = $figure->getAttribute( 'class' );
-		// Target only the <figure> with a 'wp-block-image' class attribute.
-		if ( false === strpos( $class, 'wp-block-image' ) ) {
-			return;
-		}
-
-		// Target only <figure> without a 'is-resized' class attribute.
-		if ( false !== strpos( $class, 'is-resized' ) ) {
-			return;
-		}
-
-		$new_style = 'width: auto;';
-		if ( $figure->hasAttribute( 'style' ) ) {
-			$figure->setAttribute( 'style', $new_style . $figure->getAttribute( 'style' ) );
-		} else {
-			$figure->setAttribute( 'style', $new_style );
-		}
 	}
 }

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -257,6 +257,9 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
+		// Remove sizes attribute since it causes headaches in AMP and because AMP will generate it for us. See <https://github.com/ampproject/amphtml/issues/21371>.
+		unset( $new_attributes['sizes'] );
+
 		if ( $this->is_gif_url( $new_attributes['src'] ) ) {
 			$this->did_convert_elements = true;
 

--- a/templates/style.php
+++ b/templates/style.php
@@ -44,11 +44,7 @@ $header_color            = $this->get_customizer_setting( 'header_color' );
 	margin: 0 auto;
 }
 
-.amp-wp-unknown-size img {
-	/** Worst case scenario when we can't figure out dimensions for an image. **/
-	/** Force the image into a box of fixed dimensions and use object-fit to scale. **/
-	object-fit: contain;
-}
+<?php echo file_get_contents( AMP__DIR__ . '/assets/css/amp-default.css' ); // phpcs:ignore WordPress.WP.AlternativeFunctions ?>
 
 /* Template Styles */
 

--- a/templates/style.php
+++ b/templates/style.php
@@ -34,6 +34,7 @@ $header_color            = $this->get_customizer_setting( 'header_color' );
 
 .aligncenter {
 	display: block;
+	text-align: center;
 	margin-left: auto;
 	margin-right: auto;
 }
@@ -279,6 +280,11 @@ blockquote p:last-child {
 }
 
 /* AMP Media */
+
+.alignwide,
+.alignfull {
+	clear: both;
+}
 
 amp-carousel {
 	background: <?php echo sanitize_hex_color( $border_color ); ?>;

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -187,22 +187,22 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'wide_image'                               => array(
 				'<figure class="wp-block-image"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_center_aligned'                => array(
 				'<figure class="wp-block-image aligncenter"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image aligncenter" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image aligncenter"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_left_aligned_custom_style'     => array(
 				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignleft" style="width: auto;border:solid 1px red;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_right_aligned'                 => array(
 				'<figure class="wp-block-image alignright"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignright" style="width: auto;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image alignright"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_is_resized'                    => array(

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -167,7 +167,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_center_aligned'                     => array(
 				'<img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150" />',
-				'<figure class="aligncenter" style="max-width: 350px;"><amp-img class="amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img></figure>',
+				'<amp-img class="aligncenter amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'image_left_aligned'                       => array(
@@ -275,58 +275,5 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			$whitelist_sanitizer->get_scripts()
 		);
 		$this->assertEquals( $expected, $scripts );
-	}
-
-	/**
-	 * Test handle_centering
-	 *
-	 * @covers AMP_Img_Sanitizer::handle_centering()
-	 */
-	public function test_handle_centering() {
-		$dom                = new DOMDocument();
-		$align_center_class = 'aligncenter';
-		$align_left_class   = 'alignleft';
-		$sanitizer          = new AMP_Img_Sanitizer( $dom );
-		$width              = 300;
-
-		$amp_img = AMP_DOM_Utils::create_node(
-			$dom,
-			'amp-img',
-			array(
-				'class' => $align_left_class,
-				'width' => $width,
-			)
-		);
-
-		// There's no aligncenter class, so the node shouldn't change.
-		$this->assertEquals( $amp_img, $sanitizer->handle_centering( $amp_img ) );
-
-		$amp_img = AMP_DOM_Utils::create_node(
-			$dom,
-			'amp-img',
-			array(
-				'class' => $align_left_class,
-			)
-		);
-
-		// There's no width attribute, so the node shouldn't change.
-		$this->assertEquals( $amp_img, $sanitizer->handle_centering( $amp_img ) );
-
-		$centered_amp_img = AMP_DOM_Utils::create_node(
-			$dom,
-			'amp-img',
-			array(
-				'class' => $align_center_class,
-				'width' => $width,
-			)
-		);
-		$processed_tag    = $sanitizer->handle_centering( $centered_amp_img );
-		$child            = $processed_tag->firstChild;
-
-		$this->assertEquals( 'figure', $processed_tag->nodeName );
-		$this->assertEquals( $align_center_class, $processed_tag->getAttribute( 'class' ) );
-		$this->assertEquals( "max-width: {$width}px;", $processed_tag->getAttribute( 'style' ) );
-		$this->assertEquals( 'amp-img', $child->nodeName );
-		$this->assertFalse( strpos( $child->getAttribute( 'class' ), $align_center_class ) );
 	}
 }

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -239,10 +239,14 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
+		$img_count = $dom->getElementsByTagName( 'img' )->length;
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
+
+		$xpath = new DOMXPath( $dom );
+		$this->assertEquals( $img_count ? 1 : 0, $xpath->query( '/html/head/meta[ @name = "amp-experiments-opt-in" ][ @content = "amp-img-auto-sizes" ]' )->length );
 	}
 
 	/**

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -214,6 +214,16 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="http://placehold.it/100x100" layout="fixed" width="100" height="100"><noscript><img src="http://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
 				null,
 			),
+
+			'img_with_sizes_attribute_removed'         => array(
+				'<img width="825" height="510" src="http://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw">',
+				'<amp-img width="825" height="510" src="http://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image amp-wp-enforced-sizes" alt="" layout="intrinsic"><noscript><img width="825" height="510" src="http://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw"></noscript></amp-img>',
+			),
+
+			'amp_img_with_sizes_attribute_retained'    => array(
+				'<amp-img width="825" height="510" src="http://placehold.it/825x510" alt="" layout="intrinsic"></amp-img>',
+				null,
+			),
 		);
 	}
 

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -835,7 +835,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertFalse( has_action( 'wp_head', 'wp_oembed_add_host_js' ) );
 
 		$this->assertEquals( 20, has_action( 'wp_head', 'amp_add_generator_metadata' ) );
-		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', array( self::TESTED_CLASS, 'enqueue_assets' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_enqueue_scripts', array( self::TESTED_CLASS, 'enqueue_assets' ) ) );
 
 		$this->assertEquals( 1000, has_action( 'wp_enqueue_scripts', array( self::TESTED_CLASS, 'dequeue_customize_preview_scripts' ) ) );
 		$this->assertEquals( 10, has_filter( 'customize_partial_render', array( self::TESTED_CLASS, 'filter_customize_partial_render' ) ) );


### PR DESCRIPTION
Build of PR to test: [amp.zip](https://github.com/ampproject/amp-wp/files/3024455/amp.zip) (v1.1-alpha-20190329T203700Z-034ac82d)

This PR seeks to finally lay to rest the multitude of issues we've faced regarding `amp-img` not behaving like the corresponding `img`. A key piece to this is that the `sizes` attribute can now be removed from `amp-img` and the AMP runtime will (soon) compute it automatically; see https://github.com/ampproject/amphtml/issues/21371.

Fixes issues including:

* Featured image in Twenty Nineteen appears stretched in desktop.
* Centered image is too side.
* Align-wide images are not wide enough. 
* Align-full images are not wide enough.
* Small inline image is not displayed tiny as required.
* Image in Media/Text overflows right viewport (both normal and wide alignments).
* Resized image in Media/Text is not the right dimensions.
* Centered image in Classic block is not centered.
* Inline image in Classic block appears on its own line.

See screenshots below to compare.

Fixes #1747. Fixes #1305.
See #1656, #1104, #1237, #1086.
Closes #1939.

The post content I've been using to test is as follows. I tried to consider every scenario for where an image can appear:

```html
<!-- wp:image {"id":53,"align":"center"} -->
<div class="wp-block-image"><figure class="aligncenter"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/><figcaption>Bison: centered and not resized<br></figcaption></figure></div>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>And here is an image without a caption and yet it is centered:</p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":53,"align":"center","width":247,"height":161} -->
<div class="wp-block-image"><figure class="aligncenter is-resized"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53" width="247" height="161"/></figure></div>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>And here is a centered image with a caption:</p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":53,"align":"center","width":252,"height":163} -->
<div class="wp-block-image"><figure class="aligncenter is-resized"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53" width="252" height="163"/><figcaption>Resized and centered</figcaption></figure></div>
<!-- /wp:image -->

<!-- wp:image {"id":53,"align":"left","width":252,"height":163} -->
<div class="wp-block-image"><figure class="alignleft is-resized"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53" width="252" height="163"/><figcaption>Resized and left-floated</figcaption></figure></div>
<!-- /wp:image -->

<!-- wp:image {"id":53,"align":"right","width":252,"height":163} -->
<div class="wp-block-image"><figure class="alignright is-resized"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53" width="252" height="163"/><figcaption>Resized and right-floated</figcaption></figure></div>
<!-- /wp:image -->

<!-- wp:paragraph -->
<p>This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! This text is in between two beasts! </p>
<!-- /wp:paragraph -->

<!-- wp:image {"id":53,"align":"wide"} -->
<figure class="wp-block-image alignwide"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/><figcaption>Wide</figcaption></figure>
<!-- /wp:image -->

<!-- wp:image {"id":53,"align":"full"} -->
<figure class="wp-block-image alignfull"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/><figcaption>Full bleed<br></figcaption></figure>
<!-- /wp:image -->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:paragraph -->
<p>Here is some text with an inline image: <img class="wp-image-53" style="width: 48px;" src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1.jpg" alt=""> See it is small?</p>
<!-- /wp:paragraph -->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<!-- wp:media-text {"mediaPosition":"right","mediaId":53,"mediaType":"image","isStackedOnMobile":true} -->
<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
<p class="has-large-font-size">Bison</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Image appears to the left. It is not resized. Stacking on mobile.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaId":53,"mediaType":"image","isStackedOnMobile":true} -->
<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
<p class="has-large-font-size">Bison and full width</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Image appears to the left. It is not resized. Stacking on mobile.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:media-text {"mediaId":53,"mediaType":"image","mediaWidth":19} -->
<div class="wp-block-media-text alignwide" style="grid-template-columns:19% auto"><figure class="wp-block-media-text__media"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"large"} -->
<p class="has-large-font-size">Bison</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Image appears to the left. It <em>is</em> resized. Stacking off mobile.</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:separator -->
<hr class="wp-block-separator"/>
<!-- /wp:separator -->

<p><img class="alignleft size-thumbnail wp-image-53" src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-150x150.jpg" alt="" width="150" height="150">This is a <strong>classic block</strong> that contains an image floated to the left. And there is one floated to the right here too:</p>
<p>[caption id="attachment_53" align="alignright" width="150"]<img class="size-thumbnail wp-image-53" src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-150x150.jpg" alt="" width="150" height="150"> Bison in field[/caption]</p>
<p>This is a classic block that contains an image floated to the left. This is a classic block that contains an image floated to the left. This is a classic block that contains an image floated to the left. This is a classic block that contains an image floated to the left. This is a classic block that contains an image floated to the left. This is a classic block that contains an image floated to the left. But the next image is centered:</p>
<p><img class="aligncenter wp-image-53 size-medium" src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-300x196.jpg" alt="" width="300" height="196"></p>
<p>And this centered image has a caption:</p>
<p>[caption id="attachment_53" align="aligncenter" width="300"]<img class="wp-image-53 size-medium" src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-300x196.jpg" alt="" width="300" height="196"> Bison in the field.[/caption]</p>
<p>Next line with tiny image inline:&nbsp;<img class="alignnone wp-image-53 " src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-150x150.jpg" alt="" width="16" height="16">. See how small it is?</p>
<p>Next line.</p>
```

# Desktop

<table><tr><th>Non-AMP (control)</th><th>✅ AMP with fix</th><th>🚫 AMP without fix</th></tr><tr><td valign=top><img src="https://user-images.githubusercontent.com/134745/55206463-bf1e7f00-5193-11e9-8d28-97f864e625c3.png" alt="desktop-non-amp" width="200"></td><td valign=top><img src="https://user-images.githubusercontent.com/134745/55206647-75826400-5194-11e9-9440-e142f40965c3.png" alt="desktop-amp-with-fix" width="200"></td><td valign=top><img src="https://user-images.githubusercontent.com/134745/55206832-20931d80-5195-11e9-8216-b1f1f4642734.png" width=200></td></tr></table>

# Mobile

<table><tr><th>Non-AMP (control)</th><th>✅ AMP with fix</th><th>🚫 AMP without fix</th></tr><tr><td valign=top><img src="https://user-images.githubusercontent.com/134745/55207226-8b912400-5196-11e9-9cbc-629e6fabe297.png" alt="mobile-non-amp" width="200"></td><td valign=top><img src="https://user-images.githubusercontent.com/134745/55207319-ddd24500-5196-11e9-9cb7-e299dbc8baa6.png" alt="mobile-amp-with-fix" width="200"></td><td valign=top><img src="https://user-images.githubusercontent.com/134745/55207401-3275c000-5197-11e9-99a9-86883bf9b237.png" alt="mobile-amp-without-fix" width="200"></td></tr></table>

# Classic Templates

Please note that the Classic templates generally lack styles for blocks in general, so there are some issues that aren't related to images here.

<table><tr><th>🚫 Before changes</th><th>✅ After changes</th></tr><tr><td valign=top><img src="https://user-images.githubusercontent.com/134745/55208228-b2515980-519a-11e9-8911-385fb069e169.png" alt="classic-amp-without-fix" width=200></td><td valign=top><img src="https://user-images.githubusercontent.com/134745/55208322-0fe5a600-519b-11e9-8050-6d0b5f0f6d3c.png" alt="classic-amp-with-fix" width=200></td></tr></table>