### PR TITLE
Prevent wp_targeted_link_rel() from corrupting JSON in amp_validation_error term_description

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -653,9 +653,14 @@ class AMP_Validated_URL_Post_Type {
 		$stored_validation_errors = array();
 
 		// Prevent Kses from corrupting JSON in description.
-		$has_pre_term_description_filter = has_filter( 'pre_term_description', 'wp_filter_kses' );
-		if ( false !== $has_pre_term_description_filter ) {
-			remove_filter( 'pre_term_description', 'wp_filter_kses', $has_pre_term_description_filter );
+		$pre_term_description_filters = array(
+			'wp_filter_kses'       => has_filter( 'pre_term_description', 'wp_filter_kses' ),
+			'wp_targeted_link_rel' => has_filter( 'pre_term_description', 'wp_targeted_link_rel' ),
+		);
+		foreach ( $pre_term_description_filters as $callback => $priority ) {
+			if ( false !== $priority ) {
+				remove_filter( 'pre_term_description', $callback, $priority );
+			}
 		}
 
 		$terms = array();
@@ -713,8 +718,10 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		// Finish preventing Kses from corrupting JSON in description.
-		if ( false !== $has_pre_term_description_filter ) {
-			add_filter( 'pre_term_description', 'wp_filter_kses', $has_pre_term_description_filter );
+		foreach ( $pre_term_description_filters as $callback => $priority ) {
+			if ( false !== $priority ) {
+				add_filter( 'pre_term_description', $callback, $priority );
+			}
 		}
 
 		$post_content = wp_json_encode( $stored_validation_errors );

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -376,6 +376,16 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 				),
 			),
 			array(
+				'code'    => 'rejected',
+				'evil'    => '<script>document.write( \'<a href="#" target="_blank" rel="noopener noreferrer">test</a>\' );</script>', // Test protection against wp_targeted_link_rel JSON corruption.
+				'sources' => array(
+					array(
+						'type' => 'theme',
+						'name' => 'twentyseventeen',
+					),
+				),
+			),
+			array(
 				'code'    => 'new',
 				'sources' => array(
 					array(
@@ -450,6 +460,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 
 		$error_groups = array(
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
+			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 		);


### PR DESCRIPTION
Fixes #2157.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3102297/amp.zip) (1.1.1-alpha-20190422T052832Z-b5b99124)
