### PR TITLE
Introduce admin pointers for AMP Stories

### DIFF
--- a/includes/admin/class-amp-admin-pointer.php
+++ b/includes/admin/class-amp-admin-pointer.php
@@ -1,149 +1,210 @@
 <?php
 /**
- * Admin pointer class.
+ * Class AMP_Admin_Pointer
  *
  * @package AMP
- * @since 1.0
+ * @since 1.2
  */
 
 /**
- * AMP_Admin_Pointer class.
+ * Class representing a single admin pointer.
  *
- * Outputs an admin pointer to show the new features of v1.0.
- * Based on https://code.tutsplus.com/articles/integrating-with-wordpress-ui-admin-pointers--wp-26853
- *
- * @since 1.0
+ * @since 1.2
  */
 class AMP_Admin_Pointer {
 
 	/**
-	 * The ID of the template mode admin pointer.
+	 * Unique pointer slug.
 	 *
+	 * @since 1.2
 	 * @var string
 	 */
-	const TEMPLATE_POINTER_ID = 'amp_template_mode_pointer_10';
+	private $slug;
 
 	/**
-	 * The slug of the script.
+	 * Pointer arguments.
 	 *
-	 * @var string
+	 * @since 1.2
+	 * @var array
 	 */
-	const SCRIPT_SLUG = 'amp-admin-pointer';
+	private $args = array();
 
 	/**
-	 * The slug of the tooltip script.
+	 * Internal storage for dismissed pointers, to prevent repeated parsing.
 	 *
-	 * @var string
+	 * @since 1.2
+	 * @static
+	 * @var array|null
 	 */
-	const TOOLTIP_SLUG = 'amp-validation-tooltips';
+	private static $dismissed_pointers = null;
 
 	/**
-	 * Initializes the class.
+	 * Constructor.
 	 *
-	 * @since 1.0
+	 * @since 1.2
+	 *
+	 * @param string $slug Unique pointer slug.
+	 * @param array  $args {
+	 *     Associative array of pointer arguments.
+	 *
+	 *     @type string   $selector        Required DOM selector for the element to point at.
+	 *     @type string   $description     Required pointer description. May contain inline HTML tags.
+	 *     @type string   $heading         Pointer heading. May contain inline HTML tags. Default empty string.
+	 *     @type string   $subheading      Pointer subheading. May contain inline HTML tags. Default empty string.
+	 *     @type array    $position        Position information for the pointer. Must be an array with keys
+	 *                                     'edge' and 'align'. Default is 'edge' set to 'left' and 'align' set
+	 *                                     to 'bottom'.
+	 *     @type string   $class           Additional CSS class for the pointer. Default empty string.
+	 *     @type callable $active_callback Callback function to determine whether the pointer is active in the
+	 *                                     current context. The current admin screen's hook suffix is passed to
+	 *                                     the callback. Default is that the pointer is active unconditionally.
+	 * }
 	 */
-	public function init() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_pointer' ) );
-		add_action( 'admin_enqueue_scripts', array( $this, 'register_tooltips' ) );
-	}
+	public function __construct( $slug, array $args ) {
+		$default_position = array(
+			'edge'  => is_rtl() ? 'right' : 'left',
+			'align' => 'bottom',
+		);
 
-	/**
-	 * Enqueues the pointer assets.
-	 *
-	 * If the pointer has not been dismissed, enqueues the style and script.
-	 * And outputs the pointer data for the script.
-	 *
-	 * @since 1.0
-	 */
-	public function enqueue_pointer() {
-		if ( $this->is_pointer_dismissed() ) {
-			return;
+		if ( isset( $args['position'] ) ) {
+			$args['position'] = wp_parse_args( (array) $args['position'], $default_position );
 		}
 
-		wp_enqueue_style( 'wp-pointer' );
-
-		wp_enqueue_script(
-			self::SCRIPT_SLUG,
-			amp_get_asset_url( 'js/' . self::SCRIPT_SLUG . '.js' ),
-			array( 'jquery', 'wp-pointer' ),
-			AMP__VERSION,
-			true
-		);
-
-		wp_add_inline_script(
-			self::SCRIPT_SLUG,
-			sprintf( 'ampAdminPointer.load( %s );', wp_json_encode( $this->get_pointer_data() ) )
+		$this->slug = $slug;
+		$this->args = wp_parse_args(
+			$args,
+			array(
+				'selector'        => '',
+				'description'     => '',
+				'heading'         => '',
+				'subheading'      => '',
+				'position'        => $default_position,
+				'class'           => '',
+				'active_callback' => null,
+			)
 		);
 	}
 
 	/**
-	 * Registers style and script for tooltips.
+	 * Gets the pointer slug.
 	 *
-	 * @since 1.0
+	 * @since 1.2
+	 *
+	 * @return string Unique pointer slug.
 	 */
-	public function register_tooltips() {
-		wp_register_style(
-			self::TOOLTIP_SLUG,
-			amp_get_asset_url( 'css/' . self::TOOLTIP_SLUG . '.css' ),
+	public function get_slug() {
+		return $this->slug;
+	}
+
+	/**
+	 * Checks whether the pointer is active.
+	 *
+	 * This method executes the active callback and looks at whether the pointer has been dismissed in order to
+	 * determine whether the pointer should be active or not.
+	 *
+	 * @since 1.2
+	 *
+	 * @param string $hook_suffix The current admin screen hook suffix.
+	 * @return bool True if the pointer is active, false otherwise.
+	 */
+	public function is_active( $hook_suffix ) {
+		if ( ! $this->args['selector'] || ! $this->args['description'] ) {
+			return false;
+		}
+
+		if ( ! $this->args['active_callback'] ) {
+			return true;
+		}
+
+		if ( ! call_user_func( $this->args['active_callback'], $hook_suffix ) ) {
+			return false;
+		}
+
+		// Populate dismissed pointers list only once.
+		if ( null === self::$dismissed_pointers ) {
+			// Use array_flip() for more performant lookup.
+			self::$dismissed_pointers = array_flip( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
+		}
+
+		return ! isset( self::$dismissed_pointers[ $this->slug ] );
+	}
+
+	/**
+	 * Enqueues the script for the pointer.
+	 *
+	 * @since 1.2
+	 */
+	public function enqueue() {
+		wp_enqueue_style( 'wp-pointer' );
+		wp_enqueue_script( 'wp-pointer' );
+
+		wp_enqueue_style(
+			'amp-validation-tooltips',
+			amp_get_asset_url( 'css/amp-validation-tooltips.css' ),
 			array( 'wp-pointer' ),
 			AMP__VERSION
 		);
 
-		wp_register_script(
-			self::TOOLTIP_SLUG,
-			amp_get_asset_url( 'js/' . self::TOOLTIP_SLUG . '.js' ),
-			array( 'jquery', 'wp-pointer' ),
-			AMP__VERSION,
-			true
+		add_action(
+			'admin_print_footer_scripts',
+			function() {
+				$this->print_js();
+			}
 		);
 	}
 
 	/**
-	 * Whether the AMP admin pointer has been dismissed.
+	 * Prints the script for the pointer inline.
 	 *
-	 * @since 1.0
-	 * @return boolean Is dismissed.
+	 * Requires the 'wp-pointer' script to be loaded.
+	 *
+	 * @since 1.2
 	 */
-	protected function is_pointer_dismissed() {
-
-		// Consider dismissed in v1.1, since admin pointer is only to educate about the new modes in 1.0.
-		if ( version_compare( strtok( AMP__VERSION, '-' ), '1.1', '>=' ) ) {
-			return true;
+	private function print_js() {
+		$content = '<p>' . wp_kses( $this->args['description'], 'amp_admin_pointer' ) . '</p>';
+		if ( $this->args['subheading'] ) {
+			$content = '<p><strong>' . wp_kses( $this->args['subheading'], 'amp_admin_pointer' ) . '</strong></p>' . $content;
+		}
+		if ( $this->args['heading'] ) {
+			$content = '<h3>' . wp_kses( $this->args['heading'], 'amp_admin_pointer' ) . '</h3>' . $content;
 		}
 
-		$dismissed = get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true );
-		if ( empty( $dismissed ) ) {
-			return false;
-		}
-		$dismissed = explode( ',', strval( $dismissed ) );
-
-		return in_array( self::TEMPLATE_POINTER_ID, $dismissed, true );
-	}
-
-	/**
-	 * Gets the pointer data to pass to the script.
-	 *
-	 * @since 1.0
-	 * @return array Pointer data.
-	 */
-	public function get_pointer_data() {
-		return array(
-			'pointer' => array(
-				'pointer_id' => self::TEMPLATE_POINTER_ID,
-				'target'     => '#toplevel_page_amp-options',
-				'options'    => array(
-					'content'  => sprintf(
-						'<h3>%s</h3><p><strong>%s</strong></p><p>%s</p>',
-						__( 'AMP', 'amp' ),
-						__( 'New AMP Template Modes', 'amp' ),
-						__( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Native&#8221; modes.', 'amp' )
-					),
-					'position' => array(
-						'edge'  => 'left',
-						'align' => 'middle',
-					),
-				),
-			),
+		$args = array(
+			'content'      => $content,
+			'position'     => $this->args['position'],
+			'pointerClass' => 'wp-pointer wp-amp-pointer' . ( ! empty( $this->args['class'] ) ? ' ' . $this->args['class'] : '' ),
 		);
+
+		?>
+		<script type="text/javascript">
+			( function( $ ) {
+				var options = <?php echo wp_json_encode( $args ); ?>;
+
+				if ( ! options ) {
+					return;
+				}
+
+				options = $.extend( options, {
+					close: function() {
+						$.post( ajaxurl, {
+							pointer: '<?php echo esc_js( $this->slug ); ?>',
+							action: 'dismiss-wp-pointer'
+						});
+					}
+				});
+
+				function setup() {
+					$( '<?php echo esc_js( $this->args['selector'] ); ?>' ).first().pointer( options ).pointer( 'open' );
+				};
+
+				if ( options.position && options.position.defer_loading ) {
+					$( window ).bind( 'load.wp-pointers', setup );
+				} else {
+					$( document ).ready( setup );
+				}
+
+			} )( jQuery );
+		</script>
+		<?php
 	}
 }

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Class AMP_Admin_Pointers
+ *
+ * @package AMP
+ * @since 1.2
+ */
+
+/**
+ * Class managing admin pointers to enhance discoverability.
+ *
+ * @since 1.2
+ */
+class AMP_Admin_Pointers {
+
+	/**
+	 * Registers functionality through WordPress hooks.
+	 *
+	 * @since 1.2
+	 */
+	public function init() {
+		add_action(
+			'admin_enqueue_scripts',
+			function( $hook_suffix ) {
+				$this->enqueue_scripts( $hook_suffix );
+			}
+		);
+	}
+
+	/**
+	 * Initializes admin pointers by enqueuing necessary scripts.
+	 *
+	 * @since 1.2
+	 *
+	 * @param string $hook_suffix The current admin screen hook suffix.
+	 */
+	private function enqueue_scripts( $hook_suffix ) {
+		$pointers = $this->get_pointers();
+		if ( empty( $pointers ) ) {
+			return;
+		}
+
+		// Only enqueue one pointer at a time to prevent them overlaying each other.
+		foreach ( $pointers as $pointer ) {
+			if ( ! $pointer->is_active( $hook_suffix ) ) {
+				continue;
+			}
+
+			$pointer->enqueue();
+			return;
+		}
+	}
+
+	/**
+	 * Gets available admin pointers.
+	 *
+	 * @since 1.2
+	 *
+	 * @return array List of AMP_Admin_Pointer instances.
+	 */
+	private function get_pointers() {
+		return array(
+			new AMP_Admin_Pointer(
+				'amp_template_mode_pointer_10',
+				array(
+					'selector'        => '#toplevel_page_amp-options',
+					'heading'         => __( 'AMP', 'amp' ),
+					'subheading'      => __( 'New AMP Template Modes', 'amp' ),
+					'description'     => __( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Native&#8221; modes.', 'amp' ),
+					'position'        => array(
+						'align' => 'middle',
+					),
+					'active_callback' => function() {
+						return version_compare( strtok( AMP__VERSION, '-' ), '1.1', '<' );
+					},
+				)
+			),
+			new AMP_Admin_Pointer(
+				'amp_stories_support_pointer_12',
+				array(
+					'selector'        => '#toplevel_page_amp-options',
+					'heading'         => __( 'AMP', 'amp' ),
+					'subheading'      => __( 'AMP Stories', 'amp' ),
+					'description'     => __( 'You can now enable AMP Stories, a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences.', 'amp' ),
+					'position'        => array(
+						'align' => 'middle',
+					),
+					'active_callback' => function( $hook_suffix ) {
+						if ( 'toplevel_page_amp-options' === $hook_suffix ) {
+							return false;
+						}
+						return ! AMP_Options_Manager::get_option( 'enable_amp_stories' );
+					},
+				)
+			),
+			new AMP_Admin_Pointer(
+				'amp_stories_menu_pointer_12',
+				array(
+					'selector'        => '#menu-posts-' . AMP_Story_Post_Type::POST_TYPE_SLUG,
+					'heading'         => __( 'AMP', 'amp' ),
+					'description'     => __( 'Head over here to create your first AMP story.', 'amp' ),
+					'position'        => array(
+						'align' => 'middle',
+					),
+					'active_callback' => function( $hook_suffix ) {
+						if ( 'edit.php' === $hook_suffix && AMP_Story_Post_Type::POST_TYPE_SLUG === filter_input( INPUT_GET, 'post_type' ) ) {
+							return false;
+						}
+						return AMP_Story_Post_Type::has_required_block_capabilities() && AMP_Options_Manager::get_option( 'enable_amp_stories' );
+					},
+				)
+			),
+		);
+	}
+}

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -21,9 +21,7 @@ class AMP_Admin_Pointers {
 	public function init() {
 		add_action(
 			'admin_enqueue_scripts',
-			function( $hook_suffix ) {
-				$this->enqueue_scripts( $hook_suffix );
-			}
+			array( $this, 'enqueue_scripts' )
 		);
 	}
 
@@ -34,7 +32,7 @@ class AMP_Admin_Pointers {
 	 *
 	 * @param string $hook_suffix The current admin screen hook suffix.
 	 */
-	private function enqueue_scripts( $hook_suffix ) {
+	public function enqueue_scripts( $hook_suffix ) {
 		$pointers = $this->get_pointers();
 		if ( empty( $pointers ) ) {
 			return;

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -196,6 +196,6 @@ function amp_editor_core_blocks() {
  * @since 1.0
  */
 function amp_admin_pointer() {
-	$admin_pointer = new AMP_Admin_Pointer();
-	$admin_pointer->init();
+	$admin_pointers = new AMP_Admin_Pointers();
+	$admin_pointers->init();
 }

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -38,6 +38,7 @@ class AMP_Autoloader {
 		'AMP_Template_Customizer'            => 'includes/admin/class-amp-customizer',
 		'AMP_Post_Meta_Box'                  => 'includes/admin/class-amp-post-meta-box',
 		'AMP_Admin_Pointer'                  => 'includes/admin/class-amp-admin-pointer',
+		'AMP_Admin_Pointers'                 => 'includes/admin/class-amp-admin-pointers',
 		'AMP_Post_Type_Support'              => 'includes/class-amp-post-type-support',
 		'AMP_Base_Embed_Handler'             => 'includes/embeds/class-amp-base-embed-handler',
 		'AMP_DailyMotion_Embed_Handler'      => 'includes/embeds/class-amp-dailymotion-embed',

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -530,7 +530,7 @@ class AMP_Options_Menu {
 			echo wp_kses_post(
 				sprintf(
 					/* translators: %s: AMP Stories documentation URL. */
-					__( 'AMP Stories is a visual storytelling format for the open web, which immerse your readers in fast-loading, full-screen, and visually rich experiences. Stories can be a great addition to your overall content strategy. Read more about <a href="%s">AMP Stories</a>.', 'amp' ),
+					__( 'AMP Stories is a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences. Stories can be a great addition to your overall content strategy. Read more about <a href="%s">AMP Stories</a>.', 'amp' ),
 					esc_url( 'https://amp.dev/about/stories' )
 				)
 			);

--- a/tests/test-class-amp-admin-pointer.php
+++ b/tests/test-class-amp-admin-pointer.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Tests for AMP_Admin_Pointer class.
+ * Tests for AMP_Admin_Pointers class.
  *
  * @package AMP
  */
 
 /**
- * Tests for AMP_Admin_Pointer class.
+ * Tests for AMP_Admin_Pointers class.
  *
- * @covers AMP_Admin_Pointer
+ * @covers AMP_Admin_Pointers
  * @since 1.0
  */
-class Test_AMP_Admin_Pointer extends \WP_UnitTestCase {
+class Test_AMP_Admin_Pointers extends \WP_UnitTestCase {
 
 	/**
 	 * The meta key of the dismissed pointers.
@@ -23,7 +23,7 @@ class Test_AMP_Admin_Pointer extends \WP_UnitTestCase {
 	/**
 	 * An instance of the class to test.
 	 *
-	 * @var AMP_Admin_Pointer
+	 * @var AMP_Admin_Pointers
 	 */
 	public $instance;
 
@@ -34,36 +34,16 @@ class Test_AMP_Admin_Pointer extends \WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		$this->instance = new AMP_Admin_Pointer();
+		$this->instance = new AMP_Admin_Pointers();
 	}
 
 	/**
 	 * Test init.
 	 *
-	 * @covers AMP_Admin_Pointer::init()
+	 * @covers AMP_Admin_Pointers::init()
 	 */
 	public function test_init() {
 		$this->instance->init();
-		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $this->instance, 'enqueue_pointer' ) ) );
-	}
-
-	/**
-	 * Test get_pointer_data.
-	 *
-	 * @covers AMP_Admin_Pointer::get_pointer_data()
-	 */
-	public function test_get_pointer_data() {
-		$pointer_data = $this->instance->get_pointer_data();
-		$pointer      = $pointer_data['pointer'];
-		$this->assertContains( '<h3>AMP</h3><p><strong>New AMP Template Modes</strong></p>', $pointer['options']['content'] );
-		$this->assertEquals(
-			array(
-				'align' => 'middle',
-				'edge'  => 'left',
-			),
-			$pointer['options']['position']
-		);
-		$this->assertEquals( AMP_Admin_Pointer::TEMPLATE_POINTER_ID, $pointer['pointer_id'] );
-		$this->assertEquals( '#toplevel_page_amp-options', $pointer['target'] );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $this->instance, 'enqueue_scripts' ) ) );
 	}
 }


### PR DESCRIPTION
This PR adds two new admin pointers:
* One for the newly available setting to enable AMP Stories (displayed if AMP Stories are not enabled yet)
* Another one for the AMP Stories menu item (displayed if AMP Stories enabled).

As with all admin pointers, they both can be permanently dismissed on a per-user basis. Since we now have multiple notices, two new classes are introduced and replace the previously used class for the old admin pointer (the class code was pretty much taken from Site Kit).