### PR TITLE
Use more unescaped Unicode to prevent escaped characters from appearing

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1167,9 +1167,9 @@ class AMP_Theme_Support {
 			str_replace(
 				'%s',
 				sprintf( '" + %s.replyToName + "', $state_id ),
-				wp_json_encode( $args['title_reply_to'] )
+				wp_json_encode( $args['title_reply_to'], JSON_UNESCAPED_UNICODE )
 			),
-			wp_json_encode( $args['title_reply'] )
+			wp_json_encode( $args['title_reply'], JSON_UNESCAPED_UNICODE )
 		);
 
 		$args['title_reply_before'] .= sprintf(
@@ -1252,7 +1252,7 @@ class AMP_Theme_Support {
 			esc_url( remove_query_arg( 'replytocom' ) . '#' . $respond_id ),
 			isset( $_GET['replytocom'] ) ? '' : ' hidden', // phpcs:ignore
 			esc_attr( sprintf( '%s.values.comment_parent == "0"', self::get_comment_form_state_id( get_the_ID() ) ) ),
-			esc_attr( sprintf( 'tap:AMP.setState( %s )', wp_json_encode( $tap_state ) ) ),
+			esc_attr( sprintf( 'tap:AMP.setState( %s )', wp_json_encode( $tap_state, JSON_UNESCAPED_UNICODE ) ) ),
 			esc_html( $text )
 		);
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1334,7 +1334,7 @@ class AMP_Theme_Support {
 		if ( ! $schema_org_meta_script ) {
 			$script = $dom->createElement( 'script' );
 			$script->setAttribute( 'type', 'application/ld+json' );
-			$script->appendChild( $dom->createTextNode( wp_json_encode( amp_get_schemaorg_metadata() ) ) );
+			$script->appendChild( $dom->createTextNode( wp_json_encode( amp_get_schemaorg_metadata(), JSON_UNESCAPED_UNICODE ) ) );
 			$head->appendChild( $script );
 		}
 

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -147,7 +147,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 		$script = $this->dom->createElement( 'script' );
 		$script->setAttribute( 'type', 'application/json' );
 		$amp_state->appendChild( $script );
-		$script->appendChild( $this->dom->createTextNode( wp_json_encode( $form_state ) ) );
+		$script->appendChild( $this->dom->createTextNode( wp_json_encode( $form_state, JSON_UNESCAPED_UNICODE ) ) );
 		$comment_form->insertBefore( $amp_state, $comment_form->firstChild );
 
 		// Update state when submitting form.
@@ -172,7 +172,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			sprintf(
 				'submit-success:AMP.setState( { %s: %s } )',
 				$state_id,
-				wp_json_encode( $form_reset_state )
+				wp_json_encode( $form_reset_state, JSON_UNESCAPED_UNICODE )
 			),
 		);
 		$comment_form->setAttribute( 'on', implode( ';', $on ) );


### PR DESCRIPTION
Work around issues with `amp-bind` and escaped Unicode characters. Fixes #2286. Previously #1791. 

Also reported upstream to AMP: https://github.com/ampproject/amphtml/issues/22265.

Also use unescaped Unicode for Schema.org metadata added in non-Reader mode. See #1997.

Build for testing: 
~[amp.zip](https://github.com/ampproject/amp-wp/files/3174482/amp.zip) (v1.1.2-alpha-20190513T193207Z-62716dd)~
~[amp.zip](https://github.com/ampproject/amp-wp/files/3174923/amp.zip) (v1.1.2-alpha-20190513T213644Z-462267a9)~
[amp.zip](https://github.com/ampproject/amp-wp/files/3175196/amp.zip) (v1.1.2-alpha-20190513T233533Z-0bba21e4)
