### PR TITLE
[WIP] Add Title block for AMP Stories

### DIFF
--- a/assets/src/blocks/amp-story-title/edit.js
+++ b/assets/src/blocks/amp-story-title/edit.js
@@ -14,7 +14,6 @@ import HeadingToolbar from './heading-toolbar';
 import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 import { select } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
 import {
 	RichText,
 	BlockControls,
@@ -25,7 +24,6 @@ export default function StoryTitleEdit( {
 	attributes,
 	setAttributes,
 	mergeBlocks,
-	insertBlocksAfter,
 	onReplace,
 	className,
 } ) {
@@ -57,17 +55,6 @@ export default function StoryTitleEdit( {
 				value={ displayTitle }
 				onChange={ ( value ) => setAttributes( { content: value } ) }
 				onMerge={ mergeBlocks }
-				unstableOnSplit={
-					insertBlocksAfter ?
-						( before, after, ...blocks ) => {
-							setAttributes( { content: before } );
-							insertBlocksAfter( [
-								...blocks,
-								createBlock( 'core/paragraph', { content: after } ),
-							] );
-						} :
-						undefined
-				}
 				onRemove={ () => onReplace( [] ) }
 				style={ { textAlign: align } }
 				formattingControls={ [] }

--- a/assets/src/blocks/amp-story-title/edit.js
+++ b/assets/src/blocks/amp-story-title/edit.js
@@ -1,0 +1,78 @@
+/**
+ * Displays the title of the current post.
+ * Mainly forked from the Core Heading block.
+ */
+
+/**
+ * Internal dependencies
+ */
+import HeadingToolbar from './heading-toolbar';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+import { select } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+import {
+	RichText,
+	BlockControls,
+	AlignmentToolbar,
+} from '@wordpress/block-editor';
+
+export default function StoryTitleEdit( {
+	attributes,
+	setAttributes,
+	mergeBlocks,
+	insertBlocksAfter,
+	onReplace,
+	className,
+} ) {
+	const { align, level } = attributes;
+	const tagName = 'h' + level;
+	const post = select( 'core/editor' ).getCurrentPost();
+	let displayTitle;
+	if ( post && post.title && 'auto-draft' !== post.status ) {
+		displayTitle = post.title;
+	} else {
+		displayTitle = __( '(Please set a title)', 'amp' );
+	}
+
+	return (
+		<Fragment>
+			<BlockControls>
+				<HeadingToolbar minLevel={ 2 } maxLevel={ 5 } selectedLevel={ level } onChange={ ( newLevel ) => setAttributes( { level: newLevel } ) } />
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+			<RichText
+				identifier="content"
+				wrapperClassName="wp-block-heading"
+				tagName={ tagName }
+				value={ displayTitle }
+				onChange={ ( value ) => setAttributes( { content: value } ) }
+				onMerge={ mergeBlocks }
+				unstableOnSplit={
+					insertBlocksAfter ?
+						( before, after, ...blocks ) => {
+							setAttributes( { content: before } );
+							insertBlocksAfter( [
+								...blocks,
+								createBlock( 'core/paragraph', { content: after } ),
+							] );
+						} :
+						undefined
+				}
+				onRemove={ () => onReplace( [] ) }
+				style={ { textAlign: align } }
+				formattingControls={ [] }
+				className={ className }
+			/>
+		</Fragment>
+	);
+}

--- a/assets/src/blocks/amp-story-title/heading-toolbar.js
+++ b/assets/src/blocks/amp-story-title/heading-toolbar.js
@@ -1,0 +1,37 @@
+/**
+ * Mainly forked from the Core Heading block.
+ */
+
+/**
+ * External dependencies
+ */
+import { range } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
+import { Toolbar } from '@wordpress/components';
+
+class HeadingToolbar extends Component {
+	createLevelControl( targetLevel, selectedLevel, onChange ) {
+		return {
+			icon: 'heading',
+			// translators: %s: heading level e.g: "1", "2", "3"
+			title: sprintf( __( 'Heading %d' ), targetLevel ),
+			isActive: targetLevel === selectedLevel,
+			onClick: () => onChange( targetLevel ),
+			subscript: String( targetLevel ),
+		};
+	}
+
+	render() {
+		const { minLevel, maxLevel, selectedLevel, onChange } = this.props;
+		return (
+			<Toolbar controls={ range( minLevel, maxLevel ).map( ( index ) => this.createLevelControl( index, selectedLevel, onChange ) ) } />
+		);
+	}
+}
+
+export default HeadingToolbar;

--- a/assets/src/blocks/amp-story-title/index.js
+++ b/assets/src/blocks/amp-story-title/index.js
@@ -1,0 +1,68 @@
+/**
+ * Much of this block is taken from the Core Heading block.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+
+export const name = 'amp/amp-story-title';
+
+export const settings = {
+	title: __( 'AMP Title', 'amp' ),
+	description: __( 'Displays the title of the story', 'amp' ),
+	icon: 'list-view',
+	category: 'common',
+	keywords: [
+		__( 'AMP stories', 'amp' ),
+	],
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'h1,h2,h3,h4,h5,h6',
+			default: '',
+		},
+		level: {
+			type: 'number',
+			default: 2,
+		},
+		align: {
+			type: 'string',
+		},
+		placeholder: {
+			type: 'string',
+		},
+	},
+	supports: {
+		html: false,
+	},
+
+	edit,
+
+	/**
+	 * Saves the results of the edit component.
+	 *
+	 * @todo: possibly use PHP to render this instead, as the title could change.
+	 * @return {Function} A RichText.Content component.
+	 */
+	save( { attributes } ) {
+		const { align, level, content } = attributes;
+		const tagName = 'h' + level;
+
+		return (
+			<RichText.Content
+				tagName={ tagName }
+				style={ { textAlign: align } }
+				value={ content }
+			/>
+		);
+	},
+};

--- a/assets/src/components/shortcuts.js
+++ b/assets/src/components/shortcuts.js
@@ -10,6 +10,7 @@ const Shortcuts = ( { insertBlock } ) => {
 	const blocks = [
 		'amp/amp-story-text',
 		'core/image',
+		'amp/amp-story-title',
 	];
 
 	return (

--- a/assets/src/constants.js
+++ b/assets/src/constants.js
@@ -51,6 +51,7 @@ export const ALLOWED_CHILD_BLOCKS = [
 	'core/verse',
 	'core/video',
 	'amp/amp-story-text',
+	'amp/amp-story-title',
 	'core/block', // Reusable blocks.
 	'core/template', // Reusable blocks.
 ];


### PR DESCRIPTION
* Begins the work to add a title block
* Some improvements are still needed, like possibly making this a dynamic block, and implementing the layout controls

<img width="964" alt="title-block" src="https://user-images.githubusercontent.com/4063887/55623772-35594d80-5761-11e9-80f3-afa1e433d461.png">

Closes #2007