### PR TITLE
Prevent adding noscript fallbacks for AMP components inside AMP Stories

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -191,9 +191,11 @@ class AMP_Story_Post_Type {
 			function( $sanitizers ) {
 				if ( is_singular( self::POST_TYPE_SLUG ) ) {
 					$sanitizers['AMP_Story_Sanitizer'] = array();
+					$sanitizers['AMP_Img_Sanitizer']['add_noscript_fallback']    = false;
+					$sanitizers['AMP_Audio_Sanitizer']['add_noscript_fallback']  = false;
+					$sanitizers['AMP_Video_Sanitizer']['add_noscript_fallback']  = false;
+					$sanitizers['AMP_Iframe_Sanitizer']['add_noscript_fallback'] = false; // Note that iframe is not yet allowed in an AMP Story.
 				}
-				$sanitizers['AMP_Img_Sanitizer']['add_noscript_fallback']   = false;
-				$sanitizers['AMP_Video_Sanitizer']['add_noscript_fallback'] = false;
 				return $sanitizers;
 			}
 		);

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -191,6 +191,8 @@ class AMP_Story_Post_Type {
 			function( $sanitizers ) {
 				if ( is_singular( self::POST_TYPE_SLUG ) ) {
 					$sanitizers['AMP_Story_Sanitizer'] = array();
+
+					// Disable noscript fallbacks since not allowed in AMP Stories.
 					$sanitizers['AMP_Img_Sanitizer']['add_noscript_fallback']    = false;
 					$sanitizers['AMP_Audio_Sanitizer']['add_noscript_fallback']  = false;
 					$sanitizers['AMP_Video_Sanitizer']['add_noscript_fallback']  = false;

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -192,6 +192,8 @@ class AMP_Story_Post_Type {
 				if ( is_singular( self::POST_TYPE_SLUG ) ) {
 					$sanitizers['AMP_Story_Sanitizer'] = array();
 				}
+				$sanitizers['AMP_Img_Sanitizer']['add_noscript_fallback']   = false;
+				$sanitizers['AMP_Video_Sanitizer']['add_noscript_fallback'] = false;
 				return $sanitizers;
 			}
 		);

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -145,11 +145,14 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
-				$noscript = $this->dom->createElement( 'noscript' );
-				$new_node->appendChild( $noscript );
+			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
-				$noscript->appendChild( $old_node );
+
+				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+					$noscript = $this->dom->createElement( 'noscript' );
+					$new_node->appendChild( $noscript );
+					$noscript->appendChild( $old_node );
+				}
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -21,6 +21,17 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'audio';
 
 	/**
+	 * Placeholder for default args.
+	 *
+	 * @since 1.2
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -134,7 +145,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} else {
+			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
 				$noscript = $this->dom->createElement( 'noscript' );
 				$new_node->appendChild( $noscript );
 				$node->parentNode->replaceChild( $new_node, $node );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -45,7 +45,8 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = array(
-		'add_placeholder' => false,
+		'add_placeholder'       => false,
+		'add_noscript_fallback' => true,
 	);
 
 	/**
@@ -110,11 +111,13 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Preserve original node in noscript for no-JS environments.
-			$node->setAttribute( 'src', $normalized_attributes['src'] );
-			$node->parentNode->replaceChild( $new_node, $node );
-			$noscript = $this->dom->createElement( 'noscript' );
-			$noscript->appendChild( $node );
-			$new_node->appendChild( $noscript );
+			if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+				$node->setAttribute( 'src', $normalized_attributes['src'] );
+				$node->parentNode->replaceChild( $new_node, $node );
+				$noscript = $this->dom->createElement( 'noscript' );
+				$noscript->appendChild( $node );
+				$new_node->appendChild( $noscript );
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -110,10 +110,11 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$new_node->appendChild( $placeholder_node );
 			}
 
+			$node->parentNode->replaceChild( $new_node, $node );
+
 			// Preserve original node in noscript for no-JS environments.
 			if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
 				$node->setAttribute( 'src', $normalized_attributes['src'] );
-				$node->parentNode->replaceChild( $new_node, $node );
 				$noscript = $this->dom->createElement( 'noscript' );
 				$noscript->appendChild( $node );
 				$new_node->appendChild( $noscript );

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -47,6 +47,17 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	private static $anim_extension = '.gif';
 
 	/**
+	 * Placeholder for default args.
+	 *
+	 * @since 1.2
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -287,9 +298,11 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$node->parentNode->replaceChild( $img_node, $node );
 
 		// Preserve original node in noscript for no-JS environments.
-		$noscript = $this->dom->createElement( 'noscript' );
-		$noscript->appendChild( $node );
-		$img_node->appendChild( $noscript );
+		if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+			$noscript = $this->dom->createElement( 'noscript' );
+			$noscript->appendChild( $node );
+			$img_node->appendChild( $noscript );
+		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -33,6 +33,17 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'video';
 
 	/**
+	 * Placeholder for default args.
+	 *
+	 * @since 1.2
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -152,7 +163,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} else {
+			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
 				$noscript = $this->dom->createElement( 'noscript' );
 				$new_node->appendChild( $noscript );
 				$node->parentNode->replaceChild( $new_node, $node );

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -168,11 +168,14 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
-				$noscript = $this->dom->createElement( 'noscript' );
-				$new_node->appendChild( $noscript );
+			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
-				$noscript->appendChild( $old_node );
+
+				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+					$noscript = $this->dom->createElement( 'noscript' );
+					$noscript->appendChild( $old_node );
+					$new_node->appendChild( $noscript );
+				}
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -68,6 +68,11 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			/**
+			 * Node.
+			 *
+			 * @var DOMElement $node
+			 */
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback.

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -29,6 +29,17 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 			'simple_audio' => array(
 				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio></noscript></amp-audio>',
+				array(
+					'add_noscript_fallback' => true,
+				),
+			),
+
+			'simple_audio_without_noscript' => array(
+				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a></amp-audio>',
+				array(
+					'add_noscript_fallback' => false,
+				),
 			),
 
 			'autoplay_attribute' => array(
@@ -200,13 +211,14 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Args for sanitizer.
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Audio_Sanitizer( $dom );
+		$sanitizer = new AMP_Audio_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$sanitizer = new AMP_Script_Sanitizer( $dom );

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -30,11 +30,25 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
 						<noscript>
 							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe>
 						</noscript>
 					</amp-iframe>
 				',
+				array(
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
+				),
+			),
+
+			'simple_iframe_without_noscript_or_placeholder' => array(
+				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
+				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"></amp-iframe>',
+				array(
+					'add_noscript_fallback' => false,
+					'add_placeholder'       => false,
+				),
 			),
 
 			'force_https'                               => array(
@@ -269,13 +283,14 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Sanitizer args.
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
+		$sanitizer = new AMP_Iframe_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -45,6 +45,22 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 			),
 
+			'simple_image'                             => array(
+				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" width="300" height="300"></noscript></amp-img></p>',
+				array(
+					'add_noscript_fallback' => true,
+				),
+			),
+
+			'simple_image_without_noscript'            => array(
+				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
 			'image_without_src'                        => array(
 				'<p><img width="300" height="300" /></p>',
 				'<p></p>',
@@ -232,15 +248,16 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Args.
 	 * @dataProvider get_data
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$img_count = $dom->getElementsByTagName( 'img' )->length;
-		$sanitizer = new AMP_Img_Sanitizer( $dom );
+		$sanitizer = new AMP_Img_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -29,6 +29,17 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 			'simple_video' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				array(
+					'add_noscript_fallback' => true,
+				),
+			),
+
+			'simple_video_without_noscript' => array(
+				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
+				array(
+					'add_noscript_fallback' => false,
+				),
 			),
 
 			'video_without_dimensions' => array(
@@ -181,15 +192,16 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Sanitizer args.
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 
-		$sanitizer = new AMP_Video_Sanitizer( $dom );
+		$sanitizer = new AMP_Video_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$sanitizer = new AMP_Script_Sanitizer( $dom );


### PR DESCRIPTION
This PR adds a `add_noscript_fallback` argument to the sanitizers for `img`, `video`, `audio`, and `iframe`. By default this `add_noscript_fallback` is `true`, but for AMP Stories it gets set to `false`.

Builds on #1861 and #1913.

----
It turns out that the `amp-img > noscript > img` and `amp-video > noscript > video` (and others perhaps) are not allowed in AMP Stories. T

- [x] Prevent adding `noscript > img` fallback for `amp-img`.
- [x] Prevent adding `noscript > video` fallback for `amp-video`
- [x] Check if `noscript` fallbacks are needed for other elements (e.g. `amp-audio`)
- [x] Determine why adding a Video block still fails (see below).

# [RESOLVED] Outstanding Issue: Adding a video block

Adding a video block is causing a validation error:

![image](https://user-images.githubusercontent.com/134745/55926976-3d354980-5bc8-11e9-90b1-7b55503c4ba3.png)

![image](https://user-images.githubusercontent.com/134745/55927034-72da3280-5bc8-11e9-81d9-7f14316f5cef.png)

![image](https://user-images.githubusercontent.com/134745/55927068-8c7b7a00-5bc8-11e9-9ca9-29e4ee431934.png)
