### PR TITLE
Allow Custom HTML block in stories for sake of resolving block validation errors

### DIFF
--- a/assets/src/constants.js
+++ b/assets/src/constants.js
@@ -51,6 +51,7 @@ export const ALLOWED_MOVABLE_BLOCKS = [
 	'amp/amp-story-post-author',
 	'amp/amp-story-post-date',
 	'amp/amp-story-post-title',
+	'core/html',
 	'core/block', // Reusable blocks.
 	'core/template', // Reusable blocks.
 ];


### PR DESCRIPTION
Gutenberg currently assumes the presence of the Custom HTML block, and if it doesn't exist, things can break. For example, resolving block validation errors and pasting content into an empty block (#2212) both throw errors if the `core/html` block is not registered.

Fixes #2254.