### PR TITLE
Adjust positioning of the 'Background Media' image on the front-end

### DIFF
--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -50,3 +50,7 @@ amp-story-grid-layer[template="fill"] .wp-block-image { margin: 0; }
 .is-style-half-rounded {
 	border-radius: 4px 4px 26px 26px;
 }
+
+amp-story-grid-layer amp-img > img {
+	object-position: inherit;
+}

--- a/assets/src/blocks/amp-story-page/index.js
+++ b/assets/src/blocks/amp-story-page/index.js
@@ -82,6 +82,7 @@ export const settings = {
 	save( { attributes } ) {
 		const {
 			anchor,
+			focalPoint,
 			overlayOpacity,
 			mediaUrl,
 			mediaType,
@@ -107,13 +108,17 @@ export const settings = {
 			overlayStyle.opacity = overlayOpacity / 100;
 		}
 
+		const imgStyle = {
+			objectPosition: IMAGE_BACKGROUND_TYPE === mediaType && focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : 'initial',
+		};
+
 		return (
 			<amp-story-page style={ { backgroundColor: '#ffffff' } } id={ anchor } auto-advance-after={ advanceAfter }>
 				{
 					mediaUrl && (
 						<amp-story-grid-layer template="fill">
 							{ IMAGE_BACKGROUND_TYPE === mediaType && (
-								<amp-img layout="fill" src={ mediaUrl } />
+								<amp-img layout="fill" src={ mediaUrl } style={ imgStyle } />
 							) }
 							{ VIDEO_BACKGROUND_TYPE === mediaType && (
 								<amp-video layout="fill" src={ mediaUrl } poster={ poster } muted autoplay loop />


### PR DESCRIPTION
As @miina noted in #2085, the values in the Focal Point Picker weren't appearing on the front-end for images:
<img width="413" alt="fp-picker" src="https://user-images.githubusercontent.com/4063887/55853762-13c4e100-5b28-11e9-9981-ae5db9336644.png">

* This applies the `focalPoint` values on the front-end
* But it uses `object-position` instead of `background-position`

![images-same](https://user-images.githubusercontent.com/4063887/55853533-2854a980-5b27-11e9-8c85-e1249aa869bb.gif)

Closes #2085