### PR TITLE
Use amp-embedly-card instead of amp-reddit to work around resizing issue

### DIFF
--- a/includes/embeds/class-amp-reddit-embed-handler.php
+++ b/includes/embeds/class-amp-reddit-embed-handler.php
@@ -61,15 +61,13 @@ class AMP_Reddit_Embed_Handler extends AMP_Base_Embed_Handler {
 			return '';
 		}
 
-		// @todo Sizing is not yet correct. See <https://github.com/ampproject/amphtml/issues/11869>.
 		return AMP_HTML_Utils::build_tag(
-			'amp-reddit',
+			'amp-embedly-card',
 			array(
-				'layout'         => 'responsive',
-				'data-embedtype' => 'post',
-				'width'          => '100',
-				'height'         => '100',
-				'data-src'       => $args['url'],
+				'layout'   => 'responsive',
+				'width'    => '100',
+				'height'   => '100',
+				'data-url' => $args['url'],
 			)
 		);
 	}


### PR DESCRIPTION
Before:
```html
<amp-reddit
    layout="responsive"
    data-embedtype="post"
    width="100"
    height="100" 
    data-src="https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/?ref=share&amp;ref_source=embed">
</amp-reddit>
```

After:
```html
<amp-embedly-card
    data-url="https://www.reddit.com/r/me_irl/comments/52rmir/me_irl/"
    layout="responsive"
    width="100"
    height="100">
</amp-embedly-card>
```

The amp-reddit component is plagued by an issue where users have to fill in the width/height 
https://amp.dev/documentation/examples/components/amp-reddit/?referrer=ampbyexample.com
Because of that standard embeds with 

Background:
Around the area I've touched there was a todo item which references a closed ticket (although amp-reddit still is not sizing correctly):

> `@todo Sizing is not yet correct. See <https://github.com/ampproject/amphtml/issues/11869>.`

I've found there a reference to the amp-embedly-card which is functioning correctly in sizing the embed.

See also https://github.com/ampproject/amphtml/issues/11869#issuecomment-493506507