### PR TITLE
Prevent setting a featured image automatically if one exists

### DIFF
--- a/assets/src/components/with-edit-featured-image.js
+++ b/assets/src/components/with-edit-featured-image.js
@@ -19,8 +19,10 @@ import { hasMinimumStoryPosterDimensions } from '../helpers';
  */
 export default ( BlockEdit ) => {
 	return withSelect( ( select, ownProps ) => {
+		const featuredImage = select( 'core/editor' ).getEditedPostAttribute( 'featured_media' );
 		const isCorrectBlock = ( 'core/image' === ownProps.name || 'amp/amp-story-page' === ownProps.name );
-		if ( ! isCorrectBlock || ! ownProps.attributes ) {
+
+		if ( featuredImage || ! isCorrectBlock || ! ownProps.attributes ) {
 			return;
 		}
 


### PR DESCRIPTION
* There's logic to set the featured image if one doesn't exist, when one adds a big enough image to an Image block or the 'Background Media' section
* This PR checks that there isn't already a featured image before setting it automatically
* I'm not sure why I didn't check for that before 😄 

Fixes #2088