### PR TITLE
[AMP Stories] Improve page borders/outline

### DIFF
--- a/assets/src/blocks/amp-story-page/edit.css
+++ b/assets/src/blocks/amp-story-page/edit.css
@@ -1,19 +1,21 @@
-div[data-type="amp/amp-story-page"] {
-	border: 5px solid #eff0f1;
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="amp/amp-story-page"] > .block-editor-block-list__block-edit > .block-editor-block-list__breadcrumb {
+	display: none;
+}
+
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="amp/amp-story-page"] > .block-editor-block-list__block-edit:before {
+	border: 3px solid #E3E5E7;
 	border-radius: 5px;
+	box-shadow: none;
 }
 
-div[data-type="amp/amp-story-page"]::after {
-	content: '';
-	position: absolute;
-	bottom: -5px;
-	left: 0;
-	width: 100%;
-	height: 5px;
-	background: #eff0f1;
-	transition: background-color 300ms linear;
+.block-editor-block-list__layout .block-editor-block-list__block.amp-page-active[data-type="amp/amp-story-page"] > .block-editor-block-list__block-edit:before {
+	border-color: #555d66;
 }
 
+.block-editor-block-list__layout .block-editor-block-list__block[data-type="amp/amp-story-page"] > .block-editor-block-list__block-edit > .block-editor-block-contextual-toolbar > .block-editor-block-toolbar {
+	left: 4px;
+	top: 3px;
+}
 
 /*
  * Disable the block mover at all times for page blocks.


### PR DESCRIPTION
As discussed with Thierry yesterday, the page borders in the editor looked a bit odd when hovering and selecting.

Before:

<img width="444" alt="Screenshot 2019-04-09 at 12 07 19" src="https://user-images.githubusercontent.com/841956/55867584-0ee14b00-5b83-11e9-941e-28884b42de54.png">
<img width="388" alt="Screenshot 2019-04-09 at 12 07 14" src="https://user-images.githubusercontent.com/841956/55867585-0f79e180-5b83-11e9-9ba8-5e03b138c92e.png">
<img width="435" alt="Screenshot 2019-04-09 at 12 07 03" src="https://user-images.githubusercontent.com/841956/55867586-0f79e180-5b83-11e9-8492-8ffb4fcd40bb.png">


With PR applied:

![Screenshot 2019-04-10 at 11 20 30](https://user-images.githubusercontent.com/841956/55867622-27516580-5b83-11e9-85b7-f0ce103a9f57.png)
![Screenshot 2019-04-10 at 11 20 17](https://user-images.githubusercontent.com/841956/55867625-27516580-5b83-11e9-9f6c-84beef08ee34.png)
![Screenshot 2019-04-10 at 11 20 10](https://user-images.githubusercontent.com/841956/55867626-27516580-5b83-11e9-8396-94464ab5ce8f.png)

Still not perfect, but already a big improvement.