### PR TITLE
Fix background color opacity edge case

### DIFF
--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -13,7 +13,7 @@ import { count } from '@wordpress/wordcount';
 import { _x } from '@wordpress/i18n';
 import { select, dispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
-import { getColorClassName, getFontSize, RichText } from '@wordpress/block-editor';
+import { getColorClassName, getColorObjectByAttributeValues, getFontSize, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -909,7 +909,7 @@ export const getStylesFromBlockAttributes = ( {
 	const userFontSize = fontSize ? getFontSize( fontSizes, fontSize, customFontSize ).size : customFontSize;
 	const fontSizeResponsive = userFontSize && ( ( userFontSize / STORY_PAGE_INNER_WIDTH ) * 100 ).toFixed( 2 ) + 'vw';
 
-	const appliedBackgroundColor = getBackgroundColorWithOpacity( colors, backgroundColor, customBackgroundColor, opacity );
+	const appliedBackgroundColor = getBackgroundColorWithOpacity( colors, getColorObjectByAttributeValues( colors, backgroundColor, customBackgroundColor ), customBackgroundColor, opacity );
 
 	return {
 		backgroundColor: appliedBackgroundColor,


### PR DESCRIPTION
Cherry picks a change from #2296 to fix an issue that wasn't addressed in #2278.

To reproduce:

1. Insert text block
2. Choose color from palette
3. Set opacity
4. Notice that background color is also there on the front end

All other variations (custom color, no opacity, etc.) continue to work.