### PR TITLE
Use postcss-themes where applicable

### DIFF
--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -45,7 +45,7 @@
 	position: absolute;
 	bottom: -40px;
 	margin-left: 50%;
-	border-left: 1px solid theme(outlines);
+	border-left: 1px solid theme( outlines );
 }
 
 .block-editor-block-list__block .rotatable-box-wrap .rotatable-box-wrap__handle {
@@ -64,7 +64,7 @@
 }
 
 .rotatable-box-wrap .rotatable-box-wrap__handle::before {
-	background: theme(primary);
+	background: theme( primary );
 	border: 2px solid #fff;
 	border-radius: 50%;
 	content: "";

--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -45,7 +45,7 @@
 	position: absolute;
 	bottom: -40px;
 	margin-left: 50%;
-	border-left: 1px solid #007cba;
+	border-left: 1px solid theme(outlines);
 }
 
 .block-editor-block-list__block .rotatable-box-wrap .rotatable-box-wrap__handle {
@@ -64,7 +64,7 @@
 }
 
 .rotatable-box-wrap .rotatable-box-wrap__handle::before {
-	background: #0085ba;
+	background: theme(primary);
 	border: 2px solid #fff;
 	border-radius: 50%;
 	content: "";

--- a/assets/src/components/template-inserter/edit.css
+++ b/assets/src/components/template-inserter/edit.css
@@ -1,7 +1,7 @@
 #amp-story-controls .editor-inserter__amp-inserter {
 	height: 48px;
 	width: 48px;
-	background-color: #0085BA;
+	background-color: theme(primary);
 	border-radius: 50%;
 	margin-right: 10px;
 }

--- a/assets/src/components/template-inserter/edit.css
+++ b/assets/src/components/template-inserter/edit.css
@@ -1,7 +1,7 @@
 #amp-story-controls .editor-inserter__amp-inserter {
 	height: 48px;
 	width: 48px;
-	background-color: theme(primary);
+	background-color: theme( primary );
 	border-radius: 50%;
 	margin-right: 10px;
 }


### PR DESCRIPTION
Screenshot of editor UI with non-default color scheme applied:

<img width="1677" alt="Screenshot 2019-05-07 at 17 09 16" src="https://user-images.githubusercontent.com/841956/57340500-dcc3fa00-70ea-11e9-8fe9-09f93608d7bc.png">


Fixes #2265.