### PR TITLE
Revert PHP version error message translation string from #2183

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -29,7 +29,7 @@ if ( version_compare( phpversion(), '5.4', '<' ) ) {
 		'insufficient_php_version',
 		sprintf(
 			/* translators: %s: required PHP version */
-			__( 'The AMP plugin requires PHP %s; please contact your host to update your PHP version.', 'amp' ),
+			__( 'The AMP plugin requires PHP %s. Please contact your host to update your PHP version.', 'amp' ),
 			'5.4+'
 		)
 	);


### PR DESCRIPTION
See https://github.com/ampproject/amp-wp/pull/2183/files#r278899906:

> We should turn this semicolon into a dot again in order to not make existing translations fuzzy.