### PR TITLE
Change <Button> to <a>, to work around a console warning

### DIFF
--- a/assets/src/components/template-inserter/index.js
+++ b/assets/src/components/template-inserter/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton, Button } from '@wordpress/components';
+import { Dropdown, IconButton } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';

--- a/assets/src/components/template-inserter/index.js
+++ b/assets/src/components/template-inserter/index.js
@@ -1,3 +1,9 @@
+
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
 /**
  * WordPress dependencies
  */
@@ -7,6 +13,7 @@ import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { compose } from '@wordpress/compose';
+import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -112,8 +119,10 @@ class TemplateInserter extends Component {
 											onClick={ () => {
 												onSelect( item );
 											} }
-											onKeyDown={ () => {
-												onSelect( item );
+											onKeyDown={ ( event ) => {
+												if ( includes( [ ENTER, SPACE ], event.keyCode ) ) {
+													onSelect( item );
+												}
 											} }
 											className="components-button block-editor-block-preview"
 										>

--- a/assets/src/components/template-inserter/index.js
+++ b/assets/src/components/template-inserter/index.js
@@ -105,9 +105,14 @@ class TemplateInserter extends Component {
 										/>
 									</div>
 									{ storyTemplates && storyTemplates.map( ( item ) => (
-										<Button
+										<a // eslint-disable-line jsx-a11y/anchor-is-valid, see https://github.com/ampproject/amp-wp/issues/2165
 											key={ `template-preview-${ item.id }` }
+											role="button"
+											tabIndex="0"
 											onClick={ () => {
+												onSelect( item );
+											} }
+											onKeyDown={ () => {
 												onSelect( item );
 											} }
 											className="components-button block-editor-block-preview"
@@ -116,7 +121,7 @@ class TemplateInserter extends Component {
 												name="core/block"
 												attributes={ { ref: item.id } }
 											/>
-										</Button>
+										</a>
 									) ) }
 								</div>
 							</div>


### PR DESCRIPTION
As @miina mentioned in #2165, there was a console warning: `validateDOMNesting(...): <button> cannot appear as a descendent of <button>`

So this changes the wrapping `<Button>` to `<a>`.

This isn't ideal, but it prevents the console warning.

Maybe there's a good way to selectively disable the `<Button>` components in the [BlockPreview](https://github.com/ampproject/amp-wp/blob/fc98d441277b1c83070921f8b607e53683cf0559/assets/src/components/template-inserter/index.js#L115), but I could find one.

The `<BlockPreview>` [is wrapped in](https://github.com/ampproject/amp-wp/blob/7264d585043fb863e5f144f07daff66772836230/assets/src/components/block-preview.js#L18) `<Disabled>`.

And the `<Button>` component [has a disabled property](https://github.com/WordPress/gutenberg/blob/87d7fe4be406aedb3aefa7d961ac3781ab600654/packages/components/src/button/index.js#L42) that can change the `<button>` to a `<a>`. But that property doesn't look to be `true`.

Fixes #2165