### PR TITLE
Inject width/height attributes into video elements from the Video block

### DIFF
--- a/assets/js/amp-editor-blocks.js
+++ b/assets/js/amp-editor-blocks.js
@@ -64,6 +64,7 @@ var ampEditorBlocks = ( function() { // eslint-disable-line no-unused-vars
 					value: 'intrinsic',
 					label: __( 'Intrinsic', 'amp' ),
 					notAvailable: [
+						'core/video',
 						'core-embed/youtube',
 						'core-embed/facebook',
 						'core-embed/instagram',

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -14,15 +14,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;
 
 	/**
-	 * Value used for height attribute when $attributes['height'] is empty.
-	 *
-	 * @since 0.2
-	 *
-	 * @const int
-	 */
-	const FALLBACK_HEIGHT = 400;
-
-	/**
 	 * Default values for sandboxing IFrame.
 	 *
 	 * @since 0.2

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -188,6 +188,10 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Filter video dimensions, try to get width and height from original file if missing.
 	 *
+	 * The video block will automatically have the width/height supplied for attachments.
+	 *
+	 * @see \AMP_Core_Block_Handler::ampify_video_block()
+	 *
 	 * @param array  $new_attributes Attributes.
 	 * @param string $src            Video URL.
 	 * @return array Modified attributes.

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -16,15 +16,6 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	use AMP_Noscript_Fallback;
 
 	/**
-	 * Value used for height attribute when $attributes['height'] is empty.
-	 *
-	 * @since 0.2
-	 *
-	 * @const int
-	 */
-	const FALLBACK_HEIGHT = 400;
-
-	/**
 	 * Tag.
 	 *
 	 * @var string HTML <video> tag to identify and replace with AMP version.


### PR DESCRIPTION
Determining the `width`/`height` for an embedded video is currently handled by `\AMP_Video_Sanitizer::filter_video_dimensions()`:

https://github.com/ampproject/amp-wp/blob/6478d69790bb03da1fa56c313cd4acca3eef1907/includes/sanitizers/class-amp-video-sanitizer.php#L188-L223

It attempts to look up the attachment post ID by querying attachments for one that has a `post_name` matching the filename, and then if one is returned, it will obtain the `width`/`height` from the attachment metadata. This is brittle, however, when someone uploads multiple copies of the same filename, since the `post_name` will no longer correspond to the filename. For example, uploading two copies of `foo.mp4` will result in the first having a `post_name` of `foo` and filename of `foo.mp4` but the second copy will instead have a `post_name` of `foo-2` and a filename of `foo-1.mp4` (an interesting inconsistency in how WordPress deals with name conflicts).

This was the best we had available when implementing support for video embeds when the `video` shortcode was used, since it lacked the attachment ID as context:

```html
[video width="1000" height="200" mp4="https://example.com/content/uploads/2019/04/foo.mp4"][/video]
```

With blocks however, this is no longer the case. The original attachment ID is included in the block attributes:

```html
<!-- wp:video {"id":1194} -->
<figure class="wp-block-video"><video controls src="https://example.com/content/uploads/2019/04/foo.mp4"></video></figure>
<!-- /wp:video -->
```

So in the case of video blocks, we now have the opportunity to use the `render_block` filter to intercept the return value of the video block markup and to inject the `width`/`height` from the associated attachment metadata up-front:

```html
<figure class="wp-block-video"><video height="200" width="1000" controls src="https://example.com/content/uploads/2019/04/foo.mp4"></video></figure>
```

This is then picked up by the video sanitizer to convert into an `amp-video`. (We could also consider just replacing the `<video>` with an `<amp-video>` here at this point of embedded as opposed to deferring to sanitizing during post-processing. But this can be revisited later.)

----

Additionally, it turns out that the Intrinsic layout option was being available to the Video block, incorrectly. It only supports the layouts: fill, fixed, fixed-height, flex-item, nodisplay, responsive. So this also removes that layout option. 

Lastly, this PR removes a couple unused constants.