### PR TITLE
Add checkbox to enable/disable AMP Stories (disabled by default)

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -66,7 +66,7 @@ class AMP_Story_Post_Type {
 	 */
 	public static function register() {
 
-		if ( ! function_exists( 'register_block_type' ) ) {
+		if ( ! AMP_Options_Manager::get_option( 'enable_amp_stories' ) || ! function_exists( 'register_block_type' ) ) {
 			return;
 		}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -32,6 +32,7 @@ class AMP_Options_Manager {
 		'all_templates_supported'  => true,
 		'supported_templates'      => array( 'is_singular' ),
 		'enable_response_caching'  => true,
+		'enable_amp_stories'       => false,
 		'version'                  => AMP__VERSION,
 	);
 
@@ -136,6 +137,7 @@ class AMP_Options_Manager {
 		$options['auto_accept_sanitization'] = ! empty( $new_options['auto_accept_sanitization'] );
 		$options['accept_tree_shaking']      = ! empty( $new_options['accept_tree_shaking'] );
 		$options['disable_admin_bar']        = ! empty( $new_options['disable_admin_bar'] );
+		$options['enable_amp_stories']       = ! empty( $new_options['enable_amp_stories'] );
 
 		// Validate post type support.
 		$options['supported_post_types'] = array();

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -109,6 +109,17 @@ class AMP_Options_Menu {
 			)
 		);
 
+		add_settings_field(
+			'amp_stories',
+			__( 'AMP Stories', 'amp' ),
+			array( $this, 'render_amp_stories' ),
+			AMP_Options_Manager::OPTION_NAME,
+			'general',
+			array(
+				'class' => 'amp-stories-field',
+			)
+		);
+
 		if ( wp_using_ext_object_cache() ) {
 			add_settings_field(
 				'caching',
@@ -492,6 +503,33 @@ class AMP_Options_Menu {
 				})( jQuery );
 			</script>
 		<?php endif; ?>
+		<?php
+	}
+
+	/**
+	 * AMP Stories section renderer.
+	 *
+	 * @since 1.2
+	 */
+	public function render_amp_stories() {
+		?>
+		<p>
+			<label for="enable_amp_stories">
+				<input id="enable_amp_stories" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[enable_amp_stories]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'enable_amp_stories' ) ); ?>>
+				<?php esc_html_e( 'Enable experimental support for the AMP Story post type.', 'amp' ); ?>
+			</label>
+		</p>
+		<p class="description">
+			<?php
+			echo wp_kses_post(
+				sprintf(
+					/* translators: %s is the AMP Stories landing page */
+					__( 'AMP Stories is a new visual storytelling for the open web. AMP stories immerse your readers in fast-loading full-screen experiences. Easily create visual narratives, with engaging animations and tappable interactions. The AMP story format is free and part of the open web and are available for everyone to try on their websites. They can be shared and embedded across the web without being confined to a closed ecosystem or platform. Read more about <a href="%s">AMP Stories</a>.', 'amp' ),
+					esc_url( 'https://amp.dev/about/stories' )
+				)
+			);
+			?>
+		</p>
 		<?php
 	}
 


### PR DESCRIPTION
This adds a checkbox to enable the AMP Stories feature. The feature is disabled by default.

<img width="893" alt="AMP Stories toggle" src="https://user-images.githubusercontent.com/134745/56257286-ac4df900-6106-11e9-9fe8-08489aeac200.png">

Fixes #2136.