### PR TITLE
Resizable iframes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ assets/css/*-compiled-rtl.css
 assets/css/*.map
 assets/js/*.js
 !assets/js/amp-service-worker-runtime-precaching.js
+!assets/js/wp-embed-template.js
 assets/js/*.map
 built
 /amphtml

--- a/amp.php
+++ b/amp.php
@@ -348,6 +348,7 @@ function amp_init() {
 	add_action( 'wp_loaded', 'amp_story_templates' );
 	add_action( 'wp_loaded', 'amp_add_options_menu' );
 	add_action( 'wp_loaded', 'amp_admin_pointer' );
+	add_action( 'wp_loaded', 'amp_wordpress_embed_templates' );
 	add_action( 'parse_query', 'amp_correct_query_when_is_front_page' );
 	add_action( 'admin_bar_menu', 'amp_add_admin_bar_view_link', 100 );
 

--- a/assets/js/wp-embed-template.js
+++ b/assets/js/wp-embed-template.js
@@ -1,0 +1,234 @@
+/**
+ * Customized version of wp-includes/js/wp-embed-template.js that sends
+ * AMP-compatible resize messages.
+ */
+
+(function ( window, document ) {
+	'use strict';
+
+	var supportedBrowser = ( document.querySelector && window.addEventListener ),
+		loaded = false,
+		secret,
+		secretTimeout,
+		resizing;
+
+	function sendEmbedMessage( message, value ) {
+		window.parent.postMessage( {
+			message: message,
+			value: value,
+			secret: secret
+		}, '*' );
+	}
+
+	function sendAmpMessage( type, key, value ) {
+		var message = {
+			sentinel: 'amp',
+			type: type,
+		};
+
+		if ( key && value ) {
+			message[ key ] = value;
+		}
+
+		window.parent.postMessage( message, '*' );
+	}
+
+	function onLoad() {
+		if ( loaded ) {
+			return;
+		}
+		loaded = true;
+
+		var share_dialog = document.querySelector( '.wp-embed-share-dialog' ),
+			share_dialog_open = document.querySelector( '.wp-embed-share-dialog-open' ),
+			share_dialog_close = document.querySelector( '.wp-embed-share-dialog-close' ),
+			share_input = document.querySelectorAll( '.wp-embed-share-input' ),
+			share_dialog_tabs = document.querySelectorAll( '.wp-embed-share-tab-button button' ),
+			featured_image = document.querySelector( '.wp-embed-featured-image img' ),
+			i;
+
+		if ( share_input ) {
+			for ( i = 0; i < share_input.length; i++ ) {
+				share_input[ i ].addEventListener( 'click', function ( e ) {
+					e.target.select();
+				} );
+			}
+		}
+
+		function openSharingDialog() {
+			share_dialog.className = share_dialog.className.replace( 'hidden', '' );
+			// Initial focus should go on the currently selected tab in the dialog.
+			document.querySelector( '.wp-embed-share-tab-button [aria-selected="true"]' ).focus();
+		}
+
+		function closeSharingDialog() {
+			share_dialog.className += ' hidden';
+			document.querySelector( '.wp-embed-share-dialog-open' ).focus();
+		}
+
+		if ( share_dialog_open ) {
+			share_dialog_open.addEventListener( 'click', function () {
+				openSharingDialog();
+			} );
+		}
+
+		if ( share_dialog_close ) {
+			share_dialog_close.addEventListener( 'click', function () {
+				closeSharingDialog();
+			} );
+		}
+
+		function shareClickHandler( e ) {
+			var currentTab = document.querySelector( '.wp-embed-share-tab-button [aria-selected="true"]' );
+			currentTab.setAttribute( 'aria-selected', 'false' );
+			document.querySelector( '#' + currentTab.getAttribute( 'aria-controls' ) ).setAttribute( 'aria-hidden', 'true' );
+
+			e.target.setAttribute( 'aria-selected', 'true' );
+			document.querySelector( '#' + e.target.getAttribute( 'aria-controls' ) ).setAttribute( 'aria-hidden', 'false' );
+		}
+
+		function shareKeyHandler( e ) {
+			var target = e.target,
+				previousSibling = target.parentElement.previousElementSibling,
+				nextSibling = target.parentElement.nextElementSibling,
+				newTab, newTabChild;
+
+			if ( 37 === e.keyCode ) {
+				newTab = previousSibling;
+			} else if ( 39 === e.keyCode ) {
+				newTab = nextSibling;
+			} else {
+				return false;
+			}
+
+			if ( 'rtl' === document.documentElement.getAttribute( 'dir' ) ) {
+				newTab = ( newTab === previousSibling ) ? nextSibling : previousSibling;
+			}
+
+			if ( newTab ) {
+				newTabChild = newTab.firstElementChild;
+
+				target.setAttribute( 'tabindex', '-1' );
+				target.setAttribute( 'aria-selected', false );
+				document.querySelector( '#' + target.getAttribute( 'aria-controls' ) ).setAttribute( 'aria-hidden', 'true' );
+
+				newTabChild.setAttribute( 'tabindex', '0' );
+				newTabChild.setAttribute( 'aria-selected', 'true' );
+				newTabChild.focus();
+				document.querySelector( '#' + newTabChild.getAttribute( 'aria-controls' ) ).setAttribute( 'aria-hidden', 'false' );
+			}
+		}
+
+		if ( share_dialog_tabs ) {
+			for ( i = 0; i < share_dialog_tabs.length; i++ ) {
+				share_dialog_tabs[ i ].addEventListener( 'click', shareClickHandler );
+
+				share_dialog_tabs[ i ].addEventListener( 'keydown', shareKeyHandler );
+			}
+		}
+
+		document.addEventListener( 'keydown', function ( e ) {
+			if ( 27 === e.keyCode && -1 === share_dialog.className.indexOf( 'hidden' ) ) {
+				closeSharingDialog();
+			} else if ( 9 === e.keyCode ) {
+				constrainTabbing( e );
+			}
+		}, false );
+
+		function constrainTabbing( e ) {
+			// Need to re-get the selected tab each time.
+			var firstFocusable = document.querySelector( '.wp-embed-share-tab-button [aria-selected="true"]' );
+
+			if ( share_dialog_close === e.target && ! e.shiftKey ) {
+				firstFocusable.focus();
+				e.preventDefault();
+			} else if ( firstFocusable === e.target && e.shiftKey ) {
+				share_dialog_close.focus();
+				e.preventDefault();
+			}
+		}
+
+		if ( window.self === window.top ) {
+			return;
+		}
+
+		/**
+		 * Send this document's height to the parent (embedding) site.
+		 */
+		sendEmbedMessage( 'height', Math.ceil( document.body.getBoundingClientRect().height ) );
+		sendAmpMessage( 'embed-size', 'height', Math.ceil( document.body.getBoundingClientRect().height ) );
+
+		// Send the document's height again after the featured image has been loaded.
+		if ( featured_image ) {
+			featured_image.addEventListener( 'load', function() {
+				sendEmbedMessage( 'height', Math.ceil( document.body.getBoundingClientRect().height ) );
+				sendAmpMessage( 'embed-ready' );
+				sendAmpMessage( 'embed-size', 'height', Math.ceil( document.body.getBoundingClientRect().height ) );
+			} );
+		}
+
+		/**
+		 * Detect clicks to external (_top) links.
+		 */
+		function linkClickHandler( e ) {
+			var target = e.target,
+				href;
+			if ( target.hasAttribute( 'href' ) ) {
+				href = target.getAttribute( 'href' );
+			} else {
+				href = target.parentElement.getAttribute( 'href' );
+			}
+
+			/**
+			 * Send link target to the parent (embedding) site.
+			 */
+			if ( href ) {
+				sendEmbedMessage( 'link', href );
+				e.preventDefault();
+			}
+		}
+
+		document.addEventListener( 'click', linkClickHandler );
+	}
+
+	/**
+	 * Iframe resize handler.
+	 */
+	function onResize() {
+		if ( window.self === window.top ) {
+			return;
+		}
+
+		clearTimeout( resizing );
+
+		resizing = setTimeout( function () {
+			sendEmbedMessage( 'height', Math.ceil( document.body.getBoundingClientRect().height ) );
+			sendAmpMessage( 'embed-size', 'height', Math.ceil( document.body.getBoundingClientRect().height ) );
+		}, 100 );
+	}
+
+	/**
+	 * Re-get the secret when it was added later on.
+	 */
+	function getSecret() {
+		if ( window.self === window.top || !!secret ) {
+			return;
+		}
+
+		secret = window.location.hash.replace( /.*secret=([\d\w]{10}).*/, '$1' );
+
+		clearTimeout( secretTimeout );
+
+		secretTimeout = setTimeout( function () {
+			getSecret();
+		}, 100 );
+	}
+
+	if ( supportedBrowser ) {
+		getSecret();
+		document.documentElement.className = document.documentElement.className.replace( /\bno-js\b/, '' ) + ' js';
+		document.addEventListener( 'DOMContentLoaded', onLoad, false );
+		window.addEventListener( 'load', onLoad, false );
+		window.addEventListener( 'resize', onResize, false );
+	}
+})( window, document );

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -209,3 +209,14 @@ function amp_story_templates() {
 	$story_templates = new AMP_Story_Templates();
 	$story_templates->init();
 }
+
+
+/**
+ * Bootstrap the Story Templates needed in editor.
+ *
+ * @since 1.?
+ */
+function amp_wordpress_embed_templates() {
+	$story_templates = new AMP_WordPress_Embed_Template();
+	$story_templates->init();
+}

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -106,7 +106,7 @@ class AMP_Autoloader {
 		'AMP_Widget_Archives'                => 'includes/widgets/class-amp-widget-archives',
 		'AMP_Widget_Categories'              => 'includes/widgets/class-amp-widget-categories',
 		'AMP_Widget_Text'                    => 'includes/widgets/class-amp-widget-text',
-		'AMP_WordPress_Embed_Template'       => 'includes/class-amp-embed-wordpress-template',
+		'AMP_WordPress_Embed_Template'       => 'includes/class-amp-wordpress-embed-template',
 		'WPCOM_AMP_Polldaddy_Embed'          => 'wpcom/class-amp-polldaddy-embed',
 		'AMP_Test_Stub_Sanitizer'            => 'tests/stubs',
 		'AMP_Test_World_Sanitizer'           => 'tests/stubs',

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -106,6 +106,7 @@ class AMP_Autoloader {
 		'AMP_Widget_Archives'                => 'includes/widgets/class-amp-widget-archives',
 		'AMP_Widget_Categories'              => 'includes/widgets/class-amp-widget-categories',
 		'AMP_Widget_Text'                    => 'includes/widgets/class-amp-widget-text',
+		'AMP_WordPress_Embed_Template'       => 'includes/class-amp-embed-wordpress-template',
 		'WPCOM_AMP_Polldaddy_Embed'          => 'wpcom/class-amp-polldaddy-embed',
 		'AMP_Test_Stub_Sanitizer'            => 'tests/stubs',
 		'AMP_Test_World_Sanitizer'           => 'tests/stubs',

--- a/includes/class-amp-wordpress-embed-template.php
+++ b/includes/class-amp-wordpress-embed-template.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Class AMP_WordPress_Embed_Template
+ *
+ * @package AMP
+ */
+
+/**
+ * Class AMP_WordPress_Embed_Template
+ *
+ * @since 1.0
+ */
+class AMP_WordPress_Embed_Template {
+	/**
+	 * Register embed.
+	 */
+	public function init() {
+		remove_action( 'embed_footer', 'print_embed_scripts' );
+		add_action( 'embed_footer', array( $this, 'print_embed_scripts' ) );
+		add_filter( 'oembed_dataparse', array( $this, 'filter_oembed_result' ), 20 );
+	}
+
+	/**
+	 * Prints the JavaScript in the embed iframe header.
+	 *
+	 * @see \print_embed_scripts()
+	 */
+	public function print_embed_scripts() {
+		?>
+		<script type="text/javascript">
+			<?php
+			readfile( AMP__DIR__ . '/assets/js/wp-embed-template.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_readfile
+			?>
+		</script>
+		<?php
+	}
+
+	/**
+	 * Filters oEmbed HTML results to make them resizable.
+	 *
+	 * Removes the sandbox attribute so that it gets re-added by AMP_Iframe_Sanitizer.
+	 *
+	 * @see \wp_filter_oembed_result()
+	 *
+	 * @param string $html The oEmbed HTML result.
+	 *
+	 * @return string The filtered oEmbed result.
+	 */
+	public function filter_oembed_result( $html ) {
+		if ( ! is_amp_endpoint() ) {
+			return $html;
+		}
+
+		$html = str_ireplace( 'sandbox="allow-scripts" ', '', $html );
+		$html = str_ireplace( '<iframe ', '<iframe resizable ', $html );
+
+		return $html;
+	}
+}


### PR DESCRIPTION
Even though the AMP plugin supports [many different embed providers](https://amp-wp.org/documentation/how-the-plugin-works/amp-content-rendering-in-wordpress/native-wordpress-widget-support/), WordPress does not appear to be one of them.

This PR tries to improve this, so that Story embeds can also use iframes.

Fixes #2301.