### PR TITLE
Expand externalization of data: URLs in @font-face rules

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -10,6 +10,7 @@ use \Sabberworm\CSS\CSSList\CSSList;
 use \Sabberworm\CSS\Property\Selector;
 use \Sabberworm\CSS\RuleSet\RuleSet;
 use \Sabberworm\CSS\Property\AtRule;
+use \Sabberworm\CSS\Rule\Rule;
 use \Sabberworm\CSS\CSSList\KeyFrame;
 use \Sabberworm\CSS\RuleSet\AtRuleSet;
 use \Sabberworm\CSS\Property\Import;
@@ -1105,7 +1106,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_stylesheet( $stylesheet, $options = array() ) {
 		$parsed      = null;
 		$cache_key   = null;
-		$cache_group = 'amp-parsed-stylesheet-v14'; // This should be bumped whenever the PHP-CSS-Parser is updated.
+		$cache_group = 'amp-parsed-stylesheet-v15'; // This should be bumped whenever the PHP-CSS-Parser is updated.
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(
@@ -1290,6 +1291,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 *    @type Document $css_document       CSS Document.
 	 *    @type array    $validation_results Validation results, array containing arrays with error and sanitized keys.
+	 *    @type string   $stylesheet_url     Stylesheet URL, if available.
 	 * }
 	 */
 	private function parse_stylesheet( $stylesheet_string, $options ) {
@@ -1790,7 +1792,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		if ( $ruleset instanceof AtRuleSet && 'font-face' === $ruleset->atRuleName() ) {
-			$this->process_font_face_at_rule( $ruleset );
+			$this->process_font_face_at_rule( $ruleset, $options );
 		}
 
 		$results = array_merge(
@@ -1807,18 +1809,47 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Process @font-face by making src URLs non-relative and converting data: URLs into (assumed) file URLs.
+	 * Process @font-face by making src URLs non-relative and converting data: URLs into file URLs (with educated guessing).
 	 *
 	 * @since 1.0
 	 *
 	 * @param AtRuleSet $ruleset Ruleset for @font-face.
+	 * @param array     $options {
+	 *     Options.
+	 *
+	 *     @type string $stylesheet_url Stylesheet URL, if available.
+	 * }
 	 */
-	private function process_font_face_at_rule( AtRuleSet $ruleset ) {
+	private function process_font_face_at_rule( AtRuleSet $ruleset, $options ) {
 		$src_properties = $ruleset->getRules( 'src' );
 		if ( empty( $src_properties ) ) {
 			return;
 		}
 
+		// Obtain the font-family name to guess the filename.
+		$font_family   = null;
+		$font_basename = null;
+		$properties    = $ruleset->getRules( 'font-family' );
+		if ( isset( $properties[0] ) ) {
+			$font_family = trim( $properties[0]->getValue(), '""' );
+
+			// Remove all non-word characters from the font family to serve as the filename.
+			$font_basename = preg_replace( '/[^A-Za-z0-9_\-]/', '', $font_family ); // Same as sanitize_key() minus case changes.
+		}
+
+		// Obtain the stylesheet base URL from which to guess font file locations.
+		$stylesheet_base_url = null;
+		if ( ! empty( $options['stylesheet_url'] ) ) {
+			$stylesheet_base_url = preg_replace(
+				':[^/]+(\?.*)?(#.*)?$:',
+				'',
+				$options['stylesheet_url']
+			);
+			$stylesheet_base_url = trailingslashit( $stylesheet_base_url );
+		}
+
+		// Attempt to transform data: URLs in src properties to be external file URLs.
+		$converted_count = 0;
 		foreach ( $src_properties as $src_property ) {
 			$value = $src_property->getValue();
 			if ( ! ( $value instanceof RuleValueList ) ) {
@@ -1868,52 +1899,77 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			/**
 			 * Source URL lists.
 			 *
-			 * @var URL[] $source_file_urls
-			 * @var URL[] $source_data_urls
+			 * @var string[] $source_file_urls
+			 * @var URL[]    $source_data_url_objects
 			 */
-			$source_file_urls = array();
-			$source_data_urls = array();
+			$source_file_urls        = array();
+			$source_data_url_objects = array();
 			foreach ( $sources as $i => $source ) {
 				if ( $source[0] instanceof URL ) {
-					if ( 'data:' === substr( $source[0]->getURL()->getString(), 0, 5 ) ) {
-						$source_data_urls[ $i ] = $source[0];
+					$value = $source[0]->getURL()->getString();
+					if ( 'data:' === substr( $value, 0, 5 ) ) {
+						$source_data_url_objects[ $i ] = $source[0];
 					} else {
-						$source_file_urls[ $i ] = $source[0];
+						$source_file_urls[ $i ] = $value;
 					}
 				}
 			}
 
 			// Convert data: URLs into regular URLs, assuming there will be a file present (e.g. woff fonts in core themes).
-			if ( empty( $source_file_urls ) ) {
-				continue;
-			}
-			$source_file_url = current( $source_file_urls );
-			foreach ( $source_data_urls as $i => $data_url ) {
+			foreach ( $source_data_url_objects as $i => $data_url ) {
 				$mime_type = strtok( substr( $data_url->getURL()->getString(), 5 ), ';' );
 				if ( ! $mime_type ) {
 					continue;
 				}
-				$extension   = preg_replace( ':.+/(.+-)?:', '', $mime_type );
-				$guessed_url = preg_replace(
-					':(?<=\.)\w+(\?.*)?(#.*)?$:', // Match the file extension in the URL.
-					$extension,
-					$source_file_url->getURL()->getString(),
-					1,
-					$count
-				);
-				if ( 1 !== $count ) {
-					continue;
+				$extension = preg_replace( ':.+/(.+-)?:', '', $mime_type );
+
+				$guessed_urls = array();
+
+				// Guess URLs based on any other font sources that are not using data: URLs (e.g. truetype fallback for inline woff2).
+				foreach ( $source_file_urls as $source_file_url ) {
+					$guessed_url = preg_replace(
+						':(?<=\.)\w+(\?.*)?(#.*)?$:', // Match the file extension in the URL.
+						$extension,
+						$source_file_url,
+						1,
+						$count
+					);
+					if ( 1 === $count ) {
+						$guessed_urls[] = $guessed_url;
+					}
 				}
 
-				// Ensure font file exists.
-				$path = $this->get_validated_url_file_path( $guessed_url, array( 'woff', 'woff2', 'ttf', 'otf', 'svg' ) );
-				if ( is_wp_error( $path ) ) {
-					continue;
+				/*
+				 * Guess some based on the font name in a fonts directory based on precedence of Twenty Nineteen.
+				 * The NonBreakingSpaceOverride woff2 font file is located at fonts/NonBreakingSpaceOverride.woff2.
+				 */
+				if ( $stylesheet_base_url && $font_basename ) {
+					$guessed_urls[] = $stylesheet_base_url . sprintf( 'fonts/%s.%s', $font_basename, $extension );
+					$guessed_urls[] = $stylesheet_base_url . sprintf( 'fonts/%s.%s', strtolower( $font_basename ), $extension );
 				}
 
-				$data_url->getURL()->setString( $guessed_url );
-				break;
-			}
+				// Find the font file that exists, and then replace the data: URL with the external URL for the font.
+				foreach ( $guessed_urls as $guessed_url ) {
+					$path = $this->get_validated_url_file_path( $guessed_url, array( 'woff', 'woff2', 'ttf', 'otf', 'svg' ) );
+					if ( ! is_wp_error( $path ) ) {
+						$data_url->getURL()->setString( $guessed_url );
+						$converted_count++;
+						break;
+					}
+				}
+			} // End foreach $source_data_url_objects.
+		} // End foreach $src_properties.
+
+		/*
+		 * If a data: URL has been replaced with an external file URL, then we add a font-display:swap to the @font-face
+		 * rule if one isn't already present. This prevents FO
+		 *
+		 *  If no font-display is already present, add font-display:swap since the font is now being loaded externally.
+		 */
+		if ( $converted_count && 0 === count( $ruleset->getRules( 'font-display' ) ) ) {
+			$font_display_rule = new Rule( 'font-display' );
+			$font_display_rule->setValue( 'swap' );
+			$ruleset->addRule( $font_display_rule );
 		}
 	}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1831,7 +1831,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$font_basename = null;
 		$properties    = $ruleset->getRules( 'font-family' );
 		if ( isset( $properties[0] ) ) {
-			$font_family = trim( $properties[0]->getValue(), '""' );
+			$font_family = trim( $properties[0]->getValue(), '"\'' );
 
 			// Remove all non-word characters from the font family to serve as the filename.
 			$font_basename = preg_replace( '/[^A-Za-z0-9_\-]/', '', $font_family ); // Same as sanitize_key() minus case changes.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1940,8 +1940,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 
 				/*
-				 * Guess some based on the font name in a fonts directory based on precedence of Twenty Nineteen.
-				 * The NonBreakingSpaceOverride woff2 font file is located at fonts/NonBreakingSpaceOverride.woff2.
+				 * Guess some font file URLs based on the font name in a fonts directory based on precedence of Twenty Nineteen.
+				 * For example, the NonBreakingSpaceOverride woff2 font file is located at fonts/NonBreakingSpaceOverride.woff2.
 				 */
 				if ( $stylesheet_base_url && $font_basename ) {
 					$guessed_urls[] = $stylesheet_base_url . sprintf( 'fonts/%s.%s', $font_basename, $extension );


### PR DESCRIPTION
Twenty Nineteen has quite a bit of CSS, and part of it is due to the `NonBreakingSpaceOverride` font which is inlined as a `data:` URL. While this font was temporarily removed from the frontend styles in https://github.com/WordPress/twentynineteen/pull/623 it was added back in https://github.com/WordPress/twentynineteen/pull/670 as @kjellr notes in https://github.com/WordPress/twentynineteen/pull/623#issuecomment-439571591:

> @allancole — It's possible you didn't see the PR, but @jasmussen and I merged that into the front end in https://github.com/WordPress/twentynineteen/pull/585 the other day. While not _definitely_ required, it  does fix some little quirks like the menu spacing noted in the PR. Since the custom font only covers one character, it should add just a couple kilobytes to the site's load. I'd prefer to keep it in, but not a huge deal either way.

In AMP it turns out to be a big deal, because of the 50KB budget for `style[amp-custom]`. The `data:`-URL inlined WOFF2 and WOFF files account for 3KB, which is 6% of the budget. This is a lot especially for something that definitely not required, per above.

The AMP plugin already has built-in support for externalizing `data:` URLs for font files in the case of Dashicons. That externalization depended on _one_ of the font `src` URLs to be an external file so that it could guess where to find the external file version of the `data:`-encoded font. For example, `dashicons.css` has:

```css
@font-face {
	font-family: dashicons;
	src: url("../fonts/dashicons.eot?50db0456fde2a241f005968eede3f987");
	src: url("../fonts/dashicons.eot?50db0456fde2a241f005968eede3f987#iefix") format("embedded-opentype"),
		url("data:application/x-font-woff;charset=utf-8;base64,d09GR....") format("woff"),
		url("../fonts/dashicons.ttf?50db0456fde2a241f005968eede3f987") format("truetype");
	font-weight: 400;
	font-style: normal;
}
``` 

Based on this, the plugin can successfully guess that woff font encoded in the `data:` URL would probably be located at `../fonts/dashicons.woff` since the TrueType version is located at `../fonts/dashicons.ttf`. 

That's all well and good. But what if there are no non-`data:` URLs defined? This is the case for Twenty Nineteen. It contains:

```css
@font-face {
    font-family: "NonBreakingSpaceOverride";
    src: url("data:application/font-woff2;charset=utf-8;base64,d09GM...") format("woff2"),
         url("data:application/font-woff;charset=utf-8;base64,d09GR...") format("woff");
}
```

The AMP plugin doesn't know where to locate the woff2 and woff files.

It turns out that even though Twenty Nineteen doesn't reference these files externally, they are present in the theme at:

* `fonts/NonBreakingSpaceOverride.woff2`
* `fonts/NonBreakingSpaceOverride.woff`

With this in mind, the plugin can expand its guessing of the external file locations based on the name in the `font-family`.

As an added touch for performance, when a `data:` URL is converted to an external URL, the `@font-face` gets a `font-display: swap`. This prevents the font's loading from blocking the rendering of the text.

# Before: `style.css` at 42KB

```html
<!--
The style[amp-custom] element is populated with:
     0 B: style[amp-custom=]
    81 B: style
    73 B (57%): link#amp-default-css[rel=stylesheet][id=amp-default-css][href=https://example.com/wp-content/plugins/amp/assets/css/amp-default.css?ver=1.1-beta1-20190406T044858Z-28b70b03][type=text/css][media=all]
  4348 B (37%): link#wp-block-library-css[rel=stylesheet][id=wp-block-library-css][href=https://example.com/wp-content/plugins/gutenberg/build/block-library/style.css?ver=1554612185][type=text/css][media=all]
   857 B (72%): link#wp-block-library-theme-css[rel=stylesheet][id=wp-block-library-theme-css][href=https://example.com/wp-content/plugins/gutenberg/build/block-library/theme.css?ver=1554612185][type=text/css][media=all]
 41583 B (72%): link#twentynineteen-style-css[rel=stylesheet][id=twentynineteen-style-css][href=https://example.com/wp-content/themes/twentynineteen/style.css?ver=1.0][type=text/css][media=all]
   417 B: style#twentynineteen-style-inline-css[id=twentynineteen-style-inline-css][type=text/css]
  2487 B (99%): link#twentynineteen-print-style-css[rel=stylesheet][id=twentynineteen-print-style-css][href=https://example.com/wp-content/themes/twentynineteen/print.css?ver=1.0][type=text/css][media=print]
   119 B: div.wp-block-cover has-background-dim alignwide amp-wp-d28a8c9[class=wp-block-cover has-background-dim alignwide amp-wp-d28a8c9]
Total included size: 49,965 bytes (67% of 73,555 total after tree shaking)

The following stylesheets are too large to be included in style[amp-custom]:
   122 B: style[type=text/css]
    80 B: p.has-large-font-size amp-wp-13076d9[class=has-large-font-size amp-wp-13076d9]
    79 B: p.amp-wp-f6e3d7f[class=amp-wp-f6e3d7f]
    80 B: p.amp-wp-13076d9[class=amp-wp-13076d9]
    80 B: p.amp-wp-13076d9[class=amp-wp-13076d9]
    80 B: p.amp-wp-13076d9[class=amp-wp-13076d9]
Total excluded size: 521 bytes (100% of 521 total after tree shaking)

Total combined size: 50,486 bytes (68% of 74,076 total after tree shaking)
-->
```
```css
/*...*/
@font-face {
    font-family: "NonBreakingSpaceOverride";
    src: url("data:application/font-woff2;charset=utf-8;base64,d09GMgABAAAAAAMoAA0AAAAACDQAAALTAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP0ZGVE0cGh4GYACCahEICjx3CywAATYCJANUBCAFhiEHgWwbXQfILgpsY+rQRRARwyAs6uL7pxzYhxEE+32b3aeHmifR6tklkS9hiZA0ewkqGRJE+H7/+6378ASViK/PGeavqJyOzsceKi1s3BCiQsiOdn1r/RBgIJYEgCUhbm/8/8/h4saPssnTNkkiWUBrTRtjmQSajw3Ui3pZ3LYDPD+XG2C3JA/yKAS8/rU5eNfuGqRf4eNNgV4YAlIIgxglEkWe6FYpq10+wi3g+/nUgvgPFczNrz/RsTgVm/zfbPuHZlsuQECxuyqBcQwKFBjFgKO8AqP4bAN9tFJtnM9xPcbNjeXS/x1wY/xU52f5W/X1+9cnH4YwKIaoRRAkUkj/YlAAeF/624foiIDBgBmgQBeGAyhBljUPZUm/l2dTvmpqcBDUOHdbPZWd8JsBAsGr4w8/EDn82/bUPx4eh0YNrQTBuHO2FjQEAGBwK0DeI37DpQVqdERS4gZBhpeUhWCfLFz7J99aEBgsJCHvUGAdAPp4IADDCAPCEFMGpMZ9AQpTfQtQGhLbGVBZFV8BaqNyP68oTZgHNj3M8kBPfXTTC9t90UuzYhy9ciH0grVlOcqyCytisvbsERsEYztiznR0WCrmTksJwbSNK6fd1Rvr25I9oLvctUoEbNOmXJbqgYgPXEHJ82IUsrCnpkxh23F1rfZ2zcRnJYoXtauB3VTFkFXQg3uoZYD5qE0kdjDtoDoF1h2bulGmev5HbYhbrjtohQSRI4aNOkffIcT+d3v6atpaYh3JvPoQsztCcqvaBkppDSPcQ3bw3KaCBo1f5CJWTZEgW3LjLofYg51MaVezrx8xZitYbQ9KYeoRaqQdVLwSEfrKXLK1otCWOKNdR/YwYAfon5Yk8O2MJfSD10dPGA5PIJJQMkah0ugMJiv6x4Dm7LEa8xnrRGGGLAg4sAlbsA07sAt76DOsXKO3hIjtIlpnnFrt1qW4kh6NhS83P/6HB/fl1SMAAA==") format("woff2"),
         url("data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAAAUQAA0AAAAACDQAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAAE9AAAABwAAAAchf5yU0dERUYAAATYAAAAHAAAAB4AJwAbT1MvMgAAAaAAAABJAAAAYJAcgU5jbWFwAAACIAAAAF4AAAFqUUxBZ2dhc3AAAATQAAAACAAAAAgAAAAQZ2x5ZgAAApAAAAAyAAAAPL0n8y9oZWFkAAABMAAAADAAAAA2Fi93Z2hoZWEAAAFgAAAAHQAAACQOSgWaaG10eAAAAewAAAAzAAAAVC7TAQBsb2NhAAACgAAAABAAAAAsAOQBAm1heHAAAAGAAAAAHQAAACAAWQALbmFtZQAAAsQAAAF6AAADIYvD/Adwb3N0AAAEQAAAAI4AAADsapk2o3jaY2BkYGAA4ov5mwzj+W2+MnCzXwCKMNzgCBSB0LfbQDQ7AxuI4mBgAlEAFKQIRHjaY2BkYGD3+NvCwMDBAALsDAyMDKhAFAA3+wH3AAAAeNpjYGRgYBBl4GBgYgABEMnIABJzAPMZAAVmAGUAAAB42mNgZlJhnMDAysDCKsKygYGBYRqEZtrDYMT4D8gHSmEHjgUFOQwODAqqf9g9/rYwMLB7MNUAhRlBcsxBrMlASoGBEQAj8QtyAAAAeNrjYGBkAAGmWQwMjO8gmBnIZ2NA0ExAzNjAAFYJVn0ASBsD6VAIDZb7AtELAgANIgb9AHjaY2BgYGaAYBkGRgYQSAHyGMF8FgYPIM3HwMHAxMDGoMCwQIFLQV8hXvXP//9AcRCfAcb///h/ygPW+w/vb7olBjUHCTCyMcAFGZmABBO6AogThgZgIUsXAEDcEzcAAHjaY2BgECMCyoEgACZaAed42mNgYmRgYGBnYGNgYAZSDJqMgorCgoqCjECRXwwNrCAKSP5mAAFGBiRgyAAAi/YFBQAAeNqtkc1OwkAUhU/5M25cEhcsZick0AwlBJq6MWwgJkAgYV/KAA2lJeUn+hY+gktXvpKv4dLTMqKycGHsTZNv7px7z50ZAFd4hYHjdw1Ls4EiHjVncIFnzVnc4F1zDkWjrzmPW+NNcwGlzIRKI3fJlUyrEjZQxb3mDH2fNGfRx4vmHKqG0JzHg6E0F9DOlFBGBxUI1GEzLNT4S0aLuTtsGAEUuYcQHkyg3KmIum1bNUvKlrjbbAIleqHHnS4iSudpQcySMYtdFiXlAxzSbAwfMxK6kZoHKhbjjespMTioOPZnzI+4ucCeTVyKMVKLfeAS6vSWaTinuZwzyy/Dc7vaed+6KaV0kukdPUk6yOcctZPvvxxqksq2lEW8RvHjMEO2FCl/zy6p3NEm0R9OFSafJdldc4QVeyaaObMBO0/5cCaa6d9Ggyubxire+lEojscdjoWUR1xGOy8KD8mG2ZLO2l2paDc3A39qmU2z2W5YNv5+u79e6QfGJY/hAAB42m3NywrCMBQE0DupWp/1AYI7/6DEaLQu66Mrd35BKUWKJSlFv1+rue4cGM7shgR981qSon+ZNwUJ8iDgoYU2OvDRRQ99DDDECAHGmGCKmf80hZSx/Kik/LliFbtmN6xmt+yOjdg9GztV4tROnRwX/Bsaaw51nt4Lc7tWaZYHp/MlzKx51LZs5htNri+2AAAAAQAB//8AD3jaY2BkYGDgAWIxIGZiYARCESBmAfMYAAR6AEMAAAABAAAAANXtRbgAAAAA2AhRFAAAAADYCNuG") format("woff");
}
/*...*/
```

# After: `style.css` at 39KB

```html
<!--
The style[amp-custom] element is populated with:
     0 B: style[amp-custom=]
    81 B: style
    73 B (57%): link#amp-default-css[rel=stylesheet][id=amp-default-css][href=https://example.com/wp-content/plugins/amp/assets/css/amp-default.css?ver=1.1-beta1-20190407T055539Z-9c273505][type=text/css][media=all]
  4348 B (37%): link#wp-block-library-css[rel=stylesheet][id=wp-block-library-css][href=https://example.com/wp-content/plugins/gutenberg/build/block-library/style.css?ver=1554616748][type=text/css][media=all]
   857 B (72%): link#wp-block-library-theme-css[rel=stylesheet][id=wp-block-library-theme-css][href=https://example.com/wp-content/plugins/gutenberg/build/block-library/theme.css?ver=1554616748][type=text/css][media=all]
 38893 B (71%): link#twentynineteen-style-css[rel=stylesheet][id=twentynineteen-style-css][href=https://example.com/wp-content/themes/twentynineteen/style.css?ver=1.0][type=text/css][media=all]
   417 B: style#twentynineteen-style-inline-css[id=twentynineteen-style-inline-css][type=text/css]
  2487 B (99%): link#twentynineteen-print-style-css[rel=stylesheet][id=twentynineteen-print-style-css][href=https://example.com/wp-content/themes/twentynineteen/print.css?ver=1.0][type=text/css][media=print]
   122 B: style[type=text/css]
   119 B: div.wp-block-cover has-background-dim alignwide amp-wp-d28a8c9[class=wp-block-cover has-background-dim alignwide amp-wp-d28a8c9]
    80 B: p.has-large-font-size amp-wp-13076d9[class=has-large-font-size amp-wp-13076d9]
    79 B: p.amp-wp-f6e3d7f[class=amp-wp-f6e3d7f]
Total included size: 47,556 bytes (66% of 71,146 total after tree shaking)
-->
```
```css
/*...*/
@font-face {
    font-family: "NonBreakingSpaceOverride";
    src: url("https://example.com/wp-content/themes/twentynineteen/fonts/NonBreakingSpaceOverride.woff2") format("woff2"),
         url("https://example.com/wp-content/themes/twentynineteen/fonts/NonBreakingSpaceOverride.woff") format("woff");
    font-display: swap;
}
/*...*/
```

See #1492.