### PR TITLE
Improve handling of layout for images

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -220,16 +220,21 @@ abstract class AMP_Base_Sanitizer {
 	/**
 	 * Sanitizes a CSS dimension specifier while being sensitive to dimension context.
 	 *
-	 * @param string $value A valid CSS dimension specifier; e.g. 50, 50px, 50%.
-	 * @param string $dimension 'width' or ignored. 'width' only affects $values ending in '%'.
+	 * @param string $value     A valid CSS dimension specifier; e.g. 50, 50px, 50%. Can be 'auto' for width.
+	 * @param string $dimension Dimension, either 'width' or 'height'.
 	 *
-	 * @return float|int|string Returns a numeric dimension value, or an empty string.
+	 * @return float|int|string Returns a numeric dimension value, 'auto', or an empty string.
 	 */
 	public function sanitize_dimension( $value, $dimension ) {
 
 		// Allows 0 to be used as valid dimension.
 		if ( null === $value ) {
 			return '';
+		}
+
+		// Allow special 'auto' value for fixed-height layout.
+		if ( 'width' === $dimension && 'auto' === $value ) {
+			return $value;
 		}
 
 		// Accepts both integers and floats & prevents negative values.

--- a/tests/test-amp-img-sanitizer.php
+++ b/tests/test-amp-img-sanitizer.php
@@ -260,6 +260,54 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150">',
 				'<amp-img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
 			),
+
+			'img_with_fill_layout_inline_style'        => array(
+				'<img src="https://placehold.it/20x20" data-amp-layout="fill" style="display: inline">',
+				'<amp-img src="https://placehold.it/20x20" layout="fill" style="display:block" class="amp-wp-enforced-sizes"></amp-img>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
+			'img_with_intrinsic_layout_inline_style'   => array(
+				'<img src="https://placehold.it/20x20" width="20" height="20" style="display: inline">',
+				'<amp-img src="https://placehold.it/20x20" width="20" height="20" style="display:inline-block" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
+			'img_with_responsive_layout_inline_style'  => array(
+				'<img src="https://placehold.it/20x20" width="20" height="20" style="display: inline" data-amp-layout="responsive">',
+				'<amp-img src="https://placehold.it/20x20" width="20" height="20" style="display:block" layout="responsive" class="amp-wp-enforced-sizes"></amp-img>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
+			'img_with_fixed_height_inline_style'       => array(
+				'<img src="https://placehold.it/20x200" height="20" width="auto" data-amp-layout="fixed-height" style="display: inline-block">',
+				'<amp-img src="https://placehold.it/20x200" height="20" width="auto" layout="fixed-height" style="display:block" class="amp-wp-enforced-sizes"></amp-img>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
+			'img_with_flex_item_inline_style'          => array(
+				'<img src="https://placehold.it/20x200" data-amp-layout="flex-item" style="display: inline-block">',
+				'<amp-img src="https://placehold.it/20x200" layout="flex-item" style="display:block" class="amp-wp-enforced-sizes"></amp-img>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
+
+			'img_with_nodisplay_layout_inline_style'   => array(
+				'<img src="https://placehold.it/20x20" data-amp-layout="nodisplay" style="display: inline">',
+				'<amp-img src="https://placehold.it/20x20" layout="nodisplay" style="display:none" class="amp-wp-enforced-sizes"></amp-img>',
+				array(
+					'add_noscript_fallback' => false,
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
* Prevent inline styles on images from overriding required display for layout. This prevents images with `style="display:inline"` from failing to render. See #1803.
* Eliminate fetching image dimensions for layouts that don't require them. If image has a `fixed-height` layout and it only has a `height` defined, there is no need to fetch the image for the `width`. Other layouts (like `fill`) also do not require dimensions.
* Allow special 'auto' value for width for `fixed-height` layout.

Given this `post_content`:

```html
An inline image: <img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" width="40" height="40" style="display: inline"> Do you like it?

Here is a responsive image:

<img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="668" width="1024" data-amp-layout="responsive" style="display: inline">

Image with fixed height which should look very stretched:

<img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="30" data-amp-layout="fixed-height" style="display: inline">
```

# Before 👎 

> ![image](https://user-images.githubusercontent.com/134745/56917349-1d2ed280-6a70-11e9-807d-da527471b9d4.png)

```html
<p>An inline image: <amp-img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" width="40" height="40" class="amp-wp-enforced-sizes amp-wp-2d150e5" layout="intrinsic"><noscript><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" width="40" height="40" class="amp-wp-2d150e5"></noscript></amp-img> Do you like it?</p>
<p>Here is a responsive image:</p>
<p><amp-img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="668" width="1024" layout="responsive" class="amp-wp-enforced-sizes amp-wp-2d150e5"><noscript><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="668" width="1024" class="amp-wp-2d150e5"></noscript></amp-img></p>
<p>Image with fixed height which should look very stretched:</p>
<p><amp-img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="30" layout="fixed-height" width="45.988023952096" class="amp-wp-enforced-sizes amp-wp-2d150e5"><noscript><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="30" width="45.988023952096" class=" amp-wp-2d150e5"></noscript></amp-img></p>
```

🚫  Notice the erroneous `width` being supplied for the `fixed-height` image. It should be either absent or `auto`.

# After 👍 

> ![image](https://user-images.githubusercontent.com/134745/56917272-eeb0f780-6a6f-11e9-9471-ae353c1e9033.png)

```html
<p>An inline image: <amp-img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" width="40" height="40" class="amp-wp-enforced-sizes amp-wp-6a19fc1" layout="intrinsic"><noscript><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" width="40" height="40" class="amp-wp-2d150e5"></noscript></amp-img> Do you like it?</p>
<p>Here is a responsive image:</p>
<p><amp-img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="668" width="1024" layout="responsive" class="amp-wp-enforced-sizes amp-wp-fa9aecc"><noscript><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="668" width="1024" class="amp-wp-2d150e5"></noscript></amp-img></p>
<p>Image with fixed height which should look very stretched:</p>
<p><amp-img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="30" layout="fixed-height" class="amp-wp-enforced-sizes amp-wp-fa9aecc"><noscript><img src="https://wordpressdev.lndo.site/content/uploads/2019/02/1200px-American_bison_k5680-1-1024x668.jpg" height="30" class="amp-wp-2d150e5"></noscript></amp-img></p>
```
----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3128647/amp.zip) (v1.2-alpha-20190429T181719Z-018fa900)