### PR TITLE
Prevent JS error when selecting an animation type for a block

### DIFF
--- a/assets/src/components/block-preview-label.js
+++ b/assets/src/components/block-preview-label.js
@@ -19,13 +19,20 @@ const BlockPreviewLabel = ( { content, icon, displayIcon = true, alignIcon = 'le
 	);
 };
 
-export default withSelect( ( select, { block } ) => {
+export default withSelect( ( select, { block, label } ) => {
+	if ( ! block ) {
+		return {
+			content: label,
+			icon: null,
+		};
+	}
+
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const { getAuthors, getMedia } = select( 'core' );
 
 	const blockType = getBlockType( block.name );
 
-	let label = blockType.title;
+	label = blockType.title;
 	let content;
 
 	switch ( block.name ) {


### PR DESCRIPTION
I noticed when attempting to select an animation type for a block, I'd immediately get a JS error upon selection:

<img width="1459" alt="Screen Shot 2019-04-13 at 19 47 15" src="https://user-images.githubusercontent.com/134745/56087719-52f37a80-5e25-11e9-9b65-001358c1d9bb.png">

It seems that in this case `BlockPreviewLabel` is being called with the `defaultOption` and no `block` is passed:

https://github.com/ampproject/amp-wp/blob/246a5e121da39f0ac69de65a8a3d10e45cbdafe7/assets/src/components/animation-order-picker.js#L21-L39

I'm not totally sure this is the best fix, but it at least prevents the JS error from being raised in my testing and I can successfully set the animation type.