### PR TITLE
Add sanitizer arg to prevent noscript fallbacks; preemptively remove disallowed attributes from fallback

### DIFF
--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -84,6 +84,7 @@ class AMP_Autoloader {
 		'AMP_Tag_And_Attribute_Sanitizer'    => 'includes/sanitizers/class-amp-tag-and-attribute-sanitizer',
 		'AMP_Video_Sanitizer'                => 'includes/sanitizers/class-amp-video-sanitizer',
 		'AMP_Core_Theme_Sanitizer'           => 'includes/sanitizers/class-amp-core-theme-sanitizer',
+		'AMP_Noscript_Fallback'              => 'includes/sanitizers/trait-amp-noscript-fallback',
 		'AMP_Customizer_Design_Settings'     => 'includes/settings/class-amp-customizer-design-settings',
 		'AMP_Customizer_Settings'            => 'includes/settings/class-amp-customizer-settings',
 		'AMP_Content'                        => 'includes/templates/class-amp-content',

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -21,6 +21,17 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'audio';
 
 	/**
+	 * Placeholder for default args.
+	 *
+	 * @since 1.2
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -134,7 +145,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} else {
+			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
 				$node->parentNode->replaceChild( $new_node, $node );
 
 				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -32,6 +32,15 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	);
 
 	/**
+	 * Attributes allowed on noscript fallback elements.
+	 *
+	 * This is used to prevent duplicated validation errors.
+	 *
+	 * @var array
+	 */
+	private $noscript_fallback_allowed_attributes = array();
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -53,6 +62,14 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 		if ( 0 === $num_nodes ) {
 			return;
 		}
+
+		$this->noscript_fallback_allowed_attributes = array_fill_keys(
+			array_merge(
+				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( self::$tag ) )['attr_spec_list'] ),
+				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
+			),
+			true
+		);
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
@@ -152,6 +169,17 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 					$noscript = $this->dom->createElement( 'noscript' );
 					$noscript->appendChild( $old_node );
 					$new_node->appendChild( $noscript );
+
+					// Remove all non-allowed attributes preemptively to prevent doubled validation errors.
+					$disallowed_attributes = array();
+					foreach ( $old_node->attributes as $attribute ) {
+						if ( ! isset( $this->noscript_fallback_allowed_attributes[ $attribute->nodeName ] ) ) {
+							$disallowed_attributes[] = $attribute->nodeName;
+						}
+					}
+					foreach ( $disallowed_attributes as $disallowed_attribute ) {
+						$old_node->removeAttribute( $disallowed_attribute );
+					}
 				}
 			}
 

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -53,7 +53,9 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_noscript_allowed_attributes( self::$tag );
+		if ( $this->args['add_noscript_fallback'] ) {
+			$this->initialize_noscript_allowed_attributes( self::$tag );
+		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -135,10 +135,13 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
 			} else {
-				$noscript = $this->dom->createElement( 'noscript' );
-				$new_node->appendChild( $noscript );
 				$node->parentNode->replaceChild( $new_node, $node );
-				$noscript->appendChild( $old_node );
+
+				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+					$noscript = $this->dom->createElement( 'noscript' );
+					$new_node->appendChild( $noscript );
+					$noscript->appendChild( $old_node );
+				}
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -23,7 +23,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Placeholder for default args.
 	 *
-	 * @since 1.2
+	 * @since 1.1
 	 *
 	 * @var array
 	 */

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -28,7 +28,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
 	 */
 	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_args( $this->DEFAULT_ARGS );
+		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
 
 		parent::__construct( $dom, $args );
 	}
@@ -56,7 +56,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_allowed_attributes( self::$tag );
+		$this->initialize_noscript_allowed_attributes( self::$tag );
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -145,13 +145,13 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 
 				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
 					$noscript = $this->dom->createElement( 'noscript' );
-					$new_node->appendChild( $noscript );
 					$noscript->appendChild( $old_node );
+					$new_node->appendChild( $noscript );
 				}
 			}
 

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -22,16 +22,13 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'audio';
 
 	/**
-	 * Constructor.
+	 * Default args.
 	 *
-	 * @param DOMDocument $dom  DOMDocument $dom Represents the HTML document to sanitize.
-	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
+	 * @var array
 	 */
-	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
-
-		parent::__construct( $dom, $args );
-	}
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -152,8 +149,10 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 
-				// Preserve original node in noscript for no-JS environments.
-				$this->append_old_node_noscript( $new_node, $old_node, $this->dom, $this->args );
+				if ( $this->args['add_noscript_fallback'] ) {
+					// Preserve original node in noscript for no-JS environments.
+					$this->append_old_node_noscript( $new_node, $old_node, $this->dom );
+				}
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -75,7 +75,9 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_noscript_allowed_attributes( self::$tag );
+		if ( $this->args['add_noscript_fallback'] ) {
+			$this->initialize_noscript_allowed_attributes( self::$tag );
+		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -56,7 +56,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
 	 */
 	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_args( $this->DEFAULT_ARGS );
+		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
 
 		parent::__construct( $dom, $args );
 	}
@@ -86,7 +86,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_allowed_attributes( self::$tag );
+		$this->initialize_noscript_allowed_attributes( self::$tag );
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -46,20 +46,9 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = array(
-		'add_placeholder' => false,
+		'add_placeholder'       => false,
+		'add_noscript_fallback' => true,
 	);
-
-	/**
-	 * Constructor.
-	 *
-	 * @param DOMDocument $dom  DOMDocument $dom Represents the HTML document to sanitize.
-	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
-	 */
-	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
-
-		parent::__construct( $dom, $args );
-	}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -124,11 +113,14 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$new_node->appendChild( $placeholder_node );
 			}
 
-			$node->setAttribute( 'src', $normalized_attributes['src'] );
 			$node->parentNode->replaceChild( $new_node, $node );
 
-			// Preserve original node in noscript for no-JS environments.
-			$this->append_old_node_noscript( $new_node, $node, $this->dom, $this->args );
+			if ( $this->args['add_noscript_fallback'] ) {
+				$node->setAttribute( 'src', $normalized_attributes['src'] );
+
+				// Preserve original node in noscript for no-JS environments.
+				$this->append_old_node_noscript( $new_node, $node, $this->dom );
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -45,7 +45,8 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = array(
-		'add_placeholder' => false,
+		'add_placeholder'       => false,
+		'add_noscript_fallback' => true,
 	);
 
 	/**

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -109,12 +109,15 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				$new_node->appendChild( $placeholder_node );
 			}
 
-			// Preserve original node in noscript for no-JS environments.
-			$node->setAttribute( 'src', $normalized_attributes['src'] );
 			$node->parentNode->replaceChild( $new_node, $node );
-			$noscript = $this->dom->createElement( 'noscript' );
-			$noscript->appendChild( $node );
-			$new_node->appendChild( $noscript );
+
+			// Preserve original node in noscript for no-JS environments.
+			if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+				$node->setAttribute( 'src', $normalized_attributes['src'] );
+				$noscript = $this->dom->createElement( 'noscript' );
+				$noscript->appendChild( $node );
+				$new_node->appendChild( $noscript );
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -54,7 +54,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
 	 */
 	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_args( $this->DEFAULT_ARGS );
+		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
 
 		parent::__construct( $dom, $args );
 	}
@@ -94,7 +94,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_allowed_attributes( self::$tag );
+		$this->initialize_noscript_allowed_attributes( self::$tag );
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -49,7 +49,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Placeholder for default args.
 	 *
-	 * @since 1.2
+	 * @since 1.1
 	 *
 	 * @var array
 	 */

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -41,23 +41,20 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'img';
 
 	/**
+	 * Default args.
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Animation extension.
 	 *
 	 * @var string
 	 */
 	private static $anim_extension = '.gif';
-
-	/**
-	 * Constructor.
-	 *
-	 * @param DOMDocument $dom  DOMDocument $dom Represents the HTML document to sanitize.
-	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
-	 */
-	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
-
-		parent::__construct( $dom, $args );
-	}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -302,13 +299,15 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$node->parentNode->replaceChild( $img_node, $node );
 
 		$can_include_noscript = (
+			$this->args['add_noscript_fallback']
+			&&
 			( $node->hasAttribute( 'src' ) && ! preg_match( '/^http:/', $node->getAttribute( 'src' ) ) )
 			&&
 			( ! $node->hasAttribute( 'srcset' ) || ! preg_match( '/http:/', $node->getAttribute( 'srcset' ) ) )
 		);
 		if ( $can_include_noscript ) {
 			// Preserve original node in noscript for no-JS environments.
-			$this->append_old_node_noscript( $img_node, $node, $this->dom, $this->args );
+			$this->append_old_node_noscript( $img_node, $node, $this->dom );
 		}
 	}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -47,6 +47,17 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	private static $anim_extension = '.gif';
 
 	/**
+	 * Placeholder for default args.
+	 *
+	 * @since 1.2
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -287,9 +298,11 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$node->parentNode->replaceChild( $img_node, $node );
 
 		// Preserve original node in noscript for no-JS environments.
-		$noscript = $this->dom->createElement( 'noscript' );
-		$noscript->appendChild( $node );
-		$img_node->appendChild( $noscript );
+		if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+			$noscript = $this->dom->createElement( 'noscript' );
+			$noscript->appendChild( $node );
+			$img_node->appendChild( $noscript );
+		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -86,15 +86,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.2
 	 */
 	public function sanitize() {
-		$spec = current( AMP_Allowed_Tags_Generated::get_allowed_tag( 'img' ) );
-
-		$this->noscript_fallback_allowed_attributes = array_fill_keys(
-			array_merge(
-				array_keys( $spec['attr_spec_list'] ),
-				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
-			),
-			true
-		);
 
 		/**
 		 * Node list.
@@ -109,6 +100,14 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		if ( 0 === $num_nodes ) {
 			return;
 		}
+
+		$this->noscript_fallback_allowed_attributes = array_fill_keys(
+			array_merge(
+				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( self::$tag ) )['attr_spec_list'] ),
+				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
+			),
+			true
+		);
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
@@ -325,6 +324,8 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		);
 		if ( $can_include_noscript ) {
 			$noscript = $this->dom->createElement( 'noscript' );
+			$noscript->appendChild( $node );
+			$img_node->appendChild( $noscript );
 
 			// Remove all non-allowed attributes preemptively to prevent doubled validation errors.
 			$disallowed_attributes = array();
@@ -336,9 +337,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $disallowed_attributes as $disallowed_attribute ) {
 				$node->removeAttribute( $disallowed_attribute );
 			}
-
-			$noscript->appendChild( $node );
-			$img_node->appendChild( $noscript );
 		}
 	}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -315,7 +315,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		$img_node = AMP_DOM_Utils::create_node( $this->dom, $new_tag, $new_attributes );
 		$node->parentNode->replaceChild( $img_node, $node );
 
-
 		// Preserve original node in noscript for no-JS environments.
 		$can_include_noscript = (
 			! empty( $this->args['add_noscript_fallback'] )

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -91,7 +91,9 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_noscript_allowed_attributes( self::$tag );
+		if ( $this->args['add_noscript_fallback'] ) {
+			$this->initialize_noscript_allowed_attributes( self::$tag );
+		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -34,16 +34,13 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'video';
 
 	/**
-	 * Constructor.
+	 * Default args.
 	 *
-	 * @param DOMDocument $dom  DOMDocument $dom Represents the HTML document to sanitize.
-	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
+	 * @var array
 	 */
-	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
-
-		parent::__construct( $dom, $args );
-	}
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -175,8 +172,10 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 
-				// Preserve original node in noscript for no-JS environments.
-				$this->append_old_node_noscript( $new_node, $old_node, $this->dom, $this->args );
+				if ( $this->args['add_noscript_fallback'] ) {
+					// Preserve original node in noscript for no-JS environments.
+					$this->append_old_node_noscript( $new_node, $old_node, $this->dom );
+				}
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -13,6 +13,7 @@
  * Converts <video> tags to <amp-video>
  */
 class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
+	use AMP_Noscript_Fallback;
 
 	/**
 	 * Value used for height attribute when $attributes['height'] is empty.
@@ -33,24 +34,16 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'video';
 
 	/**
-	 * Placeholder for default args.
+	 * Constructor.
 	 *
-	 * @since 1.1
-	 *
-	 * @var array
+	 * @param DOMDocument $dom  DOMDocument $dom Represents the HTML document to sanitize.
+	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
 	 */
-	protected $DEFAULT_ARGS = array(
-		'add_noscript_fallback' => true,
-	);
+	public function __construct( $dom, $args = array() ) {
+		$this->DEFAULT_ARGS = $this->merge_default_args( $this->DEFAULT_ARGS );
 
-	/**
-	 * Attributes allowed on noscript fallback elements.
-	 *
-	 * This is used to prevent duplicated validation errors.
-	 *
-	 * @var array
-	 */
-	private $noscript_fallback_allowed_attributes = array();
+		parent::__construct( $dom, $args );
+	}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -76,13 +69,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->noscript_fallback_allowed_attributes = array_fill_keys(
-			array_merge(
-				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( self::$tag ) )['attr_spec_list'] ),
-				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
-			),
-			true
-		);
+		$this->initialize_allowed_attributes( self::$tag );
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			/**
@@ -93,7 +80,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback.
-			if ( 'noscript' === $node->parentNode->nodeName && $node->parentNode->parentNode && 'amp-' === substr( $node->parentNode->parentNode->nodeName, 0, 4 ) ) {
+			if ( $this->is_inside_amp_noscript( $node ) ) {
 				continue;
 			}
 
@@ -188,22 +175,8 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 
-				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
-					$noscript = $this->dom->createElement( 'noscript' );
-					$noscript->appendChild( $old_node );
-					$new_node->appendChild( $noscript );
-
-					// Remove all non-allowed attributes preemptively to prevent doubled validation errors.
-					$disallowed_attributes = array();
-					foreach ( $old_node->attributes as $attribute ) {
-						if ( ! isset( $this->noscript_fallback_allowed_attributes[ $attribute->nodeName ] ) ) {
-							$disallowed_attributes[] = $attribute->nodeName;
-						}
-					}
-					foreach ( $disallowed_attributes as $disallowed_attribute ) {
-						$old_node->removeAttribute( $disallowed_attribute );
-					}
-				}
+				// Preserve original node in noscript for no-JS environments.
+				$this->append_old_node_noscript( $new_node, $old_node, $this->dom, $this->args );
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -153,10 +153,13 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
 			} else {
-				$noscript = $this->dom->createElement( 'noscript' );
-				$new_node->appendChild( $noscript );
 				$node->parentNode->replaceChild( $new_node, $node );
-				$noscript->appendChild( $old_node );
+
+				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+					$noscript = $this->dom->createElement( 'noscript' );
+					$noscript->appendChild( $old_node );
+					$new_node->appendChild( $noscript );
+				}
 			}
 
 			$this->did_convert_elements = true;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -33,6 +33,17 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'video';
 
 	/**
+	 * Placeholder for default args.
+	 *
+	 * @since 1.2
+	 *
+	 * @var array
+	 */
+	protected $DEFAULT_ARGS = array(
+		'add_noscript_fallback' => true,
+	);
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -157,7 +168,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} else {
+			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
 				$node->parentNode->replaceChild( $new_node, $node );
 
 				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -40,7 +40,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array       $args Optional. Sanitizer arguments. See {@see AMP_Base_Sanitizer::__construct()}.
 	 */
 	public function __construct( $dom, $args = array() ) {
-		$this->DEFAULT_ARGS = $this->merge_default_args( $this->DEFAULT_ARGS );
+		$this->DEFAULT_ARGS = $this->merge_default_noscript_args( $this->DEFAULT_ARGS );
 
 		parent::__construct( $dom, $args );
 	}
@@ -69,7 +69,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_allowed_attributes( self::$tag );
+		$this->initialize_noscript_allowed_attributes( self::$tag );
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			/**

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -44,6 +44,15 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	);
 
 	/**
+	 * Attributes allowed on noscript fallback elements.
+	 *
+	 * This is used to prevent duplicated validation errors.
+	 *
+	 * @var array
+	 */
+	private $noscript_fallback_allowed_attributes = array();
+
+	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
 	 *
 	 * @return array Mapping.
@@ -66,6 +75,14 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		if ( 0 === $num_nodes ) {
 			return;
 		}
+
+		$this->noscript_fallback_allowed_attributes = array_fill_keys(
+			array_merge(
+				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( self::$tag ) )['attr_spec_list'] ),
+				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
+			),
+			true
+		);
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			/**
@@ -175,6 +192,17 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 					$noscript = $this->dom->createElement( 'noscript' );
 					$noscript->appendChild( $old_node );
 					$new_node->appendChild( $noscript );
+
+					// Remove all non-allowed attributes preemptively to prevent doubled validation errors.
+					$disallowed_attributes = array();
+					foreach ( $old_node->attributes as $attribute ) {
+						if ( ! isset( $this->noscript_fallback_allowed_attributes[ $attribute->nodeName ] ) ) {
+							$disallowed_attributes[] = $attribute->nodeName;
+						}
+					}
+					foreach ( $disallowed_attributes as $disallowed_attribute ) {
+						$old_node->removeAttribute( $disallowed_attribute );
+					}
 				}
 			}
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -35,7 +35,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Placeholder for default args.
 	 *
-	 * @since 1.2
+	 * @since 1.1
 	 *
 	 * @var array
 	 */

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -57,6 +57,11 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			/**
+			 * Node.
+			 *
+			 * @var DOMElement $node
+			 */
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback.

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -168,7 +168,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( empty( $sources ) ) {
 				$this->remove_invalid_child( $node );
-			} elseif ( ! empty( $this->args['add_noscript_fallback'] ) ) {
+			} else {
 				$node->parentNode->replaceChild( $new_node, $node );
 
 				if ( ! empty( $this->args['add_noscript_fallback'] ) ) {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -66,7 +66,9 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$this->initialize_noscript_allowed_attributes( self::$tag );
+		if ( $this->args['add_noscript_fallback'] ) {
+			$this->initialize_noscript_allowed_attributes( self::$tag );
+		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			/**

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Trait AMP_Noscript_Fallback.
+ *
+ * @package AMP
+ */
+
+/**
+ * Trait AMP_Noscript_Fallback
+ *
+ * @since 1.1
+ *
+ * Used for sanitizers that place <noscript> tags with the original nodes on error.
+ */
+trait AMP_Noscript_Fallback {
+
+	/**
+	 * Attributes allowed on noscript fallback elements.
+	 *
+	 * This is used to prevent duplicated validation errors.
+	 *
+	 * @since 1.1
+	 * @var array
+	 */
+	private $noscript_fallback_allowed_attributes = array();
+
+	/**
+	 * Extends the default arguments array with additional defaults.
+	 *
+	 * @since 1.1
+	 *
+	 * @param array $default_args Original defaults.
+	 * @return array Extended defaults.
+	 */
+	protected function merge_default_args( array $default_args ) {
+		$default_args['add_noscript_fallback'] = true;
+		return $default_args;
+	}
+
+	/**
+	 * Initializes the internal allowed attributes array.
+	 *
+	 * @since 1.1
+	 *
+	 * @param string $tag Tag name to get allowed attributes for.
+	 */
+	protected function initialize_allowed_attributes( $tag ) {
+		$this->noscript_fallback_allowed_attributes = array_fill_keys(
+			array_merge(
+				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( $tag ) )['attr_spec_list'] ),
+				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
+			),
+			true
+		);
+	}
+
+	/**
+	 * Checks whether the given node is within an AMP-specific <noscript> element.
+	 *
+	 * @since 1.1
+	 *
+	 * @param \DOMNode $node DOM node to check.
+	 * @return bool True if in an AMP noscript element, false otherwise.
+	 */
+	protected function is_inside_amp_noscript( \DOMNode $node ) {
+		return 'noscript' === $node->parentNode->nodeName && $node->parentNode->parentNode && 'amp-' === substr( $node->parentNode->parentNode->nodeName, 0, 4 );
+	}
+
+	/**
+	 * Appends the given old node in a <noscript> element to the new node.
+	 *
+	 * If the 'add_noscript_fallback' argument is set to false, this process is skipped.
+	 *
+	 * @since 1.1
+	 *
+	 * @param \DOMNode     $new_node New node to append a noscript with the old node to.
+	 * @param \DOMNode     $old_node Old node to append in a noscript.
+	 * @param \DOMDocument $dom      DOM document instance.
+	 * @param array        $args     Arguments.
+	 */
+	protected function append_old_node_noscript( \DOMNode $new_node, \DOMNode $old_node, \DOMDocument $dom, array $args ) {
+		if ( empty( $args['add_noscript_fallback'] ) ) {
+			return;
+		}
+
+		$noscript = $dom->createElement( 'noscript' );
+		$noscript->appendChild( $old_node );
+		$new_node->appendChild( $noscript );
+
+		// Remove all non-allowed attributes preemptively to prevent doubled validation errors.
+		$disallowed_attributes = array();
+		foreach ( $old_node->attributes as $attribute ) {
+			if ( ! isset( $this->noscript_fallback_allowed_attributes[ $attribute->nodeName ] ) ) {
+				$disallowed_attributes[] = $attribute->nodeName;
+			}
+		}
+		foreach ( $disallowed_attributes as $disallowed_attribute ) {
+			$old_node->removeAttribute( $disallowed_attribute );
+		}
+	}
+}

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -25,19 +25,6 @@ trait AMP_Noscript_Fallback {
 	private $noscript_fallback_allowed_attributes = array();
 
 	/**
-	 * Extends the default arguments array with additional defaults.
-	 *
-	 * @since 1.1
-	 *
-	 * @param array $default_args Original defaults.
-	 * @return array Extended defaults.
-	 */
-	protected function merge_default_noscript_args( array $default_args ) {
-		$default_args['add_noscript_fallback'] = true;
-		return $default_args;
-	}
-
-	/**
 	 * Initializes the internal allowed attributes array.
 	 *
 	 * @since 1.1
@@ -69,20 +56,13 @@ trait AMP_Noscript_Fallback {
 	/**
 	 * Appends the given old node in a <noscript> element to the new node.
 	 *
-	 * If the 'add_noscript_fallback' argument is set to false, this process is skipped.
-	 *
 	 * @since 1.1
 	 *
 	 * @param \DOMNode     $new_node New node to append a noscript with the old node to.
 	 * @param \DOMNode     $old_node Old node to append in a noscript.
 	 * @param \DOMDocument $dom      DOM document instance.
-	 * @param array        $args     Arguments.
 	 */
-	protected function append_old_node_noscript( \DOMNode $new_node, \DOMNode $old_node, \DOMDocument $dom, array $args ) {
-		if ( empty( $args['add_noscript_fallback'] ) ) {
-			return;
-		}
-
+	protected function append_old_node_noscript( \DOMNode $new_node, \DOMNode $old_node, \DOMDocument $dom ) {
 		$noscript = $dom->createElement( 'noscript' );
 		$noscript->appendChild( $old_node );
 		$new_node->appendChild( $noscript );

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -32,7 +32,7 @@ trait AMP_Noscript_Fallback {
 	 * @param array $default_args Original defaults.
 	 * @return array Extended defaults.
 	 */
-	protected function merge_default_args( array $default_args ) {
+	protected function merge_default_noscript_args( array $default_args ) {
 		$default_args['add_noscript_fallback'] = true;
 		return $default_args;
 	}
@@ -44,7 +44,7 @@ trait AMP_Noscript_Fallback {
 	 *
 	 * @param string $tag Tag name to get allowed attributes for.
 	 */
-	protected function initialize_allowed_attributes( $tag ) {
+	protected function initialize_noscript_allowed_attributes( $tag ) {
 		$this->noscript_fallback_allowed_attributes = array_fill_keys(
 			array_merge(
 				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( $tag ) )['attr_spec_list'] ),

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -88,14 +88,12 @@ trait AMP_Noscript_Fallback {
 		$new_node->appendChild( $noscript );
 
 		// Remove all non-allowed attributes preemptively to prevent doubled validation errors.
-		$disallowed_attributes = array();
-		foreach ( $old_node->attributes as $attribute ) {
-			if ( ! isset( $this->noscript_fallback_allowed_attributes[ $attribute->nodeName ] ) ) {
-				$disallowed_attributes[] = $attribute->nodeName;
+		for ( $i = $old_node->attributes->length - 1; $i >= 0; $i-- ) {
+			$attribute = $old_node->attributes->item( $i );
+			if ( isset( $this->noscript_fallback_allowed_attributes[ $attribute->nodeName ] ) ) {
+				continue;
 			}
-		}
-		foreach ( $disallowed_attributes as $disallowed_attribute ) {
-			$old_node->removeAttribute( $disallowed_attribute );
+			$old_node->removeAttribute( $attribute->nodeName );
 		}
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -83,5 +83,6 @@
 
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>build/*</exclude-pattern>
 	<exclude-pattern>includes/sanitizers/class-amp-allowed-tags-generated.php</exclude-pattern>
 </ruleset>

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -28,7 +28,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 
 			'simple_audio' => array(
 				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
-				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio></noscript></amp-audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
 				array(
 					'add_noscript_fallback' => true,
 				),
@@ -200,6 +200,14 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 						<!--/noscript-->
 					</div>
 				',
+			),
+
+			'audio_with_extra_attributes' => array(
+				'<audio src="https://example.com/audio/file.ogg" onclick="foo()" data-foo="bar"></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
+				array(
+					'add_noscript_fallback' => true,
+				),
 			),
 		);
 	}

--- a/tests/test-amp-audio-converter.php
+++ b/tests/test-amp-audio-converter.php
@@ -29,6 +29,17 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 			'simple_audio' => array(
 				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio></noscript></amp-audio>',
+				array(
+					'add_noscript_fallback' => true,
+				),
+			),
+
+			'simple_audio_without_noscript' => array(
+				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
+				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a></amp-audio>',
+				array(
+					'add_noscript_fallback' => false,
+				),
 			),
 
 			'autoplay_attribute' => array(
@@ -200,13 +211,14 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Args for sanitizer.
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Audio_Sanitizer( $dom );
+		$sanitizer = new AMP_Audio_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$sanitizer = new AMP_Script_Sanitizer( $dom );

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -30,11 +30,25 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
 						<noscript>
 							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe>
 						</noscript>
 					</amp-iframe>
 				',
+				array(
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
+				),
+			),
+
+			'simple_iframe_without_noscript_or_placeholder' => array(
+				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
+				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"></amp-iframe>',
+				array(
+					'add_noscript_fallback' => false,
+					'add_placeholder'       => false,
+				),
 			),
 
 			'force_https'                               => array(
@@ -269,13 +283,14 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Sanitizer args.
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
-		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
+		$sanitizer = new AMP_Iframe_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -274,7 +274,6 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				null,
 			),
 
-
 			'attributes_removed_from_noscript_iframe'   => array(
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" onclick="foo()" data-foo="bar"></iframe>',
 				'

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -273,6 +273,23 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"><noscript><iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe></noscript></amp-iframe>',
 				null,
 			),
+
+
+			'attributes_removed_from_noscript_iframe'   => array(
+				'<iframe src="https://example.com/embed/132886713" width="500" height="281" onclick="foo()" data-foo="bar"></iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" data-foo="bar" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				array(
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
+				),
+			),
 		);
 	}
 

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -45,6 +45,22 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 			),
 
+			'simple_image'                             => array(
+				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" width="300" height="300"></noscript></amp-img></p>',
+				array(
+					'add_noscript_fallback' => true,
+				),
+			),
+
+			'simple_image_without_noscript'            => array(
+				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
+				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
 			'image_without_src'                        => array(
 				'<p><img width="300" height="300" /></p>',
 				'<p></p>',
@@ -232,15 +248,16 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Args.
 	 * @dataProvider get_data
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$img_count = $dom->getElementsByTagName( 'img' )->length;
-		$sanitizer = new AMP_Img_Sanitizer( $dom );
+		$sanitizer = new AMP_Img_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -46,8 +46,8 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'simple_image'                             => array(
-				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" width="300" height="300"></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/300x300" width="300" height="300" /></p>',
+				'<p><amp-img src="https://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/300x300" width="300" height="300"></noscript></amp-img></p>',
 				array(
 					'add_noscript_fallback' => true,
 				),
@@ -64,181 +64,201 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 			'image_without_src'                        => array(
 				'<p><img width="300" height="300" /></p>',
 				'<p></p>',
+				array(),
+				array( 'invalid_element' ),
 			),
 
 			'image_with_empty_src'                     => array(
 				'<p><img src="" width="300" height="300" /></p>',
 				'<p></p>',
+				array(),
+				array( 'invalid_element' ),
 			),
 
 			'image_with_layout'                        => array(
-				'<img src="http://placehold.it/100x100" data-amp-layout="fill" width="100" height="100" />',
-				'<amp-img src="http://placehold.it/100x100" layout="fill" width="100" height="100" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/100x100" data-amp-layout="fill" width="100" height="100"></noscript></amp-img>',
+				'<img src="https://placehold.it/100x100" data-amp-layout="fill" width="100" height="100" />',
+				'<amp-img src="https://placehold.it/100x100" layout="fill" width="100" height="100" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
 			),
 
 			'image_with_noloading'                     => array(
-				'<img src="http://placehold.it/100x100" data-amp-noloading="" width="100" height="100">',
-				'<amp-img src="http://placehold.it/100x100" noloading="" width="100" height="100" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/100x100" data-amp-noloading="" width="100" height="100"></noscript></amp-img>',
+				'<img src="https://placehold.it/100x100" data-amp-noloading="" width="100" height="100">',
+				'<amp-img src="https://placehold.it/100x100" noloading="" width="100" height="100" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
 			),
 
 			'image_with_layout_from_editor'            => array(
-				'<figure data-amp-layout="fill"><img src="http://placehold.it/300x300" height="300" width="300" /></figure>',
-				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 300px;"><amp-img src="http://placehold.it/300x300" layout="fill" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
+				'<figure data-amp-layout="fill"><img src="https://placehold.it/300x300" height="300" width="300" /></figure>',
+				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 300px;"><amp-img src="https://placehold.it/300x300" layout="fill" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
 			),
 
 			'image_with_noloading_from_editor'         => array(
-				'<figure data-amp-noloading="true"><img src="http://placehold.it/300x300" height="300" width="300" /></figure>',
-				'<figure data-amp-noloading="true"><amp-img src="http://placehold.it/300x300" height="300" width="300" noloading="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
+				'<figure data-amp-noloading="true"><img src="https://placehold.it/300x300" height="300" width="300" /></figure>',
+				'<figure data-amp-noloading="true"><amp-img src="https://placehold.it/300x300" height="300" width="300" noloading="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
 			),
 
 			'image_with_spaces_only_src'               => array(
 				'<p><img src="    " width="300" height="300" /></p>',
 				'<p></p>',
+				array(),
+				array( 'invalid_element' ),
 			),
 
 			'image_with_empty_width_and_height'        => array(
-				'<p><img src="http://placehold.it/200x300" width="" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/200x300" width="" height="" /></p>',
+				'<p><amp-img src="https://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_undefined_width_and_height'    => array(
-				'<p><img src="http://placehold.it/200x300" /></p>',
-				'<p><amp-img src="http://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/200x300" /></p>',
+				'<p><amp-img src="https://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_empty_width'                   => array(
-				'<p><img src="http://placehold.it/500x1000" width="" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/500x1000" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/500x1000" width="150" height="300" class=""></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/500x1000" width="" height="300" /></p>',
+				'<p><amp-img src="https://placehold.it/500x1000" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/500x1000" width="150" height="300" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_empty_height'                  => array(
-				'<p><img src="http://placehold.it/500x1000" width="300" height="" /></p>',
-				'<p><amp-img src="http://placehold.it/500x1000" width="300" height="600" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/500x1000" width="300" height="600" class=""></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/500x1000" width="300" height="" /></p>',
+				'<p><amp-img src="https://placehold.it/500x1000" width="300" height="600" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/500x1000" width="300" height="600" class=""></noscript></amp-img></p>',
 			),
 
 			'image_with_zero_width'                    => array(
-				'<p><img src="http://placehold.it/300x300" width="0" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="0" height="300" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" width="0" height="300"></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/300x300" width="0" height="300" /></p>',
+				'<p><amp-img src="https://placehold.it/300x300" width="0" height="300" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/300x300" width="0" height="300"></noscript></amp-img></p>',
 			),
 
 			'image_with_zero_width_and_height'         => array(
-				'<p><img src="http://placehold.it/300x300" width="0" height="0" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="0" height="0" class="amp-wp-enforced-sizes"><noscript><img src="http://placehold.it/300x300" width="0" height="0"></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/300x300" width="0" height="0" /></p>',
+				'<p><amp-img src="https://placehold.it/300x300" width="0" height="0" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/300x300" width="0" height="0"></noscript></amp-img></p>',
 			),
 
 			'image_with_decimal_width'                 => array(
-				'<p><img src="http://placehold.it/300x300" width="299.5" height="300" /></p>',
-				'<p><amp-img src="http://placehold.it/300x300" width="299.5" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/300x300" width="299.5" height="300"></noscript></amp-img></p>',
+				'<p><img src="https://placehold.it/300x300" width="299.5" height="300" /></p>',
+				'<p><amp-img src="https://placehold.it/300x300" width="299.5" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/300x300" width="299.5" height="300"></noscript></amp-img></p>',
 			),
 
 			'image_with_self_closing_tag'              => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
+				'<img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" />',
+				'<amp-img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
 			),
 
 			'image_with_no_end_tag'                    => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!">',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
+				'<img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!">',
+				'<amp-img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
 			),
 
 			'image_with_end_tag'                       => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></img>',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
+				'<img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></img>',
+				'<amp-img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
 			),
 
-			'image_with_on_attribute'                  => array(
-				'<img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150" />',
-				'<amp-img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" on="tap:my-lightbox" width="350" height="150"></noscript></amp-img>',
+			'image_with_extra_attributes'              => array(
+				'<img src="https://placehold.it/350x150" on="tap:my-lightbox" onclick="showLightbox()" media="(min-width: 650px)" role="button" itemscope="image" tabindex="0" width="350" height="150" alt="ALT!" />',
+				'<amp-img src="https://placehold.it/350x150" on="tap:my-lightbox" media="(min-width: 650px)" role="button" itemscope="image" tabindex="0" width="350" height="150" alt="ALT!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" on="tap:my-lightbox" role="button" itemscope="image" tabindex="0" width="350" height="150" alt="ALT!"></noscript></amp-img>',
+				array(),
+				array(
+					'invalid_attribute', // The onclick attribute.
+				),
 			),
 
 			'image_with_no_dimensions_is_forced'       => array(
-				'<img src="http://placehold.it/350x150" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150" class=""></noscript></amp-img>',
+				'<img src="https://placehold.it/350x150" />',
+				'<amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" class=""></noscript></amp-img>',
 			),
 
 			'image_with_bad_src_url_get_fallback_dims' => array(
-				'<img src="http://example.com/404.png" />',
-				'<amp-img src="http://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height"></noscript></amp-img>',
+				'<img src="https://example.com/404.png" />',
+				'<amp-img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height"></noscript></amp-img>',
 			),
 
 			'gif_image_conversion'                     => array(
-				'<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />',
-				'<amp-anim src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
+				'<img src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />',
+				'<amp-anim src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
 			),
 
 			'gif_image_url_with_querystring'           => array(
-				'<img src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" />',
-				'<amp-anim src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
+				'<img src="https://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" />',
+				'<amp-anim src="https://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
 			),
 
 			'multiple_same_image'                      => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/350x150" width="350" height="150" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
+				'<img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/350x150" width="350" height="150" />',
+				'<amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'multiple_different_images'                => array(
-				'<img src="http://placehold.it/350x150" width="350" height="150" /><img src="http://placehold.it/360x160" width="360" height="160" /><img src="http://placehold.it/370x170" width="370" height="170" /><img src="http://placehold.it/380x180" width="380" height="180" />',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="http://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/360x160" width="360" height="160"></noscript></amp-img><amp-img src="http://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/370x170" width="370" height="170"></noscript></amp-img><amp-img src="http://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/380x180" width="380" height="180"></noscript></amp-img>',
+				'<img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/360x160" width="360" height="160" /><img src="https://placehold.it/370x170" width="370" height="170" /><img src="https://placehold.it/380x180" width="380" height="180" />',
+				'<amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/360x160" width="360" height="160"></noscript></amp-img><amp-img src="https://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/370x170" width="370" height="170"></noscript></amp-img><amp-img src="https://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/380x180" width="380" height="180"></noscript></amp-img>',
 			),
 
 			'image_center_aligned'                     => array(
-				'<img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150" />',
-				'<amp-img class="aligncenter amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="aligncenter" src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
+				'<img class="aligncenter" src="https://placehold.it/350x150" width="350" height="150" />',
+				'<amp-img class="aligncenter amp-wp-enforced-sizes" src="https://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="aligncenter" src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'image_left_aligned'                       => array(
-				'<img class="alignleft" src="http://placehold.it/350x150" width="350" height="150" />',
-				'<amp-img class="alignleft amp-wp-enforced-sizes" src="http://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="alignleft" src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
+				'<img class="alignleft" src="https://placehold.it/350x150" width="350" height="150" />',
+				'<amp-img class="alignleft amp-wp-enforced-sizes" src="https://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="alignleft" src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			),
 
 			'image_with_caption'                       => array(
-				'<figure class="wp-caption aligncenter"><img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
-				'<figure class="wp-caption aligncenter"><amp-img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312 amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"></noscript></amp-img><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
+				'<figure class="wp-caption aligncenter"><img src="https://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
+				'<figure class="wp-caption aligncenter"><amp-img src="https://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312 amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"></noscript></amp-img><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
 			),
 
 			'image_with_custom_lightbox_attrs'         => array(
-				'<figure data-amp-lightbox="true"><img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
-				'<figure data-amp-lightbox="true"><amp-img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure data-amp-lightbox="true"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
+				'<figure data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			),
 
 			'wide_image'                               => array(
-				'<figure class="wp-block-image"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_center_aligned'                => array(
-				'<figure class="wp-block-image aligncenter"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image aligncenter"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image aligncenter"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image aligncenter"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_left_aligned_custom_style'     => array(
-				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_right_aligned'                 => array(
-				'<figure class="wp-block-image alignright"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image alignright"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image alignright"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image alignright"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'wide_image_is_resized'                    => array(
-				'<figure class="wp-block-image is-resized"><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
-				'<figure class="wp-block-image is-resized"><amp-img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="http://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
+				'<figure class="wp-block-image is-resized"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
+				'<figure class="wp-block-image is-resized"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
 			),
 
 			'amp_img_with_noscript_fallback'           => array(
-				'<amp-img src="http://placehold.it/100x100" layout="fixed" width="100" height="100"><noscript><img src="http://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
+				'<amp-img src="https://placehold.it/100x100" layout="fixed" width="100" height="100"><noscript><img src="https://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
 				null,
 			),
 
 			'img_with_sizes_attribute_removed'         => array(
-				'<img width="825" height="510" src="http://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw">',
-				'<amp-img width="825" height="510" src="http://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image amp-wp-enforced-sizes" alt="" layout="intrinsic"><noscript><img width="825" height="510" src="http://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw"></noscript></amp-img>',
+				'<img width="825" height="510" src="https://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw">',
+				'<amp-img width="825" height="510" src="https://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image amp-wp-enforced-sizes" alt="" layout="intrinsic"><noscript><img width="825" height="510" src="https://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw"></noscript></amp-img>',
 			),
 
 			'amp_img_with_sizes_attribute_retained'    => array(
-				'<amp-img width="825" height="510" src="http://placehold.it/825x510" alt="" layout="intrinsic"></amp-img>',
+				'<amp-img width="825" height="510" src="https://placehold.it/825x510" alt="" layout="intrinsic"></amp-img>',
 				null,
+			),
+
+			'img_with_http_protocol_src'               => array(
+				'<img src="http://placehold.it/350x150" width="350" height="150">',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+			),
+
+			'img_with_http_protocol_srcset'            => array(
+				'<img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150">',
+				'<amp-img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
 		);
 	}
@@ -246,19 +266,40 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	/**
 	 * Test converter.
 	 *
-	 * @param string $source   Source.
-	 * @param string $expected Expected.
-	 * @param array  $args     Args.
+	 * @param string   $source               Source.
+	 * @param string   $expected             Expected.
+	 * @param array    $args                 Args.
+	 * @param string[] $expected_error_codes Expected error codes.
 	 * @dataProvider get_data
 	 */
-	public function test_converter( $source, $expected = null, $args = array() ) {
+	public function test_converter( $source, $expected = null, $args = array(), $expected_error_codes = array() ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
+
+		$error_codes = array();
+
+		$args = array_merge(
+			array(
+				'use_document_element'      => true,
+				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
+					$error_codes[] = $error['code'];
+				},
+			),
+			$args
+		);
+
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$img_count = $dom->getElementsByTagName( 'img' )->length;
+
 		$sanitizer = new AMP_Img_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
+
+		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom, $args );
+		$sanitizer->sanitize();
+
+		$this->assertEqualSets( $error_codes, $expected_error_codes );
+
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
 
@@ -270,7 +311,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 * Test that amp-anim does not get included for a PNG.
 	 */
 	public function test_no_gif_no_image_scripts() {
-		$source   = '<img src="http://placehold.it/350x150.png" width="350" height="150" alt="Placeholder!" />';
+		$source   = '<img src="https://placehold.it/350x150.png" width="350" height="150" alt="Placeholder!" />';
 		$expected = array();
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
@@ -291,7 +332,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 * Test that amp-anim does get included for a GIF.
 	 */
 	public function test_no_gif_image_scripts() {
-		$source   = '<img src="http://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />';
+		$source   = '<img src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />';
 		$expected = array( 'amp-anim' => true );
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -29,6 +29,17 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 			'simple_video' => array(
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
+				array(
+					'add_noscript_fallback' => true,
+				),
+			),
+
+			'simple_video_without_noscript' => array(
+				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
+				array(
+					'add_noscript_fallback' => false,
+				),
 			),
 
 			'video_without_dimensions' => array(
@@ -181,15 +192,16 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source   Source.
 	 * @param string $expected Expected.
+	 * @param array  $args     Sanitizer args.
 	 */
-	public function test_converter( $source, $expected = null ) {
+	public function test_converter( $source, $expected = null, $args = array() ) {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 
-		$sanitizer = new AMP_Video_Sanitizer( $dom );
+		$sanitizer = new AMP_Video_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$sanitizer = new AMP_Script_Sanitizer( $dom );

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -68,8 +68,8 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 			),
 
 			'video_with_custom_attribute' => array(
-				'<video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video>',
-				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar"></video></noscript></amp-video>',
+				'<video width="300" height="300" src="https://example.com/video.mp4" onclick="foo()" data-foo="bar"></video>',
+				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 			),
 
 			'video_with_sizes_attribute_is_overridden' => array(


### PR DESCRIPTION
When a disallowed attribute appears on an input `img`, `video`, `audio`, or `iframe` currently the validation error will be duplicated once for the replaced AMP component and again for the original element added inside as a `noscript`. This PR prevents a duplication of the validation error by removing the disallowed attributes preemptively.

Also, in case the `noscript` fallback elements are not desired, a `add_noscript_fallback` arg is introduced for the image, audio, video, and iframe sanitizers to prevent it from being added (this is needed for AMP stories, and these commits were picked from #2107).

Lastly, as reported in https://github.com/ampproject/amphtml/pull/21686 the `amp-img` allows the HTTP protocol whereas the `amp-img > noscript > img` does not. So this PR prevents adding the `noscript > img` fallback if it lacks the HTTPS protocol. 

Fixes #2126.