### PR TITLE
Prevent using video icon as poster when no featured image assigned

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -88,7 +88,7 @@ class EditPage extends Component {
 			mediaUrl: media.url,
 			mediaId: media.id,
 			mediaType,
-			poster: VIDEO_BACKGROUND_TYPE === mediaType && media.image ? media.image.src : undefined,
+			poster: VIDEO_BACKGROUND_TYPE === mediaType && media.image && media.image.src !== media.icon ? media.image.src : undefined,
 		} );
 	}
 


### PR DESCRIPTION
Fixes #2284.