### PR TITLE
[AMP Stories] Add overlay settings to Page

### DIFF
--- a/assets/src/blocks/amp-story/edit.js
+++ b/assets/src/blocks/amp-story/edit.js
@@ -95,11 +95,13 @@ class EditPage extends Component {
 		const { attributes, media, setAttributes, totalAnimationDuration } = this.props;
 
 		const {
-			backgroundColor,
+			gradientBottomColor,
 			mediaId,
 			mediaType,
 			mediaUrl,
 			focalPoint,
+			overlayColor,
+			overlayOpacity,
 			poster,
 			autoAdvanceAfter,
 			autoAdvanceAfterDuration,
@@ -108,7 +110,6 @@ class EditPage extends Component {
 		const instructions = <p>{ __( 'To edit the background image or video, you need permission to upload media.', 'amp' ) }</p>;
 
 		const style = {
-			backgroundColor,
 			backgroundImage: IMAGE_BACKGROUND_TYPE === mediaType && mediaUrl ? `url(${ mediaUrl })` : undefined,
 			backgroundPosition: IMAGE_BACKGROUND_TYPE === mediaType && focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : 'cover',
 			backgroundRepeat: 'no-repeat',
@@ -134,20 +135,48 @@ class EditPage extends Component {
 			autoAdvanceAfterHelp = __( 'Based on the duration of all animated blocks on the page', 'amp' );
 		}
 
+		const overlayStyle = {
+			width: '100%',
+			height: '100%',
+		};
+		if ( ! gradientBottomColor && overlayColor ) {
+			overlayStyle.backgroundColor = overlayColor;
+			overlayStyle.opacity = overlayOpacity / 100;
+		} else if ( gradientBottomColor ) {
+			const topColor = overlayColor ? overlayColor : 'transparent';
+			overlayStyle.backgroundImage = `linear-gradient(to bottom, ${ topColor }, ${ gradientBottomColor })`;
+			overlayStyle.opacity = overlayOpacity / 100;
+		}
+
 		return (
 			<Fragment>
 				<InspectorControls key="controls">
 					<PanelColorSettings
-						title={ __( 'Color Settings', 'amp' ) }
+						title={ __( 'Overlay Settings', 'amp' ) }
 						initialOpen={ false }
 						colorSettings={ [
 							{
-								value: backgroundColor,
-								onChange: ( value ) => setAttributes( { backgroundColor: value } ),
-								label: __( 'Background Color', 'amp' ),
+								value: overlayColor,
+								onChange: ( value ) => setAttributes( { overlayColor: value } ),
+								label: __( 'Color', 'amp' ),
+							},
+							{
+								value: gradientBottomColor,
+								onChange: ( value ) => setAttributes( { gradientBottomColor: value } ),
+								label: __( 'Bottom Color: Use for Gradient Only', 'amp' ),
 							},
 						] }
-					/>
+					>
+						<RangeControl
+							label={ __( 'Opacity', 'amp' ) }
+							value={ overlayOpacity }
+							onChange={ ( value ) => setAttributes( { overlayOpacity: value } ) }
+							min={ 0 }
+							max={ 100 }
+							step={ 5 }
+							required
+						/>
+					</PanelColorSettings>
 					<PanelBody title={ __( 'Background Media', 'amp' ) }>
 						<Fragment>
 							<BaseControl>
@@ -249,6 +278,9 @@ class EditPage extends Component {
 								<source src={ mediaUrl } type={ media.mime_type } />
 							</video>
 						</div>
+					) }
+					{ ( overlayColor || gradientBottomColor ) && (
+						<div style={ overlayStyle }></div>
 					) }
 					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED_CHILD_BLOCKS } />
 				</div>

--- a/assets/src/blocks/amp-story/edit.js
+++ b/assets/src/blocks/amp-story/edit.js
@@ -133,7 +133,7 @@ class EditPage extends Component {
 					this.setBackgroundColors( value, index );
 				},
 				/* translators: %s: color number */
-				label: useNumberedLabels ? sprintf( __( 'Color %s', 'amp' ), index + 1 ) :  __( 'Color', 'amp' ),
+				label: useNumberedLabels ? sprintf( __( 'Color %s', 'amp' ), index + 1 ) : __( 'Color', 'amp' ),
 			};
 		} );
 

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -7,6 +7,7 @@ import { InnerBlocks } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
+import { addBackgroundColorToOverlay } from '../../helpers';
 import { IMAGE_BACKGROUND_TYPE, VIDEO_BACKGROUND_TYPE } from '../../constants';
 import EditPage from './edit';
 import blockIcon from '../../../images/amp-story-page-icon.svg';
@@ -46,8 +47,8 @@ const schema = {
 	autoAdvanceAfterMedia: {
 		type: 'string',
 	},
-	overlayColor: {
-		default: null,
+	backgroundColors: {
+		default: '[]',
 	},
 	overlayOpacity: {
 		default: 50,
@@ -85,9 +86,7 @@ export const settings = {
 	save( { attributes } ) {
 		const {
 			anchor,
-			overlayColor,
 			overlayOpacity,
-			gradientBottomColor,
 			mediaUrl,
 			mediaType,
 			poster,
@@ -95,6 +94,8 @@ export const settings = {
 			autoAdvanceAfterDuration,
 			autoAdvanceAfterMedia,
 		} = attributes;
+
+		const backgroundColors = JSON.parse( attributes.backgroundColors );
 
 		let advanceAfter;
 
@@ -104,14 +105,10 @@ export const settings = {
 			advanceAfter = autoAdvanceAfterMedia;
 		}
 
-		const overlayStyle = {
-			opacity: overlayOpacity / 100,
-		};
-		if ( ! gradientBottomColor && overlayColor ) {
-			overlayStyle.backgroundColor = overlayColor;
-		} else if ( gradientBottomColor ) {
-			const topColor = overlayColor ? overlayColor : 'transparent';
-			overlayStyle.backgroundImage = `linear-gradient(to bottom, ${ topColor }, ${ gradientBottomColor })`;
+		let overlayStyle = {};
+		if ( 0 < backgroundColors.length ) {
+			overlayStyle = addBackgroundColorToOverlay( overlayStyle, backgroundColors );
+			overlayStyle.opacity = overlayOpacity / 100;
 		}
 
 		return (

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -53,10 +53,6 @@ const schema = {
 	overlayOpacity: {
 		default: 50,
 	},
-	gradientBottomColor: {
-		default: null,
-		type: 'string',
-	},
 };
 
 export const settings = {

--- a/assets/src/blocks/amp-story/index.js
+++ b/assets/src/blocks/amp-story/index.js
@@ -19,9 +19,6 @@ const schema = {
 		selector: 'amp-story-page',
 		attribute: 'id',
 	},
-	backgroundColor: {
-		default: '#ffffff',
-	},
 	mediaId: {
 		type: 'number',
 	},
@@ -47,6 +44,16 @@ const schema = {
 		type: 'number',
 	},
 	autoAdvanceAfterMedia: {
+		type: 'string',
+	},
+	overlayColor: {
+		default: null,
+	},
+	overlayOpacity: {
+		default: 50,
+	},
+	gradientBottomColor: {
+		default: null,
 		type: 'string',
 	},
 };
@@ -78,7 +85,9 @@ export const settings = {
 	save( { attributes } ) {
 		const {
 			anchor,
-			backgroundColor,
+			overlayColor,
+			overlayOpacity,
+			gradientBottomColor,
 			mediaUrl,
 			mediaType,
 			poster,
@@ -95,8 +104,18 @@ export const settings = {
 			advanceAfter = autoAdvanceAfterMedia;
 		}
 
+		const overlayStyle = {
+			opacity: overlayOpacity / 100,
+		};
+		if ( ! gradientBottomColor && overlayColor ) {
+			overlayStyle.backgroundColor = overlayColor;
+		} else if ( gradientBottomColor ) {
+			const topColor = overlayColor ? overlayColor : 'transparent';
+			overlayStyle.backgroundImage = `linear-gradient(to bottom, ${ topColor }, ${ gradientBottomColor })`;
+		}
+
 		return (
-			<amp-story-page style={ { backgroundColor } } id={ anchor } auto-advance-after={ advanceAfter }>
+			<amp-story-page style={ { backgroundColor: '#ffffff' } } id={ anchor } auto-advance-after={ advanceAfter }>
 				{
 					mediaUrl && (
 						<amp-story-grid-layer template="fill">
@@ -109,6 +128,8 @@ export const settings = {
 						</amp-story-grid-layer>
 					)
 				}
+				<amp-story-grid-layer template="fill" style={ overlayStyle }>
+				</amp-story-grid-layer>
 				<amp-story-grid-layer template="vertical">
 					<InnerBlocks.Content />
 				</amp-story-grid-layer>

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -476,19 +476,25 @@ export const hasMinimumStoryPosterDimensions = ( media ) => {
 /**
  * Adds either background color or gradient to style depending on the settings.
  *
- * @todo This is strictly for two colors at this moment, add option for more.
- *
  * @param {Object} overlayStyle Original style.
  * @param {Array} backgroundColors Array of color settings.
  * @return {Object} Adjusted style.
  */
 export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) => {
-	if ( 1 === backgroundColors.length ) {
-		overlayStyle.backgroundColor = backgroundColors[ 0 ].color;
+	const validBackgroundColors = backgroundColors.filter( Boolean );
+
+	if ( ! validBackgroundColors ) {
+		return overlayStyle;
+	}
+
+	if ( 1 === validBackgroundColors.length ) {
+		overlayStyle.backgroundColor = validBackgroundColors[ 0 ].color;
 	} else {
-		const topColor = backgroundColors[ 0 ].color ? backgroundColors[ 0 ].color : 'transparent';
-		const bottomColor = backgroundColors[ 1 ].color ? backgroundColors[ 1 ].color : 'transparent';
-		overlayStyle.backgroundImage = `linear-gradient(to bottom, ${ topColor }, ${ bottomColor })`;
+		const gradientList = validBackgroundColors.map( ( { color } ) => {
+			return color || 'transparent';
+		} ).join( ', ' );
+
+		overlayStyle.backgroundImage = `linear-gradient(to bottom, ${ gradientList })`;
 	}
 	return overlayStyle;
 };

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -472,3 +472,23 @@ export const hasMinimumStoryPosterDimensions = ( media ) => {
 		( media.width >= minWidth && media.height >= minHeight )
 	);
 };
+
+/**
+ * Adds either background color or gradient to style depending on the settings.
+ *
+ * @todo This is strictly for two colors at this moment, add option for more.
+ *
+ * @param {Object} overlayStyle Original style.
+ * @param {Array} backgroundColors Array of color settings.
+ * @return {Object} Adjusted style.
+ */
+export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) => {
+	if ( 1 === backgroundColors.length ) {
+		overlayStyle.backgroundColor = backgroundColors[ 0 ].color;
+	} else {
+		const topColor = backgroundColors[ 0 ].color ? backgroundColors[ 0 ].color : 'transparent';
+		const bottomColor = backgroundColors[ 1 ].color ? backgroundColors[ 1 ].color : 'transparent';
+		overlayStyle.backgroundImage = `linear-gradient(to bottom, ${ topColor }, ${ bottomColor })`;
+	}
+	return overlayStyle;
+};


### PR DESCRIPTION
See #2013.

Adds Overlay settings to page which includes two color settings and opacity.
If one color is selected then the background is filled with the color, otherwise gradient is used.

![Screen Shot 2019-04-02 at 12 41 44 PM](https://user-images.githubusercontent.com/3294597/55396669-bbe51380-5544-11e9-9e73-76268a225322.png)
