### PR TITLE
Fix compatibility with PWA v0.1 by checking if constant exists

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -257,7 +257,7 @@ function is_amp_endpoint() {
 	}
 
 	// Always return false when requesting service worker.
-	if ( class_exists( 'WP_Service_Workers' ) && ! empty( $wp_query ) && $wp_query->get( WP_Service_Workers::QUERY_VAR ) ) {
+	if ( class_exists( 'WP_Service_Workers' ) && ! empty( $wp_query ) && defined( 'WP_Service_Workers::QUERY_VAR' ) && $wp_query->get( WP_Service_Workers::QUERY_VAR ) ) {
 		return false;
 	}
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -403,7 +403,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->go_to( home_url( '?feed=rss' ) );
 		$this->assertFalse( is_amp_endpoint() );
 
-		if ( class_exists( 'WP_Service_Workers' ) && function_exists( 'pwa_add_error_template_query_var' ) ) {
+		if ( class_exists( 'WP_Service_Workers' ) && defined( 'WP_Service_Workers::QUERY_VAR' ) && function_exists( 'pwa_add_error_template_query_var' ) ) {
 			$this->go_to( home_url( "?p=$post_id" ) );
 			global $wp_query;
 			$wp_query->set( WP_Service_Workers::QUERY_VAR, WP_Service_Workers::SCOPE_FRONT );


### PR DESCRIPTION
The `WP_Service_Workers::QUERY_VAR` constant is introduced with PWA 0.2, so we need to make sure that the constant exists before using it.

Fixes #2133.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3082531/amp.zip) (1.1-RC1-20190416T002529Z-0c64266d)