### PR TITLE
Improve preview in Block Navigation

### DIFF
--- a/assets/src/components/animation-order-picker.js
+++ b/assets/src/components/animation-order-picker.js
@@ -2,51 +2,11 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { BlockIcon } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { PreviewPicker } from './';
-
-function ButtonContent( { option, displayIcon = true } ) {
-	const { label: name, block, blockType } = option;
-
-	if ( ! block ) {
-		return name;
-	}
-
-	let label;
-
-	// Todo: Cover more special cases if needed.
-	switch ( block.name ) {
-		case 'core/image':
-			if ( block.attributes.url ) {
-				const content = block.attributes.url.slice( block.attributes.url.lastIndexOf( '/' ) ).slice( 0, 30 );
-
-				if ( content.length > 0 ) {
-					label = content;
-				}
-			}
-
-			break;
-		case 'amp/amp-story-text':
-			const content = block.attributes.content.length > 0 ? block.attributes.content.replace( /<[^<>]+>/g, ' ' ).slice( 0, 30 ) : '';
-
-			label = content.length > 0 ? content : blockType.title;
-			break;
-		default:
-			label = blockType.title;
-	}
-
-	return (
-		<Fragment>
-			{ label.length > 20 ? `${ label.substr( 0, 20 ) }…` : label }
-			{ displayIcon && <BlockIcon icon={ blockType.icon } /> }
-		</Fragment>
-	);
-}
+import { PreviewPicker, BlockPreviewLabel } from './';
 
 /**
  * Animation order picker component.
@@ -72,12 +32,19 @@ function AnimationOrderPicker( {
 			label={ __( 'Begin after', 'amp' ) }
 			ariaLabel={ ( { value: currentValue, blockType } ) => ! currentValue ? __( 'Begin immediately', 'amp' ) : sprintf( __( 'Begin after: %s', 'amp' ), blockType.title ) }
 			renderToggle={ ( currentOption ) => (
-				<ButtonContent option={ currentOption } displayIcon={ false } />
+				<BlockPreviewLabel
+					{ ...currentOption }
+					displayIcon={ false }
+					alignIcon="right"
+				/>
 			) }
 			renderOption={ ( option ) => {
 				return (
 					<span className="components-preview-picker__dropdown-label">
-						<ButtonContent option={ option } />
+						<BlockPreviewLabel
+							{ ...option }
+							alignIcon="right"
+						/>
 					</span>
 				);
 			} }

--- a/assets/src/components/block-navigation.js
+++ b/assets/src/components/block-navigation.js
@@ -6,7 +6,11 @@ import { Button, NavigableMenu } from '@wordpress/components';
 import { getBlockType } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { BlockIcon } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { BlockPreviewLabel } from './';
 
 function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock } ) {
 	return (
@@ -32,9 +36,11 @@ function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock } ) {
 								className={ className }
 								onClick={ () => selectBlock( block.clientId ) }
 							>
-								<BlockIcon icon={ blockType.icon } showColors />
-								{ blockType.title }
-								{ isSelected && <span className="screen-reader-text">{ __( '(selected block)', 'amp' ) }</span> }
+								<BlockPreviewLabel
+									block={ block }
+									blockType={ blockType }
+									accessibilityText={ isSelected && __( '(selected block)', 'amp' ) }
+								/>
 							</Button>
 						</div>
 					</li>

--- a/assets/src/components/block-preview-label.js
+++ b/assets/src/components/block-preview-label.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { BlockIcon } from '@wordpress/block-editor';
+
+export default ( { label: name, block, blockType, displayIcon = true, alignIcon = 'left', accessibilityText } ) => {
+	if ( ! block ) {
+		return name;
+	}
+
+	let label;
+	let content;
+
+	// Todo: Cover more special cases if needed.
+	switch ( block.name ) {
+		case 'core/image':
+			if ( block.attributes.url ) {
+				content = block.attributes.url.slice( block.attributes.url.lastIndexOf( '/' ) ).slice( 0, 30 );
+
+				if ( content.length > 0 ) {
+					label = content;
+				}
+			}
+
+			break;
+		case 'amp/amp-story-text':
+			content = block.attributes.content.length > 0 ? block.attributes.content.replace( /<[^<>]+>/g, ' ' ).slice( 0, 30 ) : '';
+
+			label = content.length > 0 ? content : blockType.title;
+			break;
+		default:
+			label = blockType.title;
+	}
+
+	return (
+		<Fragment>
+			{ displayIcon && 'left' === alignIcon && <BlockIcon icon={ blockType.icon } /> }
+			{ label.length > 20 ? `${ label.substr( 0, 20 ) }…` : label }
+			{ accessibilityText && <span className="screen-reader-text">{ accessibilityText }</span> }
+			{ displayIcon && 'right' === alignIcon && <BlockIcon icon={ blockType.icon } /> }
+		</Fragment>
+	);
+};

--- a/assets/src/components/block-preview-label.js
+++ b/assets/src/components/block-preview-label.js
@@ -9,7 +9,7 @@ export default ( { label: name, block, blockType, displayIcon = true, alignIcon 
 		return name;
 	}
 
-	let label;
+	let label = blockType.title;
 	let content;
 
 	// Todo: Cover more special cases if needed.
@@ -29,8 +29,6 @@ export default ( { label: name, block, blockType, displayIcon = true, alignIcon 
 
 			label = content.length > 0 ? content : blockType.title;
 			break;
-		default:
-			label = blockType.title;
 	}
 
 	return (

--- a/assets/src/components/index.js
+++ b/assets/src/components/index.js
@@ -2,6 +2,7 @@ export { default as AnimationControls } from './animation-controls';
 export { default as AnimationOrderPicker } from './animation-order-picker';
 export { default as BlockNavigation } from './block-navigation';
 export { default as BlockPreview } from './block-preview';
+export { default as BlockPreviewLabel } from './block-preview-label';
 export { default as EditorCarousel } from './editor-carousel';
 export { default as StoryControls } from './story-controls';
 export { default as Shortcuts } from './shortcuts';


### PR DESCRIPTION
Re-uses the "smart" preview from the animation order picker for the block navigation UI.

Instead of seeing "Text" dozens of times for every block, this now shows an excerpt of the block content, which is way more user friendly.

Screenshots:

<img width="811" alt="Screenshot 2019-04-03 at 12 00 53" src="https://user-images.githubusercontent.com/841956/55474272-9de0e700-5608-11e9-989c-f80dbef25435.png">

<img width="471" alt="Screenshot 2019-04-03 at 12 01 05" src="https://user-images.githubusercontent.com/841956/55474227-886bbd00-5608-11e9-8d69-b25c02f8ebed.png">


Fixes #1971.