### PR TITLE
Release 1.1.1

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://amp-wp.org
  * Author: AMP Project Contributors
  * Author URI: https://github.com/ampproject/amp-wp/graphs/contributors
- * Version: 1.1.1-alpha
+ * Version: 1.1.1
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -115,7 +115,7 @@ if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) || ! file_exists( __DIR__
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '1.1.1-alpha' );
+define( 'AMP__VERSION', '1.1.1' );
 
 /**
  * Print admin notice if plugin installed with incorrect slug (which impacts WordPress's auto-update system).

--- a/bin/tag-built.sh
+++ b/bin/tag-built.sh
@@ -2,10 +2,14 @@
 
 set -e
 
-tag=$(git describe --tags)
+tag=$(cat build/amp.php | grep 'Version:' | sed 's/.*: //')
 if [[ -z "$tag" ]]; then
-    echo "Error: Unable to determine tag."
+    echo "Error: Unable to determine tag from build/amp.php."
     exit 1
+fi
+if ! git rev-parse "$tag" >/dev/null 2>&1; then
+    echo "Error: Tag does not exist: $tag"
+    exit 2
 fi
 
 built_tag="$tag-built"
@@ -19,8 +23,9 @@ if ! git diff-files --quiet || ! git diff-index --quiet --cached HEAD --; then
     exit 3
 fi
 
-git checkout "$tag"
-npm run build
+if [[ -e built ]]; then
+    rm -rf built
+fi
 mkdir built
 git clone . built/
 cd built

--- a/contributing.md
+++ b/contributing.md
@@ -169,9 +169,10 @@ Contributors who want to make a new release, follow these steps:
 7. Run `npm run deploy` to commit the plugin to WordPress.org.
 8. Confirm the release is available on WordPress.org; try installing it on a WordPress install and confirm it works.
 9. Publish GitHub release.
-10. Create built release tag: `git fetch --tags && git checkout $(git tag | tail -n1) && ./bin/tag-built.sh` (then add link from release)
-11. Create a new branch off of the release branch (e.g. `update/develop-with-1.0.x`), merge `develop` into it and resolve conflicts (e.g. with version), and then open pull request to merge changes into `develop`.
-12. Merge release tag into `master`.
-13. Publish release blog post, including link to GitHub release.
-14. Close the GitHub milestone and project.
-15. Make announcements.
+10. Create built release tag (from the just-created `build` directory): `git fetch --tags && ./bin/tag-built.sh` (then add link from release)
+11. For new major/minor releases, create a release branch from the tag. Patch versions are made from the release branch.
+12. Bump `Stable tag` in the `readme.txt`/`readme.md` in `develop`. Cherry-pick other changes as necessary.
+13. Merge release tag into `master`.
+14. Publish release blog post, including link to GitHub release.
+15. Close the GitHub milestone and project.
+16. Make announcements.

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Enable AMP on your WordPress site, the WordPress way.
 **Tags:** [amp](https://wordpress.org/plugins/tags/amp), [mobile](https://wordpress.org/plugins/tags/mobile)  
 **Requires at least:** 4.9  
 **Tested up to:** 5.1  
-**Stable tag:** 1.1.0  
+**Stable tag:** 1.1.1  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Requires PHP:** 5.4  
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: automattic, xwp, google, westonruter, ryankienstra, batmoo, stubgo
 Tags: amp, mobile
 Requires at least: 4.9
 Tested up to: 5.1
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP: 5.4


### PR DESCRIPTION
_Drafted release notes:_

* Fix `first_child_tag_name_oneof` constraint to only apply if first child exists. This prevents sanitizer from erroneously removing `amp-state[src]` elements. Props westonruter. See https://github.com/ampproject/amp-wp/pull/2152.
* Prevent `wp_targeted_link_rel()` from corrupting JSON in `amp_validation_error`'s `term_description`. See https://github.com/ampproject/amp-wp/pull/2158. Props westonruter.
* Improve i18n strings and placeholders. See https://github.com/ampproject/amp-wp/pull/2140. Props swissspidy.
* Fix link to outdated wiki page for AMP analytics. See https://github.com/ampproject/amp-wp/pull/2141. Props  swissspidy.

See [1.1.1 milestone](https://github.com/ampproject/amp-wp/milestone/14?closed=1) and [diff of changes from 1.1.0](https://github.com/ampproject/amp-wp/compare/1.1.0...1.1).

Build of 1.1.1: [amp.zip](https://github.com/ampproject/amp-wp/files/3105838/amp.zip)
