### PR TITLE
[AMP Stories] Remove adding text and color settings incorrectly

### DIFF
--- a/assets/src/components/with-amp-story-settings.js
+++ b/assets/src/components/with-amp-story-settings.js
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { StoryBlockMover, FontFamilyPicker, ResizableBox, AnimationControls, RotatableBox } from './';
-import { ALLOWED_CHILD_BLOCKS, ALLOWED_MOVABLE_BLOCKS } from '../constants';
+import { ALLOWED_CHILD_BLOCKS, ALLOWED_MOVABLE_BLOCKS, BLOCKS_WITH_TEXT_SETTINGS } from '../constants';
 import { maybeEnqueueFontStyle } from '../helpers';
 
 const { getComputedStyle } = window;
@@ -157,6 +157,7 @@ export default createHigherOrderComponent(
 
 			const isImageBlock = 'core/image' === name;
 			const isTextBlock = 'amp/amp-story-text' === name;
+			const needsTextSettings = BLOCKS_WITH_TEXT_SETTINGS.includes( name );
 			const isMovableBlock = ALLOWED_MOVABLE_BLOCKS.includes( name );
 
 			const {
@@ -241,7 +242,7 @@ export default createHigherOrderComponent(
 							</RotatableBox>
 						</ResizableBox>
 					) }
-					{ isMovableBlock && (
+					{ needsTextSettings && (
 						<InspectorControls>
 							<PanelBody title={ __( 'Text Settings', 'amp' ) }>
 								<FontFamilyPicker
@@ -312,6 +313,25 @@ export default createHigherOrderComponent(
 									step={ 5 }
 								/>
 							</PanelColorSettings>
+							<PanelBody
+								title={ __( 'Animation', 'amp' ) }
+							>
+								<AnimationControls
+									animatedBlocks={ getAnimatedBlocks }
+									animationType={ ampAnimationType }
+									animationDuration={ ampAnimationDuration ? parseInt( ampAnimationDuration ) : '' }
+									animationDelay={ ampAnimationDelay ? parseInt( ampAnimationDelay ) : '' }
+									animationAfter={ animationAfter }
+									onAnimationTypeChange={ onAnimationTypeChange }
+									onAnimationDurationChange={ onAnimationDurationChange }
+									onAnimationDelayChange={ onAnimationDelayChange }
+									onAnimationAfterChange={ onAnimationOrderChange }
+								/>
+							</PanelBody>
+						</InspectorControls>
+					) }
+					{ isMovableBlock && (
+						<InspectorControls>
 							<PanelBody
 								title={ __( 'Animation', 'amp' ) }
 							>

--- a/assets/src/constants.js
+++ b/assets/src/constants.js
@@ -58,6 +58,13 @@ export const ALLOWED_MOVABLE_BLOCKS = [
 	'core/template', // Reusable blocks.
 ];
 
+export const BLOCKS_WITH_TEXT_SETTINGS = [
+	'amp/amp-story-text',
+	'amp/amp-story-post-author',
+	'amp/amp-story-post-date',
+	'amp/amp-story-post-title',
+];
+
 export const ALLOWED_CHILD_BLOCKS = [
 	...ALLOWED_MOVABLE_BLOCKS,
 	'amp/amp-story-cta',


### PR DESCRIPTION
Removes adding Text and Color settings to the blocks that actually don't use these, such as Image, List, Quote, Code, etc.