### PR TITLE
Allow dragging rotated, unselected blocks

### DIFF
--- a/assets/src/components/block-mover/draggable.js
+++ b/assets/src/components/block-mover/draggable.js
@@ -94,12 +94,13 @@ class Draggable extends Component {
 		event.dataTransfer.setData( 'text', JSON.stringify( transferData ) );
 
 		// Prepare element clone and append to element wrapper.
-		const elementRect = element.getBoundingClientRect();
 		const elementWrapper = element.parentNode;
 
 		this.cloneWrapper = document.createElement( 'div' );
 		this.cloneWrapper.classList.add( cloneWrapperClass );
-		this.cloneWrapper.style.width = `${ elementRect.width }px`;
+
+		this.cloneWrapper.style.width = `${ element.clientWidth }px`;
+		this.cloneWrapper.style.height = `${ element.clientHeight }px`;
 
 		const clone = element.cloneNode( true );
 		this.cloneWrapper.style.transform = clone.style.transform;

--- a/assets/src/components/block-mover/draggable.js
+++ b/assets/src/components/block-mover/draggable.js
@@ -13,6 +13,11 @@ import { noop } from 'lodash';
 import { Component } from '@wordpress/element';
 import { withSafeTimeout } from '@wordpress/compose';
 
+/**
+ * Internal dependencies
+ */
+import { getPixelsFromPercentage } from '../../stories-editor/helpers';
+
 const cloneWrapperClass = 'components-draggable__clone';
 
 const isChromeUA = ( ) => /Chrome/i.test( window.navigator.userAgent );
@@ -73,12 +78,9 @@ class Draggable extends Component {
 
 	/**
 	 *  - Clones the current element and spawns clone over original element.
-	 *  - Sets transfer data.
 	 *  - Adds dragover listener.
 	 *
-	 * @param {Object} event		 The non-custom DragEvent.
-	 * @param {string} elementId	 The HTML id of the element to be dragged.
-	 * @param {Object} transferData The data to be set to the event's dataTransfer - to be accessible in any later drop logic.
+	 * @param {Object} event Custom DragEvent.
 	 */
 	onDragStart( event ) {
 		const { elementId, transferData, onDragStart = noop } = this.props;
@@ -94,24 +96,23 @@ class Draggable extends Component {
 		// Prepare element clone and append to element wrapper.
 		const elementRect = element.getBoundingClientRect();
 		const elementWrapper = element.parentNode;
-		const elementTopOffset = parseInt( elementRect.top, 10 );
-		const elementLeftOffset = parseInt( elementRect.left, 10 );
 
-		const pageWrapperRect = parentPage.getBoundingClientRect();
-
-		const clone = element.cloneNode( true );
-		clone.id = `clone-${ elementId }`;
-		clone.style.top = 0;
-		clone.style.left = 0;
 		this.cloneWrapper = document.createElement( 'div' );
 		this.cloneWrapper.classList.add( cloneWrapperClass );
 		this.cloneWrapper.style.width = `${ elementRect.width }px`;
 
+		const clone = element.cloneNode( true );
+		this.cloneWrapper.style.transform = clone.style.transform;
+
 		// Position clone over the original element.
-		this.cloneWrapper.style.top = `${ elementTopOffset - parseInt( pageWrapperRect.top, 10 ) }px`;
+		this.cloneWrapper.style.top = `${ getPixelsFromPercentage( 'y', parseInt( clone.style.top ) ) }px`;
 		// Add 5px adjustment for having the block mover right next to the clone.
-		// @todo This will need some additional adjusting once we add padding to the Page in the editor.
-		this.cloneWrapper.style.left = `${ elementLeftOffset - parseInt( pageWrapperRect.left, 10 ) - 5 }px`;
+		this.cloneWrapper.style.left = `${ getPixelsFromPercentage( 'x', parseInt( clone.style.left ) ) }px`;
+
+		clone.id = `clone-${ elementId }`;
+		clone.style.top = 0;
+		clone.style.left = 0;
+		clone.style.transform = 'none';
 
 		// Hack: Remove iFrames as it's causing the embeds drag clone to freeze
 		[ ...clone.querySelectorAll( 'iframe' ) ].forEach( ( child ) => child.parentNode.removeChild( child ) );

--- a/assets/src/components/block-mover/draggable.js
+++ b/assets/src/components/block-mover/draggable.js
@@ -42,7 +42,8 @@ class Draggable extends Component {
 
 	/**
 	 * Removes the element clone, resets cursor, and removes drag listener.
-	 * @param  {Object} event     The non-custom DragEvent.
+	 *
+	 * @param {Object} event The non-custom DragEvent.
 	 */
 	onDragEnd( event ) {
 		const { onDragEnd = noop } = this.props;
@@ -54,9 +55,10 @@ class Draggable extends Component {
 		this.props.setTimeout( onDragEnd );
 	}
 
-	/*
+	/**
 	 * Updates positioning of element clone based on mouse movement during dragging.
-	 * @param  {Object} event     The non-custom DragEvent.
+	 *
+	 * @param  {Object} event The non-custom DragEvent.
 	 */
 	onDragOver( event ) {
 		this.cloneWrapper.style.top =
@@ -81,6 +83,8 @@ class Draggable extends Component {
 	 *  - Adds dragover listener.
 	 *
 	 * @param {Object} event Custom DragEvent.
+	 * @param {string} elementId	The HTML id of the element to be dragged.
+	 * @param {Object} transferData The data to be set to the event's dataTransfer - to be accessible in any later drop logic.
 	 */
 	onDragStart( event ) {
 		const { elementId, transferData, onDragStart = noop } = this.props;

--- a/assets/src/components/block-mover/index.js
+++ b/assets/src/components/block-mover/index.js
@@ -75,7 +75,6 @@ export class BlockMover extends Component {
 						blockElementId={ blockElementId }
 						isVisible={ isDraggable }
 						onDragStart={ onDragStart }
-						onDragEnd={ onDragEnd }
 					/>
 					<IconButton
 						className="editor-block-mover__control block-editor-block-mover__control"
@@ -108,10 +107,9 @@ export default compose(
 		};
 	} ),
 	withDispatch( ( dispatch, { clientId, rootClientId } ) => {
-		const { moveBlocksDown, moveBlocksUp, clearSelectedBlock } = dispatch( 'core/block-editor' );
+		const { moveBlocksDown, moveBlocksUp } = dispatch( 'core/block-editor' );
 
 		return {
-			onDragEnd: clearSelectedBlock,
 			bringForward: () => moveBlocksDown( clientId, rootClientId ),
 			sendBackward: () => moveBlocksUp( clientId, rootClientId ),
 		};

--- a/assets/src/components/block-mover/index.js
+++ b/assets/src/components/block-mover/index.js
@@ -48,7 +48,7 @@ export class BlockMover extends Component {
 	}
 
 	render() {
-		const { bringForward, sendBackward, isFirst, isLast, isDraggable, onDragStart, onDragEnd, clientId, blockElementId, instanceId } = this.props;
+		const { bringForward, sendBackward, isFirst, isLast, isDraggable, onDragStart, clientId, blockElementId, instanceId } = this.props;
 		const { isFocused } = this.state;
 
 		// We emulate a disabled state because forcefully applying the `disabled`

--- a/assets/src/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/components/higher-order/with-amp-story-settings.js
@@ -73,12 +73,11 @@ const applyWithSelect = withSelect( ( select, props ) => {
 	};
 } );
 
-const applyWithDispatch = withDispatch( ( dispatch, { toggleSelection }, { select } ) => {
+const applyWithDispatch = withDispatch( ( dispatch, {}, { select } ) => {
 	const {
 		getSelectedBlockClientId,
 		getBlockRootClientId,
 	} = select( 'core/block-editor' );
-	const { clearSelectedBlock } = dispatch( 'core/block-editor' );
 
 	const item = getSelectedBlockClientId();
 	const page = getBlockRootClientId( item );
@@ -102,13 +101,6 @@ const applyWithDispatch = withDispatch( ( dispatch, { toggleSelection }, { selec
 		},
 		onAnimationDelayChange( value ) {
 			changeAnimationDelay( page, item, value );
-		},
-		startBlockRotation: () => toggleSelection( false ),
-		stopBlockRotation: () => {
-			toggleSelection( true );
-
-			clearSelectedBlock();
-			document.activeElement.blur();
 		},
 	};
 } );
@@ -145,8 +137,6 @@ export default createHigherOrderComponent(
 				onAnimationDelayChange,
 				getAnimatedBlocks,
 				animationAfter,
-				startBlockRotation,
-				stopBlockRotation,
 			} = props;
 
 			const isChildBlock = ALLOWED_CHILD_BLOCKS.includes( name );
@@ -193,15 +183,10 @@ export default createHigherOrderComponent(
 							initialAngle={ rotationAngle }
 							className="amp-story-editor__rotate-container"
 							angle={ isSelected ? 0 : rotationAngle }
-							onRotateStart={ () => {
-								startBlockRotation();
-							} }
 							onRotateStop={ ( event, angle ) => {
 								setAttributes( {
 									rotationAngle: angle,
 								} );
-
-								stopBlockRotation();
 							} }
 						>
 							<BlockEdit { ...props } />
@@ -227,15 +212,10 @@ export default createHigherOrderComponent(
 								initialAngle={ rotationAngle }
 								className="amp-story-editor__rotate-container"
 								angle={ isSelected ? 0 : rotationAngle }
-								onRotateStart={ () => {
-									startBlockRotation();
-								} }
 								onRotateStop={ ( event, angle ) => {
 									setAttributes( {
 										rotationAngle: angle,
 									} );
-
-									stopBlockRotation();
 								} }
 							>
 								<BlockEdit { ...props } />

--- a/assets/src/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/components/higher-order/with-amp-story-settings.js
@@ -183,7 +183,7 @@ export default createHigherOrderComponent(
 						<StoryBlockMover
 							clientId={ props.clientId }
 							blockElementId={ `block-${ props.clientId }` }
-							isDraggable={ ! props.isPartOfMultiSelection && isSelected }
+							isDraggable={ ! props.isPartOfMultiSelection }
 						/>
 					) }
 					{ ! isMovableBlock && ( <BlockEdit { ...props } /> ) }

--- a/assets/src/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/components/higher-order/with-amp-story-settings.js
@@ -73,7 +73,7 @@ const applyWithSelect = withSelect( ( select, props ) => {
 	};
 } );
 
-const applyWithDispatch = withDispatch( ( dispatch, {}, { select } ) => {
+const applyWithDispatch = withDispatch( ( dispatch, { toggleSelection }, { select } ) => {
 	const {
 		getSelectedBlockClientId,
 		getBlockRootClientId,
@@ -101,6 +101,10 @@ const applyWithDispatch = withDispatch( ( dispatch, {}, { select } ) => {
 		},
 		onAnimationDelayChange( value ) {
 			changeAnimationDelay( page, item, value );
+		},
+		startBlockRotation: () => toggleSelection( false ),
+		stopBlockRotation: () => {
+			toggleSelection( true );
 		},
 	};
 } );
@@ -137,6 +141,8 @@ export default createHigherOrderComponent(
 				onAnimationDelayChange,
 				getAnimatedBlocks,
 				animationAfter,
+				startBlockRotation,
+				stopBlockRotation,
 			} = props;
 
 			const isChildBlock = ALLOWED_CHILD_BLOCKS.includes( name );
@@ -183,10 +189,14 @@ export default createHigherOrderComponent(
 							initialAngle={ rotationAngle }
 							className="amp-story-editor__rotate-container"
 							angle={ isSelected ? 0 : rotationAngle }
+							onRotateStart={ () => {
+								startBlockRotation();
+							} }
 							onRotateStop={ ( event, angle ) => {
 								setAttributes( {
 									rotationAngle: angle,
 								} );
+								stopBlockRotation();
 							} }
 						>
 							<BlockEdit { ...props } />
@@ -212,10 +222,15 @@ export default createHigherOrderComponent(
 								initialAngle={ rotationAngle }
 								className="amp-story-editor__rotate-container"
 								angle={ isSelected ? 0 : rotationAngle }
+								onRotateStart={ () => {
+									startBlockRotation();
+								} }
 								onRotateStop={ ( event, angle ) => {
 									setAttributes( {
 										rotationAngle: angle,
 									} );
+
+									stopBlockRotation();
 								} }
 							>
 								<BlockEdit { ...props } />

--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -61,6 +61,7 @@
 }
 
 .wp-block.amp-page-active .wp-block:hover .rotatable-box-wrap,
-.wp-block.amp-page-active .wp-block .rotatable-box-wrap:hover {
+.wp-block.amp-page-active .wp-block .rotatable-box-wrap:hover,
+.wp-block.amp-page-active .wp-block.is-rotating .rotatable-box-wrap {
 	opacity: 1;
 }

--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -65,3 +65,7 @@
 .wp-block.amp-page-active .wp-block.is-rotating .rotatable-box-wrap {
 	opacity: 1;
 }
+.wp-block.amp-page-active .wp-block.is-rotating:hover .components-resizable-box__handle,
+.wp-block.amp-page-active .wp-block.is-rotating .components-resizable-box__handle:hover {
+	opacity: 0;
+}

--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -3,22 +3,9 @@
 	display: none !important;
 }
 
-.block-editor-block-list__block.is-typing .rotatable-box-wrap,
-.block-editor-block-list__block .rotatable-box-wrap {
-	display: block;
-	opacity: 0;
-	transition: opacity .3s;
-}
-
 .components-draggable__clone .block-editor-block-list__block .rotatable-box-wrap {
 	display: none;
 	opacity: 0;
-}
-
-.editor-inner-blocks .block-editor-block-list__block.is-rotating .rotatable-box-wrap,
-.editor-inner-blocks .block-editor-block-list__block.is-selected .rotatable-box-wrap,
-.editor-inner-blocks .block-editor-block-list__block.is-hovered .rotatable-box-wrap {
-	opacity: 1;
 }
 
 .editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__insertion-point,
@@ -63,4 +50,17 @@
 	height: 16px;
 	width: 16px;
 	margin: 0 auto;
+}
+
+
+.wp-block .rotatable-box-wrap,
+.wp-block.is-typing .rotatable-box-wrap{
+	display: block;
+	opacity: 0;
+	transition: opacity .3s;
+}
+
+.wp-block.amp-page-active .wp-block:hover .rotatable-box-wrap,
+.wp-block.amp-page-active .wp-block .rotatable-box-wrap:hover {
+	opacity: 1;
 }

--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -21,17 +21,7 @@
 	opacity: 1;
 }
 
-.block-editor-block-list__block:not(.is-rotating) {
-	transition: transform .3s ease-in-out;
-}
-
-.block-editor-block-list__block.is-typing:not(.is-rotating),
-.block-editor-block-list__block.is-selected:not(.is-rotating) {
-	transform: rotate(0deg) !important;
-}
-
 .editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__insertion-point,
-.editor-inner-blocks .block-editor-block-list__block.is-rotating .editor-block-mover,
 .editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__breadcrumb,
 .editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-contextual-toolbar,
 .block-editor-block-list__layout .block-editor-block-list__block.is-rotating > .block-editor-block-list__block-edit::before {

--- a/assets/src/components/rotatable-box/index.js
+++ b/assets/src/components/rotatable-box/index.js
@@ -97,7 +97,6 @@ class RotatableBox extends Component {
 		e.preventDefault();
 
 		this.elementRef.classList.add( 'is-rotating' );
-		this.elementRef.style.transform = `rotate(${ this.props.angle }deg)`;
 
 		this.setState(
 			{

--- a/assets/src/components/story-block-drop-zone.js
+++ b/assets/src/components/story-block-drop-zone.js
@@ -53,8 +53,6 @@ class BlockDropZone extends Component {
 			positionLeft: getPercentageFromPixels( 'x', clonePosition.left - wrapperPosition.left ),
 			positionTop: getPercentageFromPixels( 'y', clonePosition.top - wrapperPosition.top ),
 		} );
-		// Make sure the block stays selected. // @todo This is not working.
-		selectBlock( srcClientId );
 	}
 
 	render() {

--- a/assets/src/components/story-block-drop-zone.js
+++ b/assets/src/components/story-block-drop-zone.js
@@ -41,9 +41,9 @@ class BlockDropZone extends Component {
 			return;
 		}
 
-		// Get the current position of the clone.
+		// We have to remove the rotation for getting accurate position.
+		clone.parentNode.style.transform = 'none';
 		const clonePosition = clone.getBoundingClientRect();
-
 		const wrapperPosition = wrapperEl.getBoundingClientRect();
 
 		// We will set the new position based on where the clone was moved to, with reference being the wrapper element.

--- a/assets/src/components/story-block-drop-zone.js
+++ b/assets/src/components/story-block-drop-zone.js
@@ -27,7 +27,7 @@ class BlockDropZone extends Component {
 	}
 
 	onDrop( event ) {
-		const { updateBlockAttributes, srcClientId } = this.props;
+		const { updateBlockAttributes, srcClientId, selectBlock } = this.props;
 
 		const elementId = `block-${ srcClientId }`;
 		const cloneElementId = `clone-block-${ srcClientId }`;
@@ -53,6 +53,8 @@ class BlockDropZone extends Component {
 			positionLeft: getPercentageFromPixels( 'x', clonePosition.left - wrapperPosition.left ),
 			positionTop: getPercentageFromPixels( 'y', clonePosition.top - wrapperPosition.top ),
 		} );
+		// Make sure the block stays selected. // @todo This is not working.
+		selectBlock( srcClientId );
 	}
 
 	render() {
@@ -65,11 +67,12 @@ class BlockDropZone extends Component {
 	}
 }
 export default withDispatch( ( dispatch ) => {
-	const { updateBlockAttributes } = dispatch( 'core/block-editor' );
+	const { updateBlockAttributes, selectBlock } = dispatch( 'core/block-editor' );
 
 	return {
 		updateBlockAttributes( ...args ) {
 			updateBlockAttributes( ...args );
 		},
+		selectBlock,
 	};
 } )( BlockDropZone );

--- a/assets/src/components/story-block-drop-zone.js
+++ b/assets/src/components/story-block-drop-zone.js
@@ -27,7 +27,7 @@ class BlockDropZone extends Component {
 	}
 
 	onDrop( event ) {
-		const { updateBlockAttributes, srcClientId, selectBlock } = this.props;
+		const { updateBlockAttributes, srcClientId } = this.props;
 
 		const elementId = `block-${ srcClientId }`;
 		const cloneElementId = `clone-block-${ srcClientId }`;
@@ -65,12 +65,11 @@ class BlockDropZone extends Component {
 	}
 }
 export default withDispatch( ( dispatch ) => {
-	const { updateBlockAttributes, selectBlock } = dispatch( 'core/block-editor' );
+	const { updateBlockAttributes } = dispatch( 'core/block-editor' );
 
 	return {
 		updateBlockAttributes( ...args ) {
 			updateBlockAttributes( ...args );
 		},
-		selectBlock,
 	};
 } )( BlockDropZone );

--- a/assets/src/components/story-block-drop-zone.js
+++ b/assets/src/components/story-block-drop-zone.js
@@ -42,6 +42,7 @@ class BlockDropZone extends Component {
 		}
 
 		// We have to remove the rotation for getting accurate position.
+		clone.parentNode.style.visibility = 'hidden';
 		clone.parentNode.style.transform = 'none';
 		const clonePosition = clone.getBoundingClientRect();
 		const wrapperPosition = wrapperEl.getBoundingClientRect();

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -668,6 +668,22 @@ export const getPercentageFromPixels = ( axis, pixelValue ) => {
 };
 
 /**
+ * Get pixel value from percentage, based on the full width / height of the page.
+ *
+ * @param {string} axis X or Y axis.
+ * @param {number} percentageValue Value in pixels.
+ * @return {number} Value in percentage.
+ */
+export const getPixelsFromPercentage = ( axis, percentageValue ) => {
+	if ( 'x' === axis ) {
+		return Math.round( ( percentageValue / 100 ) * STORY_PAGE_INNER_WIDTH );
+	} else if ( 'y' === axis ) {
+		return Math.round( ( percentageValue / 100 ) * STORY_PAGE_INNER_HEIGHT );
+	}
+	return 0;
+};
+
+/**
  * Returns the minimum dimensions for a story poster image.
  *
  * @link https://www.ampproject.org/docs/reference/components/amp-story#poster-guidelines-(for-poster-portrait-src,-poster-landscape-src,-and-poster-square-src)


### PR DESCRIPTION
Fixes #2252.

- Allow dragging rotated elements.
- Keep the element rotated at all times.
- Fix position calculation considering rotation.
- Make sure that the element stays selected after dragging and also after rotating. (Fixes #2211)

Todo separately (issue #2275):
- Based on the decision about dragging functionality perhaps remove the drag icon and allow dragging element from borders (as in Google Slides for example) or from anywhere.