### PR TITLE
Fix first_child_tag_name_oneof constraint to only apply if first child exists

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1841,7 +1841,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// If the first element is not of the required type, invalidate the entire element.
-		if ( isset( $child_tags['first_child_tag_name_oneof'] ) && ( empty( $child_elements[0] ) || ! in_array( $child_elements[0]->nodeName, $child_tags['first_child_tag_name_oneof'], true ) ) ) {
+		if ( isset( $child_tags['first_child_tag_name_oneof'] ) && ! empty( $child_elements[0] ) && ! in_array( $child_elements[0]->nodeName, $child_tags['first_child_tag_name_oneof'], true ) ) {
 			return false;
 		}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -979,6 +979,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array(),
 			),
 
+			'amp-state-src' => array(
+				'<amp-state id="myRemoteState" src="https://data.com/articles.json"></amp-state>',
+				null,
+				array( 'amp-bind' ),
+			),
+
 			// Adapted from <https://www.ampproject.org/docs/reference/components/amp-selector>.
 			'reference-points-amp_selector_and_carousel_with_boolean_attributes' => array(
 				str_replace(


### PR DESCRIPTION
As reported in a [support forum topic](https://wordpress.org/support/topic/always-error/), the following markup is now erroneously marked as a validation error:

```html
<amp-state id="myRemoteState" src="https://example.com/articles.json"></amp-state>
```

It worked in 1.0 but it regressed in 1.1. The regression is due to https://github.com/ampproject/amp-wp/pull/1860. Namely, the `first_child_tag_name_oneof` validator constraint is incorrectly being implemented by also implying that there _has_ to be a child to begin with. However, this was an incorrect interpretation it appears.

In any case, the constraints to ensure there is a minimum number of tags is implemented later in the method:

https://github.com/ampproject/amp-wp/blob/621a0502f56c8d8e00b4ddbd61bc5ff013307a40/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L1859-L1867

Fixing this doesn't cause any tests to fail, and it also causes the `amp-state[src]` markup to not fail.

----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3099805/amp.zip) (1.1.1-alpha-20190420T060818Z-871da341)