### PR TITLE
Prevent placeholder blocks for audio and image from causing validation errors

### DIFF
--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -44,11 +44,24 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 	 * @return string Filtered block content.
 	 */
 	public function filter_rendered_block( $block_content, $block ) {
-		if ( isset( $block['blockName'] ) && isset( $this->block_ampify_methods[ $block['blockName'] ] ) ) {
+		if ( ! isset( $block['blockName'] ) ) {
+			return $block_content;
+		}
+		if ( isset( $this->block_ampify_methods[ $block['blockName'] ] ) ) {
 			$block_content = call_user_func(
 				array( $this, $this->block_ampify_methods[ $block['blockName'] ] ),
 				$block_content
 			);
+		} elseif ( 'core/image' === $block['blockName'] || 'core/audio' === $block['blockName'] ) {
+			/*
+			 * While the video block placeholder just outputs an empty video element, the placeholders for image and
+			 * audio blocks output empty <img> and <audio> respectively. These will result in AMP validation errors,
+			 * so we need to empty out the block content to prevent this from happening. Note that <source> is used
+			 * for <img> because eventually the image block could use <picture>.
+			 */
+			if ( ! preg_match( '/src=|<source/', $block_content ) ) {
+				$block_content = '';
+			}
 		}
 		return $block_content;
 	}

--- a/tests/test-class-amp-core-block-handler.php
+++ b/tests/test-class-amp-core-block-handler.php
@@ -59,4 +59,29 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 			$this->assertNotContains( 'on="change', $rendered );
 		}
 	}
+
+	/**
+	 * Test that placeholder blocks don't result in validation errors.
+	 *
+	 * @covers \AMP_Core_Block_Handler::filter_rendered_block()
+	 */
+	public function test_placeholder_blocks() {
+		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
+			$this->markTestSkipped( 'Missing required render_block filter.' );
+		}
+
+		$handler = new AMP_Core_Block_Handler();
+		$handler->unregister_embed(); // Make sure we are on the initial clean state.
+		$handler->register_embed();
+
+		$audio_placeholder_block = "<!-- wp:audio -->\n<figure class=\"wp-block-audio\"><audio controls></audio></figure>\n<!-- /wp:audio -->";
+		$audio_populated_block   = "<!-- wp:audio -->\n<figure class=\"wp-block-audio\"><audio controls src=\"https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3\"></audio></figure>\n<!-- /wp:audio -->";
+		$this->assertEmpty( apply_filters( 'the_content', $audio_placeholder_block ) );
+		$this->assertNotEmpty( apply_filters( 'the_content', $audio_populated_block ) );
+
+		$image_placeholder_block = "<!-- wp:image -->\n<figure class=\"wp-block-image\"><img alt=\"\"/></figure>\n<!-- /wp:image -->";
+		$image_populated_block   = "<!-- wp:image -->\n<figure class=\"wp-block-image\"><img src=\"https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg\" alt=\"\"/></figure>\n<!-- /wp:image -->";
+		$this->assertEmpty( apply_filters( 'the_content', $image_placeholder_block ) );
+		$this->assertNotEmpty( apply_filters( 'the_content', $image_populated_block ) );
+	}
 }


### PR DESCRIPTION
Given this raw markup:

```html
<!-- wp:image -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image -->
<figure class="wp-block-image"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt=""/></figure>
<!-- /wp:image -->

<!-- wp:image {"id":53} -->
<figure class="wp-block-image"><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" alt="" class="wp-image-53"/><figcaption>Bison in field</figcaption></figure>
<!-- /wp:image -->

<!-- wp:audio -->
<figure class="wp-block-audio"><audio controls></audio></figure>
<!-- /wp:audio -->

<!-- wp:audio {"id":88} -->
<figure class="wp-block-audio"><audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio></figure>
<!-- /wp:audio -->

<!-- wp:audio -->
<figure class="wp-block-audio"><audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio></figure>
<!-- /wp:audio -->
```

There are validation errors for the image block and audio blocks that are in the placeholder state:

![image](https://user-images.githubusercontent.com/134745/55757425-bdad4c00-5a08-11e9-983e-c700a473c716.png)

![image](https://user-images.githubusercontent.com/134745/55757438-c43bc380-5a08-11e9-8386-1dff8f839410.png)

Compare this with the video block in a placeholder state:

![image](https://user-images.githubusercontent.com/134745/55757463-d0c01c00-5a08-11e9-9b5d-4636bb63e623.png)

```html
<!-- wp:video -->
<figure class="wp-block-video"></figure>
<!-- /wp:video -->
```

For some reason the image block and audio block both have empty `img` and `audio` elements respectively, while the `video` block does not. There are AMP validation errors for the image block and audio block because AMP requires a source to be supplied.

This PR fixes the problem by just emptying such placeholder blocks for image and audio when no source is present.