### PR TITLE
Slightly improve issue with the text block resized with background

### DIFF
--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -1,7 +1,7 @@
 amp-story-grid-layer[template="fill"] .wp-block-image { margin: 0; }
 
 .has-background {
-	padding: 7px !important;
+	padding: 1px 5px !important;
 	display: flex;
 }
 


### PR DESCRIPTION
* As Miina found, when the Text block is resized small and has a background width, it appears too tall in the block editor.
* This removes the padding-top and bottom, leaving only padding-left and right.
* It doesn't completely fix the difference in the front-end and back-end display, but the text isn't cut off in the front-end.
* Still, the text on the front-end isn't quite the right size (see "After" below).

# Before
![before-pr-padding](https://user-images.githubusercontent.com/4063887/56712093-df8a1c80-66f2-11e9-8b0d-1f48f7cd1685.gif)

# After 
![after-pr-padding](https://user-images.githubusercontent.com/4063887/56712118-ef096580-66f2-11e9-878a-ad92683dee46.gif)

See #2162