### PR TITLE
Hide Block Manager option

### DIFF
--- a/assets/css/amp-editor-story-blocks.css
+++ b/assets/css/amp-editor-story-blocks.css
@@ -90,6 +90,13 @@
 	left: 0 !important;
 }
 
+/**
+ * Hide Block Manager option
+ */
+.edit-post-more-menu__content .components-menu-group:nth-last-of-type(2) div[role="menu"] > .components-button:first-child {
+	display: none;
+}
+
 /*
  * 100. Shame
  */


### PR DESCRIPTION
Screenshot of the options menu without the Block Manager option:

<img width="291" alt="Screenshot 2019-05-02 at 21 13 41" src="https://user-images.githubusercontent.com/841956/57100425-314c2b80-6d1f-11e9-8d86-b0449b311a82.png">

Fixes #2180.