### PR TITLE
Hide alignment controls and video toggles

### DIFF
--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -74,3 +74,11 @@ amp-story-grid-layer amp-img > img {
 .is-style-white.wp-block-quote {
 	background-image: url("../images/quote-white.svg");
 }
+
+/**
+ * See https://github.com/ampproject/amp-wp/issues/2283
+ */
+.edit-post-layout[data-block-name="core/video"] .edit-post-settings-sidebar__panel-block .block-editor-block-inspector__card + div > .components-panel__body:first-child .components-toggle-control:nth-child(2),
+.edit-post-layout[data-block-name="core/video"] .edit-post-settings-sidebar__panel-block .block-editor-block-inspector__card + div > .components-panel__body:first-child .components-toggle-control:nth-child(6) {
+	display: none;
+}

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -146,10 +146,10 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
  * Hackily hide the alignment options from the image block since they are irrelevant for an image block in a story.
  * In the future the underlying alignment buttons should be removed entirely. See <https://github.com/ampproject/amp-wp/issues/2115>.
  */
-.editor-block-list__block[data-type="core/image"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2),
-.editor-block-list__block[data-type="core/pullquote"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2),
-.editor-block-list__block[data-type="core/embed"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2),
-.editor-block-list__block[data-type="core/video"] > div.editor-block-list__block-edit.block-editor-block-list__block-edit > div.editor-block-contextual-toolbar.block-editor-block-contextual-toolbar > div.editor-block-toolbar.block-editor-block-toolbar > div:nth-child(2) {
+.edit-post-header-toolbar__block-toolbar[data-block-name="core/image"] .block-editor-block-toolbar > .components-toolbar,
+.edit-post-header-toolbar__block-toolbar[data-block-name="core/pullquote"] .block-editor-block-toolbar > .components-toolbar,
+.edit-post-header-toolbar__block-toolbar[data-block-name="core/embed"] .block-editor-block-toolbar > .components-toolbar,
+.edit-post-header-toolbar__block-toolbar[data-block-name="core/video"] .block-editor-block-toolbar > .components-toolbar {
 	display: none;
 }
 

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -146,10 +146,10 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
  * Hackily hide the alignment options from the image block since they are irrelevant for an image block in a story.
  * In the future the underlying alignment buttons should be removed entirely. See <https://github.com/ampproject/amp-wp/issues/2115>.
  */
-.edit-post-header-toolbar__block-toolbar[data-block-name="core/image"] .block-editor-block-toolbar > .components-toolbar,
-.edit-post-header-toolbar__block-toolbar[data-block-name="core/pullquote"] .block-editor-block-toolbar > .components-toolbar,
-.edit-post-header-toolbar__block-toolbar[data-block-name="core/embed"] .block-editor-block-toolbar > .components-toolbar,
-.edit-post-header-toolbar__block-toolbar[data-block-name="core/video"] .block-editor-block-toolbar > .components-toolbar {
+.edit-post-layout[data-block-name="core/image"] .edit-post-header-toolbar__block-toolbar  .block-editor-block-toolbar > .components-toolbar,
+.edit-post-layout[data-block-name="core/pullquote"] .edit-post-header-toolbar__block-toolbar  .block-editor-block-toolbar > .components-toolbar,
+.edit-post-layout[data-block-name="core/embed"] .edit-post-header-toolbar__block-toolbar  .block-editor-block-toolbar > .components-toolbar,
+.edit-post-layout[data-block-name="core/video"] .edit-post-header-toolbar__block-toolbar  .block-editor-block-toolbar > .components-toolbar {
 	display: none;
 }
 

--- a/assets/src/stories-editor/index.js
+++ b/assets/src/stories-editor/index.js
@@ -54,6 +54,7 @@ import { ALLOWED_BLOCKS } from './constants';
 import store from './store';
 
 const {
+	getSelectedBlock,
 	getSelectedBlockClientId,
 	getBlocksByClientId,
 	getClientIdsWithDescendants,
@@ -147,24 +148,33 @@ let allBlocksWithChildren = getClientIdsWithDescendants();
 
 let editorMode = getEditorMode();
 
+let selectedBlock;
+
 subscribe( async () => {
 	maybeInitializeAnimations();
 
 	const defaultBlockName = getDefaultBlockName();
-	const selectedBlockClientId = getSelectedBlockClientId();
+	const newSelectedBlock = getSelectedBlock();
 
 	// Switch default block depending on context
-	if ( selectedBlockClientId ) {
-		const selectedBlock = getBlock( selectedBlockClientId );
-
-		if ( 'amp/amp-story-page' === selectedBlock.name && 'amp/amp-story-page' !== defaultBlockName ) {
+	if ( newSelectedBlock ) {
+		if ( 'amp/amp-story-page' === newSelectedBlock.name && 'amp/amp-story-page' !== defaultBlockName ) {
 			setDefaultBlockName( 'amp/amp-story-page' );
-		} else if ( 'amp/amp-story-page' !== selectedBlock.name && 'amp/amp-story-text' !== defaultBlockName ) {
+		} else if ( 'amp/amp-story-page' !== newSelectedBlock.name && 'amp/amp-story-text' !== defaultBlockName ) {
 			setDefaultBlockName( 'amp/amp-story-text' );
 		}
-	} else if ( ! selectedBlockClientId && 'amp/amp-story-page' !== defaultBlockName ) {
+	} else if ( 'amp/amp-story-page' !== defaultBlockName ) {
 		setDefaultBlockName( 'amp/amp-story-page' );
 	}
+
+	if ( selectedBlock !== newSelectedBlock ) {
+		const toolbar = document.querySelector( '.edit-post-header-toolbar__block-toolbar' );
+		if ( toolbar ) {
+			toolbar.setAttribute( 'data-block-name', newSelectedBlock ? newSelectedBlock.name : '' );
+		}
+	}
+
+	selectedBlock = newSelectedBlock;
 
 	const newBlockOrder = getBlockOrder();
 	const newlyAddedPages = newBlockOrder.find( ( block ) => ! blockOrder.includes( block ) );

--- a/assets/src/stories-editor/index.js
+++ b/assets/src/stories-editor/index.js
@@ -55,7 +55,6 @@ import store from './store';
 
 const {
 	getSelectedBlock,
-	getSelectedBlockClientId,
 	getBlocksByClientId,
 	getClientIdsWithDescendants,
 	getBlockRootClientId,

--- a/assets/src/stories-editor/index.js
+++ b/assets/src/stories-editor/index.js
@@ -168,9 +168,9 @@ subscribe( async () => {
 	}
 
 	if ( selectedBlock !== newSelectedBlock ) {
-		const toolbar = document.querySelector( '.edit-post-header-toolbar__block-toolbar' );
-		if ( toolbar ) {
-			toolbar.setAttribute( 'data-block-name', newSelectedBlock ? newSelectedBlock.name : '' );
+		const editPostLayout = document.querySelector( '.edit-post-layout' );
+		if ( editPostLayout ) {
+			editPostLayout.setAttribute( 'data-block-name', newSelectedBlock ? newSelectedBlock.name : '' );
 		}
 	}
 


### PR DESCRIPTION
Fixes #2115 (again).
See #2283.

Video block:

<img width="276" alt="Screenshot 2019-05-13 at 15 37 16" src="https://user-images.githubusercontent.com/841956/57658885-3d44b280-7595-11e9-9ec4-27a57fcec970.png">

Image block:

<img width="378" alt="Screenshot 2019-05-13 at 15 39 47" src="https://user-images.githubusercontent.com/841956/57658925-5fd6cb80-7595-11e9-8e7f-fa90643048aa.png">

Pullquote block:

<img width="510" alt="Screenshot 2019-05-13 at 15 39 28" src="https://user-images.githubusercontent.com/841956/57658947-741ac880-7595-11e9-8afe-eee90d6c0acf.png">

Embed block:

<img width="344" alt="Screenshot 2019-05-13 at 15 40 28" src="https://user-images.githubusercontent.com/841956/57658969-7c730380-7595-11e9-8598-d3f0802f6b5a.png">
