### PR TITLE
[AMP Stories] Fix displaying a saved AMP Story as unsaved when loading

### DIFF
--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -59,7 +59,7 @@ const {
 	getBlockOrder,
 	getBlock,
 	getBlockAttributes,
-} = select( 'core/editor' );
+} = select( 'core/block-editor' );
 
 const {
 	isReordering,
@@ -71,7 +71,7 @@ const {
 const {
 	moveBlockToPosition,
 	updateBlockAttributes,
-} = dispatch( 'core/editor' );
+} = dispatch( 'core/block-editor' );
 
 const {
 	setCurrentPage,

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -39,6 +39,7 @@ import {
 	addAMPExtraProps,
 	getTotalAnimationDuration,
 	renderStoryComponents,
+	maybeInitializeAnimations,
 	maybeSetInitialPositioning,
 	maybeSetTagName,
 	maybeUpdateAutoAdvanceAfterMedia,
@@ -74,10 +75,6 @@ const {
 
 const {
 	setCurrentPage,
-	addAnimation,
-	changeAnimationType,
-	changeAnimationDuration,
-	changeAnimationDelay,
 } = dispatch( 'amp/story' );
 
 /**
@@ -100,21 +97,7 @@ domReady( () => {
 	const firstPage = allBlocks.find( ( { name } ) => name === 'amp/amp-story-page' );
 	setCurrentPage( firstPage ? firstPage.clientId : undefined );
 
-	// Set initial animation order state for all child blocks.
 	for ( const block of allBlocks ) {
-		const page = getBlockRootClientId( block.clientId );
-
-		if ( page ) {
-			const { ampAnimationType, ampAnimationAfter, ampAnimationDuration, ampAnimationDelay } = block.attributes;
-			const predecessor = allBlocks.find( ( b ) => b.attributes.anchor === ampAnimationAfter );
-
-			addAnimation( page, block.clientId, predecessor ? predecessor.clientId : undefined );
-
-			changeAnimationType( page, block.clientId, ampAnimationType );
-			changeAnimationDuration( page, block.clientId, ampAnimationDuration ? parseInt( ampAnimationDuration.replace( 'ms', '' ) ) : undefined );
-			changeAnimationDelay( page, block.clientId, ampAnimationDelay ? parseInt( ampAnimationDelay.replace( 'ms', '' ) ) : undefined );
-		}
-
 		// Load all needed fonts.
 		if ( block.attributes.ampFontFamily ) {
 			maybeEnqueueFontStyle( block.attributes.ampFontFamily );
@@ -155,6 +138,8 @@ let blockOrder = getBlockOrder();
 let allBlocksWithChildren = getClientIdsWithDescendants();
 
 subscribe( () => {
+	maybeInitializeAnimations();
+
 	const defaultBlockName = getDefaultBlockName();
 	const selectedBlockClientId = getSelectedBlockClientId();
 

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -345,12 +345,11 @@ class EditPage extends Component {
 
 export default withSelect( ( select, { clientId, attributes } ) => {
 	const { getMedia } = select( 'core' );
-	const { getBlockOrder, getBlocksByClientId } = select( 'core/editor' );
+	const { getBlockOrder, getBlocksByClientId, getBlockRootClientId } = select( 'core/block-editor' );
 
 	const innerBlocks = getBlocksByClientId( getBlockOrder( clientId ) );
 	const isFirstPage = getBlockOrder().indexOf( clientId ) === 0;
 	const isCallToActionAllowed = ! isFirstPage && ! innerBlocks.some( ( { name } ) => name === 'amp/amp-story-cta' );
-	const { getBlockRootClientId } = select( 'core/editor' );
 	const { getAnimatedBlocks } = select( 'amp/story' );
 
 	const { mediaId } = attributes;

--- a/assets/src/components/block-navigation/index.js
+++ b/assets/src/components/block-navigation/index.js
@@ -86,7 +86,7 @@ function BlockNavigation( { blocks, selectBlock, selectedBlockClientId, isReorde
 export default compose(
 	withSelect( ( select ) => {
 		const { getCurrentPage, isReordering } = select( 'amp/story' );
-		const { getBlockOrder, getBlocksByClientId, getSelectedBlockClientId } = select( 'core/editor' );
+		const { getBlockOrder, getBlocksByClientId, getSelectedBlockClientId } = select( 'core/block-editor' );
 
 		const blocks = getCurrentPage() ? getBlocksByClientId( getBlockOrder( getCurrentPage() ) ) : [];
 
@@ -99,7 +99,7 @@ export default compose(
 	withDispatch( ( dispatch, { onSelect = () => undefined } ) => {
 		return {
 			selectBlock( clientId ) {
-				dispatch( 'core/editor' ).selectBlock( clientId );
+				dispatch( 'core/block-editor' ).selectBlock( clientId );
 				onSelect( clientId );
 			},
 		};

--- a/assets/src/components/editor-carousel/index.js
+++ b/assets/src/components/editor-carousel/index.js
@@ -96,7 +96,7 @@ export default compose(
 			getBlockOrder,
 			getBlocksByClientId,
 			getAdjacentBlockClientId,
-		} = select( 'core/editor' );
+		} = select( 'core/block-editor' );
 		const { getCurrentPage, isReordering } = select( 'amp/story' );
 
 		const currentPage = getCurrentPage();
@@ -113,7 +113,7 @@ export default compose(
 	} ),
 	withDispatch( ( dispatch ) => {
 		const { setCurrentPage } = dispatch( 'amp/story' );
-		const { selectBlock } = dispatch( 'core/editor' );
+		const { selectBlock } = dispatch( 'core/block-editor' );
 
 		return {
 			onChangePage: ( pageClientId ) => {

--- a/assets/src/components/inserter/menu.js
+++ b/assets/src/components/inserter/menu.js
@@ -367,12 +367,13 @@ export default compose(
 			getBlockName,
 			getBlockRootClientId,
 			getBlockSelectionEnd,
+			canInsertBlockType,
+			getBlockListSettings,
 		} = select( 'core/block-editor' );
 		const {
 			getChildBlockNames,
 		} = select( 'core/blocks' );
 		const { getCurrentPage } = select( 'amp/story' );
-		const { canInsertBlockType, getBlockListSettings } = select( 'core/editor' );
 
 		let destinationRootClientId = rootClientId;
 		if ( ! destinationRootClientId && ! clientId && ! isAppender ) {

--- a/assets/src/components/reorderer/index.js
+++ b/assets/src/components/reorderer/index.js
@@ -37,7 +37,7 @@ const Reorderer = ( { pages } ) => {
 };
 
 export default withSelect( ( select ) => {
-	const { getBlocksByClientId } = select( 'core/editor' );
+	const { getBlocksByClientId } = select( 'core/block-editor' );
 	const { getBlockOrder } = select( 'amp/story' );
 
 	const pages = getBlocksByClientId( getBlockOrder() );

--- a/assets/src/components/shortcuts.js
+++ b/assets/src/components/shortcuts.js
@@ -37,7 +37,7 @@ const Shortcuts = ( { insertBlock, canInsertBlockType } ) => {
 
 const applyWithSelect = withSelect( ( select ) => {
 	const { getCurrentPage } = select( 'amp/story' );
-	const { canInsertBlockType, getBlockListSettings } = select( 'core/editor' );
+	const { canInsertBlockType, getBlockListSettings } = select( 'core/block-editor' );
 
 	return {
 		canInsertBlockType: ( name ) => {
@@ -49,8 +49,8 @@ const applyWithSelect = withSelect( ( select ) => {
 
 const applyWithDispatch = withDispatch( ( dispatch, props, { select } ) => {
 	const { getCurrentPage } = select( 'amp/story' );
-	const { getBlockOrder } = select( 'core/editor' );
-	const { insertBlock } = dispatch( 'core/editor' );
+	const { getBlockOrder } = select( 'core/block-editor' );
+	const { insertBlock } = dispatch( 'core/block-editor' );
 
 	return {
 		insertBlock: ( name ) => {

--- a/assets/src/components/with-active-page-state.js
+++ b/assets/src/components/with-active-page-state.js
@@ -11,7 +11,7 @@ import { withSelect, dispatch } from '@wordpress/data';
  */
 const withActivePageState = ( BlockListBlock ) => {
 	return withSelect( ( select, { clientId } ) => {
-		const { getBlockRootClientId } = select( 'core/editor' );
+		const { getBlockRootClientId } = select( 'core/block-editor' );
 		const { getCurrentPage } = select( 'amp/story' );
 
 		return {
@@ -37,7 +37,7 @@ const withActivePageState = ( BlockListBlock ) => {
 		};
 
 		const { setCurrentPage } = dispatch( 'amp/story' );
-		const { selectBlock } = dispatch( 'core/editor' );
+		const { selectBlock } = dispatch( 'core/block-editor' );
 
 		if ( ! isActivePage ) {
 			return (

--- a/assets/src/components/with-amp-story-settings.js
+++ b/assets/src/components/with-amp-story-settings.js
@@ -38,7 +38,7 @@ const applyFallbackStyles = withFallbackStyles( ( node, ownProps ) => {
 } );
 
 const applyWithSelect = withSelect( ( select, props ) => {
-	const { getSelectedBlockClientId, getBlockRootClientId, getBlock } = select( 'core/editor' );
+	const { getSelectedBlockClientId, getBlockRootClientId, getBlock } = select( 'core/block-editor' );
 	const { getAnimatedBlocks, isValidAnimationPredecessor } = select( 'amp/story' );
 
 	const currentBlock = getSelectedBlockClientId();

--- a/assets/src/components/with-attributes.js
+++ b/assets/src/components/with-attributes.js
@@ -12,7 +12,7 @@ import { withSelect } from '@wordpress/data';
 export default createHigherOrderComponent(
 	withSelect(
 		( select, props ) => {
-			const { getBlockAttributes } = select( 'core/editor' );
+			const { getBlockAttributes } = select( 'core/block-editor' );
 
 			let attributes;
 

--- a/assets/src/components/with-block-name.js
+++ b/assets/src/components/with-block-name.js
@@ -12,7 +12,7 @@ import { withSelect } from '@wordpress/data';
 export default createHigherOrderComponent(
 	withSelect(
 		( select, props ) => {
-			const { getBlockName } = select( 'core/editor' );
+			const { getBlockName } = select( 'core/block-editor' );
 
 			return {
 				blockName: getBlockName( props.clientId ),

--- a/assets/src/components/with-call-to-action-validation.js
+++ b/assets/src/components/with-call-to-action-validation.js
@@ -21,7 +21,7 @@ const enhance = compose(
 	 * @return {Component} Enhanced component with merged state data props.
 	 */
 	withSelect( ( select, props ) => {
-		const { getBlockRootClientId, getBlock, getBlockOrder, getBlocksByClientId } = select( 'core/editor' );
+		const { getBlockRootClientId, getBlock, getBlockOrder, getBlocksByClientId } = select( 'core/block-editor' );
 
 		if ( 'amp/amp-story-cta' !== props.name ) {
 			return {};
@@ -44,7 +44,7 @@ const enhance = compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { originalBlockClientId } ) => ( {
-		selectFirst: () => dispatch( 'core/editor' ).selectBlock( originalBlockClientId ),
+		selectFirst: () => dispatch( 'core/block-editor' ).selectBlock( originalBlockClientId ),
 	} ) ),
 );
 

--- a/assets/src/components/with-edit-featured-image.js
+++ b/assets/src/components/with-edit-featured-image.js
@@ -27,7 +27,7 @@ export default ( BlockEdit ) => {
 		}
 
 		const selectedMediaId = ownProps.attributes.mediaId || ownProps.attributes.id;
-		const selectedBlock = select( 'core/editor' ).getSelectedBlock();
+		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if ( ! selectedMediaId || ! selectedBlock || ! selectedBlock.attributes ) {
 			return;
 		}

--- a/assets/src/components/with-has-selected-inner-block.js
+++ b/assets/src/components/with-has-selected-inner-block.js
@@ -12,7 +12,7 @@ import { withSelect } from '@wordpress/data';
 export default createHigherOrderComponent(
 	withSelect(
 		( select, props ) => {
-			const { hasSelectedInnerBlock } = select( 'core/editor' );
+			const { hasSelectedInnerBlock } = select( 'core/block-editor' );
 
 			return {
 				hasSelectedInnerBlock: hasSelectedInnerBlock( props.clientId, true ),

--- a/assets/src/components/with-page-number.js
+++ b/assets/src/components/with-page-number.js
@@ -16,7 +16,7 @@ const applyWithSelect = withSelect( ( select, props ) => {
 	const {
 		getBlockOrder,
 		getBlockRootClientId,
-	} = select( 'core/editor' );
+	} = select( 'core/block-editor' );
 	const {	isReordering } = select( 'amp/story' );
 
 	if ( '' !== getBlockRootClientId( props.clientId ) ) {

--- a/assets/src/components/with-selected-block.js
+++ b/assets/src/components/with-selected-block.js
@@ -7,7 +7,7 @@ import { withSelect } from '@wordpress/data';
 export default createHigherOrderComponent(
 	withSelect(
 		( select ) => {
-			const { getSelectedBlock } = select( 'core/editor' );
+			const { getSelectedBlock } = select( 'core/block-editor' );
 
 			return {
 				selectedBlock: getSelectedBlock(),

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -45,7 +45,7 @@ const {
 	getBlockOrder,
 	getBlock,
 	getClientIdsWithDescendants,
-} = select( 'core/editor' );
+} = select( 'core/block-editor' );
 
 const {
 	addAnimation,
@@ -58,7 +58,7 @@ const {
 	getAnimatedBlocks,
 } = select( 'amp/story' );
 
-const { updateBlockAttributes } = dispatch( 'core/editor' );
+const { updateBlockAttributes } = dispatch( 'core/block-editor' );
 
 export const maybeEnqueueFontStyle = ( name ) => {
 	if ( ! name || 'undefined' === typeof ampStoriesFonts ) {

--- a/assets/src/helpers.js
+++ b/assets/src/helpers.js
@@ -18,8 +18,7 @@ import { getColorClassName, getColorObjectByAttributeValues, RichText } from '@w
 /**
  * Internal dependencies
  */
-// eslint-disable-next-line no-unused-vars
-import store from './stores/amp-story';
+import './stores/amp-story';
 import {
 	BlockNavigation,
 	EditorCarousel,

--- a/assets/src/stores/amp-story/reducer.js
+++ b/assets/src/stores/amp-story/reducer.js
@@ -8,7 +8,7 @@ import { select, combineReducers } from '@wordpress/data';
  */
 import { isValidAnimationPredecessor } from './selectors';
 
-const { getBlock, getBlockOrder } = select( 'core/editor' );
+const { getBlock, getBlockOrder } = select( 'core/block-editor' );
 
 /**
  * Reducer handling animation state changes.

--- a/assets/src/temporarily-disabled-plugins/template-menu-item.js
+++ b/assets/src/temporarily-disabled-plugins/template-menu-item.js
@@ -20,7 +20,7 @@ const addTemplate = () => {
 	const {
 		__experimentalReceiveReusableBlocks: receiveReusableBlocks,
 		__experimentalSaveReusableBlock: saveReusableBlock,
-	} = dispatch( 'core/editor' );
+	} = dispatch( 'core/block-editor' );
 
 	// @todo Allow multi-page templates.
 	const parsedBlock = getBlock( getSelectedBlockClientId() );


### PR DESCRIPTION
This PR Moves setting the initial state of animation order out of `domReady`.

Also replaces the `core/editor` with `core/block-editor` where it's still used.