### PR TITLE
Fix block navigation label class name to correct styling

### DIFF
--- a/assets/src/components/block-navigation/index.js
+++ b/assets/src/components/block-navigation/index.js
@@ -51,9 +51,9 @@ function BlockNavigation( { blocks, selectBlock, selectedBlockClientId, isReorde
 	return (
 		<NavigableMenu
 			role="presentation"
-			className="editor-block-navigation__container block-editor-block-navigation__container"
+			className="block-editor-block-navigation__container"
 		>
-			<p className="editor-block-navigation__label">{ __( 'Block Navigation', 'amp' ) }</p>
+			<p className="block-editor-block-navigation__label">{ __( 'Block Navigation', 'amp' ) }</p>
 			{ hasBlocks && (
 				<BlockNavigationList
 					blocks={ blocks }
@@ -62,7 +62,7 @@ function BlockNavigation( { blocks, selectBlock, selectedBlockClientId, isReorde
 				/>
 			) }
 			{ ! hasBlocks && (
-				<p className="editor-block-navigation__paragraph">
+				<p className="block-editor-block-navigation__paragraph">
 					{ __( 'No blocks created yet.', 'amp' ) }
 				</p>
 			) }


### PR DESCRIPTION
Before:

<img width="337" alt="Screenshot 2019-05-13 at 21 04 23" src="https://user-images.githubusercontent.com/841956/57670202-09808180-75c3-11e9-9405-bc8d28210f51.png">


After:

<img width="335" alt="Screenshot 2019-05-13 at 21 04 18" src="https://user-images.githubusercontent.com/841956/57670203-0be2db80-75c3-11e9-80fc-1e7f94ebb32d.png">
