### PR TITLE
Remove stray semicolon in AMP_Analytics_Options_Submenu

### DIFF
--- a/includes/options/class-amp-analytics-options-submenu.php
+++ b/includes/options/class-amp-analytics-options-submenu.php
@@ -86,8 +86,7 @@ class AMP_Analytics_Options_Submenu {
 			.amp-analytics-options.notice {
 				width: 300px;
 			}
-		</style>;
-
+		</style>
 		<?php
 	}
 }


### PR DESCRIPTION
Props @360zen for reporting this [in the forums](https://wordpress.org/support/topic/erroneous-semicolon-on-analytics-options-page/).