### PR TITLE
Consider element attributes when determining if an parent element is empty and can be removed

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -10,6 +10,12 @@ fi
 
 function after_wp_install {
 	echo -n "Installing Gutenberg..."
-	svn export -q https://plugins.svn.wordpress.org/gutenberg/trunk/ "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
+	if [[ "$WP_VERSION" = "4.9" ]]; then
+		# The last version that supported WordPress 4.9:
+		gutenberg_plugin_svn_url=https://plugins.svn.wordpress.org/gutenberg/tags/4.9.0/
+	else
+		gutenberg_plugin_svn_url=https://plugins.svn.wordpress.org/gutenberg/trunk/
+	fi
+	svn export -q "$gutenberg_plugin_svn_url" "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
 	echo "done"
 }

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1973,7 +1973,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( $node && $parent ) {
 			$this->remove_invalid_child( $node );
 		}
-		while ( $parent && ! $parent->hasChildNodes() && $this->root_element !== $parent ) {
+
+		// @todo Does this parent removal even make sense anymore?
+		while ( $parent && ! $parent->hasChildNodes() && ! $parent->hasAttributes() && $this->root_element !== $parent ) {
 			$node   = $parent;
 			$parent = $parent->parentNode;
 			if ( $parent ) {

--- a/tests/test-class-amp-core-block-handler.php
+++ b/tests/test-class-amp-core-block-handler.php
@@ -25,6 +25,9 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		if ( ! function_exists( 'register_block_type' ) ) {
 			$this->markTestIncomplete( 'Files needed for testing missing.' );
 		}
+		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
+			$this->markTestSkipped( 'Missing required render_block filter.' );
+		}
 
 		$handler = new AMP_Core_Block_Handler();
 		$handler->unregister_embed(); // Make sure we are on the initial clean state.

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -680,6 +680,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'',
 			),
 
+			'non_empty_parent_nodes_of_non_whitelisted_tags_removed' => array(
+				'<div><span><span class="not-empty"><invalid_tag></invalid_tag></span></span></div>',
+				'<div><span><span class="not-empty"></span></span></div>',
+			),
+
 			'replace_non_whitelisted_node_with_children' => array(
 				'<p>This is some text <invalid_tag>with a disallowed tag</invalid_tag> in the middle of it.</p>',
 				'<p>This is some text with a disallowed tag in the middle of it.</p>',

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -709,6 +709,11 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_block_data() {
+		$latest_posts_block = WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );
+
+		$reflection_function = new ReflectionFunction( $latest_posts_block->render_callback );
+		$is_gutenberg = false !== strpos( $reflection_function->getFileName(), 'gutenberg' );
+
 		return array(
 			'paragraph'    => array(
 				"<!-- wp:paragraph -->\n<p>Latest posts:</p>\n<!-- /wp:paragraph -->",
@@ -721,9 +726,10 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 			'latest_posts' => array(
 				'<!-- wp:latest-posts {"postsToShow":1,"categories":""} /-->',
 				sprintf(
-					'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"block_attrs":{"postsToShow":1,"categories":""},"type":"%1$s","name":"%2$s","function":"render_block_core_latest_posts"}--><ul class="wp-block-latest-posts"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_attrs":{"postsToShow":1,"categories":""},"type":"%1$s","name":"%2$s","function":"render_block_core_latest_posts"}-->',
-					version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ? 'plugin' : 'core',
-					version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ? 'gutenberg' : 'wp-includes'
+					'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"block_attrs":{"postsToShow":1,"categories":""},"type":"%1$s","name":"%2$s","function":"%3$s"}--><ul class="wp-block-latest-posts"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_attrs":{"postsToShow":1,"categories":""},"type":"%1$s","name":"%2$s","function":"%3$s"}-->',
+					$is_gutenberg ? 'plugin' : 'core',
+					$is_gutenberg ? 'gutenberg' : 'wp-includes',
+					$latest_posts_block->render_callback
 				),
 				array(
 					'element' => 'ul',


### PR DESCRIPTION
We discovered an issue when a site is served via HTTP instead of HTTPS. An `amp-img` [allows](https://github.com/ampproject/amphtml/blob/7b16d1cc109eb77a8e0477dd8eff9501fae638b2/validator/validator-main.protoascii#L4963-L4979) for its image to use the `http` protocol, so this is valid AMP:

```html
<amp-img src="http://example.com/bison-1024x668.jpg" srcset="http://example.com/bison-1024x668.jpg 1024w, http://example.com/bison-300x196.jpg 300w, http://example.com/bison-768x501.jpg 768w, http://example.com/bison.jpg 1200w" sizes="(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px" width="1024" height="668" layout="intrinsic"></amp-img>
```

With #1861 there was introduced `noscript > img` fallbacks for serving when a user with JS disabled accesses a (canonical) AMP page. This results in markup like:

```html
<amp-img src="http://example.com/bison-1024x668.jpg" srcset="http://example.com/bison-1024x668.jpg 1024w, http://example.com/bison-300x196.jpg 300w, http://example.com/bison-768x501.jpg 768w, http://example.com/bison.jpg 1200w" sizes="(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px" width="1024" height="668" layout="intrinsic">
  <noscript>
    <img src="http://example.com/bison-1024x668.jpg" srcset="http://example.com/bison-1024x668.jpg 1024w, http://example.com/bison-300x196.jpg 300w, http://example.com/bison-768x501.jpg 768w, http://example.com/bison.jpg 1200w" sizes="(max-width: 767px) 89vw, (max-width: 1000px) 54vw, (max-width: 1071px) 543px, 580px" width="1024" height="668">
  </noscript>
</amp-img>
```

It turns out that this actually is invalid AMP:

![image](https://user-images.githubusercontent.com/134745/55438471-81847200-5556-11e9-9f1c-169443cb3ecc.png)

The `src` and `srcset` attributes are flagged as errors because—perhaps unintentionally—the `noscript > img` element [does not allow](https://github.com/ampproject/amphtml/blob/7b16d1cc109eb77a8e0477dd8eff9501fae638b2/validator/validator-main.protoascii#L2235-L2245) the `http` protocol.

The resulting behavior is the tag-and-attribute sanitizer proceeds to remove the `img`. Then the `AMP_Tag_And_Attribute_Sanitizer::remove_node()` has a `while` loop to walk up the DOM tree to examine each parent, and for each empty parent, they are removed. This is a problem because `noscript` is an empty element is removed and `amp-img` is also then an empty element and is removed. The problem is that “emptiness” is not taking into account the _attributes_ of the parent elements. So this fixes that. Nevertheless, we should also evaluate in the future if empty parents really should be removed in the first place.

An issue also needs to be opened against the AMPHTML validator to allow `http` protocol for `noscript > img` elements.

----

Also fixes tests which apparently break when testing on WordPress 4.9 and the latest Gutenberg by explicitly installing an old version of Gutenberg that works with 4.9.