### PR TITLE
Hide the block inserter and the shortcuts when reordering pages

### DIFF
--- a/assets/src/components/inserter/index.js
+++ b/assets/src/components/inserter/index.js
@@ -2,7 +2,7 @@
  * This is an almost 1:1 copy of the Inserter component in @wordpress/block-editor.
  *
  * It has been included here in a slightly modified way, namely without the hasItems
- * limitation.
+ * limitation and with an additional restriction to hide the inserter while reordering is in progress.
  */
 
 /**
@@ -11,10 +11,12 @@
 import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { compose, ifCondition } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
+import { withIsReordering } from '../';
 import InserterMenu from './menu';
 
 const defaultRenderToggle = ( { onToggle, disabled, isOpen } ) => (
@@ -105,4 +107,9 @@ class Inserter extends Component {
 	}
 }
 
-export default Inserter;
+export default compose(
+	withIsReordering,
+	ifCondition(
+		( { isReordering } ) => ! isReordering
+	),
+)( Inserter );

--- a/assets/src/components/inserter/index.js
+++ b/assets/src/components/inserter/index.js
@@ -12,11 +12,11 @@ import { __ } from '@wordpress/i18n';
 import { Dropdown, IconButton } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { compose, ifCondition } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
-import { withIsReordering } from '../';
 import InserterMenu from './menu';
 
 const defaultRenderToggle = ( { onToggle, disabled, isOpen } ) => (
@@ -107,8 +107,16 @@ class Inserter extends Component {
 	}
 }
 
+const applyWithSelect = withSelect( ( select ) => {
+	const { isReordering } = select( 'amp/story' );
+
+	return {
+		isReordering: isReordering(),
+	};
+} );
+
 export default compose(
-	withIsReordering,
+	applyWithSelect,
 	ifCondition(
 		( { isReordering } ) => ! isReordering
 	),

--- a/assets/src/components/shortcuts/index.js
+++ b/assets/src/components/shortcuts/index.js
@@ -7,11 +7,6 @@ import { withDispatch, withSelect } from '@wordpress/data';
 import { IconButton } from '@wordpress/components';
 import { compose, ifCondition } from '@wordpress/compose';
 
-/**
- * Internal dependencies
- */
-import { withIsReordering } from '../';
-
 const Shortcuts = ( { insertBlock, canInsertBlockType } ) => {
 	const blocks = [
 		'amp/amp-story-text',
@@ -43,8 +38,10 @@ const Shortcuts = ( { insertBlock, canInsertBlockType } ) => {
 const applyWithSelect = withSelect( ( select ) => {
 	const { getCurrentPage } = select( 'amp/story' );
 	const { canInsertBlockType, getBlockListSettings } = select( 'core/block-editor' );
+	const { isReordering } = select( 'amp/story' );
 
 	return {
+		isReordering: isReordering(),
 		canInsertBlockType: ( name ) => {
 			// canInsertBlockType() alone is not enough, see https://github.com/WordPress/gutenberg/issues/14515
 			const blockSettings = getBlockListSettings( getCurrentPage() );
@@ -71,10 +68,7 @@ const applyWithDispatch = withDispatch( ( dispatch, props, { select } ) => {
 } );
 
 export default compose(
-	withIsReordering,
-	ifCondition(
-		( { isReordering } ) => ! isReordering
-	),
 	applyWithSelect,
 	applyWithDispatch,
+	ifCondition( ( { isReordering } ) => ! isReordering ),
 )( Shortcuts );

--- a/assets/src/components/shortcuts/index.js
+++ b/assets/src/components/shortcuts/index.js
@@ -5,7 +5,12 @@ import { getBlockType, createBlock } from '@wordpress/blocks';
 import { BlockIcon } from '@wordpress/block-editor';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { IconButton } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
+import { compose, ifCondition } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { withIsReordering } from '../';
 
 const Shortcuts = ( { insertBlock, canInsertBlockType } ) => {
 	const blocks = [
@@ -66,6 +71,10 @@ const applyWithDispatch = withDispatch( ( dispatch, props, { select } ) => {
 } );
 
 export default compose(
+	withIsReordering,
+	ifCondition(
+		( { isReordering } ) => ! isReordering
+	),
 	applyWithSelect,
 	applyWithDispatch,
 )( Shortcuts );

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -11,7 +11,7 @@ import { each, every, isEqual } from 'lodash';
 import { render } from '@wordpress/element';
 import { count } from '@wordpress/wordcount';
 import { _x } from '@wordpress/i18n';
-import { select, dispatch, withSelect } from '@wordpress/data';
+import { select, dispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { getColorClassName, RichText } from '@wordpress/block-editor';
 
@@ -519,20 +519,6 @@ export const renderStoryComponents = () => {
 		}
 	}
 
-	/**
-	 * Gets a component that conditionally displays, depending on whether the pages are reordering.
-	 *
-	 * @param {Function} component The component to conditionally display.
-	 * @return {Function|null} The passed omponent, or null.
-	 */
-	const getConditionalDisplay = ( component ) => {
-		return withSelect( ( ownSelect ) => {
-			return { isReordering: ownSelect( 'amp/story' ).isReordering() };
-		} )( ( { isReordering } ) => {
-			return isReordering ? null : component;
-		} );
-	};
-
 	if ( editorBlockNavigation ) {
 		if ( ! document.getElementById( 'amp-story-shortcuts' ) ) {
 			const shortcuts = document.createElement( 'div' );
@@ -540,9 +526,8 @@ export const renderStoryComponents = () => {
 
 			editorBlockNavigation.parentNode.parentNode.insertBefore( shortcuts, editorBlockNavigation.parentNode.nextSibling );
 
-			const ConditionallyDisplayedShortcuts = getConditionalDisplay( <Shortcuts /> );
 			render(
-				<ConditionallyDisplayedShortcuts />,
+				<Shortcuts />,
 				shortcuts
 			);
 		}
@@ -553,9 +538,8 @@ export const renderStoryComponents = () => {
 		const inserterWrapper = editorBlockNavigation.parentNode.parentNode.querySelector( '.block-editor-inserter' ).parentNode;
 		inserterWrapper.parentNode.replaceChild( customInserter, inserterWrapper );
 
-		const ConditionallyDisplayedInserter = getConditionalDisplay( <Inserter position="bottom right" /> );
 		render(
-			<ConditionallyDisplayedInserter />,
+			<Inserter position="bottom right" />,
 			customInserter
 		);
 	}

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -11,7 +11,7 @@ import { each, every, isEqual } from 'lodash';
 import { render } from '@wordpress/element';
 import { count } from '@wordpress/wordcount';
 import { _x } from '@wordpress/i18n';
-import { select, dispatch } from '@wordpress/data';
+import { select, dispatch, withSelect } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 import { getColorClassName, RichText } from '@wordpress/block-editor';
 
@@ -519,6 +519,20 @@ export const renderStoryComponents = () => {
 		}
 	}
 
+	/**
+	 * Gets a component that conditionally displays, depending on whether the pages are reordering.
+	 *
+	 * @param {Function} component The component to conditionally display.
+	 * @return {Function|null} The passed omponent, or null.
+	 */
+	const getConditionalDisplay = ( component ) => {
+		return withSelect( ( ownSelect ) => {
+			return { isReordering: ownSelect( 'amp/story' ).isReordering() };
+		} )( ( { isReordering } ) => {
+			return isReordering ? null : component;
+		} );
+	};
+
 	if ( editorBlockNavigation ) {
 		if ( ! document.getElementById( 'amp-story-shortcuts' ) ) {
 			const shortcuts = document.createElement( 'div' );
@@ -526,8 +540,9 @@ export const renderStoryComponents = () => {
 
 			editorBlockNavigation.parentNode.parentNode.insertBefore( shortcuts, editorBlockNavigation.parentNode.nextSibling );
 
+			const ConditionallyDisplayedShortcuts = getConditionalDisplay( <Shortcuts /> );
 			render(
-				<Shortcuts />,
+				<ConditionallyDisplayedShortcuts />,
 				shortcuts
 			);
 		}
@@ -538,8 +553,9 @@ export const renderStoryComponents = () => {
 		const inserterWrapper = editorBlockNavigation.parentNode.parentNode.querySelector( '.block-editor-inserter' ).parentNode;
 		inserterWrapper.parentNode.replaceChild( customInserter, inserterWrapper );
 
+		const ConditionallyDisplayedInserter = getConditionalDisplay( <Inserter position="bottom right" /> );
 		render(
-			<Inserter position="bottom right" />,
+			<ConditionallyDisplayedInserter />,
 			customInserter
 		);
 	}


### PR DESCRIPTION
As Pascal mentioned, it's confusing if you can add blocks while reordering the pages.
So this disables these buttons when reordering.

![shortcuts-inserter-hidden](https://user-images.githubusercontent.com/4063887/57289221-d2b0e580-706f-11e9-969d-31aee30d3dd8.gif)

Closes #2248
