### PR TITLE
[AMP Stories] Fix accuracy of resizing and drag-drop

### DIFF
--- a/assets/src/blocks/amp-story-page/edit.css
+++ b/assets/src/blocks/amp-story-page/edit.css
@@ -52,7 +52,7 @@
 #amp-story-editor .wp-block[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__layout:first-of-type {
 	width: 100%;
 	max-width: 338px;
-	height: 553px;
+	height: 563px;
 	position: relative;
 }
 
@@ -104,7 +104,7 @@
 }
 
 .editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div .editor-inner-blocks.block-editor-inner-blocks {
-	height: 543px;
+	height: 563px;
 }
 
 [data-block] {

--- a/assets/src/blocks/amp-story-page/edit.css
+++ b/assets/src/blocks/amp-story-page/edit.css
@@ -51,8 +51,8 @@
 #amp-story-editor .wp-block[data-type="amp/amp-story-page"],
 #amp-story-editor .wp-block[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__layout:first-of-type {
 	width: 100%;
-	max-width: 338px;
-	height: 563px;
+	max-width: 328px;
+	height: 553px;
 	position: relative;
 }
 
@@ -104,7 +104,7 @@
 }
 
 .editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div .editor-inner-blocks.block-editor-inner-blocks {
-	height: 563px;
+	height: 553px;
 }
 
 [data-block] {

--- a/assets/src/components/block-navigation/edit.css
+++ b/assets/src/components/block-navigation/edit.css
@@ -55,7 +55,7 @@
 	--block-settings-sidebar-width: 280px;
 	--admin-menu-expanded-sidebar-width: 160px;
 	--admin-menu-collapsed-sidebar-width: 36px;
-	--amp-story-content-width: 338px;
+	--amp-story-content-width: 328px;
 	--block-editor-horizontal-margin: 40px;
 	--scrollbar-width: 20px;
 	--block-navigation-right-margin: 20px;

--- a/assets/src/components/editor-carousel/index.js
+++ b/assets/src/components/editor-carousel/index.js
@@ -12,7 +12,7 @@ import { compose } from '@wordpress/compose';
  */
 import Indicator from './indicator';
 import { Reorderer } from '../';
-import { STORY_PAGE_WIDTH } from './../../constants';
+import { STORY_PAGE_INNER_WIDTH } from './../../constants';
 import './edit.css';
 
 const PAGE_MARGIN = 20;
@@ -35,7 +35,7 @@ class EditorCarousel extends Component {
 			wrapper.style.display = 'none';
 		} else {
 			wrapper.style.display = '';
-			wrapper.style.transform = `translateX(calc(50% - ${ STORY_PAGE_WIDTH / 2 }px - ${ ( this.props.currentIndex ) * PAGE_MARGIN }px - ${ this.props.currentIndex * STORY_PAGE_WIDTH }px))`;
+			wrapper.style.transform = `translateX(calc(50% - ${ STORY_PAGE_INNER_WIDTH / 2 }px - ${ ( this.props.currentIndex ) * PAGE_MARGIN }px - ${ this.props.currentIndex * STORY_PAGE_INNER_WIDTH }px))`;
 		}
 	}
 

--- a/assets/src/constants.js
+++ b/assets/src/constants.js
@@ -30,9 +30,6 @@ import Ubuntu from '../images/font-names/ubuntu.svg';
 export const STORY_PAGE_INNER_WIDTH = 328;
 export const STORY_PAGE_INNER_HEIGHT = 553;
 
-const storyPageBorderWidth = 10;
-export const STORY_PAGE_WIDTH = STORY_PAGE_INNER_WIDTH + storyPageBorderWidth;
-
 export const ALLOWED_TOP_LEVEL_BLOCKS = [
 	'amp/amp-story-page',
 	'core/block', // Reusable blocks.


### PR DESCRIPTION
Fixes #2161.

Restores the original width and height of the editor to restore the accuracy of dragging and resizing, also to make sure that the ratio matches the FE ratio.

Also removes 10px page border width from the Pages' carousel calculation since that was removed within #2105.