### PR TITLE
Simplify what's passed to withSelect, thanks to K Adam's suggestion

### DIFF
--- a/assets/src/components/with-edit-featured-image.js
+++ b/assets/src/components/with-edit-featured-image.js
@@ -43,9 +43,5 @@ export default ( BlockEdit ) => {
 		if ( media && media.media_details && hasMinimumStoryPosterDimensions( media.media_details ) ) {
 			dispatch( 'core/editor' ).editPost( { featured_media: selectedMediaId } );
 		}
-	} )( ( props ) => {
-		return (
-			<BlockEdit { ...props } />
-		);
-	} );
+	} )( BlockEdit );
 };


### PR DESCRIPTION
* K Adam [suggested in an unrelated Slack conversation](https://wordpress.slack.com/archives/C02QB2JS7/p1556566857076000) that this might be able to use simply `BlockEdit`, instead of an anonymous function
* This looks to work, and it simplifies it
