### PR TITLE
Require Gutenberg plugin for now and link to installation

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -82,11 +82,9 @@ class AMP_Story_Post_Type {
 		if ( ! function_exists( 'register_block_type' ) ) {
 			return false;
 		}
-		return (
-			version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.2', '>=' )
-			||
-			function_exists( 'gutenberg_pre_init' )
-		);
+
+		// TODO: Require only the latest WordPress version itself, not the plugin.
+		return function_exists( 'gutenberg_pre_init' );
 	}
 
 	/**

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -516,7 +516,20 @@ class AMP_Options_Menu {
 		?>
 		<?php if ( ! $has_required_block_capabilities ) : ?>
 			<div class="notice notice-info notice-alt inline">
-				<p><?php esc_html_e( 'To use AMP stories, you must either have WordPress 5.2 or the latest version of the Gutenberg plugin installed.', 'amp' ); ?></p>
+				<p>
+					<?php
+					$gutenberg = 'Gutenberg';
+					// Link to Gutenberg plugin installation if eligible.
+					if ( current_user_can( 'install_plugins' ) ) {
+						$gutenberg = '<a href="' . esc_url( add_query_arg( 'tab', 'beta', admin_url( 'plugin-install.php' ) ) ) . '">' . $gutenberg . '</a>';
+					}
+					printf(
+						/* translators: %s: Gutenberg plugin name */
+						esc_html__( 'To use AMP stories, you currently must have the latest version of the %s plugin installed.', 'amp' ),
+						$gutenberg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					);
+					?>
+				</p>
 			</div>
 		<?php endif; ?>
 		<p>


### PR DESCRIPTION
AMP stories currently do not work with WordPress 5.2 alone. Therefore for the initial release we should require the Gutenberg plugin to be installed. This PR makes that change in requirements, and also links to the admin screen for installing or activating the plugin (Gutenberg is listed first in Beta Testing plugins list).

We should definitely revisit later to also support WordPress without the plugin.