### PR TITLE
Replace `WP_DEBUG` constant with individual constants

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -241,6 +241,7 @@ add_action( 'after_setup_theme', 'amp_after_setup_theme', 5 );
  * @since 0.1
  */
 function amp_init() {
+	AMP_HTTP::$server_timing = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || current_user_can( 'manage_options' );
 
 	/**
 	 * Triggers on init when AMP plugin is active.

--- a/amp.php
+++ b/amp.php
@@ -241,7 +241,6 @@ add_action( 'after_setup_theme', 'amp_after_setup_theme', 5 );
  * @since 0.1
  */
 function amp_init() {
-	AMP_HTTP::$server_timing = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || current_user_can( 'manage_options' );
 
 	/**
 	 * Triggers on init when AMP plugin is active.

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -21,6 +21,13 @@ class AMP_HTTP {
 	public static $headers_sent = array();
 
 	/**
+	 * Whether Server-Timing headers are sent.
+	 *
+	 * @var bool
+	 */
+	public static $server_timing = true;
+
+	/**
 	 * AMP-specific query vars that were purged.
 	 *
 	 * @since 0.7
@@ -83,7 +90,7 @@ class AMP_HTTP {
 	 * @return bool Return value of send_header call. If WP_DEBUG is not enabled or admin user (who can manage_options) is not logged-in, this will always return false.
 	 */
 	public static function send_server_timing( $name, $duration = null, $description = null ) {
-		if ( ! WP_DEBUG && ! current_user_can( 'manage_options' ) ) {
+		if ( ! self::$server_timing ) {
 			return false;
 		}
 		$value = $name;

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -23,9 +23,17 @@ class AMP_HTTP {
 	/**
 	 * Whether Server-Timing headers are sent.
 	 *
+	 * By default this is false to prevent breaking some web servers with an unexpected number of response headers. To
+	 * enable in `WP_DEBUG` mode, consider the following plugin code:
+	 *
+	 *     add_action( 'amp_init', function () {
+	 *         AMP_HTTP::$server_timing = ( ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || current_user_can( 'manage_options' ) );
+	 *     } );
+	 *
+	 * @link https://gist.github.com/westonruter/053f8f47c21df51f1a081fc41b47f547
 	 * @var bool
 	 */
-	public static $server_timing = true;
+	public static $server_timing = false;
 
 	/**
 	 * AMP-specific query vars that were purged.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1694,34 +1694,51 @@ class AMP_Theme_Support {
 			$stream_fragment = WP_Service_Worker_Navigation_Routing_Component::get_stream_fragment_query_var();
 		}
 
+		/**
+		 * Filters whether response (post-processor) caching is enabled.
+		 *
+		 * When enabled and when an external object cache is present, the output of the post-processor phase is stored in
+		 * in the object cache. When another request is made that generates the same HTML output, the previously-cached
+		 * post-processor output will then be served immediately and bypass needlessly re-running the sanitizers.
+		 * This does not apply when:
+		 *
+		 * - AMP validation is being performed.
+		 * - The response is in the Customizer preview.
+		 * - Response caching is disabled due to a high-rate of cache misses.
+		 *
+		 * @param bool $enable_response_caching Whether response caching is enabled.
+		 */
+		$enable_response_caching = apply_filters( 'amp_response_caching_enabled', ! ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || ! empty( $args['enable_response_caching'] ) );
+		$enable_response_caching = (
+			$enable_response_caching
+			&&
+			! AMP_Validation_Manager::should_validate_response()
+			&&
+			! is_customize_preview()
+		);
+
+		// When response caching is enabled, determine if it should be turned off for cache misses.
+		$caches_for_url = null;
+		if ( $enable_response_caching ) {
+			list( $disable_response_caching, $caches_for_url ) = self::check_for_cache_misses();
+			$enable_response_caching                           = ! $disable_response_caching;
+		}
+
 		$args = array_merge(
 			array(
-				'content_max_width'       => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
-				'use_document_element'    => true,
-				'allow_dirty_styles'      => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
-				'allow_dirty_scripts'     => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
-				'enable_response_caching' => (
-					! ( defined( 'WP_DEBUG' ) && WP_DEBUG )
-					&&
-					! AMP_Validation_Manager::should_validate_response()
-					&&
-					! is_customize_preview()
-				),
-				'user_can_validate'       => AMP_Validation_Manager::has_cap(),
-				'stream_fragment'         => $stream_fragment,
+				'content_max_width'    => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
+				'use_document_element' => true,
+				'allow_dirty_styles'   => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
+				'allow_dirty_scripts'  => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
+				'user_can_validate'    => AMP_Validation_Manager::has_cap(),
+				'stream_fragment'      => $stream_fragment,
 			),
-			$args
+			$args,
+			compact( 'enable_response_caching' )
 		);
 
 		$current_url = amp_get_current_url();
 		$non_amp_url = amp_remove_endpoint( $current_url );
-
-		// When response caching is enabled, determine if it should be turned off for cache misses.
-		$caches_for_url = null;
-		if ( true === $args['enable_response_caching'] ) {
-			list( $disable_response_caching, $caches_for_url ) = self::check_for_cache_misses();
-			$args['enable_response_caching']                   = ! $disable_response_caching;
-		}
 
 		/*
 		 * Set response cache hash, the data values dictates whether a new hash key should be generated or not.

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -14,6 +14,14 @@
 class Test_AMP_HTTP extends WP_UnitTestCase {
 
 	/**
+	 * Set up before class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		AMP_HTTP::$server_timing = true;
+	}
+
+	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 *
 	 * @global WP_Scripts $wp_scripts

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -21,6 +21,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	const TESTED_CLASS = 'AMP_Theme_Support';
 
 	/**
+	 * Set up before class.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		AMP_HTTP::$server_timing = true;
+	}
+
+	/**
 	 * Set up.
 	 */
 	public function setUp() {


### PR DESCRIPTION
This allows for more granular control of some of the AMP plugin behaviour. For sake of backwards compatibility, the default values of new constants use the `WP_DEBUG` constant.

The reason for this change is that we ran into issues where we needed to turn on `WP_DEBUG` on production servers for AMP pages. These servers use varnish for caching and the AMP pages would often break because of excessive `Server-Timing` headers. We needed a way to disable these headers while keeping `WP_DEBUG` active.