### PR TITLE
Use RawHTML to mimic RichText.Content behavior

### DIFF
--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -251,15 +251,8 @@ class TextBlockEdit extends Component {
 						wrapperClassName="wp-block-amp-story-text"
 						tagName="p"
 						// Ensure line breaks are normalised to HTML.
-						value={ content.replace( /\n/g, '<br>' ) }
-						onChange={ ( nextContent ) => {
-							setAttributes( {
-								// Ensure line breaks are normalised to characters. This
-								// saves space, is easier to read, and ensures display
-								// filters work correctly.
-								content: nextContent.replace( /<br ?\/?>/g, '\n' ),
-							} );
-						} }
+						value={ content }
+						onChange={ ( nextContent ) => setAttributes( { content: nextContent } ) }
 						onReplace={ this.onReplace }
 						style={ {
 							backgroundColor: ( backgroundColor.color && 100 !== opacity ) ? `rgba( ${ r }, ${ g }, ${ b }, ${ a })` : backgroundColor.color,

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -14,6 +14,7 @@ import {
 	getColorObjectByAttributeValues,
 } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -186,6 +187,7 @@ export const settings = {
 					style={ styles }
 					className={ className }
 					value={ content }
+					format="string"
 				/>
 			);
 		}
@@ -194,11 +196,12 @@ export const settings = {
 
 		styles.display = 'flex';
 
+		// Uses RawHTML to mimic RichText.Content behavior.
 		return (
 			<ContentTag
 				style={ styles }
 				className={ className }>
-				<amp-fit-text layout="flex-item" className="amp-text-content">{ content }</amp-fit-text>
+				<amp-fit-text layout="flex-item" className="amp-text-content"><RawHTML>{ content }</RawHTML></amp-fit-text>
 			</ContentTag>
 		);
 	},

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -853,11 +853,6 @@ class AMP_Story_Post_Type {
 	public static function render_block_with_google_fonts( $props, $content ) {
 		$prop_name = 'ampFontFamily';
 
-		// Prevent adding br tags outside of the amp-story-grid-layer.
-		$content = trim( $content );
-
-		$content = nl2br( $content, false );
-
 		// Short-circuit if no font family present.
 		if ( empty( $props[ $prop_name ] ) ) {
 			return $content;


### PR DESCRIPTION
As reported in #2087, HTML tags are escaped when using `amp-fit-text`.

I initially advocated against using `RawHTML` to solve this, but it now seems that there's no way around it. Turns out, `RichText.Content` uses that [as well](https://github.com/WordPress/gutenberg/blob/ba64d414eaa687ce31daab7f8fad9110dcfd7800/packages/block-editor/src/components/rich-text/index.js#L1230-L1254).

Fixes #2087