### PR TITLE
Discontinue showing theme support admin pointer in 1.1

### DIFF
--- a/includes/admin/class-amp-admin-pointer.php
+++ b/includes/admin/class-amp-admin-pointer.php
@@ -105,6 +105,12 @@ class AMP_Admin_Pointer {
 	 * @return boolean Is dismissed.
 	 */
 	protected function is_pointer_dismissed() {
+
+		// Consider dismissed in v1.1, since admin pointer is only to educate about the new modes in 1.0.
+		if ( version_compare( strtok( AMP__VERSION, '-' ), '1.1', '>=' ) ) {
+			return true;
+		}
+
 		$dismissed = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
 		if ( empty( $dismissed ) ) {
 			return false;

--- a/tests/test-class-amp-admin-pointer.php
+++ b/tests/test-class-amp-admin-pointer.php
@@ -48,51 +48,6 @@ class Test_AMP_Admin_Pointer extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Test enqueue_pointer.
-	 *
-	 * @covers AMP_Admin_Pointer::enqueue_pointer()
-	 */
-	public function test_enqueue_pointer() {
-		$user_id             = $this->factory()->user->create();
-		$pointer_script_slug = 'wp-pointer';
-		wp_set_current_user( $user_id );
-
-		// This pointer isn't in the meta value of dismissed pointers, so the method should enqueue the assets.
-		update_user_meta( $user_id, self::DISMISSED_KEY, 'foo-pointer' );
-		$this->instance->enqueue_pointer();
-		$script = wp_scripts()->registered[ AMP_Admin_Pointer::SCRIPT_SLUG ];
-
-		$this->assertTrue( wp_style_is( $pointer_script_slug ) );
-		$this->assertTrue( wp_script_is( AMP_Admin_Pointer::SCRIPT_SLUG ) );
-		$this->assertEquals( array( 'jquery', 'wp-pointer' ), $script->deps );
-		$this->assertEquals( AMP_Admin_Pointer::SCRIPT_SLUG, $script->handle );
-		$this->assertEquals( amp_get_asset_url( 'js/amp-admin-pointer.js' ), $script->src );
-		$this->assertEquals( AMP__VERSION, $script->ver );
-		$this->assertContains( 'ampAdminPointer.load(', $script->extra['after'][1] );
-	}
-
-	/**
-	 * Test is_pointer_dismissed.
-	 *
-	 * @covers AMP_Admin_Pointer::is_pointer_dismissed()
-	 */
-	public function test_is_pointer_dismissed() {
-		$user_id = $this->factory()->user->create();
-		wp_set_current_user( $user_id );
-		$method = new ReflectionMethod( 'AMP_Admin_Pointer', 'is_pointer_dismissed' );
-		$method->setAccessible( true );
-
-		// When this pointer is in the meta value of dismissed pointers, this should be true.
-		update_user_meta( $user_id, self::DISMISSED_KEY, AMP_Admin_Pointer::TEMPLATE_POINTER_ID );
-		$this->instance->enqueue_pointer();
-		$this->assertTrue( $method->invoke( $this->instance ) );
-
-		// When this pointer isn't in the meta value of dismissed pointers, this should be false.
-		update_user_meta( $user_id, self::DISMISSED_KEY, 'foo-pointer' );
-		$this->assertFalse( $method->invoke( $this->instance ) );
-	}
-
-	/**
 	 * Test get_pointer_data.
 	 *
 	 * @covers AMP_Admin_Pointer::get_pointer_data()


### PR DESCRIPTION
This admin pointer currently is shown to all users who activate the plugin:

![image](https://user-images.githubusercontent.com/134745/55510220-9f171180-5612-11e9-9a5f-a77d31156c64.png)

With the upcoming 1.1 release, to me it seems that this can be suppressed until there is need for another admin pointer for some new feature (e.g. AMP Stories).

This is why I didn't just remove all the code in the PR, since I presume we'll use it again soon.