### PR TITLE
Prevent erroneously converting form selector to amp-form

### DIFF
--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -25,17 +25,6 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'form';
 
 	/**
-	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
-	 *
-	 * @return array Mapping.
-	 */
-	public function get_selector_conversion_mapping() {
-		return array(
-			'form' => array( 'amp-form' ),
-		);
-	}
-
-	/**
 	 * Sanitize the <form> elements from the HTML contained in this instance's DOMDocument.
 	 *
 	 * @link https://www.ampproject.org/docs/reference/components/amp-form

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1157,7 +1157,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_stylesheet( $stylesheet, $options = array() ) {
 		$parsed      = null;
 		$cache_key   = null;
-		$cache_group = 'amp-parsed-stylesheet-v16'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group = 'amp-parsed-stylesheet-v17'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -607,6 +607,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'article>video{border:solid 1px green}',
 				'article>amp-video{border:solid 1px green}',
 			),
+			'form' => array(
+				sprintf( '<div id="search"><form method="get" action="https://example.com"><label id="s">Search</label><input type="search" name="s" id="s"></form></div>' ),
+				'#search form label{display:block}',
+				'#search form label{display:block}',
+			),
 			'video_with_amp_video' => array(
 				'<amp-video class="video"></amp-video>',
 				'amp-video.video video{border:solid 1px green}',
@@ -630,7 +635,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'type_class_names' => array(
 				'<audio src="https://example.org/foo.mp3" width="100" height="100" class="audio iframe video img form">',
 				'.video{color:blue;} audio.audio{color:purple;} .iframe{color:black;} .img{color:purple;} .form:not(form){color:green;}',
-				'.video{color:blue}amp-audio.audio{color:purple}.iframe{color:black}.img{color:purple}.form:not(amp-form){color:green}',
+				'.video{color:blue}amp-audio.audio{color:purple}.iframe{color:black}.img{color:purple}.form:not(form){color:green}',
 			),
 		);
 	}


### PR DESCRIPTION
When testing the 1.1-beta2 with the Twenty Twelve theme I saw the comments form looking unusual:

> <img width="600" alt="Comments form in Twenty Twelve on an AMP page" src="https://user-images.githubusercontent.com/134745/56097676-84635900-5eac-11e9-90dc-1366f3151972.png">

It should look like this:

> <img width="532" alt="Comments form in Twenty Twelve on a non-AMP page" src="https://user-images.githubusercontent.com/134745/56097678-8af1d080-5eac-11e9-8e7b-236e3aaf0033.png">

At issue are CSS selectors in Twenty Twelve that [include `#respond form`](https://github.com/WordPress/wordpress-develop/blob/master/src/wp-content/themes/twentytwelve/style.css#L1329-L1362), for example:

```css
#respond form label {
	display: block;
	line-height: 1.714285714;
}
```

The problem is that the form sanitizer was erroneously converting `form` to `amp-form`, which of course does not exist (unlike other such components, like `amp-video` for `video`). So the fix is to just eliminate the `get_selector_conversion_mapping` entirely for this sanitizer.