### PR TITLE
Speed up PHPCS

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -81,6 +81,12 @@
 	<arg name="extensions" value="php"/>
 	<file>.</file>
 
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 20 files simultaneously. -->
+	<arg name="parallel" value="20"/>
+
 	<exclude-pattern>*/node_modules/*</exclude-pattern>
 	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<exclude-pattern>build/*</exclude-pattern>


### PR DESCRIPTION
Right now, running PHPCS against the plugin takes almost 2 minutes on my MacBook Pro with PHP 7.3. I am a bit impatient and think this should be improved.

Thankfully, PHPCS supports parallel processing of files. After applying the same configuration for that as in WordPress core, running PHPCS now only takes about 20-30 seconds.

Also, I figured adding the `basepath` option makes sense. This way, PHPCS warnings will not only include the full path to the file (e.g. `/Users/Pascal/.../amp/includes/...`), but just the relative one (`./includes/...`).