### PR TITLE
[AMP Stories] Hide all block insertion points

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -141,6 +141,10 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
 	display: none;
 }
 
+#amp-story-editor .block-editor-block-list__block>.block-editor-block-list__insertion-point {
+	display: none !important;
+}
+
 /*
  * 4. Layers stacking.
  * Setup on top of each other layering on the story children.

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -141,6 +141,7 @@ div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > div > div > di
 	display: none;
 }
 
+#amp-story-editor .block-editor-block-list__layout .block-editor-default-block-appender,
 #amp-story-editor .block-editor-block-list__block>.block-editor-block-list__insertion-point {
 	display: none !important;
 }


### PR DESCRIPTION
Prevents all these inserters before/after a block from showing up.

Does not address the inserter visibility on the right side of the page, as this is more related to #1966.

Fixes #2047.