### PR TITLE
Update amphtml to v1904021746450

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -4321,6 +4321,47 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-script' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'disallowed_ancestor' => array(
+						'amp-script',
+					),
+					'requires_extension' => array(
+						'amp-script',
+					),
+				),
+			),
+		),
 		'amp-selector' => array(
 			array(
 				'attr_spec_list' => array(
@@ -13140,6 +13181,31 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'name' => 'amp-riddle-quiz',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-script',
 						'version' => array(
 							'0.1',
 							'latest',

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 846;
+	private static $spec_file_revision = 855;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -9917,6 +9917,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'child_tags' => array(
 						'child_tag_name_oneof' => array(
+							'ol',
 							'ul',
 						),
 						'mandatory_num_child_tags' => 1,
@@ -13428,6 +13429,9 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'deprecated_version' => array(
+							'0.1',
+						),
 						'name' => 'amp-story',
 						'version' => array(
 							'0.1',
@@ -14815,6 +14819,7 @@ class AMP_Allowed_Tags_Generated {
 						'form div [submitting][template]',
 						'form div [verify-error][template]',
 					),
+					'mandatory_ancestor' => 'body',
 					'requires_extension' => array(
 						'amp-mustache',
 					),
@@ -15447,6 +15452,42 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > track[kind=subtitles]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'[label]' => array(),
+					'[src]' => array(),
+					'[srclang]' => array(),
+					'default' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'kind' => array(
+						'value' => array(
+							'captions',
+							'chapters',
+							'descriptions',
+							'metadata',
+						),
+					),
+					'label' => array(),
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory' => true,
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+					'srclang' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-ima-video',
+					'spec_name' => 'amp-ima-video > track',
 				),
 			),
 			array(

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1410,6 +1410,40 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				null,
 				array( 'amp-smartlinks' ),
 			),
+
+			'amp-script-1' => array(
+				'<amp-script layout="container" src="https://example.com/hello-world.js"><button id="hello">Insert Hello World!</button></amp-script>',
+				null,
+				array( 'amp-script' ),
+			),
+			'amp-script-2' => array(
+				'
+					<amp-script layout="container" src="https://example.com/examples/amp-script/hello-world.js">
+						<div class="root">
+							<button id="hello">Insert Hello World!</button>
+							<button id="long">Long task</button>
+							<button id="amp-img">Insert amp-img</button>
+							<button id="script">Insert &lt;script&gt;</button>
+							<button id="img">Insert &lt;img&gt;</button>
+						</div>
+					</amp-script>
+					
+					<amp-script layout="container" src="https://example.com/examples/amp-script/empty.js">
+						<div class="root">should be empty</div>
+					</amp-script>
+				',
+				null,
+				array( 'amp-script' ),
+			),
+			'amp-script-3' => array(
+				'
+					<amp-script src="https://example.com/examples/amp-script/todomvc.ssr.js" layout="container">
+						<div><header class="header"><h1>todos</h1><input class="new-todo" placeholder="What needs to be done?" autofocus="true"></header></div>
+					</amp-script>
+				',
+				null,
+				array( 'amp-script' ),
+			),
 		);
 	}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -150,7 +150,14 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp-ima-video' => array(
-				'<amp-ima-video width="640" height="360" data-tag="https://example.com/foo" layout="responsive" data-src="https://example.com/bar"></amp-ima-video>',
+				'
+					<amp-ima-video width="640" height="360" data-tag="https://example.com/foo" layout="responsive" data-src="https://example.com/bar">
+						<source src="https://example.com/foo.mp4" type="video/mp4">
+						<source src="https://example.com/foo.webm" type="video/webm">
+						<track label="English subtitles" kind="subtitles" srclang="en" src="https://example.com/subtitles.vtt">
+						<script type="application/json">{"locale": "en","numRedirects": 4}</script>
+					</amp-ima-video>
+				',
 				null, // No change.
 				array( 'amp-ima-video' ),
 			),
@@ -712,8 +719,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'remove_node_with_disallowed_ancestor_and_disallowed_child_nodes' => array(
-				'<amp-sidebar><amp-app-banner>This node is not allowed here.</amp-app-banner><nav><i>bad</i><ul><li>Hello</li></ul><i>bad</i></nav><amp-app-banner>This node is not allowed here.</amp-app-banner></amp-sidebar>',
-				'<amp-sidebar><nav><ul><li>Hello</li></ul></nav></amp-sidebar>',
+				'<amp-sidebar><amp-app-banner>This node is not allowed here.</amp-app-banner><nav><i>bad</i><ul><li>Hello</li></ul><ol><li>Hello</li></ol><i>bad</i></nav><amp-app-banner>This node is not allowed here.</amp-app-banner></amp-sidebar>',
+				'<amp-sidebar><nav><ul><li>Hello</li></ul><ol><li>Hello</li></ol></nav></amp-sidebar>',
 				array( 'amp-sidebar' ),
 			),
 


### PR DESCRIPTION
Previously #2041.

* Add `amp-script`. Note that it is not yet uncommented in [`validator-amp-script.protoascii`](https://github.com/ampproject/amphtml/blob/bddc60cefc9c653693a13abf48ca4c25a9523cbe/extensions/amp-script/validator-amp-script.protoascii) so the AMP validator will mark pages with `amp-script` as invalid, but it is being uncommented to facilitate experimentation (as otherwise the sanitizer would strip it out).
* Allow `ol` inside `nav` like `ul` is allowed.
* Allow `track` under `amp-ima-video`.
* Require that `template` be inside the `body`.
* Deprecate `amp-story` version `0.1`.

See https://github.com/ampproject/amphtml/releases/tag/1904021746450

The `amp-script` extension is forcibly included here by patching `amphtml` as follows before running `amphtml-update.sh`:

```diff
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index 19e132e7b..19063d51c 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -15,39 +15,38 @@
 #
 
 # Invalid until launch ready.
-# tags: {
-#   tag_name: "SCRIPT"
-#   extension_spec: {
-#     name: "amp-script"
-#     version: "0.1"
-#     version: "latest"
-#   }
-#   attr_lists: "common-extension-attrs"
-# }
+tags: {
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-script"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
 
-# tags: {  # <amp-script>
-#   html_format: AMP
-#   tag_name: "AMP-SCRIPT"
-#   disallowed_ancestor: "AMP-SCRIPT"
-#   requires_extension: "amp-script"
-#   unique: true # TODO(choumx): Remove when global size limit is implemented.
-#   attrs: {
-#     name: "src"
-#     mandatory: true
-#     value_url: {
-#       protocol: "https"
-#       allow_relative: false
-#     }
-#     blacklisted_value_regex: "__amp_source_origin"
-#   }
-#   attr_lists: "extended-amp-global"
-#   amp_layout {
-#     supported_layouts: CONTAINER
-#     supported_layouts: FILL
-#     supported_layouts: FIXED
-#     supported_layouts: FIXED_HEIGHT
-#     supported_layouts: FLEX_ITEM
-#     supported_layouts: NODISPLAY
-#     supported_layouts: RESPONSIVE
-#   }
-# }
+tags: {  # <amp-script>
+  html_format: AMP
+  tag_name: "AMP-SCRIPT"
+  disallowed_ancestor: "AMP-SCRIPT"
+  requires_extension: "amp-script"
+  attrs: {
+    name: "src"
+    mandatory: true
+    value_url: {
+      protocol: "https"
+      allow_relative: false
+    }
+    blacklisted_value_regex: "__amp_source_origin"
+  }
+  attr_lists: "extended-amp-global"
+  amp_layout {
+    supported_layouts: CONTAINER
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
```