### PR TITLE
Fix Latest Stories block styling; prevent registering block when Stories not enabled

### DIFF
--- a/assets/src/block-editor/blocks/amp-latest-stories/edit.js
+++ b/assets/src/block-editor/blocks/amp-latest-stories/edit.js
@@ -1,4 +1,3 @@
-/* global ampLatestStoriesBlockData */
 /**
  * AMP Latest Stories edit component, mainly forked from the Gutenberg 'Latest Posts' class LatestPostsEdit.
  */
@@ -26,6 +25,8 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
 
+const { ampLatestStoriesBlockData } = window;
+
 const blockName = 'amp/amp-latest-stories';
 
 class LatestStoriesEdit extends Component {
@@ -35,14 +36,9 @@ class LatestStoriesEdit extends Component {
 	 * This block uses <ServerSideRender>, so sometimes the stylesheet isn't present.
 	 * This checks if it is, and conditionally adds it.
 	 */
-	componentWillMount() {
-		this.isStillMounted = true;
-
-		if ( 'undefined' === typeof ampLatestStoriesBlockData ) {
-			return;
-		}
-
+	componentDidMount() {
 		const stylesheetQuery = document.querySelector( `link[href="${ ampLatestStoriesBlockData.storyCardStyleURL }"]` );
+
 		if ( ! stylesheetQuery ) {
 			const stylesheet = document.createElement( 'link' );
 			stylesheet.setAttribute( 'rel', 'stylesheet' );
@@ -50,10 +46,6 @@ class LatestStoriesEdit extends Component {
 			stylesheet.setAttribute( 'href', ampLatestStoriesBlockData.storyCardStyleURL );
 			document.head.appendChild( stylesheet );
 		}
-	}
-
-	componentWillUnmount() {
-		this.isStillMounted = false;
 	}
 
 	render() {

--- a/assets/src/block-editor/blocks/amp-latest-stories/edit.js
+++ b/assets/src/block-editor/blocks/amp-latest-stories/edit.js
@@ -29,6 +29,12 @@ import { withSelect } from '@wordpress/data';
 const blockName = 'amp/amp-latest-stories';
 
 class LatestStoriesEdit extends Component {
+	/**
+	 * If the stylesheet isn't present, this adds it to the <head>.
+	 *
+	 * This block uses <ServerSideRender>, so sometimes the stylesheet isn't present.
+	 * This checks if it is, and conditionally adds it.
+	 */
 	componentWillMount() {
 		this.isStillMounted = true;
 

--- a/assets/src/block-editor/blocks/amp-latest-stories/edit.js
+++ b/assets/src/block-editor/blocks/amp-latest-stories/edit.js
@@ -1,3 +1,4 @@
+/* global ampEditorBlocks */
 /**
  * AMP Latest Stories edit component, mainly forked from the Gutenberg 'Latest Posts' class LatestPostsEdit.
  */
@@ -30,6 +31,19 @@ const blockName = 'amp/amp-latest-stories';
 class LatestStoriesEdit extends Component {
 	componentWillMount() {
 		this.isStillMounted = true;
+
+		if ( 'undefined' === typeof ampEditorBlocks ) {
+			return;
+		}
+
+		const stylesheetQuery = document.querySelector( `link[href="${ ampEditorBlocks.latestStoriesCssUrl }"]` );
+		if ( ! stylesheetQuery ) {
+			const stylesheet = document.createElement( 'link' );
+			stylesheet.setAttribute( 'rel', 'stylesheet' );
+			stylesheet.setAttribute( 'type', 'text/css' );
+			stylesheet.setAttribute( 'href', ampEditorBlocks.latestStoriesCssUrl );
+			document.head.appendChild( stylesheet );
+		}
 	}
 
 	componentWillUnmount() {

--- a/assets/src/block-editor/blocks/amp-latest-stories/edit.js
+++ b/assets/src/block-editor/blocks/amp-latest-stories/edit.js
@@ -1,4 +1,4 @@
-/* global ampEditorBlocks */
+/* global ampLatestStoriesBlockData */
 /**
  * AMP Latest Stories edit component, mainly forked from the Gutenberg 'Latest Posts' class LatestPostsEdit.
  */
@@ -38,16 +38,16 @@ class LatestStoriesEdit extends Component {
 	componentWillMount() {
 		this.isStillMounted = true;
 
-		if ( 'undefined' === typeof ampEditorBlocks ) {
+		if ( 'undefined' === typeof ampLatestStoriesBlockData ) {
 			return;
 		}
 
-		const stylesheetQuery = document.querySelector( `link[href="${ ampEditorBlocks.latestStoriesCssUrl }"]` );
+		const stylesheetQuery = document.querySelector( `link[href="${ ampLatestStoriesBlockData.storyCardStyleURL }"]` );
 		if ( ! stylesheetQuery ) {
 			const stylesheet = document.createElement( 'link' );
 			stylesheet.setAttribute( 'rel', 'stylesheet' );
 			stylesheet.setAttribute( 'type', 'text/css' );
-			stylesheet.setAttribute( 'href', ampEditorBlocks.latestStoriesCssUrl );
+			stylesheet.setAttribute( 'href', ampLatestStoriesBlockData.storyCardStyleURL );
 			document.head.appendChild( stylesheet );
 		}
 	}

--- a/assets/src/block-editor/index.js
+++ b/assets/src/block-editor/index.js
@@ -1,5 +1,3 @@
-/* global ampLatestStoriesBlockData */
-
 /**
  * WordPress dependencies
  */
@@ -16,6 +14,8 @@ import withCroppedFeaturedImage from '../components/with-cropped-featured-image'
 import withFeaturedImageNotice from '../components/higher-order/with-featured-image-notice';
 import { getMinimumFeaturedImageDimensions } from '../common/helpers';
 import './store';
+
+const { ampLatestStoriesBlockData } = window;
 
 // Display a notice in the Featured Image panel if none exists or its width is too small.
 addFilter( 'editor.PostFeaturedImage', 'ampEditorBlocks/withFeaturedImageNotice', withFeaturedImageNotice );

--- a/assets/src/block-editor/index.js
+++ b/assets/src/block-editor/index.js
@@ -1,3 +1,5 @@
+/* global ampLatestStoriesBlockData */
+
 /**
  * WordPress dependencies
  */
@@ -47,6 +49,11 @@ const blocks = require.context( './blocks', true, /(?<!test\/)index\.js$/ );
 
 blocks.keys().forEach( ( modulePath ) => {
 	const { name, settings } = blocks( modulePath );
+
+	// Prevent registering latest-stories block if not enabled.
+	if ( 'amp/amp-latest-stories' === name && typeof ampLatestStoriesBlockData === 'undefined' ) {
+		return;
+	}
 
 	const blockRequiresAmp = AMP_DEPENDENT_BLOCKS.includes( name );
 

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -154,6 +154,12 @@ class AMP_Editor_Blocks {
 				'after'
 			);
 		}
+
+		wp_localize_script(
+			'amp-editor-blocks',
+			'ampEditorBlocks',
+			array( 'latestStoriesCssUrl' => amp_get_asset_url( 'css/amp-story-card.css' ) )
+		);
 	}
 
 	/**

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -12,13 +12,6 @@
 class AMP_Editor_Blocks {
 
 	/**
-	 * Script handle used for amp-editor-blocks.
-	 *
-	 * @var string
-	 */
-	const SCRIPT_HANDLE = 'amp-editor-blocks';
-
-	/**
 	 * List of AMP scripts that need to be printed when AMP components are used in non-AMP document context ("dirty AMP").
 	 *
 	 * @var array
@@ -132,6 +125,8 @@ class AMP_Editor_Blocks {
 	 * Has to be loaded before registering the blocks in registerCoreBlocks.
 	 */
 	public function enqueue_block_editor_assets() {
+		$script_handle = 'amp-editor-blocks';
+
 		if ( AMP_Story_Post_Type::POST_TYPE_SLUG !== get_current_screen()->post_type ) {
 			wp_enqueue_style(
 				'amp-editor-blocks-style',
@@ -142,7 +137,7 @@ class AMP_Editor_Blocks {
 		}
 
 		wp_enqueue_script(
-			self::SCRIPT_HANDLE,
+			$script_handle,
 			amp_get_asset_url( 'js/amp-editor-blocks.js' ),
 			array( 'wp-editor', 'wp-edit-post', 'wp-blocks', 'lodash', 'wp-i18n', 'wp-element', 'wp-components' ),
 			AMP__VERSION,
@@ -150,13 +145,13 @@ class AMP_Editor_Blocks {
 		);
 
 		if ( function_exists( 'wp_set_script_translations' ) ) {
-			wp_set_script_translations( self::SCRIPT_HANDLE, 'amp' );
+			wp_set_script_translations( $script_handle, 'amp' );
 		} elseif ( function_exists( 'wp_get_jed_locale_data' ) || function_exists( 'gutenberg_get_jed_locale_data' ) ) {
 			$locale_data  = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
 			$translations = wp_json_encode( $locale_data );
 
 			wp_add_inline_script(
-				self::SCRIPT_HANDLE,
+				$script_handle,
 				'wp.i18n.setLocaleData( ' . $translations . ', "amp" );',
 				'after'
 			);

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -12,6 +12,13 @@
 class AMP_Editor_Blocks {
 
 	/**
+	 * Script handle used for amp-editor-blocks.
+	 *
+	 * @var string
+	 */
+	const SCRIPT_HANDLE = 'amp-editor-blocks';
+
+	/**
 	 * List of AMP scripts that need to be printed when AMP components are used in non-AMP document context ("dirty AMP").
 	 *
 	 * @var array
@@ -135,7 +142,7 @@ class AMP_Editor_Blocks {
 		}
 
 		wp_enqueue_script(
-			'amp-editor-blocks',
+			self::SCRIPT_HANDLE,
 			amp_get_asset_url( 'js/amp-editor-blocks.js' ),
 			array( 'wp-editor', 'wp-edit-post', 'wp-blocks', 'lodash', 'wp-i18n', 'wp-element', 'wp-components' ),
 			AMP__VERSION,
@@ -143,23 +150,17 @@ class AMP_Editor_Blocks {
 		);
 
 		if ( function_exists( 'wp_set_script_translations' ) ) {
-			wp_set_script_translations( 'amp-editor-blocks', 'amp' );
+			wp_set_script_translations( self::SCRIPT_HANDLE, 'amp' );
 		} elseif ( function_exists( 'wp_get_jed_locale_data' ) || function_exists( 'gutenberg_get_jed_locale_data' ) ) {
 			$locale_data  = function_exists( 'wp_get_jed_locale_data' ) ? wp_get_jed_locale_data( 'amp' ) : gutenberg_get_jed_locale_data( 'amp' );
 			$translations = wp_json_encode( $locale_data );
 
 			wp_add_inline_script(
-				'amp-editor-blocks',
+				self::SCRIPT_HANDLE,
 				'wp.i18n.setLocaleData( ' . $translations . ', "amp" );',
 				'after'
 			);
 		}
-
-		wp_localize_script(
-			'amp-editor-blocks',
-			'ampEditorBlocks',
-			array( 'latestStoriesCssUrl' => amp_get_asset_url( 'css/amp-story-card.css' ) )
-		);
 	}
 
 	/**

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -570,12 +570,6 @@ class AMP_Story_Post_Type {
 	 * Export data used for Latest Stories block.
 	 */
 	public static function export_latest_stories_block_editor_data() {
-
-		// Not relevant on the amp_story post type, since Latest Stories is not registered there.
-		if ( self::POST_TYPE_SLUG === get_current_screen()->post_type ) {
-			return;
-		}
-
 		$url = add_query_arg(
 			'ver',
 			wp_styles()->registered[ self::STORY_CARD_CSS_SLUG ]->ver,
@@ -586,7 +580,7 @@ class AMP_Story_Post_Type {
 		$url = apply_filters( 'style_loader_src', $url, self::STORY_CARD_CSS_SLUG );
 
 		wp_add_inline_script(
-			AMP_Editor_Blocks::SCRIPT_HANDLE,
+			AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE,
 			sprintf(
 				'var ampLatestStoriesBlockData = %s;',
 				wp_json_encode(

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -174,6 +174,8 @@ class AMP_Story_Post_Type {
 
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ) );
 
+		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'export_latest_stories_block_editor_data' ), 100 );
+
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_custom_stories_styles' ) );
 
 		// Remove unnecessary settings.
@@ -561,6 +563,33 @@ class AMP_Story_Post_Type {
 			amp_get_asset_url( '/css/' . self::STORY_CARD_CSS_SLUG . '.css' ),
 			array(),
 			AMP__VERSION
+		);
+	}
+
+	/**
+	 * Export data used for Latest Stories block.
+	 */
+	public static function export_latest_stories_block_editor_data() {
+		$url = add_query_arg(
+			'ver',
+			wp_styles()->registered[ self::STORY_CARD_CSS_SLUG ]->ver,
+			wp_styles()->registered[ self::STORY_CARD_CSS_SLUG ]->src
+		);
+
+		/** This filter is documented in wp-includes/class.wp-styles.php */
+		$url = apply_filters( 'style_loader_src', $url, self::STORY_CARD_CSS_SLUG );
+
+		wp_add_inline_script(
+			AMP_Editor_Blocks::SCRIPT_HANDLE,
+			sprintf(
+				'var ampLatestStoriesBlockData = %s;',
+				wp_json_encode(
+					array(
+						'storyCardStyleURL' => $url,
+					)
+				)
+			),
+			'before'
 		);
 	}
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -651,13 +651,7 @@ class AMP_Story_Post_Type {
 		);
 
 		// Also enqueue this since it's possible to embed another story into a story.
-		wp_enqueue_style(
-			'amp-story-card',
-			amp_get_asset_url( 'css/amp-story-card.css' ),
-			array( self::AMP_STORIES_STYLE_HANDLE ),
-			AMP__VERSION,
-			false
-		);
+		wp_enqueue_style( self::STORY_CARD_CSS_SLUG );
 
 		self::enqueue_general_styles();
 	}

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -174,8 +174,6 @@ class AMP_Story_Post_Type {
 
 		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ) );
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'export_latest_stories_block_editor_data' ), 100 );
-
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_custom_stories_styles' ) );
 
 		// Remove unnecessary settings.

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -570,6 +570,12 @@ class AMP_Story_Post_Type {
 	 * Export data used for Latest Stories block.
 	 */
 	public static function export_latest_stories_block_editor_data() {
+
+		// Not relevant on the amp_story post type, since Latest Stories is not registered there.
+		if ( self::POST_TYPE_SLUG === get_current_screen()->post_type ) {
+			return;
+		}
+
 		$url = add_query_arg(
 			'ver',
 			wp_styles()->registered[ self::STORY_CARD_CSS_SLUG ]->ver,

--- a/tests/test-class-amp-editor-blocks.php
+++ b/tests/test-class-amp-editor-blocks.php
@@ -57,7 +57,9 @@ class Test_AMP_Editor_Blocks extends \WP_UnitTestCase {
 	/**
 	 * Test enqueue_block_editor_assets().
 	 *
-	 * @covers \AMP_Editor_Blocks::enqueue_block_editor_assets().
+	 * @covers \AMP_Story_Post_Type::register_story_card_styling()
+	 * @covers \AMP_Editor_Blocks::enqueue_block_editor_assets()
+	 * @covers \AMP_Story_Post_Type::export_latest_stories_block_editor_data()
 	 */
 	public function test_enqueue_block_editor_assets() {
 		set_current_screen( 'admin.php' );
@@ -76,8 +78,8 @@ class Test_AMP_Editor_Blocks extends \WP_UnitTestCase {
 		$this->assertEquals( AMP__VERSION, $script->ver );
 		$this->assertTrue( in_array( $slug, $scripts->queue, true ) );
 
-		$data = $script->extra['data'];
-		$this->assertContains( 'var ampEditorBlocks', $data );
-		$this->assertContains( 'amp-story-card.css', $data );
+		AMP_Story_Post_Type::register_story_card_styling( wp_styles() );
+		AMP_Story_Post_Type::export_latest_stories_block_editor_data();
+		$this->assertContains( 'ampLatestStoriesBlockData', implode( '', $script->extra['before'] ) );
 	}
 }

--- a/tests/test-class-amp-editor-blocks.php
+++ b/tests/test-class-amp-editor-blocks.php
@@ -75,5 +75,9 @@ class Test_AMP_Editor_Blocks extends \WP_UnitTestCase {
 		$this->assertContains( $expected_file_name, $script->src );
 		$this->assertEquals( AMP__VERSION, $script->ver );
 		$this->assertTrue( in_array( $slug, $scripts->queue, true ) );
+
+		$data = $script->extra['data'];
+		$this->assertContains( 'var ampEditorBlocks', $data );
+		$this->assertContains( 'amp-story-card.css', $data );
 	}
 }

--- a/tests/test-class-amp-editor-blocks.php
+++ b/tests/test-class-amp-editor-blocks.php
@@ -57,9 +57,7 @@ class Test_AMP_Editor_Blocks extends \WP_UnitTestCase {
 	/**
 	 * Test enqueue_block_editor_assets().
 	 *
-	 * @covers \AMP_Story_Post_Type::register_story_card_styling()
 	 * @covers \AMP_Editor_Blocks::enqueue_block_editor_assets()
-	 * @covers \AMP_Story_Post_Type::export_latest_stories_block_editor_data()
 	 */
 	public function test_enqueue_block_editor_assets() {
 		set_current_screen( 'admin.php' );
@@ -77,9 +75,5 @@ class Test_AMP_Editor_Blocks extends \WP_UnitTestCase {
 		$this->assertContains( $expected_file_name, $script->src );
 		$this->assertEquals( AMP__VERSION, $script->ver );
 		$this->assertTrue( in_array( $slug, $scripts->queue, true ) );
-
-		AMP_Story_Post_Type::register_story_card_styling( wp_styles() );
-		AMP_Story_Post_Type::export_latest_stories_block_editor_data();
-		$this->assertContains( 'ampLatestStoriesBlockData', implode( '', $script->extra['before'] ) );
 	}
 }

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -90,7 +90,9 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	/**
 	 * Test enqueue_block_assets.
 	 *
-	 * @see AMP_Post_Meta_Box::enqueue_block_assets()
+	 * @covers AMP_Post_Meta_Box::enqueue_block_assets()
+	 * @covers AMP_Story_Post_Type::register_story_card_styling()
+	 * @covers AMP_Story_Post_Type::export_latest_stories_block_editor_data()
 	 */
 	public function test_enqueue_block_assets() {
 		if ( ! function_exists( 'register_block_type' ) ) {
@@ -127,6 +129,11 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertEquals( AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE, $block_script->handle );
 		$this->assertEquals( amp_get_asset_url( 'js/' . AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE . '.js' ), $block_script->src );
 		$this->assertEquals( AMP__VERSION, $block_script->ver );
+
+		// Test Stories integration.
+		AMP_Story_Post_Type::register_story_card_styling( wp_styles() );
+		AMP_Story_Post_Type::export_latest_stories_block_editor_data();
+		$this->assertContains( 'ampLatestStoriesBlockData', implode( '', wp_scripts()->registered[ AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ]->extra['before'] ) );
 	}
 
 	/**


### PR DESCRIPTION
* Applies Weston's suggestion of checking in `componentWillMount()` for whether the stylesheet is present
* Uses `wp_localize_script` to make the URL of `amp-story-card.css` available. Maybe there's a better way to do this.

# Before 
![before-no-styling](https://user-images.githubusercontent.com/4063887/57904938-633eb100-783a-11e9-804e-b5e522fbc490.gif)

# After
![after-styling-present](https://user-images.githubusercontent.com/4063887/57905018-a731b600-783a-11e9-8c95-6232c4df1dfc.gif)

Fixes #2300