### PR TITLE
[AMP Stories] Add opacity to Text block

### DIFF
--- a/assets/js/amp-service-worker-runtime-precaching.js
+++ b/assets/js/amp-service-worker-runtime-precaching.js
@@ -1,0 +1,9 @@
+/* global self, caches, URLS */
+// See AMP_Service_Workers::add_amp_runtime_caching() and <https://github.com/ampproject/amp-by-example/blob/a4d798cac6a534e0c46e78944a2718a8dab3c057/boilerplate-generator/templates/files/serviceworkerJs.js#L9-L22>.
+{
+	self.addEventListener( 'install', ( event ) => {
+		event.waitUntil(
+			caches.open( wp.serviceWorker.core.cacheNames.runtime ).then( ( cache ) => cache.addAll( URLS ) )
+		);
+	} );
+}

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -136,6 +136,8 @@ class TextBlockEdit extends Component {
 			}
 		}
 
+		const [ r, g, b, a ] = getRgbaFromHex( backgroundColor.color, opacity );
+
 		return (
 			<Fragment>
 				<BlockControls>
@@ -251,7 +253,7 @@ class TextBlockEdit extends Component {
 						onChange={ ( value ) => setAttributes( { content: value } ) }
 						onReplace={ this.onReplace }
 						style={ {
-							backgroundColor: ( backgroundColor.color && 100 !== opacity ) ? getRgbaFromHex( backgroundColor.color, opacity ) : backgroundColor.color,
+							backgroundColor: ( backgroundColor.color && 100 !== opacity ) ? `rgba( ${ r }, ${ g }, ${ b }, ${ a })` : backgroundColor.color,
 							color: textColor.color,
 							fontSize: ampFitText ? autoFontSize : userFontSize,
 							fontWeight: 'h1' === tagName || 'h2' === tagName ? 700 : 'normal',

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -33,7 +33,7 @@ import {
  * Internal dependencies
  */
 import { FontFamilyPicker } from '../../components';
-import { maybeEnqueueFontStyle, calculateFontSize } from '../../helpers';
+import { maybeEnqueueFontStyle, calculateFontSize, getRgbaFromHex } from '../../helpers';
 
 const { getComputedStyle } = window;
 
@@ -182,7 +182,10 @@ class TextBlockEdit extends Component {
 						colorSettings={ [
 							{
 								value: backgroundColor.color,
-								onChange: setBackgroundColor,
+								onChange: ( value ) => {
+									setAttributes( { backgroundHexValue: value } );
+									setBackgroundColor( value );
+								},
 								label: __( 'Background Color', 'amp' ),
 							},
 							{
@@ -201,15 +204,15 @@ class TextBlockEdit extends Component {
 								fontSize: fontSize.size,
 							} }
 						/>
+						<RangeControl
+							label={ __( 'Background Opacity', 'amp' ) }
+							value={ opacity }
+							onChange={ ( value ) => setAttributes( { opacity: value } ) }
+							min={ 5 }
+							max={ 100 }
+							step={ 5 }
+						/>
 					</PanelColorSettings>
-					<RangeControl
-						label={ __( 'Opacity', 'amp' ) }
-						value={ opacity }
-						onChange={ ( value ) => setAttributes( { opacity: value } ) }
-						min={ 0 }
-						max={ 100 }
-						step={ 5 }
-					/>
 				</InspectorControls>
 				<ResizableBox
 					className={ classnames(
@@ -248,12 +251,11 @@ class TextBlockEdit extends Component {
 						onChange={ ( value ) => setAttributes( { content: value } ) }
 						onReplace={ this.onReplace }
 						style={ {
-							backgroundColor: backgroundColor.color,
+							backgroundColor: ( backgroundColor.color && 100 !== opacity ) ? getRgbaFromHex( backgroundColor.color, opacity ) : backgroundColor.color,
 							color: textColor.color,
 							fontSize: ampFitText ? autoFontSize : userFontSize,
 							fontWeight: 'h1' === tagName || 'h2' === tagName ? 700 : 'normal',
 							textAlign: align,
-							opacity: opacity / 100,
 						} }
 						className={ classnames( className, {
 							'has-text-color': textColor.color,

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -14,6 +14,7 @@ import {
 	SelectControl,
 	withFallbackStyles,
 	ToggleControl,
+	RangeControl,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
@@ -121,6 +122,7 @@ class TextBlockEdit extends Component {
 			height,
 			width,
 			tagName,
+			opacity,
 		} = attributes;
 
 		const minTextHeight = 20;
@@ -200,6 +202,14 @@ class TextBlockEdit extends Component {
 							} }
 						/>
 					</PanelColorSettings>
+					<RangeControl
+						label={ __( 'Opacity', 'amp' ) }
+						value={ opacity }
+						onChange={ ( value ) => setAttributes( { opacity: value } ) }
+						min={ 0 }
+						max={ 100 }
+						step={ 5 }
+					/>
 				</InspectorControls>
 				<ResizableBox
 					className={ classnames(
@@ -243,6 +253,7 @@ class TextBlockEdit extends Component {
 							fontSize: ampFitText ? autoFontSize : userFontSize,
 							fontWeight: 'h1' === tagName || 'h2' === tagName ? 700 : 'normal',
 							textAlign: align,
+							opacity: opacity / 100,
 						} }
 						className={ classnames( className, {
 							'has-text-color': textColor.color,

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -18,7 +18,7 @@ import { select } from '@wordpress/data';
  * Internal dependencies
  */
 import edit from './edit';
-import { getPercentageFromPixels } from '../../helpers';
+import { getPercentageFromPixels, getRgbaFromHex } from '../../helpers';
 import { STORY_PAGE_INNER_WIDTH } from '../../constants';
 
 export const name = 'amp/amp-story-text';
@@ -72,6 +72,9 @@ const schema = {
 	customTextColor: {
 		type: 'string',
 	},
+	backgroundHexValue: {
+		type: 'string',
+	},
 	backgroundColor: {
 		type: 'string',
 	},
@@ -122,6 +125,7 @@ export const settings = {
 			ampFitText,
 			autoFontSize,
 			backgroundColor,
+			backgroundHexValue,
 			textColor,
 			customBackgroundColor,
 			customTextColor,
@@ -139,7 +143,7 @@ export const settings = {
 			'has-text-color': textColor || customTextColor,
 			'has-background': backgroundColor || customBackgroundColor,
 			[ textClass ]: textClass,
-			[ backgroundClass ]: backgroundClass,
+			[ backgroundClass ]: ( ! opacity || 100 === opacity ) ? backgroundClass : undefined,
 		} );
 
 		// Calculate fontsize using vw to make it responsive.
@@ -148,14 +152,21 @@ export const settings = {
 		const userFontSize = fontSize ? getFontSize( fontSizes, fontSize, customFontSize ).size : customFontSize;
 		const fontSizeResponsive = ( ( userFontSize / STORY_PAGE_INNER_WIDTH ) * 100 ).toFixed( 2 ) + 'vw';
 
+		let appliedBackgroundColor;
+		// If we need to assign opacity.
+		if ( 100 !== opacity && ( backgroundColor || customBackgroundColor ) ) {
+			appliedBackgroundColor = getRgbaFromHex( backgroundHexValue, opacity );
+		} else if ( ! backgroundClass ) {
+			appliedBackgroundColor = customBackgroundColor;
+		}
+
 		const styles = {
-			backgroundColor: backgroundClass ? undefined : customBackgroundColor,
+			backgroundColor: appliedBackgroundColor,
 			color: textClass ? undefined : customTextColor,
 			fontSize: ampFitText ? autoFontSize : fontSizeResponsive,
 			width: `${ getPercentageFromPixels( 'x', width ) }%`,
 			height: `${ getPercentageFromPixels( 'y', height ) }%`,
 			textAlign: align,
-			opacity: opacity / 100,
 		};
 
 		if ( ! ampFitText ) {

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -78,6 +78,10 @@ const schema = {
 	customBackgroundColor: {
 		type: 'string',
 	},
+	opacity: {
+		default: 100,
+		type: 'number',
+	},
 	height: {
 		default: 50,
 		type: 'number',
@@ -124,6 +128,7 @@ export const settings = {
 			width,
 			height,
 			tagName,
+			opacity,
 		} = attributes;
 
 		const textClass = getColorClassName( 'color', textColor );
@@ -150,6 +155,7 @@ export const settings = {
 			width: `${ getPercentageFromPixels( 'x', width ) }%`,
 			height: `${ getPercentageFromPixels( 'y', height ) }%`,
 			textAlign: align,
+			opacity: opacity / 100,
 		};
 
 		if ( ! ampFitText ) {

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -148,10 +148,10 @@ export const settings = {
 		const { colors, fontSizes } = select( 'core/block-editor' ).getSettings();
 
 		/*
-         * Calculate fontsize using vw to make it responsive.
-         *
-         * Get the font size in px based on the slug with fallback to customFontSize.
-         */
+		 * Calculate fontsize using vw to make it responsive.
+		 *
+		 * Get the font size in px based on the slug with fallback to customFontSize.
+		 */
 		const userFontSize = fontSize ? getFontSize( fontSizes, fontSize, customFontSize ).size : customFontSize;
 		const fontSizeResponsive = ( ( userFontSize / STORY_PAGE_INNER_WIDTH ) * 100 ).toFixed( 2 ) + 'vw';
 

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -155,7 +155,8 @@ export const settings = {
 		let appliedBackgroundColor;
 		// If we need to assign opacity.
 		if ( 100 !== opacity && ( backgroundColor || customBackgroundColor ) ) {
-			appliedBackgroundColor = getRgbaFromHex( backgroundHexValue, opacity );
+			const [ r, g, b, a ] = getRgbaFromHex( backgroundHexValue, opacity );
+			appliedBackgroundColor = `rgba( ${ r }, ${ g }, ${ b }, ${ a })`;
 		} else if ( ! backgroundClass ) {
 			appliedBackgroundColor = customBackgroundColor;
 		}

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -504,15 +504,20 @@ export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) =>
  *
  * @param {string} hex Hex value.
  * @param {number} opacity Opacity.
- * @return {string|undefined} Rgba value.
+ * @return {Object} Rgba value.
  */
 export const getRgbaFromHex = ( hex, opacity ) => {
 	if ( ! hex ) {
-		return undefined;
+		return [];
 	}
 	hex = hex.replace( '#', '' );
 	const r = parseInt( hex.substring( 0, 2 ), 16 );
 	const g = parseInt( hex.substring( 2, 4 ), 16 );
 	const b = parseInt( hex.substring( 4, 6 ), 16 );
-	return `rgba( ${ r }, ${ g }, ${ b }, ${ opacity / 100 })`;
+	return [
+		r,
+		g,
+		b,
+		opacity / 100
+	];
 };

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -518,6 +518,6 @@ export const getRgbaFromHex = ( hex, opacity ) => {
 		r,
 		g,
 		b,
-		opacity / 100
+		opacity / 100,
 	];
 };

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -498,3 +498,21 @@ export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) =>
 	}
 	return overlayStyle;
 };
+
+/**
+ * Converts hex to rgba.
+ *
+ * @param {string} hex Hex value.
+ * @param {number} opacity Opacity.
+ * @return {string|undefined} Rgba value.
+ */
+export const getRgbaFromHex = ( hex, opacity ) => {
+	if ( ! hex ) {
+		return undefined;
+	}
+	hex = hex.replace( '#', '' );
+	const r = parseInt( hex.substring( 0, 2 ), 16 );
+	const g = parseInt( hex.substring( 2, 4 ), 16 );
+	const b = parseInt( hex.substring( 4, 6 ), 16 );
+	return `rgba( ${ r }, ${ g }, ${ b }, ${ opacity / 100 })`;
+};


### PR DESCRIPTION
Fixes #2058.

This adds an opacity control to the Text block that affects the background color only, not the whole block.