### PR TITLE
Address AMP Stories embed and Latest Stories styling issues

### DIFF
--- a/assets/css/amp-story-card.css
+++ b/assets/css/amp-story-card.css
@@ -29,6 +29,11 @@ div.amp-block-latest-stories > ul.latest-stories-carousel {
 	overflow-x: hidden;
 }
 
+.amp-story-embed .latest_stories__link:hover {
+	box-shadow: none;
+	-webkit-box-shadow: none;
+}
+
 /* Applies the darker gradient background, to allow the white text to display even against a white featured image. */
 .latest_stories__link:after {
 	display: block;

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -1373,11 +1373,10 @@ class AMP_Story_Post_Type {
 	}
 
 	/**
-	 * Changes attributes of the AMP Story embed <iframe>.
+	 * Changes the height of the AMP Story embed <iframe>.
 	 *
-	 * The embed typically appears in the editor in an <iframe>, and without an <iframe> on the front-end.
+	 * In the block editor, this embed typically appears in an <iframe>, though on the front-end it's not in an <iframe>.
 	 * The height of the <iframe> isn't enough to display the full story, so this increases it.
-	 * Also, this removes attributes that AMP does not allow for the <amp-iframe>, like marginwidth.
 	 *
 	 * @param string  $output The embed output.
 	 * @param WP_Post $post The post for the embed.

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -1196,7 +1196,7 @@ class AMP_Story_Post_Type {
 			<?php if ( $is_amp_carousel ) : ?>
 				<amp-carousel layout="fixed-height" height="<?php echo esc_attr( $min_height ); ?>" type="carousel" class="latest-stories-carousel">
 			<?php else : ?>
-				<ul class="latest-stories-carousel" style="height:<?php echo esc_attr( $min_height ); ?>px;">
+				<ul class="latest-stories-carousel">
 			<?php endif; ?>
 				<?php foreach ( $story_query->posts as $post ) : ?>
 					<<?php echo $is_amp_carousel ? 'div' : 'li'; ?> class="slide latest-stories__slide">

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -1388,31 +1388,12 @@ class AMP_Story_Post_Type {
 			return $output;
 		}
 
-		preg_match( '/<iframe sandbox="allow-scripts" [^>]*>/', $output, $matches );
-		if ( ! $matches ) {
-			return $output;
-		}
-
-		$original_iframe = $matches[0];
-		$new_iframe      = preg_replace(
-			'/(?<=\sheight=")\w+(?=")/',
-			strval( ( self::STORY_LARGE_IMAGE_DIMENSION / 2 ) + 4 ),
-			$original_iframe
+		// Add 4px more height, as the <iframe> needs that to display the full image.
+		$new_height = strval( ( self::STORY_LARGE_IMAGE_DIMENSION / 2 ) + 4 );
+		return preg_replace(
+			'/(<iframe sandbox="allow-scripts"[^>]*\sheight=")(\w+)("[^>]*>)/',
+			sprintf( '${1}%s${3}', $new_height ),
+			$output
 		);
-
-		// Remove attributes that AMP doesn't allow for the <amp-iframe>.
-		if ( is_amp_endpoint() ) {
-			$new_iframe = preg_replace(
-				array(
-					'/\ssecurity="[\w]+"/',
-					'/\smarginwidth="[\w]+"/',
-					'/\smarginheight="[\w]+"/',
-				),
-				'',
-				$new_iframe
-			);
-		}
-
-		return str_replace( $original_iframe, $new_iframe, $output );
 	}
 }

--- a/tests/test-class-amp-story-post-type.php
+++ b/tests/test-class-amp-story-post-type.php
@@ -331,16 +331,6 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 			'<iframe sandbox="allow-scripts" width="600" height="468" security="restricted" marginwidth="10" marginheight="10">',
 			AMP_Story_Post_Type::change_embed_iframe_attributes( $original_embed_markup, $amp_story )
 		);
-
-		// Simulate this being an AMP endpoint, and avoid a _doing_it_wrong() warning for is_amp_endpoint().
-		add_theme_support( 'amp' );
-		do_action( 'wp' );
-
-		// This is an AMP endpoint, so it should also remove other illegal attributes.
-		$this->assertEquals(
-			'<iframe sandbox="allow-scripts" width="600" height="468">',
-			AMP_Story_Post_Type::change_embed_iframe_attributes( $original_embed_markup, $amp_story )
-		);
 	}
 
 	/**

--- a/tests/test-class-amp-story-post-type.php
+++ b/tests/test-class-amp-story-post-type.php
@@ -35,6 +35,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		$wp_rewrite->set_permalink_structure( false );
 		unset( $_SERVER['HTTPS'] );
+		unset( $GLOBALS['current_screen'] );
 		parent::tearDown();
 	}
 
@@ -305,6 +306,40 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		$block_quote            = '<blockquote class="wp-embedded-content">Example Title</blockquote>';
 		$output_with_blockquote = $block_quote . $initial_output;
 		$this->assertEquals( $initial_output, AMP_Story_Post_Type::remove_title_from_embed( $output_with_blockquote, $correct_post ) );
+	}
+
+	/**
+	 * Test change_embed_iframe_attributes.
+	 *
+	 * @covers \AMP_Editor_Blocks::change_embed_iframe_attributes()
+	 */
+	public function test_change_embed_iframe_attributes() {
+		$original_embed_markup = '<iframe sandbox="allow-scripts" width="600" height="343" security="restricted" marginwidth="10" marginheight="10">';
+		$non_amp_story         = $this->factory()->post->create_and_get();
+
+		// This isn't an AMP story embed, so it shouldn't change the markup.
+		$this->assertEquals( $original_embed_markup, AMP_Story_Post_Type::change_embed_iframe_attributes( $original_embed_markup, $non_amp_story ) );
+
+		// This is an AMP story embed, but the markup doesn't have an <iframe>, so it shouldn't be changed.
+		$amp_story                   = $this->factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+		$embed_markup_without_iframe = '<div class="wp-embed"><img src="https://example.com/baz.jpeg></div>';
+		$this->assertEquals( $embed_markup_without_iframe, AMP_Story_Post_Type::change_embed_iframe_attributes( $embed_markup_without_iframe, $amp_story ) );
+
+		// This is an AMP story embed, so it should change the height.
+		$this->assertEquals(
+			'<iframe sandbox="allow-scripts" width="600" height="468" security="restricted" marginwidth="10" marginheight="10">',
+			AMP_Story_Post_Type::change_embed_iframe_attributes( $original_embed_markup, $amp_story )
+		);
+
+		// Simulate this being an AMP endpoint, and avoid a _doing_it_wrong() warning for is_amp_endpoint().
+		add_theme_support( 'amp' );
+		do_action( 'wp' );
+
+		// This is an AMP endpoint, so it should also remove other illegal attributes.
+		$this->assertEquals(
+			'<iframe sandbox="allow-scripts" width="600" height="468">',
+			AMP_Story_Post_Type::change_embed_iframe_attributes( $original_embed_markup, $amp_story )
+		);
 	}
 
 	/**

--- a/tests/test-class-amp-story-post-type.php
+++ b/tests/test-class-amp-story-post-type.php
@@ -314,6 +314,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers \AMP_Editor_Blocks::change_embed_iframe_attributes()
 	 */
 	public function test_change_embed_iframe_attributes() {
+		remove_theme_support( 'amp' );
 		$original_embed_markup = '<iframe sandbox="allow-scripts" width="600" height="343" security="restricted" marginwidth="10" marginheight="10">';
 		$non_amp_story         = $this->factory()->post->create_and_get();
 


### PR DESCRIPTION
* Addresses styling issues in the AMP Stories discoverability blocks
* The inline `height` on the `.latest-stories-carousel` seemed to make the element too tall