### PR TITLE
Greatly simplify createSkeletonTemplate

### DIFF
--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -3,7 +3,7 @@
  */
 import uuid from 'uuid/v4';
 import classnames from 'classnames';
-import { each, every, isEqual } from 'lodash';
+import { every, isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -761,77 +761,24 @@ export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) =>
 };
 
 /**
- * Object of block attributes to set to default when inserting a template.
- */
-const emptyTemplateMapping = {
-	// @todo This can use just arrays of attribute keys instead of object.
-	'amp/amp-story-text': {
-		content: '',
-	},
-	'amp/amp-story-page': {
-		mediaUrl: null,
-		mediaType: null,
-		focalPoint: {},
-	},
-	'core/image': {
-		url: null,
-		positionLeft: null,
-	},
-	'amp/amp-story-cta': {
-		text: null,
-		link: null,
-	},
-	'core/quote': {
-		citation: null,
-		value: null,
-	},
-};
-
-/**
- * Gets a skeleton template block from pre-populated block.
- *
- * @param {Object}   block            Original block.
- * @param {Object}   block.name       Block name.
- * @param {Object[]} block.attributes Block attributes.
- *
- * @return {Object} Block object.
- */
-const getSkeletonTemplateBlock = ( block ) => {
-	if ( ! emptyTemplateMapping[ block.name ] ) {
-		return block.attributes;
-	}
-
-	const attributes = {};
-	each( block.attributes, function( value, key ) {
-		if ( undefined === emptyTemplateMapping[ block.name ][ key ] ) {
-			attributes[ key ] = value;
-		}
-	} );
-
-	// Image block's left positioning should be set to 0.
-	if ( 'core/image' === block.name ) {
-		attributes.positionLeft = 0;
-	}
-
-	return attributes;
-};
-
-/**
  * Creates a skeleton template from pre-populated template.
  *
- * @param {Object}   template             Block object.
- * @param {Object}   template.name        Block name.
+ * Basically resets all block attributes back to their defaults.
+ *
+ * @param {Object}   template             Template block object.
+ * @param {string}   template.name        Block name.
  * @param {Object[]} template.innerBlocks List of inner blocks.
- * @param {Object[]} template.attributes  Block attributes.
  *
  * @return {Object} Skeleton template block.
  */
 export const createSkeletonTemplate = ( template ) => {
-	const children = [];
-	template.innerBlocks.forEach( function( childBlock ) {
-		children.push( createBlock( childBlock.name, getSkeletonTemplateBlock( childBlock ) ) );
-	} );
-	return createBlock( template.name, getSkeletonTemplateBlock( template ), children );
+	const innerBlocks = [];
+
+	for ( const innerBlock of template.innerBlocks ) {
+		innerBlocks.push( createBlock( innerBlock.name, {} ) );
+	}
+
+	return createBlock( template.name, {}, innerBlocks );
 };
 
 /**

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -758,6 +758,27 @@ export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) =>
 };
 
 /**
+ * Resets a block's attributes except for a few ones relevant for the layout.
+ *
+ * @param {Object} block Block object.
+ * @param {Object} block.attributes Block attributes.
+ *
+ * @return {Object} Filtered block attributes.
+ */
+const resetBlockAttributes = ( block ) => {
+	const attributes = {};
+	const attributesToKeep = [ 'positionTop', 'positionLeft', 'width', 'height', 'ampFitText', 'tagName' ];
+
+	for ( const key in block.attributes ) {
+		if ( block.attributes.hasOwnProperty( key ) && attributesToKeep.includes( key ) ) {
+			attributes[ key ] = block.attributes[ key ];
+		}
+	}
+
+	return attributes;
+};
+
+/**
  * Creates a skeleton template from pre-populated template.
  *
  * Basically resets all block attributes back to their defaults.
@@ -772,10 +793,10 @@ export const createSkeletonTemplate = ( template ) => {
 	const innerBlocks = [];
 
 	for ( const innerBlock of template.innerBlocks ) {
-		innerBlocks.push( createBlock( innerBlock.name, {} ) );
+		innerBlocks.push( createBlock( innerBlock.name, resetBlockAttributes( innerBlock ) ) );
 	}
 
-	return createBlock( template.name, {}, innerBlocks );
+	return createBlock( template.name, resetBlockAttributes( template ), innerBlocks );
 };
 
 /**

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -767,7 +767,7 @@ export const addBackgroundColorToOverlay = ( overlayStyle, backgroundColors ) =>
  */
 const resetBlockAttributes = ( block ) => {
 	const attributes = {};
-	const attributesToKeep = [ 'positionTop', 'positionLeft', 'width', 'height', 'ampFitText', 'tagName' ];
+	const attributesToKeep = [ 'positionTop', 'positionLeft', 'width', 'height', 'tagName' ];
 
 	for ( const key in block.attributes ) {
 		if ( block.attributes.hasOwnProperty( key ) && attributesToKeep.includes( key ) ) {


### PR DESCRIPTION
Basically resets all block attributes back to their defaults when inserting a template. No more background colors that you first need to remove.

Fixes #2307.