### PR TITLE
[AMP Stories] Fix recursion bug.

### DIFF
--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -30,14 +30,23 @@ class TextBlockEdit extends Component {
 		this.onReplace = this.onReplace.bind( this );
 	}
 
-	componentDidUpdate() {
-		const { attributes, setAttributes } = this.props;
+	componentDidUpdate( prevProps ) {
+		const { attributes, isSelected, setAttributes } = this.props;
 		const {
 			height,
 			width,
 			autoFontSize,
 			ampFitText,
 		} = attributes;
+
+		// If not selected, only proceed if height or width has changed.
+		if (
+			! isSelected &&
+			prevProps.attributes.height === height &&
+			prevProps.attributes.width === width
+		) {
+			return;
+		}
 
 		if ( ampFitText && attributes.content.length ) {
 			// Check if the font size is OK, if not, update the font size if not.

--- a/assets/src/blocks/amp-story-text/edit.js
+++ b/assets/src/blocks/amp-story-text/edit.js
@@ -31,7 +31,7 @@ class TextBlockEdit extends Component {
 	}
 
 	componentDidUpdate() {
-		const { attributes, isSelected, setAttributes } = this.props;
+		const { attributes, setAttributes } = this.props;
 		const {
 			height,
 			width,
@@ -39,7 +39,7 @@ class TextBlockEdit extends Component {
 			ampFitText,
 		} = attributes;
 
-		if ( isSelected && ampFitText ) {
+		if ( ampFitText && attributes.content.length ) {
 			// Check if the font size is OK, if not, update the font size if not.
 			const element = document.querySelector( `#block-${ this.props.clientId } .block-editor-rich-text__editable` );
 			if ( element ) {

--- a/assets/src/blocks/amp-story-text/index.js
+++ b/assets/src/blocks/amp-story-text/index.js
@@ -45,6 +45,7 @@ const schema = {
 	},
 	autoFontSize: {
 		type: 'number',
+		default: 45,
 	},
 	ampFitText: {
 		type: 'boolean',


### PR DESCRIPTION
Fixes #2064.

Looks like the recursion came from calculating the auto font size in the Text block.

There are a few things that have influenced the amp-fit-text calculation:
- The post showing updated at the first load even though it is saved. This causes the update to run right away and starts the font calculation (will be handled separately within #2172).
- The recursion itself seemed to happen from the fact that for some reason the placeholder font size is not being updated within the `calculateFontSize` function with `measurer.style.fontSize = mid + 'px';`, thus the measurer's width and height do not change when changing the font size. It changes only once the font size has been assigned and the element re-renders, causing a new update, and causing a new calculation which again -- doesn't consider the placeholder's size and then later causes a new calculation again, etc. etc. This PR handles the issue by setting a default autoFontSize for the sake of the placeholder and not calculating font unless content has been added. This fixes the recursion error, however, would be good to look into the option of changing the placeholders font size too. (You can see the problem by editing empty Text block's `font-size` CSS directly in the browser -- the size of the placeholder doesn't change when changing the font size.)
- After resizing, the block is unselected, this causes the font not being calculated properly, previously the font was calculated only when the block is selected.