### PR TITLE
Force Fixed Toolbar

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -93,7 +93,7 @@
 /**
  * Hide option to toggle fixed toolbar.
  */
-.edit-post-more-menu__content .components-menu-group .components-button:first-of-type {
+.edit-post-more-menu__content .components-menu-group:first-of-type .components-button:first-of-type {
 	display: none;
 }
 

--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -90,6 +90,13 @@
 	left: 0 !important;
 }
 
+/**
+ * Hide option to toggle fixed toolbar.
+ */
+.edit-post-more-menu__content .components-menu-group .components-button:first-of-type {
+	display: none;
+}
+
 /*
  * 100. Shame
  */

--- a/assets/src/amp-story-editor-blocks.js
+++ b/assets/src/amp-story-editor-blocks.js
@@ -61,22 +61,21 @@ const {
 } = select( 'core/block-editor' );
 
 const {
+	moveBlockToPosition,
+	updateBlockAttributes,
+} = dispatch( 'core/block-editor' );
+
+const { getEditorMode, isFeatureActive } = select( 'core/edit-post' );
+const { toggleFeature } = dispatch( 'core/edit-post' );
+
+const {
 	isReordering,
 	getBlockOrder: getCustomBlockOrder,
 	getCurrentPage,
 	getAnimatedBlocks,
 } = select( 'amp/story' );
 
-const { getEditorMode } = select( 'core/edit-post' );
-
-const {
-	moveBlockToPosition,
-	updateBlockAttributes,
-} = dispatch( 'core/block-editor' );
-
-const {
-	setCurrentPage,
-} = dispatch( 'amp/story' );
+const {	setCurrentPage } = dispatch( 'amp/story' );
 
 /**
  * Initialize editor integration.
@@ -103,6 +102,11 @@ domReady( () => {
 		if ( block.attributes.ampFontFamily ) {
 			maybeEnqueueFontStyle( block.attributes.ampFontFamily );
 		}
+	}
+
+	// Enforce fixed toolbar.
+	if ( ! isFeatureActive( 'fixedToolbar' ) ) {
+		toggleFeature( 'fixedToolbar' );
 	}
 
 	renderStoryComponents();


### PR DESCRIPTION
This PR enforces the fixed toolbar upon page load and hides the option to change that.

Screenshot of the fixed toolbar:

<img width="656" alt="Screenshot 2019-05-02 at 20 58 25" src="https://user-images.githubusercontent.com/841956/57099818-a0c11b80-6d1d-11e9-8421-09ab4ebe7ca3.png">

I've decided against subscribing for any changes here, as I don't think it's needed. I'd rather wait for https://github.com/WordPress/gutenberg/issues/15264.

Fixes #2179.