### PR TITLE
Account for escaped chars in CSS class names

### DIFF
--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -206,6 +206,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul{color:red}',
 				),
 			),
+
+			'selector_with_escaped_char_class_name'      => array(
+				'<style>.lg\:w-full { width: 100%; }</style><div class="bg-black w-16 lg:w-full hover:bg-blue"></div>',
+				'<div class="bg-black w-16 lg:w-full hover:bg-blue"></div>',
+				array(
+					'.lg\:w-full{width:100%}',
+				),
+			),
 		);
 	}
 
@@ -734,6 +742,19 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				array(
 					'[loop]'     => true,
 					'[controls]' => true,
+				),
+			),
+			'escaped_char_class_name' => array(
+				'<div class="bg-black w-16 lg:w-full hover:bg-blue @@@"></div>',
+				array(
+					'.lg'               => false,
+					'.hover'            => false,
+					'.hover\:bg-blue'   => true,
+					'.lg\:w-full'       => true,
+					'.lg\:w-full:hover' => true,
+					'.lg\:w-medium'     => false,
+					'.\@\@\@'           => true,
+					'.\@\@\@\@'         => false,
 				),
 			),
 		);


### PR DESCRIPTION
CSS class names normally just contain alphanumeric characters, in addition to hyphens and underscores. However, they _can_ include other characters as long as they are escaped with a backslash. This PR fixes the tree shaker class name extraction to account for escaped characters.

Fixes #2259.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3146323/amp.zip) (v1.1.2-alpha-20190506T022223Z-2b70b363)