### PR TITLE
Add tree shaking for attribute-extant selectors

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1163,7 +1163,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( wp_using_ext_object_cache() ) {
 			$parsed = wp_cache_get( $cache_key, $cache_group );
 		} else {
-			$parsed = get_transient( $cache_key . $cache_group );
+			$parsed = get_transient( $cache_group . '-' . $cache_key );
 		}
 
 		/*
@@ -1192,7 +1192,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				wp_cache_set( $cache_key, $parsed, $cache_group );
 			} else {
 				// The expiration is to ensure transient doesn't stick around forever since no LRU flushing like with external object cache.
-				set_transient( $cache_key . $cache_group, $parsed, MONTH_IN_SECONDS );
+				set_transient( $cache_group . '-' . $cache_key, $parsed, MONTH_IN_SECONDS );
 			}
 		}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1498,7 +1498,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						$selectors_parsed[ $selector ] = array();
 
 						// Remove :not() and pseudo selectors to eliminate false negatives, such as with `body:not(.title-tagline-hidden) .site-branding-text`.
-						$reduced_selector = preg_replace( '/:[a-zA-Z0-9_-]+(\(.+?\))?/', '', $selector );
+						$reduced_selector = preg_replace( '/::?[a-zA-Z0-9_-]+(\(.+?\))?/', '', $selector );
 
 						/*
 						 * Gather attribute names while removing attribute selectors to eliminate false negative,
@@ -1539,9 +1539,17 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						);
 
 						// Extract tag names.
-						if ( preg_match_all( '/[a-zA-Z0-9_-]+/', $reduced_selector, $matches ) ) {
-							$selectors_parsed[ $selector ][ self::SELECTOR_EXTRACTED_TAGS ] = $matches[0];
-						}
+						$reduced_selector = preg_replace_callback(
+							'/[a-zA-Z0-9_-]+/',
+							function( $matches ) use ( $selector, &$selectors_parsed ) {
+								$selectors_parsed[ $selector ][ self::SELECTOR_EXTRACTED_TAGS ][] = $matches[0];
+								return '';
+							},
+							$reduced_selector
+						);
+
+						// At this point, $reduced_selector should contain just the remnants of the selector, primarily combinators.
+						unset( $reduced_selector );
 					}
 
 					$stylesheet[] = array(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -205,10 +205,25 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Attributes used in the document.
 	 *
+	 * This is initially populated with boolean attributes which can be mutated by AMP at runtime,
+	 * since they can by dynamically added at any time.
+	 *
 	 * @since 1.1
 	 * @var array
 	 */
-	private $used_attributes = array();
+	private $used_attributes = array(
+		'autofocus' => true,
+		'checked'   => true,
+		'controls'  => true,
+		'disabled'  => true,
+		'hidden'    => true,
+		'loop'      => true,
+		'multiple'  => true,
+		'open'      => true,
+		'readonly'  => true,
+		'required'  => true,
+		'selected'  => true,
+	);
 
 	/**
 	 * Tag names used in document.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1507,7 +1507,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$selectors   = explode( $between_selectors . ',', $split_stylesheet[ ++$i ] );
 					$declaration = $split_stylesheet[ ++$i ];
 
-					// @todo The following logic could be made much more robust of PHP-CSS-Parser did parsing of selectors. See <https://github.com/sabberworm/PHP-CSS-Parser/pull/138#issuecomment-418193262>.
+					// @todo The following logic could be made much more robust if PHP-CSS-Parser did parsing of selectors. See <https://github.com/sabberworm/PHP-CSS-Parser/pull/138#issuecomment-418193262> and <https://github.com/ampproject/amp-wp/issues/2102>.
 					$selectors_parsed = array();
 					foreach ( $selectors as $selector ) {
 						$selectors_parsed[ $selector ] = array();

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1505,7 +1505,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						 * such as with `.social-navigation a[href*="example.com"]:before`.
 						 */
 						$reduced_selector = preg_replace_callback(
-							'/\[([A-Za-z0-9_-]+)(\W?=[\]]+)?\]/',
+							'/\[([A-Za-z0-9_:-]+)(\W?=[^\]]+)?\]/',
 							function( $matches ) use ( $selector, &$selectors_parsed ) {
 								$selectors_parsed[ $selector ][ self::SELECTOR_EXTRACTED_ATTRIBUTES ][] = $matches[1];
 								return '';

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1515,6 +1515,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						// Remove :not() and pseudo selectors to eliminate false negatives, such as with `body:not(.title-tagline-hidden) .site-branding-text`.
 						$reduced_selector = preg_replace( '/::?[a-zA-Z0-9_-]+(\(.+?\))?/', '', $selector );
 
+						// Ignore any selector terms that occur under a dynamic selector.
+						if ( $dynamic_selector_pattern ) {
+							$reduced_selector = preg_replace( '#((?:' . $dynamic_selector_pattern . ')(?:\.[a-z0-9_-]+)*)[^a-z0-9_-].*#si', '$1', $reduced_selector . ' ' );
+						}
+
 						/*
 						 * Gather attribute names while removing attribute selectors to eliminate false negative,
 						 * such as with `.social-navigation a[href*="example.com"]:before`.
@@ -1527,11 +1532,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 							},
 							$reduced_selector
 						);
-
-						// Ignore any selector terms that occur under a dynamic selector.
-						if ( $dynamic_selector_pattern ) {
-							$reduced_selector = preg_replace( '#((?:' . $dynamic_selector_pattern . ')(?:\.[a-z0-9_-]+)*)[^a-z0-9_-].*#si', '$1', $reduced_selector . ' ' );
-						}
 
 						// Extract class names.
 						$reduced_selector = preg_replace_callback(

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -592,6 +592,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'div img.logo{border:solid 1px red}',
 				'', // The selector is removed because there is no div element.
 			),
+			'attribute_selectors' => array(
+				// @todo The [hidden] selector should not be removed even when the attribute is not present.
+				'<div id="content" tabindex="-1"></div><button type=button>Hello</button><a href="#">Top</a><span hidden></span>',
+				'[type="button"], [type="reset"], [type^="submit"] {color:red} a[href^=http]:after, a[href^="#"]:after { color:blue } [hidden] {display:none}#content[tabindex="-1"]:focus{ outline: solid 1px red; }',
+				'[type="button"],[type="reset"],[type^="submit"]{color:red}a[href^=http]:after,a[href^="#"]:after{color:blue}[hidden]{display:none}#content[tabindex="-1"]:focus{outline:solid 1px red}', // Any selector mentioning [type] or [href] will persist since value is not used for tree shaking.
+			),
 			'playbuzz' => array(
 				'<p>hello</p><div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
 				'p + div.pb_feed{border:solid 1px blue}',

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -318,7 +318,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					)
 				),
 				array(
-					'form [submit-success] b,div[submit-failure] b{color:green}',
+					'form [submit-success] b{color:green}', // The [submit-failure] selector is removed because there is no div[submit-failure].
 					'amp-live-list li .highlighted{background:yellow}',
 					'',
 					'body amp-list .portland{color:blue}',
@@ -358,7 +358,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				array(),
 			),
 			'unamerican_lang_attribute_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
-				'<html amp><head><meta charset="utf-8"><style>html[lang=en-US] {color:red} html[lang="en-US"] {color:white} html[lang^=en] {color:blue} html[lang="en-CA"] {color:red}  html[lang^=ar] { color:green; } html[lang="es-MX"] { color:green; }</style></head><body><span>Test</span></body></html>',
+				'<html lang="en-US" amp><head><meta charset="utf-8"><style>html[lang=en-US] {color:red} html[lang="en-US"] {color:white} html[lang^=en] {color:blue} html[lang="en-CA"] {color:red}  html[lang^=ar] { color:green; } html[lang="es-MX"] { color:green; }</style></head><body><span>Test</span></body></html>',
 				array(
 					'html[lang=en-US]{color:red}html[lang="en-US"]{color:white}html[lang^=en]{color:blue}',
 				),
@@ -1045,7 +1045,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			@media screen {}
 			</style>
 		';
-		$html .= '</head><body><span class="b">...</span><span id="exists"></span></body></html>';
+		$html .= '</head><body><span class="b" data-value="">...</span><span id="exists"></span></body></html>';
 		$dom   = AMP_DOM_Utils::get_dom( $html );
 
 		$error_codes = array();

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -593,10 +593,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'', // The selector is removed because there is no div element.
 			),
 			'attribute_selectors' => array(
-				// @todo The [hidden] selector should not be removed even when the attribute is not present.
-				'<div id="content" tabindex="-1"></div><button type=button>Hello</button><a href="#">Top</a><span hidden></span>',
-				'[type="button"], [type="reset"], [type^="submit"] {color:red} a[href^=http]:after, a[href^="#"]:after { color:blue } [hidden] {display:none}#content[tabindex="-1"]:focus{ outline: solid 1px red; }',
-				'[type="button"],[type="reset"],[type^="submit"]{color:red}a[href^=http]:after,a[href^="#"]:after{color:blue}[hidden]{display:none}#content[tabindex="-1"]:focus{outline:solid 1px red}', // Any selector mentioning [type] or [href] will persist since value is not used for tree shaking.
+				'<div id="content" tabindex="-1"></div><button type=button>Hello</button><a href="#">Top</a><span></span>',
+				'[type="button"], [type="reset"], [type^="submit"] {color:red} a[href^=http]:after, a[href^="#"]:after { color:blue } span[hidden] {display:none}#content[tabindex="-1"]:focus{ outline: solid 1px red; }',
+				'[type="button"],[type="reset"],[type^="submit"]{color:red}a[href^=http]:after,a[href^="#"]:after{color:blue}span[hidden]{display:none}#content[tabindex="-1"]:focus{outline:solid 1px red}', // Any selector mentioning [type] or [href] will persist since value is not used for tree shaking.
 			),
 			'playbuzz' => array(
 				'<p>hello</p><div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
@@ -659,6 +658,120 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		);
 		$stylesheets = array_values( $sanitized['stylesheets'] );
 		$this->assertEquals( $output, $stylesheets[0] );
+	}
+
+	/**
+	 * Provide data for attribute selector test.
+	 *
+	 * @return array Data.
+	 */
+	public function get_attribute_selector_data() {
+		return array(
+			'type_attribute' => array(
+				'<input type="color">',
+				// All selectors remain because only the existence of the attribute is examined.
+				array(
+					'[type="button"]' => true,
+					'[type*="reset"]' => true,
+					'[type^="submit"]' => true,
+					'[type$="button"]' => true,
+				),
+			),
+			'tabindex_attribute' => array(
+				'<span tabindex="-1"></span>',
+				// The div[tabindex] is removed because there is no div. The span[tabindex^=2] remains because value is not considered.
+				array(
+					'div[tabindex]' => false,
+					'span[tabindex]' => true,
+					'span[tabindex=-1]' => true,
+					'span[tabindex^=2]' => true,
+				),
+			),
+			'href_attribute' => array(
+				'<a href="foo">Foo</a>',
+				array(
+					'a[href^=http]:after' => true,
+					'a[href^="#"]:after' => true,
+				),
+			),
+			'hidden_attribute' => array(
+				'<span>not hidden</span>',
+				// Only div[hidden] should be removed because there is no div element; the other [hidden] selectors remain because it can be dynamically added.
+				array(
+					'span[hidden]' => true,
+					'[hidden]' => true,
+					'div[hidden]' => false,
+					'span:not([hidden])' => true,
+				),
+			),
+			'selected_readonly_disabled_multiple_autofocus_required' => array(
+				'<input><select><option></option></select>',
+				array(
+					'[autofocus]' => true,
+					'[checked]'   => true,
+					'[disabled]'  => true,
+					'[multiple]'  => true,
+					'[readonly]'  => true,
+					'[required]'  => true,
+					'[selected]'  => true,
+				),
+			),
+			'open_attribute' => array(
+				'<details><summary>More</summary>Details</details>',
+				array(
+					'[open]'             => true,
+					'amp-lightbox[open]' => false,
+					'details[open]'      => true,
+				),
+			),
+			'media_attributes' => array(
+				'<amp-video width="720" height="305" layout="responsive" src="https://yourhost.com/videos/myvideo.mp4" poster="https://yourhost.com/posters/poster.png" artwork="https://yourhost.com/artworks/artwork.png" title="Awesome video" artist="Awesome artist" album="Amazing album"></amp-video>',
+				array(
+					'[loop]'     => true,
+					'[controls]' => true,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Test attribute selector tree shaking.
+	 *
+	 * @dataProvider get_attribute_selector_data
+	 *
+	 * @param string $markup      Source HTML markup.
+	 * @param array  $selectors   Mapping of selectors to whether they are expected.
+	 */
+	public function test_attribute_selector( $markup, $selectors ) {
+		$style = implode(
+			'',
+			array_map(
+				function ( $selector ) {
+					return sprintf( '%s{ color: red; }', $selector );
+				},
+				array_keys( $selectors )
+			)
+		);
+
+		$html = "<html amp><head><meta charset=utf-8><style amp-custom>$style</style></head><body>$markup</body></html>";
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+
+		$sanitizer_classes = amp_get_content_sanitizers();
+		$sanitizer_classes['AMP_Style_Sanitizer']['remove_unused_rules'] = 'always';
+
+		$sanitized = AMP_Content_Sanitizer::sanitize_document(
+			$dom,
+			$sanitizer_classes,
+			array(
+				'use_document_element' => true,
+			)
+		);
+
+		$stylesheets = array_values( $sanitized['stylesheets'] );
+
+		$actual_selectors   = array_values( array_filter( preg_split( '/{.+?}/s', $stylesheets[0] ) ) );
+		$expected_selectors = array_keys( array_filter( $selectors ) );
+		$this->assertEqualSets( $expected_selectors, $actual_selectors );
 	}
 
 	/**


### PR DESCRIPTION
As noted in https://github.com/ampproject/amp-wp/issues/1492#issuecomment-480553806, one additional CSS reduction which can be done for Twenty Nineteen is eliminate the selectors that mention `[focus-within]` since those polyfill rules will not work in AMP (since they require JS). That eliminates 1.5KB of CSS.

It turns out that the infrastructure for doing attribute-based tree shaking was implemented in #1959 since it now checks if certain attributes are present on the page to know whether or not a given AMP component will be needed (e.g. `dock` for `amp-video-docking`). With this in hand, the CSS selector parsing can be extended to also extract the attribute names that are referenced in the selector and then at runtime check if any of those attributes exist in the document.

Note that the attribute selector tree shaking only considers if an attribute is mentioned. It does not check the _value_ of the attribute. In other words, consider this CSS:

```css
<style>
span[hidden] {
    display: none;
}
span[data-pos] {
    color: red;
}
span[data-pos="object"] {
    color: green;
}
span[data-pos^="interjection"] {
    color: green;
}
span[data-punctuation] {
    color: purple;
}
</style>
<span data-pos="noun">John</span>
<span data-pos="verb">kicks</span>
<span data-pos="adverb">quickly</span>
```

Only the last rule with the selector `span[data-punctuation]` would be tree-shaken. The others remain because the `value` is not taken into consideration. The reason is that the value, especially in the case of `amp-bind`, can be mutated at runtime (see [bindings](https://www.ampproject.org/docs/reference/components/amp-bind#bindings)); this is also the case for the `[hidden]` selector since it and other such boolean attributes can be added/removed by AMP at runtime.

# Results

Here are the savings for each core theme, along with other core styles also being included:

theme | before | after | diff | savings
------|--------|-------|------|--------
twentyeleven | 20293 | 20012 | -281 | -1.38%
twentyfifteen | 38444 | 38163 | -281 | -0.73%
twentyfourteen | 23982 | 23701 | -281 | -1.17%
twentynineteen | 38986 | 37039 | -1947 | -4.99%
twentyseventeen | 30003 | 29722 | -281 | -0.94%
twentysixteen | 30625 | 30304 | -321 | -1.05%
twentyten | 14692 | 14411 | -281 | -1.91%
twentythirteen | 21617 | 21336 | -281 | -1.30%
twentytwelve | 20736 | 20455 | -281 | -1.36%

As expected, the greatest savings is for Twenty Nineteen, where the `focus-within` rules are removed.

👉 Interestingly, with this change, **the core theme with the most CSS after tree shaking is now Twenty Fifteen**. Previously it was Twenty Nineteen. Twenty Sixteen remains in third place, followed by Twenty Seventeen.

With this along with #2079, the amount of CSS for Twenty Nineteen has gone down 4.6KB (-11.07%).

----

Here is the script (beware that running will clear out all widgets on an install):

```bash
#!/bin/bash

set -e
url=$1

if [[ -z "$url" ]]; then
	echo "Error: Must supply the URL to an AMP page as the first argument."
	exit 2
fi

function curl_grep_included_size {
	curl -s "$url" > /tmp/response
	if grep -s 'Total excluded size' /tmp/response >/dev/null; then
		echo '-1'
	else
		cat /tmp/response | grep 'Total included size' | sed 's/.*: //' | sed 's/ bytes.*//' | sed 's/,//'
	fi
}

echo "theme | before | after | diff | savings" > results.txt;
echo "------|--------|-------|------|--------" >> results.txt;

wp transient delete --all
for theme in $(wp theme list --field=name | egrep 'twenty' | grep -v '-'); do
	wp theme activate "$theme"
	wp widget reset --all # For consistency.
	git checkout develop
	before_bytes=$(curl_grep_included_size)
	git checkout add/attribute-selector-tree-shaking
	after_bytes=$(curl_grep_included_size)
	reduction_bytes=$(expr "$after_bytes" - "$before_bytes")
	reduction_percentage=$(php -r "printf( '%.2f%%', -( 1 - \$argv[1] / \$argv[2] ) * 100 );" "$after_bytes" "$before_bytes" )

	echo -e "$theme | $before_bytes | $after_bytes | $reduction_bytes | $reduction_percentage" >> results.txt
done

cat results.txt
```

Here is how I invoked:

```bash
lando ssh -c "./check-tree-shaker-savings.sh https://wordpressdev.lndo.site/2019/04/09/welcome-to-the-gutenberg-editor-4/?amp"
```

# Todo

- [x] Add tests.
- [x] Determine which attributes should be excluded from tree-shaking (e.g. `hidden`), considering which attributes that AMP can add/remove.
- [x] Test themes to see which selectors are removed now with this change. Check savings for each.

See #1492.