### PR TITLE
Remove intl from required extensions

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -38,9 +38,11 @@ if ( version_compare( phpversion(), '5.4', '<' ) ) {
 // See composer.json for this list.
 $_amp_required_extensions = array(
 	'curl',
+	'date',
 	'dom',
 	'iconv',
 	'libxml',
+	'spl',
 );
 $_amp_missing_extensions  = array();
 foreach ( $_amp_required_extensions as $_amp_required_extension ) {

--- a/amp.php
+++ b/amp.php
@@ -40,7 +40,6 @@ $_amp_required_extensions = array(
 	'curl',
 	'dom',
 	'iconv',
-	'intl',
 	'libxml',
 );
 $_amp_missing_extensions  = array();

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "ext-curl": "*",
     "ext-dom": "*",
     "ext-iconv": "*",
-    "ext-intl": "*",
     "ext-libxml": "*",
     "cweagans/composer-patches": "1.6.5",
     "fasterimage/fasterimage": "1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -7,12 +7,19 @@
   "require": {
     "php": "^5.4 || ^7.0",
     "ext-curl": "*",
+    "ext-date": "*",
     "ext-dom": "*",
     "ext-iconv": "*",
     "ext-libxml": "*",
+    "ext-spl": "*",
     "cweagans/composer-patches": "1.6.5",
     "fasterimage/fasterimage": "1.4.0",
     "sabberworm/php-css-parser": "8.3.0"
+  },
+  "suggest": {
+    "ext-intl": "Enables use of idn_to_utf8() to convert punycode domains to UTF-8 for use with an AMP Cache.",
+    "ext-json": "Provides native implementation of json_encode()/json_decode().",
+    "ext-mbstring": "Used by PHP-CSS-Parser when working with stylesheets."
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "0.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdb4b18c2d8983eadff4218c7ab982d8",
+    "content-hash": "f69361cbea4d0ca9724005700514b134",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -466,11 +466,10 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^5.4 || ^7.0",
+        "ext-curl": "*",
         "ext-dom": "*",
         "ext-iconv": "*",
-        "ext-intl": "*",
-        "ext-libxml": "*",
-        "ext-curl": "*"
+        "ext-libxml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
It turns out that `intl` isn't actually a requirement. I tried deploying changes merged in #2183 to Pantheon and upon doing so the plugin stopped initializing due to the `intl` extension not being installed. In fact, the extension is not required as we do a `function_exists` check before using it:

https://github.com/ampproject/amp-wp/blob/98c25457875a30fc18ca2b2a34d74561ab59dc88/includes/class-amp-http.php#L205-L209