### PR TITLE
Hide block alignment buttons from images in AMP Stories

### DIFF
--- a/assets/src/blocks/amp-story-page/edit.css
+++ b/assets/src/blocks/amp-story-page/edit.css
@@ -134,7 +134,10 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
  * Hackily hide the alignment options from the image block since they are irrelevant for an image block in a story.
  * In the future the underlying alignment buttons should be removed entirely. See <https://github.com/ampproject/amp-wp/issues/2115>.
  */
-.editor-block-list__block[data-type="core/image"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2) {
+.editor-block-list__block[data-type="core/image"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2),
+.editor-block-list__block[data-type="core/pullquote"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2),
+.editor-block-list__block[data-type="core/embed"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2),
+.editor-block-list__block[data-type="core/video"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2) {
 	display: none;
 }
 

--- a/assets/src/blocks/amp-story-page/edit.css
+++ b/assets/src/blocks/amp-story-page/edit.css
@@ -130,6 +130,14 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
 	margin-top: 0;
 }
 
+/*
+ * Hackily hide the alignment options from the image block since they are irrelevant for an image block in a story.
+ * In the future the underlying alignment buttons should be removed entirely. See <https://github.com/ampproject/amp-wp/issues/2115>.
+ */
+.editor-block-list__block[data-type="core/image"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2) {
+	display: none;
+}
+
 #amp-story-editor .components-draggable__clone {
 	position: absolute;
 }


### PR DESCRIPTION
Use CSS to hide the alignment buttons in the toolbar for the blocks that have them: image, pullquote, embed, and video. Note that this does not apply when “Top Toolbar” is enabled.

Before:

![image](https://user-images.githubusercontent.com/134745/56062229-96b08c00-5d20-11e9-92f6-75f1d258eadb.png)

After:

![image](https://user-images.githubusercontent.com/134745/56062158-5f41df80-5d20-11e9-8650-2b3d102503c8.png)

Fixes #2115.