### PR TITLE
Improve video poster image handling

### DIFF
--- a/assets/src/blocks/amp-story-page/edit.css
+++ b/assets/src/blocks/amp-story-page/edit.css
@@ -185,6 +185,10 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
 	height: 100%;
 }
 
+.editor-amp-story-page-background.editor-post-featured-image__preview img {
+	object-fit: cover;
+}
+
 .editor-amp-story-page-video {
 	position: absolute;
 	top: 0;
@@ -196,14 +200,15 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
 	object-fit: cover;
 }
 
-#editor-amp-story-page-poster__help {
-	margin-top: 0;
-}
-
 .editor-amp-story-page-background {
 	display: block;
 }
 
-.editor-amp-story-page-background + .is-destructive {
+.editor-amp-story-page-background ~ .components-button {
 	margin-top: 1em;
+	margin-right: 8px;
+}
+
+#editor-amp-story-page-poster__help {
+	margin-top: 0;
 }

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -266,7 +266,7 @@ class EditPage extends Component {
 										{
 											! poster &&
 											<Notice status="error" isDismissible={ false } >
-												{ __( 'A poster image must be supplied.', 'amp' ) }
+												{ __( 'A poster image must be set.', 'amp' ) }
 											</Notice>
 										}
 										<MediaUpload

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -326,9 +326,9 @@ class EditPage extends Component {
 				</InspectorControls>
 				<div key="contents" style={ style }>
 					{ /* todo: show poster image as background-image instead */ }
-					{ VIDEO_BACKGROUND_TYPE === mediaType && media && ! poster && (
+					{ VIDEO_BACKGROUND_TYPE === mediaType && media && (
 						<div className="editor-amp-story-page-video-wrap">
-							<video autoPlay muted loop className="editor-amp-story-page-video">
+							<video autoPlay muted loop className="editor-amp-story-page-video" poster={ poster }>
 								<source src={ mediaUrl } type={ media.mime_type } />
 							</video>
 						</div>

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -161,7 +161,7 @@ class EditPage extends Component {
 
 		const style = {
 			backgroundImage: IMAGE_BACKGROUND_TYPE === mediaType && mediaUrl ? `url(${ mediaUrl })` : undefined,
-			backgroundPosition: IMAGE_BACKGROUND_TYPE === mediaType && focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : '50% 50%',
+			backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
 			backgroundRepeat: 'no-repeat',
 			backgroundSize: 'cover',
 		};

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -276,7 +277,13 @@ class EditPage extends Component {
 											modalClass="editor-amp-story-background-video-poster__media-modal"
 											render={ ( { open } ) => (
 												<Button
-													className={ 'editor-amp-story-page-background ' + ( ! poster ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' ) }
+													className={ classnames(
+														'editor-amp-story-page-background',
+														{
+															'editor-post-featured-image__toggle': ! poster,
+															'editor-post-featured-image__preview': poster,
+														}
+													) }
 													onClick={ open }
 													aria-label={ ! poster ? null : __( 'Edit or update the poster image', 'amp' ) }
 												>

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -88,11 +88,8 @@ class EditPage extends Component {
 			mediaUrl: media.url,
 			mediaId: media.id,
 			mediaType,
+			poster: VIDEO_BACKGROUND_TYPE === mediaType && media.image ? media.image.src : undefined,
 		} );
-
-		if ( IMAGE_BACKGROUND_TYPE === mediaType ) {
-			this.props.setAttributes( { poster: undefined } );
-		}
 	}
 
 	removeBackgroundColor( index ) {

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -159,7 +159,7 @@ class EditPage extends Component {
 
 		const style = {
 			backgroundImage: IMAGE_BACKGROUND_TYPE === mediaType && mediaUrl ? `url(${ mediaUrl })` : undefined,
-			backgroundPosition: `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
+			backgroundPosition: IMAGE_BACKGROUND_TYPE === mediaType && `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%`,
 			backgroundRepeat: 'no-repeat',
 			backgroundSize: 'cover',
 		};
@@ -249,7 +249,7 @@ class EditPage extends Component {
 								{ !! mediaId &&
 								<MediaUploadCheck>
 									<Button onClick={ () => setAttributes( { mediaUrl: undefined, mediaId: undefined, mediaType: undefined } ) } isLink isDestructive>
-										{ VIDEO_BACKGROUND_TYPE === mediaType ? __( 'Remove video', 'amp' ) : __( 'Remove image', 'amp' ) }
+										{ VIDEO_BACKGROUND_TYPE === mediaType ? __( 'Remove Video', 'amp' ) : __( 'Remove image', 'amp' ) }
 									</Button>
 								</MediaUploadCheck>
 								}
@@ -258,8 +258,14 @@ class EditPage extends Component {
 								<MediaUploadCheck>
 									<BaseControl
 										id="editor-amp-story-page-poster"
-										label={ __( 'Poster Image (required)', 'amp' ) }
-										help={ __( 'The recommended dimensions for a poster image are: 720p (720w x 1280h)', 'amp' ) }
+										label={ __( 'Poster Image', 'amp' ) }
+										help={ sprintf(
+											/* translators: 1: 720p. 2: 720w. 3: 1280h */
+											__( 'The recommended dimensions for a poster image are: %1$s (%2$s x %3$s)', 'amp' ),
+											'720p',
+											'720w',
+											'1080h',
+										) }
 									>
 										{
 											! poster &&
@@ -282,40 +288,28 @@ class EditPage extends Component {
 														}
 													) }
 													onClick={ open }
-													aria-label={ ! poster ? null : __( 'Edit or update the poster image', 'amp' ) }
+													aria-label={ ! poster ? null : __( 'Replace Poster Image', 'amp' ) }
 												>
-													{ !! poster &&
-													<ResponsiveWrapper
-														naturalWidth={ 960 }
-														naturalHeight={ 1280 }
-													>
-														<img src={ poster } alt="" />
-													</ResponsiveWrapper>
-													}
+													{ poster && (
+														<ResponsiveWrapper
+															naturalWidth={ 960 }
+															naturalHeight={ 1280 }
+														>
+															<img src={ poster } alt="" />
+														</ResponsiveWrapper>
+													) }
 													{ ! poster &&
-														__( 'Set poster image', 'amp' )
+														__( 'Set Poster Image', 'amp' )
 													}
 												</Button>
 											) }
 										/>
-
-										{ !! poster &&
-											<Fragment>
-												<MediaUpload
-													title={ __( 'Select Poster Image', 'amp' ) }
-													onSelect={ ( image ) => setAttributes( { poster: image.url } ) }
-													allowedTypes={ ALLOWED_MEDIA_TYPES }
-													modalClass="editor-amp-story-background-video-poster__media-modal"
-													render={ ( { open } ) => (
-														<Button onClick={ open } className="editor-amp-story-page-background" isDefault isLarge>
-															{ __( 'Replace Poster Image', 'amp' ) }
-														</Button>
-													) }
-												/>
+										{
+											poster && (
 												<Button onClick={ () => setAttributes( { poster: undefined } ) } isLink isDestructive>
-													{ __( 'Remove poster image', 'amp' ) }
+													{ __( 'Remove Poster Image', 'amp' ) }
 												</Button>
-											</Fragment>
+											)
 										}
 									</BaseControl>
 								</MediaUploadCheck>
@@ -368,7 +362,7 @@ class EditPage extends Component {
 						</div>
 					) }
 					{ backgroundColors.length > 0 && (
-						<div style={ overlayStyle }></div>
+						<div style={ overlayStyle } />
 					) }
 					<InnerBlocks template={ TEMPLATE } allowedBlocks={ allowedBlocks } />
 				</div>

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -159,7 +159,7 @@ class EditPage extends Component {
 
 		const style = {
 			backgroundImage: IMAGE_BACKGROUND_TYPE === mediaType && mediaUrl ? `url(${ mediaUrl })` : undefined,
-			backgroundPosition: IMAGE_BACKGROUND_TYPE === mediaType && focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : 'cover',
+			backgroundPosition: IMAGE_BACKGROUND_TYPE === mediaType && focalPoint ? `${ focalPoint.x * 100 }% ${ focalPoint.y * 100 }%` : '50% 50%',
 			backgroundRepeat: 'no-repeat',
 			backgroundSize: 'cover',
 		};

--- a/assets/src/blocks/amp-story-page/edit.js
+++ b/assets/src/blocks/amp-story-page/edit.js
@@ -20,8 +20,10 @@ import {
 	Button,
 	BaseControl,
 	FocalPointPicker,
+	Notice,
 	SelectControl,
 	RangeControl,
+	ResponsiveWrapper,
 } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
@@ -261,27 +263,55 @@ class EditPage extends Component {
 										label={ __( 'Poster Image (required)', 'amp' ) }
 										help={ __( 'The recommended dimensions for a poster image are: 720p (720w x 1280h)', 'amp' ) }
 									>
+										{
+											! poster &&
+											<Notice status="error" isDismissible={ false } >
+												{ __( 'A poster image must be supplied.', 'amp' ) }
+											</Notice>
+										}
 										<MediaUpload
 											title={ __( 'Select Poster Image', 'amp' ) }
 											onSelect={ ( image ) => setAttributes( { poster: image.url } ) }
 											allowedTypes={ POSTER_ALLOWED_MEDIA_TYPES }
+											modalClass="editor-amp-story-background-video-poster__media-modal"
 											render={ ( { open } ) => (
 												<Button
-													isDefault
+													className={ 'editor-amp-story-page-background ' + ( ! poster ? 'editor-post-featured-image__toggle' : 'editor-post-featured-image__preview' ) }
 													onClick={ open }
-													className="editor-amp-story-page-background"
+													aria-label={ ! poster ? null : __( 'Edit or update the poster image', 'amp' ) }
 												>
-													{ ! poster ? __( 'Select Poster Image', 'amp' ) : __( 'Replace image', 'amp' ) }
+													{ !! poster &&
+													<ResponsiveWrapper
+														naturalWidth={ 960 }
+														naturalHeight={ 1280 }
+													>
+														<img src={ poster } alt="" />
+													</ResponsiveWrapper>
+													}
+													{ ! poster &&
+														__( 'Set poster image', 'amp' )
+													}
 												</Button>
 											) }
 										/>
-										{ poster &&
-										<Button
-											onClick={ () => setAttributes( { poster: undefined } ) }
-											isLink
-											isDestructive>
-											{ __( 'Remove Poster Image', 'amp' ) }
-										</Button>
+
+										{ !! poster &&
+											<Fragment>
+												<MediaUpload
+													title={ __( 'Select Poster Image', 'amp' ) }
+													onSelect={ ( image ) => setAttributes( { poster: image.url } ) }
+													allowedTypes={ ALLOWED_MEDIA_TYPES }
+													modalClass="editor-amp-story-background-video-poster__media-modal"
+													render={ ( { open } ) => (
+														<Button onClick={ open } className="editor-amp-story-page-background" isDefault isLarge>
+															{ __( 'Replace Poster Image', 'amp' ) }
+														</Button>
+													) }
+												/>
+												<Button onClick={ () => setAttributes( { poster: undefined } ) } isLink isDestructive>
+													{ __( 'Remove poster image', 'amp' ) }
+												</Button>
+											</Fragment>
 										}
 									</BaseControl>
 								</MediaUploadCheck>


### PR DESCRIPTION
- Ensure poster image is centered in editor as it will be on frontend.
- Make sure video is displayed instead of poster image.
- Add warning when no poster image is selected.
- Show preview of poster similar to how is done for the featured image.

Fixes #2214.

# No Poster Image Selected

> ![image](https://user-images.githubusercontent.com/134745/57098846-e525ca80-6ccf-11e9-81ec-05bd4a01769c.png)

# Poster Image Selected

> ![image](https://user-images.githubusercontent.com/134745/57098700-8eb88c00-6ccf-11e9-975b-25199554a6d7.png)

# Video Plays in Editor

> ![image](https://user-images.githubusercontent.com/134745/57098933-156d6900-6cd0-11e9-8bf0-d1c1f47418d2.png)
