### PR TITLE
Fix PHP notice for undefined theme support arg for service_worker

### DIFF
--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -45,7 +45,7 @@ class AMP_Service_Worker {
 			'image_caching'        => false,
 			'google_fonts_caching' => false,
 		);
-		if ( is_array( $theme_support['service_worker'] ) ) {
+		if ( isset( $theme_support['service_worker'] ) && is_array( $theme_support['service_worker'] ) ) {
 			$enabled_options = array_merge(
 				$enabled_options,
 				$theme_support['service_worker']


### PR DESCRIPTION
Amends #1261. Fixes:

> Notice: Undefined index: service_worker in /app/wp-content/plugins/amp/includes/class-amp-service-worker.php on line 48