### PR TITLE
Add link to ecosystem page on AMP settings screen

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -379,6 +379,9 @@ class AMP_Options_Manager {
 			.amp-welcome-notice {
 				padding: 38px;
 			}
+			.amp-welcome-notice + .notice {
+				clear: both;
+			}
 			.amp-welcome-icon-holder {
 				width: 200px;
 				height: 200px;

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -146,7 +146,7 @@ class AMP_Options_Menu {
 		$transitional_description = sprintf( __( 'Uses the active theme’s templates to generate non-AMP and AMP versions of your content, allowing for each canonical URL to have a corresponding (paired) AMP URL. This mode is useful to progressively transition towards a fully AMP-first site. Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
 		$reader_description       = __( 'Formerly called the <b>classic mode</b>, this mode generates paired AMP content using simplified templates which may not match the look-and-feel of your site. Only posts/pages can be served as AMP in Reader mode. No redirection is performed for mobile visitors; AMP pages are served by AMP consumption platforms.', 'amp' );
 		/* translators: %s: URL to the ecosystem page. */
-		$ecosystem_description = sprintf( __( 'For a list of themes and plugins that are known to be AMP compatible, please see our <a href="%s">ecosystem page</a>.' ), esc_url( 'https://amp-wp.org/ecosystem/' ) );
+		$ecosystem_description = sprintf( __( 'For a list of themes and plugins that are known to be AMP compatible, please see the <a href="%s">ecosystem page</a>.' ), esc_url( 'https://amp-wp.org/ecosystem/' ) );
 
 		$builtin_support = in_array( get_template(), AMP_Core_Theme_Sanitizer::get_supported_themes(), true );
 		?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -145,6 +145,8 @@ class AMP_Options_Menu {
 		/* translators: %s: URL to the documentation. */
 		$transitional_description = sprintf( __( 'Uses the active theme’s templates to generate non-AMP and AMP versions of your content, allowing for each canonical URL to have a corresponding (paired) AMP URL. This mode is useful to progressively transition towards a fully AMP-first site. Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
 		$reader_description       = __( 'Formerly called the <b>classic mode</b>, this mode generates paired AMP content using simplified templates which may not match the look-and-feel of your site. Only posts/pages can be served as AMP in Reader mode. No redirection is performed for mobile visitors; AMP pages are served by AMP consumption platforms.', 'amp' );
+		/* translators: %s: URL to the ecosystem page. */
+		$ecosystem_description = sprintf( __( 'For a list of themes and plugins that are known to be AMP compatible, please see our <a href="%s">ecosystem page</a>.' ), esc_url( 'https://amp-wp.org/ecosystem/' ) );
 
 		$builtin_support = in_array( get_template(), AMP_Core_Theme_Sanitizer::get_supported_themes(), true );
 		?>
@@ -152,6 +154,9 @@ class AMP_Options_Menu {
 			<div class="notice notice-info notice-alt inline">
 				<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
 			</div>
+			<p>
+				<?php echo wp_kses_post( $ecosystem_description ); ?>
+			</p>
 			<p>
 				<?php if ( amp_is_canonical() ) : ?>
 					<strong><?php esc_html_e( 'Native:', 'amp' ); ?></strong>
@@ -168,6 +173,9 @@ class AMP_Options_Menu {
 						<p><?php esc_html_e( 'Your active theme is known to work well in transitional or native mode.', 'amp' ); ?></p>
 					</div>
 				<?php endif; ?>
+				<p>
+					<?php echo wp_kses_post( $ecosystem_description ); ?>
+				</p>
 				<dl>
 					<dt>
 						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, 'native' ); ?>>


### PR DESCRIPTION
In order to help users discover the themes and plugins that are AMP compatible, we should actively link to the ecosystem page to share it with them.

This PR also fixes a float issue with the floated image in the welcome message notice causing the following warning to be unexpectedly indented.

# Before

<img width="917" alt="Screen Shot 2019-04-16 at 13 20 28" src="https://user-images.githubusercontent.com/134745/56182000-fec9df80-604a-11e9-8e48-1756ab404bc4.png">
<img width="916" alt="Screen Shot 2019-04-16 at 13 20 47" src="https://user-images.githubusercontent.com/134745/56182002-fec9df80-604a-11e9-9101-b96d8b682f70.png">

# After

<img width="915" alt="Screen Shot 2019-04-16 at 13 21 46" src="https://user-images.githubusercontent.com/134745/56182003-ff627600-604a-11e9-9fbd-29dda88e0090.png">
<img width="911" alt="Screen Shot 2019-04-16 at 13 21 59" src="https://user-images.githubusercontent.com/134745/56182004-ff627600-604a-11e9-8733-46a32cae3a69.png">
