### PR TITLE
Add 'View AMP' link to admin bar in Reader mode; add admin bar item for non-admin users

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -272,6 +272,7 @@ function amp_init() {
 	add_action( 'wp_loaded', 'amp_add_options_menu' );
 	add_action( 'wp_loaded', 'amp_admin_pointer' );
 	add_action( 'parse_query', 'amp_correct_query_when_is_front_page' );
+	add_action( 'admin_bar_menu', 'amp_add_admin_bar_view_link', 100 );
 
 	// Redirect the old url of amp page to the updated url.
 	add_filter( 'old_slug_redirect_url', 'amp_redirect_old_slug_to_new_url' );

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1071,7 +1071,8 @@ function amp_wp_kses_mustache( $markup ) {
 /**
  * Add "View AMP" admin bar item for Transitional/Reader mode.
  *
- * Note that in Transitional mode, the admin bar item will be further amended by `AMP_Validation_Manager::add_admin_bar_menu_items()`.
+ * Note that when theme support is present (in Native/Transitional modes), the admin bar item will be further amended by
+ * the `AMP_Validation_Manager::add_admin_bar_menu_items()` method.
  *
  * @see \AMP_Validation_Manager::add_admin_bar_menu_items()
  *

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -190,7 +190,7 @@ class AMP_Validation_Manager {
 			}
 		);
 
-		add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_menu_items' ), 100 );
+		add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_menu_items' ), 101 );
 
 		// Add filter to auto-accept tree shaking validation error.
 		if ( AMP_Options_Manager::get_option( 'accept_tree_shaking' ) || AMP_Options_Manager::get_option( 'auto_accept_sanitization' ) ) {
@@ -259,6 +259,7 @@ class AMP_Validation_Manager {
 	 * - Parent admin and first submenu item: link to validate the URL.
 	 *
 	 * @see AMP_Validation_Manager::finalize_validation() Where the emoji is updated.
+	 * @see amp_add_admin_bar_view_link() Where an admin bar item may have been added already for Reader/Transitional modes.
 	 *
 	 * @param WP_Admin_Bar $wp_admin_bar Admin bar.
 	 */
@@ -357,12 +358,7 @@ class AMP_Validation_Manager {
 		}
 
 		$parent = array(
-			'id'    => 'amp',
-			'title' => sprintf(
-				'<span id="amp-admin-bar-item-status-icon">%s</span> %s',
-				$icon,
-				esc_html( is_amp_endpoint() ? __( 'AMP', 'amp' ) : __( 'View AMP', 'amp' ) )
-			),
+			'id' => 'amp',
 		);
 
 		$first_item_is_validate = (
@@ -374,10 +370,10 @@ class AMP_Validation_Manager {
 			$title          = __( 'Validate AMP', 'amp' );
 			$parent['href'] = esc_url( $validate_url );
 		} elseif ( is_amp_endpoint() ) {
-			$title          = __( 'AMP', 'amp' );
+			$title          = __( 'AMP', 'amp' ); // @todo This link will actually be to the non-AMP version!
 			$parent['href'] = esc_url( $non_amp_url );
 		} else {
-			$title          = __( 'View AMP', 'amp' );
+			$title          = __( 'AMP', 'amp' );
 			$parent['href'] = esc_url( $amp_url );
 		}
 		$parent['title'] = sprintf(
@@ -386,6 +382,7 @@ class AMP_Validation_Manager {
 			esc_html( $title )
 		);
 
+		// Note that this will correctly merge/amend any existing AMP nav menu item added in amp_add_admin_bar_view_link().
 		$wp_admin_bar->add_menu( $parent );
 
 		// Add admin bar item to switch between AMP and non-AMP if parent node is also an AMP link.

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -128,7 +128,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'rest_api_init', self::TESTED_CLASS . '::add_rest_api_fields' ) );
 
 		$this->assertContains( AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR, wp_removable_query_args() );
-		$this->assertEquals( 100, has_action( 'admin_bar_menu', array( self::TESTED_CLASS, 'add_admin_bar_menu_items' ) ) );
+		$this->assertEquals( 101, has_action( 'admin_bar_menu', array( self::TESTED_CLASS, 'add_admin_bar_menu_items' ) ) );
 
 		$this->assertFalse( has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
 		$this->assertEquals( 10, has_filter( 'amp_validation_error_sanitized', array( self::TESTED_CLASS, 'filter_tree_shaking_validation_error_as_accepted' ) ) );


### PR DESCRIPTION
Fixes #2203:

> A very common support request is confusion about why adding `/amp/` to the URL leads to a 404 instead. This is normally due to trying to access the AMP version of a Page or some other hierarchical post type, for which `?amp` is used for the AMP URL. […] When users do not have the AMP Validator extension installed, they will not see the AMP link in the browser extension button. If users are unfamiliar with the `amphtml` link in the head, they will have no idea how to find the AMP version or even if there is an AMP version available.
> 
> So we should consider adding the AMP link to the admin bar for AMP-enabled posts, even in reader mode:
> 
> ![image](https://user-images.githubusercontent.com/134745/56830333-eca22b00-681a-11e9-983c-b25a0002ae85.png)

The “View AMP” link on the top-level admin bar item is shortened to just “AMP”:

![image](https://user-images.githubusercontent.com/134745/57040588-c0205180-6c14-11e9-801e-fee33db85610.png)

When looking at the AMP version, the order of the submenu items switch so that the first item is Validate, which corresponds with the parent icon change from 🔗 to ✅/ ⚠️:

![image](https://user-images.githubusercontent.com/134745/57040681-0a093780-6c15-11e9-90d0-b738b22d56ad.png)

![image](https://user-images.githubusercontent.com/134745/57040622-dcbc8980-6c14-11e9-9ef4-a4376e6791f8.png)

The order changes because the first submenu item needs to be the same as the parent menu item for the sake of touch screens.

When there are rejected validation errors, the parent item is also still “AMP” but there is no child to view (since re-validation is the only option available):

![image](https://user-images.githubusercontent.com/134745/57040778-4c327900-6c15-11e9-9e7e-eb8a50dc491a.png)

This is similar to Native mode which used to say “Validate AMP” but also now just says “AMP”:

![image](https://user-images.githubusercontent.com/134745/57040892-a3d0e480-6c15-11e9-8e77-7b5ad75f2058.png)

----

This PR also ensures that when a user is non-privileged (e.g. a subscriber role) that they will continue to get the AMP link added, but without the re-validation logic:

![image](https://user-images.githubusercontent.com/134745/57036861-6155da80-6c0a-11e9-8a92-6dd66cde2528.png)

![image](https://user-images.githubusercontent.com/134745/57036874-6dda3300-6c0a-11e9-9bb0-ff8596a54a11.png)
