### PR TITLE
Introduce stylesheet prioritization when determining which to concatenate

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1299,6 +1299,24 @@ class AMP_Theme_Support {
 			41
 		);
 
+		// Override default admin bar bump to add element ID and remove obsolete IE hacks.
+		if ( has_action( 'wp_head', '_admin_bar_bump_cb' ) ) {
+			remove_action( 'wp_head', '_admin_bar_bump_cb' );
+			add_action(
+				'wp_head',
+				function () {
+					?>
+					<style id="admin-bar-bump-css" type="text/css" media="screen">
+						html { margin-top: 32px !important; }
+						@media screen and ( max-width: 782px ) {
+							html { margin-top: 46px !important; }
+						}
+					</style>
+					<?php
+				}
+			);
+		}
+
 		// Emulate customize support script in PHP, to assume Customizer.
 		add_filter(
 			'body_class',

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -931,22 +931,13 @@ class AMP_Theme_Support {
 			PHP_INT_MAX
 		);
 
+		add_action( 'admin_bar_init', array( __CLASS__, 'init_admin_bar' ) );
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ), 0 ); // Enqueue before theme's styles.
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'dequeue_customize_preview_scripts' ), 1000 );
 		add_filter( 'customize_partial_render', array( __CLASS__, 'filter_customize_partial_render' ) );
 
 		add_action( 'wp_footer', 'amp_print_analytics' );
-
-		/*
-		 * Disable admin bar because admin-bar.css (28K) and Dashicons (48K) alone
-		 * combine to surpass the 50K limit imposed for the amp-custom style.
-		 */
-		if ( AMP_Options_Manager::get_option( 'disable_admin_bar' ) ) {
-			add_filter( 'show_admin_bar', '__return_false', 100 );
-		} else {
-			add_action( 'admin_bar_init', array( __CLASS__, 'init_admin_bar' ) );
-		}
 
 		/*
 		 * Start output buffering at very low priority for sake of plugins and themes that use template_redirect

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -28,7 +28,6 @@ class AMP_Options_Manager {
 		'analytics'                => array(),
 		'auto_accept_sanitization' => true,
 		'accept_tree_shaking'      => true,
-		'disable_admin_bar'        => false,
 		'all_templates_supported'  => true,
 		'supported_templates'      => array( 'is_singular' ),
 		'enable_response_caching'  => true,
@@ -137,7 +136,6 @@ class AMP_Options_Manager {
 
 		$options['auto_accept_sanitization'] = ! empty( $new_options['auto_accept_sanitization'] );
 		$options['accept_tree_shaking']      = ! empty( $new_options['accept_tree_shaking'] );
-		$options['disable_admin_bar']        = ! empty( $new_options['disable_admin_bar'] );
 		$options['enable_amp_stories']       = ! empty( $new_options['enable_amp_stories'] );
 
 		// Validate post type support.

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -365,16 +365,6 @@ class AMP_Options_Menu {
 				updateHiddenClasses();
 			})( jQuery );
 			</script>
-
-			<p>
-				<label for="disable_admin_bar">
-					<input id="disable_admin_bar" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[disable_admin_bar]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'disable_admin_bar' ) ); ?>>
-					<?php esc_html_e( 'Disable admin bar on AMP pages.', 'amp' ); ?>
-				</label>
-			</p>
-			<p class="description">
-				<?php esc_html_e( 'An additional stylesheet is required to properly render the admin bar. If the additional stylesheet causes the total CSS to surpass 50KB then the admin bar should be disabled to prevent a validation error or an unstyled admin bar in AMP responses.', 'amp' ); ?>
-			</p>
 		</fieldset>
 		<?php
 	}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -121,16 +121,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	);
 
 	/**
-	 * Stylesheets.
-	 *
-	 * Values are the CSS stylesheets. Keys are MD5 hashes of the stylesheets,
-	 *
-	 * @since 0.7
-	 * @var string[]
-	 */
-	private $stylesheets = array();
-
-	/**
 	 * List of stylesheet parts prior to selector/rule removal (tree shaking).
 	 *
 	 * Keys are MD5 hashes of stylesheets.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2489,7 +2489,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$message .= '.' . $pending_stylesheet['node']->getAttribute( 'class' );
 				}
 				foreach ( $pending_stylesheet['node']->attributes as $attribute ) {
-					if ( 'id' !== $attribute->nodeName || 'class' !== $attribute->nodeName ) {
+					if ( 'id' !== $attribute->nodeName && 'class' !== $attribute->nodeName ) {
 						$message .= sprintf( '[%s=%s]', $attribute->nodeName, $attribute->nodeValue );
 					}
 				}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2969,7 +2969,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$pending_stylesheet_indices = array_keys( $this->pending_stylesheets );
 		usort(
 			$pending_stylesheet_indices,
-			function( $a, $b ) use ( $group_config ) {
+			function( $a, $b ) {
 				return $this->pending_stylesheets[ $a ]['priority'] - $this->pending_stylesheets[ $b ]['priority'];
 			}
 		);

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -854,7 +854,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		} elseif ( $node instanceof DOMElement && 'style' === $node->nodeName ) {
 			$element_id = (string) $node->getAttribute( 'id' );
-			if ( 'wp-custom-css' === $element_id ) {
+			if ( 'admin-bar-inline-css' === $element_id ) {
+				$priority = $admin_bar_priority;
+			} elseif ( 'wp-custom-css' === $element_id ) {
 				// Additional CSS from Customizer.
 				$priority = 60;
 			} else {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -404,13 +404,21 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Get stylesheets.
+	 * Get stylesheets for amp-custom.
 	 *
 	 * @since 0.7
-	 * @returns array Values are the CSS stylesheets. Keys are MD5 hashes of the stylesheets.
+	 * @returns array Values are the CSS stylesheets.
 	 */
 	public function get_stylesheets() {
-		return $this->stylesheets;
+		return wp_list_pluck(
+			array_filter(
+				$this->pending_stylesheets,
+				function( $pending_stylesheet ) {
+					return $pending_stylesheet['included'] && 'custom' === $pending_stylesheet['group'];
+				}
+			),
+			'stylesheet'
+		);
 	}
 
 	/**
@@ -769,6 +777,103 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Get the priority of the stylesheet associated with the given element.
+	 *
+	 * As with hooks, lower priorities mean they should be included first.
+	 * The higher the priority value, the more likely it will be that the
+	 * stylesheet will be among those excluded due to 'excessive_css' when
+	 * concatenated CSS reaches 50KB.
+	 *
+	 * @todo This will eventually need to be abstracted to not be CMS-specific, allowing for the prioritization scheme to be defined by configuration.
+	 *
+	 * @param DOMNode|DOMElement|DOMAttr $node Node.
+	 * @return int Priority.
+	 */
+	private function get_stylesheet_priority( DOMNode $node ) {
+		$print_priority_base = 100;
+		$admin_bar_priority  = 200;
+
+		$remove_url_scheme = function( $url ) {
+			return preg_replace( '/^https?:/', '', $url );
+		};
+
+		if ( $node instanceof DOMElement && 'link' === $node->nodeName ) {
+			$element_id      = (string) $node->getAttribute( 'id' );
+			$schemeless_href = $remove_url_scheme( $node->getAttribute( 'href' ) );
+			$is_plugin_asset = (
+				0 === strpos( $schemeless_href, $remove_url_scheme( trailingslashit( plugins_url( WP_PLUGIN_DIR ) ) ) )
+				||
+				0 === strpos( $schemeless_href, $remove_url_scheme( trailingslashit( plugins_url( WPMU_PLUGIN_URL ) ) ) )
+			);
+			$style_handle    = null;
+			if ( preg_match( '/^(.+)-css$/', $element_id, $matches ) ) {
+				$style_handle = $matches[1];
+			}
+
+			$core_frontend_handles = array(
+				'wp-block-library',
+				'wp-block-library-theme',
+			);
+			$non_amp_handles       = array(
+				'mediaelement',
+				'wp-mediaelement',
+				'thickbox',
+			);
+
+			if ( in_array( $style_handle, $non_amp_handles, true ) ) {
+				// Styles are for non-AMP JS only so not be used in AMP at all.
+				$priority = 1000;
+			} elseif ( 'admin-bar' === $style_handle ) {
+				// Admin bar has lowest priority. If it gets excluded, then the entire admin bar should be removed.
+				$priority = $admin_bar_priority;
+			} elseif ( 'dashicons' === $style_handle ) {
+				// Dashicons could be used by the theme, but low priority compared to other styles.
+				$priority = 90;
+			} elseif ( false !== strpos( $schemeless_href, $remove_url_scheme( trailingslashit( get_template_directory_uri() ) ) ) ) {
+				// Highest priority are parent theme styles.
+				$priority = 1;
+			} elseif ( false !== strpos( $schemeless_href, $remove_url_scheme( trailingslashit( get_stylesheet_directory_uri() ) ) ) ) {
+				// Penultimate highest priority are child theme styles.
+				$priority = 10;
+			} elseif ( in_array( $style_handle, $core_frontend_handles, true ) ) {
+				// Styles from wp-includes which are enqueued for themes are next highest priority.
+				$priority = 20;
+			} elseif ( $is_plugin_asset ) {
+				// Styles from plugins are next-highest priority.
+				$priority = 30;
+			} elseif ( 0 === strpos( $schemeless_href, $remove_url_scheme( includes_url() ) ) ) {
+				// Other styles from wp-includes come next.
+				$priority = 40;
+			} else {
+				// Everything else, perhaps wp-admin styles or stylesheets from remote servers.
+				$priority = 50;
+			}
+
+			if ( 'print' === $node->getAttribute( 'media' ) ) {
+				$priority += $print_priority_base;
+			}
+		} elseif ( $node instanceof DOMElement && 'style' === $node->nodeName ) {
+			$element_id = (string) $node->getAttribute( 'id' );
+			if ( 'wp-custom-css' === $element_id ) {
+				// Additional CSS from Customizer.
+				$priority = 60;
+			} else {
+				// Other style elements, including from Recent Comments widget.
+				$priority = 70;
+			}
+
+			if ( 'print' === $node->getAttribute( 'media' ) ) {
+				$priority += $print_priority_base;
+			}
+		} else {
+			// Style attribute.
+			$priority = 70;
+		}
+
+		return $priority;
+	}
+
+	/**
 	 * Eliminate relative segments (../ and ./) from a path.
 	 *
 	 * @param string $path Path with relative segments. This is not a URL, so no host and no query string.
@@ -987,9 +1092,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->pending_stylesheets[] = array_merge(
 			array(
-				'keyframes' => $is_keyframes,
-				'node'      => $element,
-				'sources'   => $this->current_sources,
+				'group'    => $is_keyframes ? 'keyframes' : 'custom',
+				'node'     => $element,
+				'sources'  => $this->current_sources,
+				'priority' => $this->get_stylesheet_priority( $element ),
 			),
 			wp_array_slice_assoc( $processed, array( 'stylesheet', 'imported_font_urls' ) )
 		);
@@ -1103,9 +1209,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->pending_stylesheets[] = array_merge(
 			array(
-				'keyframes' => false,
-				'node'      => $element,
-				'sources'   => $this->current_sources, // Needed because node is removed below.
+				'group'    => 'custom',
+				'node'     => $element,
+				'sources'  => $this->current_sources, // Needed because node is removed below.
+				'priority' => $this->get_stylesheet_priority( $element ),
 			),
 			wp_array_slice_assoc( $processed, array( 'stylesheet', 'imported_font_urls' ) )
 		);
@@ -1172,6 +1279,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *    @type array $stylesheet         Stylesheet parts, where arrays are tuples for declaration blocks.
 	 *    @type array $validation_results Validation results, array containing arrays with error and sanitized keys.
 	 *    @type array $imported_font_urls Imported font stylesheet URLs.
+	 *    @type int   $priority           The priority of the stylesheet.
 	 * }
 	 */
 	private function process_stylesheet( $stylesheet, $options = array() ) {
@@ -2255,9 +2363,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		if ( $processed['stylesheet'] ) {
 			$this->pending_stylesheets[] = array(
+				'group'      => 'custom',
 				'stylesheet' => $processed['stylesheet'],
 				'node'       => $element,
 				'sources'    => $this->current_sources,
+				'priority'   => $this->get_stylesheet_priority( $style_attribute ),
 			);
 
 			if ( $element->hasAttribute( 'class' ) ) {
@@ -2280,22 +2390,22 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @see https://www.ampproject.org/docs/fundamentals/spec#keyframes-stylesheet
 	 */
 	private function finalize_styles() {
-		$stylesheet_sets = array(
+		$stylesheet_groups = array(
 			'custom'    => array(
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-custom.css */",
 				'total_size'          => 0,
 				'cdata_spec'          => $this->style_custom_cdata_spec,
 				'pending_stylesheets' => array(),
-				'final_stylesheets'   => array(),
 				'remove_unused_rules' => $this->args['remove_unused_rules'],
+				'included_count'      => 0,
 			),
 			'keyframes' => array(
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-keyframes.css */",
 				'total_size'          => 0,
 				'cdata_spec'          => $this->style_keyframes_cdata_spec,
 				'pending_stylesheets' => array(),
-				'final_stylesheets'   => array(),
 				'remove_unused_rules' => 'never', // Not relevant.
+				'included_count'      => 0,
 			),
 		);
 
@@ -2307,16 +2417,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		 */
 		$imports = array();
 
-		// Divide pending stylesheet between custom and keyframes, and calculate size of each.
-		while ( ! empty( $this->pending_stylesheets ) ) {
-			$pending_stylesheet = array_shift( $this->pending_stylesheets );
-
-			$set_name = ! empty( $pending_stylesheet['keyframes'] ) ? 'keyframes' : 'custom';
-			$size     = 0;
+		// Divide pending stylesheet between custom and keyframes, and calculate size of each (before tree shaking).
+		foreach ( $this->pending_stylesheets as $pending_stylesheet ) {
+			$size = 0;
 			foreach ( $pending_stylesheet['stylesheet'] as $i => $part ) {
 				if ( is_string( $part ) ) {
 					$size += strlen( $part );
-					if ( '@import' === substr( $part, 0, 7 ) ) {
+					if ( '@import' === substr( $part, 0, 7 ) ) { // @todo Only when fetch failed, right?
 						$imports[] = $part;
 						unset( $pending_stylesheet['stylesheet'][ $i ] );
 					}
@@ -2325,9 +2432,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$size += strlen( $part[1] ); // Declaration block.
 				}
 			}
-			$stylesheet_sets[ $set_name ]['total_size']           += $size;
-			$stylesheet_sets[ $set_name ]['imports']               = $imports;
-			$stylesheet_sets[ $set_name ]['pending_stylesheets'][] = $pending_stylesheet;
+			$stylesheet_groups[ $pending_stylesheet['group'] ]['total_size'] += $size; // Used in finalize_stylesheet_group() to determine if tree shaking is needed.
+			$stylesheet_groups[ $pending_stylesheet['group'] ]['imports']     = $imports; // @todo Shouldn't this be merging with previous??
 
 			if ( ! empty( $pending_stylesheet['imported_font_urls'] ) ) {
 				$imported_font_urls = array_merge( $imported_font_urls, $pending_stylesheet['imported_font_urls'] );
@@ -2335,19 +2441,17 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Process the pending stylesheets.
-		foreach ( array_keys( $stylesheet_sets ) as $set_name ) {
-			$stylesheet_sets[ $set_name ] = $this->finalize_stylesheet_set( $stylesheet_sets[ $set_name ] );
+		foreach ( array_keys( $stylesheet_groups ) as $group ) {
+			$stylesheet_groups[ $group ]['included_count'] = $this->finalize_stylesheet_group( $group, $stylesheet_groups[ $group ] );
 		}
-
-		$this->stylesheets = $stylesheet_sets['custom']['final_stylesheets'];
 
 		// If we're not working with the document element (e.g. for legacy post templates) then there is nothing left to do.
 		if ( empty( $this->args['use_document_element'] ) ) {
-			return;
+			return; // @todo This would no longer be true with <https://github.com/ampproject/amp-wp/issues/2202>.
 		}
 
 		// Add style[amp-custom] to document.
-		if ( ! empty( $stylesheet_sets['custom']['final_stylesheets'] ) ) {
+		if ( $stylesheet_groups['custom']['included_count'] > 0 ) {
 
 			// Ensure style[amp-custom] is present in the document.
 			if ( ! $this->amp_custom_style_element ) {
@@ -2356,9 +2460,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$this->head->appendChild( $this->amp_custom_style_element );
 			}
 
-			$css  = implode( '', $stylesheet_sets['custom']['imports'] ); // For native dirty AMP.
-			$css .= implode( '', $stylesheet_sets['custom']['final_stylesheets'] );
-			$css .= $stylesheet_sets['custom']['source_map_comment'];
+			$css  = implode( '', $stylesheet_groups['custom']['imports'] ); // For native dirty AMP.
+			$css .= implode( '', $this->get_stylesheets() );
+			$css .= $stylesheet_groups['custom']['source_map_comment'];
 
 			/*
 			 * Let the style[amp-custom] be populated with the concatenated CSS.
@@ -2376,8 +2480,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$excluded_size          = 0;
 			$excluded_original_size = 0;
 			$included_sources       = array();
-			foreach ( $stylesheet_sets['custom']['pending_stylesheets'] as $i => $pending_stylesheet ) {
-				if ( ! ( $pending_stylesheet['node'] instanceof DOMElement ) || ! empty( $pending_stylesheet['duplicate'] ) ) {
+			foreach ( $this->pending_stylesheets as $i => $pending_stylesheet ) {
+				if ( 'custom' !== $pending_stylesheet['group'] || ! ( $pending_stylesheet['node'] instanceof DOMElement ) || ! empty( $pending_stylesheet['duplicate'] ) ) {
 					continue;
 				}
 				$message = sprintf( '% 6d B', $pending_stylesheet['size'] );
@@ -2398,7 +2502,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					}
 				}
 
-				if ( ! empty( $pending_stylesheet['included'] ) ) {
+				if ( $pending_stylesheet['included'] ) {
 					$included_sources[]      = $message;
 					$included_size          += $pending_stylesheet['size'];
 					$included_original_size += $pending_stylesheet['original_size'];
@@ -2506,7 +2610,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Add style[amp-keyframes] to document.
-		if ( ! empty( $stylesheet_sets['keyframes']['final_stylesheets'] ) ) {
+		if ( $stylesheet_groups['keyframes']['included_count'] > 0 ) {
 			$body = $this->dom->getElementsByTagName( 'body' )->item( 0 );
 			if ( ! $body ) {
 				$this->should_sanitize_validation_error(
@@ -2516,8 +2620,19 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					)
 				);
 			} else {
-				$css  = implode( '', $stylesheet_sets['keyframes']['final_stylesheets'] );
-				$css .= $stylesheet_sets['keyframes']['source_map_comment'];
+				$css  = implode(
+					'',
+					wp_list_pluck(
+						array_filter(
+							$this->pending_stylesheets,
+							function( $pending_stylesheet ) {
+								return $pending_stylesheet['included'] && 'keyframes' === $pending_stylesheet['group'];
+							}
+						),
+						'stylesheet'
+					)
+				);
+				$css .= $stylesheet_groups['keyframes']['source_map_comment'];
 
 				$style_element = $this->dom->createElement( 'style' );
 				$style_element->setAttribute( 'amp-keyframes', '' );
@@ -2631,21 +2746,23 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Finalize a stylesheet set (amp-custom or amp-keyframes).
+	 * Finalize a stylesheet group (amp-custom or amp-keyframes).
 	 *
-	 * @since 1.0
+	 * @since 1.2
 	 *
-	 * @param array $stylesheet_set Stylesheet set.
-	 * @return array Finalized stylesheet set.
+	 * @param string $group        Group name (either 'custom' or 'keyframes').
+	 * @param array  $group_config Group config.
+	 * @return int Number of included stylesheets in group.
 	 */
-	private function finalize_stylesheet_set( $stylesheet_set ) {
-		$max_bytes         = $stylesheet_set['cdata_spec']['max_bytes'] - strlen( $stylesheet_set['source_map_comment'] );
-		$is_too_much_css   = $stylesheet_set['total_size'] > $max_bytes;
+	private function finalize_stylesheet_group( $group, $group_config ) {
+		$included_count    = 0;
+		$max_bytes         = $group_config['cdata_spec']['max_bytes'] - strlen( $group_config['source_map_comment'] );
+		$is_too_much_css   = $group_config['total_size'] > $max_bytes;
 		$should_tree_shake = (
-			'always' === $stylesheet_set['remove_unused_rules'] || (
+			'always' === $group_config['remove_unused_rules'] || (
 				$is_too_much_css
 				&&
-				'sometimes' === $stylesheet_set['remove_unused_rules']
+				'sometimes' === $group_config['remove_unused_rules']
 			)
 		);
 
@@ -2658,11 +2775,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			);
 		}
 
-		$stylesheet_set['processed_nodes'] = array();
+		$previously_seen_stylesheet_index = array();
+		foreach ( $this->pending_stylesheets as $pending_stylesheet_index => &$pending_stylesheet ) {
+			if ( $group !== $pending_stylesheet['group'] ) {
+				continue;
+			}
 
-		$final_size = 0;
-		$dom        = $this->dom;
-		foreach ( $stylesheet_set['pending_stylesheets'] as &$pending_stylesheet ) {
 			$stylesheet_parts = array();
 			$original_size    = 0;
 			foreach ( $pending_stylesheet['stylesheet'] as $stylesheet_part ) {
@@ -2692,8 +2810,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 									0 === count(
 										array_filter(
 											$parsed_selector[ self::SELECTOR_EXTRACTED_IDS ],
-											function( $id ) use ( $dom ) {
-												return ! $dom->getElementById( $id );
+											function( $id ) {
+												return ! $this->dom->getElementById( $id );
 											}
 										)
 									)
@@ -2772,44 +2890,62 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					}
 				}
 			}
+
+			$pending_stylesheet['stylesheet']    = implode( '', $stylesheet_parts );
 			$pending_stylesheet['original_size'] = $original_size;
+			$pending_stylesheet['included']      = null; // To be determined below.
+			$pending_stylesheet['size']          = strlen( $pending_stylesheet['stylesheet'] ); // @todo Should this use mb_strlen()?
+			$pending_stylesheet['hash']          = md5( $pending_stylesheet['stylesheet'] );
 
-			$stylesheet = implode( '', $stylesheet_parts );
+			// If this stylesheet is a duplicate of something that came before, mark the previous as not included automatically.
+			if ( isset( $previously_seen_stylesheet_index[ $pending_stylesheet['hash'] ] ) ) {
+				$this->pending_stylesheets[ $previously_seen_stylesheet_index[ $pending_stylesheet['hash'] ] ]['included']  = false;
+				$this->pending_stylesheets[ $previously_seen_stylesheet_index[ $pending_stylesheet['hash'] ] ]['duplicate'] = true;
+			}
+			$previously_seen_stylesheet_index[ $pending_stylesheet['hash'] ] = $pending_stylesheet_index;
 			unset( $stylesheet_parts );
-			$sheet_size                 = strlen( $stylesheet );
-			$pending_stylesheet['size'] = $sheet_size;
+		}
 
-			// Skip considering stylesheet if an identical one has already been processed.
-			$hash = md5( $stylesheet );
-			if ( isset( $stylesheet_set['final_stylesheets'][ $hash ] ) ) {
-				$pending_stylesheet['included']  = true;
-				$pending_stylesheet['duplicate'] = true;
+		// Determine which stylesheets are included based on their priorities.
+		$pending_stylesheet_indices = array_keys( $this->pending_stylesheets );
+		usort(
+			$pending_stylesheet_indices,
+			function( $a, $b ) use ( $group_config ) {
+				return $this->pending_stylesheets[ $a ]['priority'] - $this->pending_stylesheets[ $b ]['priority'];
+			}
+		);
+		$current_concatenated_size = 0;
+		foreach ( $pending_stylesheet_indices as $i ) {
+			if ( $group !== $this->pending_stylesheets[ $i ]['group'] ) {
 				continue;
 			}
-			$pending_stylesheet['duplicate'] = false;
+
+			// Skip duplicates.
+			if ( false === $this->pending_stylesheets[ $i ]['included'] ) {
+				continue;
+			}
 
 			// Report validation error if size is now too big.
-			if ( $final_size + $sheet_size > $max_bytes ) {
+			if ( $current_concatenated_size + $this->pending_stylesheets[ $i ]['size'] > $max_bytes ) {
 				$validation_error = array(
 					'code' => 'excessive_css',
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				);
-				if ( isset( $pending_stylesheet['sources'] ) ) {
-					$validation_error['sources'] = $pending_stylesheet['sources'];
+				if ( isset( $this->pending_stylesheets[ $i ]['sources'] ) ) {
+					$validation_error['sources'] = $this->pending_stylesheets[ $i ]['sources'];
 				}
 
-				if ( $this->should_sanitize_validation_error( $validation_error, wp_array_slice_assoc( $pending_stylesheet, array( 'node' ) ) ) ) {
-					$pending_stylesheet['included'] = false;
+				if ( $this->should_sanitize_validation_error( $validation_error, wp_array_slice_assoc( $this->pending_stylesheets[ $i ], array( 'node' ) ) ) ) {
+					$this->pending_stylesheets[ $i ]['included'] = false;
 					continue; // Skip to the next stylesheet.
 				}
 			}
 
-			$final_size += $sheet_size;
+			$this->pending_stylesheets[ $i ]['included'] = true;
+			$included_count++;
 
-			$pending_stylesheet['included']               = true;
-			$stylesheet_set['final_stylesheets'][ $hash ] = $stylesheet;
+			$current_concatenated_size += $this->pending_stylesheets[ $i ]['size'];
 		}
-
-		return $stylesheet_set;
+		return $included_count;
 	}
 }

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2646,7 +2646,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return;
 		}
 
-		$admin_bar = $this->dom->getElementById( 'wpadminbar' );
+		$admin_bar_id = 'wpadminbar';
+		$admin_bar    = $this->dom->getElementById( $admin_bar_id );
 		if ( ! $admin_bar ) {
 			return;
 		}
@@ -2667,8 +2668,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		if ( ! $included ) {
+			$comment_text = sprintf(
+				/* translators: %s: CSS selector for admin bar element  */
+				__( 'Admin bar (%s) was removed to preserve AMP validity due to excessive CSS.', 'amp' ),
+				'#' . $admin_bar_id
+			);
 			$admin_bar->parentNode->replaceChild(
-				$this->dom->createComment( ' ' . __( 'Admin bar (#wpadminbar) was removed to preserve AMP validity due to excessive CSS.', 'amp' ) . ' ' ),
+				$this->dom->createComment( ' ' . $comment_text . ' ' ),
 				$admin_bar
 			);
 		}
@@ -2932,7 +2938,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$pending_stylesheet['stylesheet']    = implode( '', $stylesheet_parts );
 			$pending_stylesheet['original_size'] = $original_size;
 			$pending_stylesheet['included']      = null; // To be determined below.
-			$pending_stylesheet['size']          = strlen( $pending_stylesheet['stylesheet'] ); // @todo Should this use mb_strlen()?
+			$pending_stylesheet['size']          = strlen( $pending_stylesheet['stylesheet'] );
 			$pending_stylesheet['hash']          = md5( $pending_stylesheet['stylesheet'] );
 
 			// If this stylesheet is a duplicate of something that came before, mark the previous as not included automatically.

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1444,14 +1444,17 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$parsed_stylesheet['validation_results']
 		);
 
-		/**
-		 * CSS Doc.
-		 *
-		 * @var Document $css_document
-		 */
-		$css_document = $parsed_stylesheet['css_document'];
-
 		if ( ! empty( $parsed_stylesheet['css_document'] ) && method_exists( $css_list, 'replace' ) ) {
+			/**
+			 * CSS Doc.
+			 *
+			 * @var Document $css_document
+			 */
+			$css_document = $parsed_stylesheet['css_document'];
+
+			// Work around bug in \Sabberworm\CSS\CSSList\CSSList::replace() when array keys are not 0-based.
+			$css_list->setContents( array_values( $css_list->getContents() ) );
+
 			$css_list->replace( $item, $css_document->getContents() );
 		} else {
 			$css_list->remove( $item );

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1362,10 +1362,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
 		$this->assertNotContains( 'The following stylesheets are too large to be included', $comment->nodeValue );
 		$this->assertContains( '15 B: style.body', $comment->nodeValue );
-		$this->assertContains( '17 B: style.foo1', $comment->nodeValue );
+		$this->assertContains( '17 B: style.foo3', $comment->nodeValue, 'Expected the foo3 to persist because it has preceding identical stylesheets for foo1 and foo2.' );
 		$this->assertContains( '17 B: style.bard', $comment->nodeValue );
 		$this->assertNotContains( 'style.foo2', $comment->nodeValue );
-		$this->assertNotContains( 'style.foo3', $comment->nodeValue );
+		$this->assertNotContains( 'style.foo1', $comment->nodeValue );
 		$this->assertContains( 'Total included size: 49 bytes (100% of 49 total after tree shaking', $comment->nodeValue );
 
 		// Test that it contains the comment with duplicate styles removed with tree shaking.
@@ -1382,10 +1382,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
 		$this->assertNotContains( 'The following stylesheets are too large to be included', $comment->nodeValue );
 		$this->assertContains( '15 B: style.body', $comment->nodeValue );
-		$this->assertContains( '17 B: style.foo1', $comment->nodeValue );
+		$this->assertNotContains( '17 B: style.foo1', $comment->nodeValue );
 		$this->assertContains( '0 B: style.bard', $comment->nodeValue );
 		$this->assertNotContains( 'style.foo2', $comment->nodeValue );
-		$this->assertNotContains( 'style.foo3', $comment->nodeValue );
+		$this->assertContains( 'style.foo3', $comment->nodeValue );
 		$this->assertContains( 'Total included size: 32 bytes (72% of 44 total after tree shaking)', $comment->nodeValue );
 
 		// Test that it contains the comment with duplicate styles removed with excessive CSS.
@@ -1402,10 +1402,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
 		$this->assertContains( 'The following stylesheets are too large to be included', $comment->nodeValue );
 		$this->assertContains( '15 B: style.body', $comment->nodeValue );
-		$this->assertContains( '17 B: style.foo1', $comment->nodeValue );
+		$this->assertNotContains( '17 B: style.foo1', $comment->nodeValue );
 		$this->assertContains( '0 B: style.bard', $comment->nodeValue );
 		$this->assertNotContains( 'style.foo2', $comment->nodeValue );
-		$this->assertNotContains( 'style.foo3', $comment->nodeValue );
+		$this->assertContains( 'style.foo3', $comment->nodeValue );
 		$this->assertContains( 'Total included size: 32 bytes (72% of 44 total after tree shaking)', $comment->nodeValue );
 		$this->assertContains( '50024 B: style.excessive', $comment->nodeValue );
 		$this->assertContains( 'Total excluded size: 50,024 bytes (100% of 50,024 total after tree shaking)', $comment->nodeValue );

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -1921,75 +1921,166 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function get_import_test_data() {
 		return array(
-			'local_admin_css_file' => array(
-				admin_url( 'css/colors/../login.css' ),
-				'<style>@import "%s"; div::after{content:"After login"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+			'local_css_files' => array(
+				array(
+					admin_url( 'css/colors/../login.css' ),
+					includes_url( 'css/buttons.css' ),
+				),
+				'<style>div::after{content:"After login"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				0, // Zero HTTP requests.
 				null, // No preempting of request, as no external requests.
-				function ( WP_UnitTestCase $test, $stylesheets ) {
+				function ( WP_UnitTestCase $test, $stylesheet ) {
+					$expected_order = array(
+						preg_quote( 'input[type="checkbox"]:disabled', '/' ),
+						preg_quote( '.wp-core-ui .button', '/' ),
+						preg_quote( 'div::after{content:"After login"}', '/' ),
+					);
 					$test->assertRegExp(
-						'/.*' . preg_quote( 'input[type="checkbox"]:disabled', '/' ) . '.*' . preg_quote( 'div::after{content:"After login"}', '/' ) . '/s',
-						$stylesheets[0]
+						'/.*' . implode( '.*', $expected_order ) . '/s',
+						$stylesheet
 					);
 				},
 			),
 
+			'local_css_with_import_failure_rejecting' => array(
+				array(
+					admin_url( 'css/local-does-not-exist.css' ),
+					'https://bogus.example.com/remote-does-not-exist.css',
+					admin_url( 'css/colors/../login.css' ),
+					'https://bogus.example.com/remote-also-does-not-exist.css',
+				),
+				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				3, // Three HTTP requests (to bogus.example.com). The local-does-not-exist.css checks filesystem directly.
+				function ( $requested_url ) {
+					if ( false !== strpos( $requested_url, 'does-not-exist' ) ) {
+						return new WP_Error( 'does_not_exist' );
+					}
+					return null;
+				},
+				function ( WP_UnitTestCase $test, $stylesheet ) {
+					$expected_order = array(
+						'local-does-not-exist.css',
+						'remote-does-not-exist.css',
+						'remote-also-does-not-exist.css',
+						'remote-finally-does-not-exist.css',
+						'.form-table td', // From imported forms.css.
+						'body.locale-he-il', // From imported l10n.css.
+						'.login .message', // From login.css.
+						'div::after{content:"End"}',
+					);
+
+					$previous = -1;
+					foreach ( $expected_order as $i => $expected ) {
+						$test->assertContains( $expected, $stylesheet, "Did not see $expected at position $i." );
+						$position = strpos( $stylesheet, $expected );
+						$test->assertGreaterThan( $previous, $position, "Expected $expected to be after previous (at position $i)." );
+						$previous = $position;
+					}
+				},
+				array(
+					'auto_reject' => true,
+				),
+			),
+
+			'local_css_with_import_failure_accepting' => array(
+				array(
+					admin_url( 'css/local-does-not-exist.css' ),
+					'https://bogus.example.com/remote-does-not-exist.css',
+					admin_url( 'css/colors/../login.css' ),
+					'https://bogus.example.com/remote-also-does-not-exist.css',
+				),
+				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				3, // Three HTTP requests (to bogus.example.com). The local-does-not-exist.css checks filesystem directly.
+				function ( $requested_url ) {
+					if ( false !== strpos( $requested_url, 'does-not-exist' ) ) {
+						return new WP_Error( 'does_not_exist' );
+					}
+					return null;
+				},
+				function ( WP_UnitTestCase $test, $stylesheet ) {
+					$expected_absent = array(
+						'local-does-not-exist.css',
+						'remote-does-not-exist.css',
+						'remote-also-does-not-exist.css',
+						'remote-finally-does-not-exist.css',
+					);
+					foreach ( $expected_absent as $expected ) {
+						$test->assertNotContains( $expected, $stylesheet, "Expected to not see $expected." );
+					}
+
+					$expected_order = array(
+						'.form-table td', // From imported forms.css.
+						'body.locale-he-il', // From imported l10n.css.
+						'.login .message', // From login.css.
+						'div::after{content:"End"}',
+					);
+
+					$previous = -1;
+					foreach ( $expected_order as $i => $expected ) {
+						$test->assertContains( $expected, $stylesheet, "Did not see $expected at position $i." );
+						$position = strpos( $stylesheet, $expected );
+						$test->assertGreaterThan( $previous, $position, "Expected $expected to be after previous (at position $i)." );
+						$previous = $position;
+					}
+				},
+				array(
+					'auto_reject' => false,
+				),
+			),
+
 			'dynamic_stylesheet_with_relative_import' => array(
 				includes_url( '/dynamic/import-buttons.php' ),
-				'<style>@import url("%s"); div::after{content:"After import-buttons"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After import-buttons"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				1,
-				function( $requested_url, $stylesheet_url ) {
-					if ( wp_parse_url( $stylesheet_url, PHP_URL_PATH ) === wp_parse_url( $requested_url, PHP_URL_PATH ) ) {
+				function( $requested_url ) {
+					if ( false !== strpos( $requested_url, 'import-buttons.php' ) ) {
 						return '@import url( "../css/./foo/../buttons.css" );body{color:#123456}';
 					}
 					return null;
 				},
-				function ( WP_UnitTestCase $test, $stylesheets ) {
-					$this->assertCount( 1, $stylesheets );
+				function ( WP_UnitTestCase $test, $stylesheet ) {
 					$test->assertRegExp(
 						'/.*' . preg_quote( '.wp-core-ui .button', '/' ) . '.*' . preg_quote( 'body{color:#123456}', '/' ) . '.*' . preg_quote( 'div::after{content:"After import-buttons"}', '/' ) . '/s',
-						$stylesheets[0]
+						$stylesheet
 					);
 				},
 			),
 
 			'dynamic_stylesheet_with_absolute_import' => array(
 				includes_url( '/dynamic/import-buttons.php' ),
-				'<style>@import "%s";  div::after{content:"After import-buttons2"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After import-buttons2"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				1,
-				function( $requested_url, $stylesheet_url ) {
-					if ( wp_parse_url( $stylesheet_url, PHP_URL_PATH ) === wp_parse_url( $requested_url, PHP_URL_PATH ) ) {
+				function( $requested_url ) {
+					if ( false !== strpos( $requested_url, 'import-buttons.php' ) ) {
 						return sprintf( '@import "%s";body{color:#123456}', includes_url( '/css/buttons.css' ) );
 					}
 					return null;
 				},
-				function ( WP_UnitTestCase $test, $stylesheets ) {
-					$this->assertCount( 1, $stylesheets );
+				function ( WP_UnitTestCase $test, $stylesheet ) {
 					$test->assertRegExp(
 						'/.*' . preg_quote( '.wp-core-ui .button', '/' ) . '.*' . preg_quote( 'body{color:#123456}', '/' ) . '.*' . preg_quote( 'div::after{content:"After import-buttons2"}', '/' ) . '/s',
-						$stylesheets[0]
+						$stylesheet
 					);
 				},
 			),
 
 			'dynamic_stylesheet_with_nested_dynamic_stylesheet' => array(
 				includes_url( '/dynamic/import-buttons.php' ),
-				'<style>@import "%s";  div::after{content:"After import-buttons2"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After import-buttons2"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				2,
-				function( $requested_url, $stylesheet_url ) {
+				function( $requested_url ) {
 					$self_call_url = includes_url( '/dynamic/nested.php' );
-					if ( wp_parse_url( $stylesheet_url, PHP_URL_PATH ) === wp_parse_url( $requested_url, PHP_URL_PATH ) ) {
+					if ( false !== strpos( $requested_url, 'import-buttons.php' ) ) {
 						return sprintf( '@import "%s";body{color:#123456}', $self_call_url );
 					} elseif ( wp_parse_url( $self_call_url, PHP_URL_PATH ) === wp_parse_url( $requested_url, PHP_URL_PATH ) ) {
 						return 'div::before{ content:"HELLO NESTED"; }';
 					}
 					return null;
 				},
-				function ( WP_UnitTestCase $test, $stylesheets ) {
-					$this->assertCount( 1, $stylesheets );
+				function ( WP_UnitTestCase $test, $stylesheet ) {
 					$test->assertRegExp(
 						'/.*' . preg_quote( 'div::before{content:"HELLO NESTED"}', '/' ) . '.*' . preg_quote( 'body{color:#123456}', '/' ) . '.*' . preg_quote( 'div::after{content:"After import-buttons2"}', '/' ) . '/s',
-						$stylesheets[0]
+						$stylesheet
 					);
 				},
 			),
@@ -2002,31 +2093,46 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @dataProvider get_import_test_data
 	 * @covers AMP_Style_Sanitizer::parse_import_stylesheet()
 	 *
-	 * @param string   $stylesheet_url              Stylesheet URL.
-	 * @param string   $markup_format               HTML markup for the stylesheet URL.
-	 * @param int      $expected_http_request_count Expected number of HTTP requests.
-	 * @param callable $mock_response               Function that returns the mocked CSS data.
-	 * @param callable $assert                      Function that runs the assertions.
+	 * @param array|string $stylesheet_urls             Stylesheet URLs.
+	 * @param string       $style_element               HTML markup for the stylesheet URL.
+	 * @param int          $expected_http_request_count Expected number of HTTP requests.
+	 * @param callable     $mock_response               Function that returns the mocked CSS data.
+	 * @param callable     $assert                      Function that runs the assertions.
+	 * @param array        $options                     Additional options.
 	 */
-	public function test_css_import( $stylesheet_url, $markup_format, $expected_http_request_count, $mock_response, $assert ) {
+	public function test_css_import( $stylesheet_urls, $style_element, $expected_http_request_count, $mock_response, $assert, $options = array() ) {
+		$stylesheet_urls = (array) $stylesheet_urls;
+
 		$markup  = '<html><head>';
-		$markup .= sprintf( $markup_format, $stylesheet_url );
+		$imports = implode(
+			'',
+			array_map(
+				function ( $stylesheet_url ) {
+					return sprintf( '@import url("%s");', $stylesheet_url );
+				},
+				$stylesheet_urls
+			)
+		);
+		$markup .= preg_replace( ':(?<=<style>):', $imports, $style_element );
 		$markup .= '</head><body>hello</body></html>';
 
 		$http_request_count = 0;
 
 		add_filter(
 			'pre_http_request',
-			function( $preempt, $request, $url ) use ( $mock_response, $stylesheet_url, &$http_request_count ) {
+			function( $preempt, $request, $url ) use ( $mock_response, $stylesheet_urls, &$http_request_count ) {
 				$http_request_count++;
 				unset( $request );
 				if ( $mock_response ) {
-					$body = call_user_func( $mock_response, $url, $stylesheet_url );
+					$body = call_user_func( $mock_response, $url, $stylesheet_urls );
 					if ( null !== $body ) {
 						$preempt = array(
-							'response' => array( 'code' => 200 ),
+							'response' => array(
+								'code'    => is_wp_error( $body ) ? 404 : 200,
+								'message' => is_wp_error( $body ) ? 'Not Found' : 'OK',
+							),
 							'headers'  => array( 'content-type' => 'text/css' ),
-							'body'     => $body,
+							'body'     => is_wp_error( $body ) ? '' : $body,
 						);
 					}
 				}
@@ -2036,18 +2142,25 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			3
 		);
 
-		$dom       = AMP_DOM_Utils::get_dom( $markup );
+		$dom = AMP_DOM_Utils::get_dom( $markup );
+
+		if ( ! empty( $options['auto_reject'] ) ) {
+			add_filter( 'amp_validation_error_sanitized', '__return_false' );
+		}
+
 		$sanitizer = new AMP_Style_Sanitizer(
 			$dom,
 			array(
-				'use_document_element' => true,
-				'remove_unused_rules'  => 'never',
+				'use_document_element'      => true,
+				'remove_unused_rules'       => 'never',
+				'validation_error_callback' => 'AMP_Validation_Manager::add_validation_error',
 			)
 		);
 		$sanitizer->sanitize();
-		$stylesheets = array_values( $sanitizer->get_stylesheets() );
 
-		call_user_func( $assert, $this, $stylesheets, $dom );
+		$stylesheet = $dom->getElementsByTagName( 'style' )->item( 0 )->textContent;
+
+		call_user_func( $assert, $this, $stylesheet, $dom );
 		$this->assertEquals( $expected_http_request_count, $http_request_count );
 	}
 

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -106,7 +106,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				'analytics'                => array(),
 				'auto_accept_sanitization' => true,
 				'accept_tree_shaking'      => true,
-				'disable_admin_bar'        => false,
 				'all_templates_supported'  => true,
 				'supported_templates'      => array( 'is_singular' ),
 				'enable_response_caching'  => true,

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -871,15 +871,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add_hooks() when admin bar is turned off.
-	 */
-	public function test_add_hooks_no_admin_bar() {
-		AMP_Options_Manager::update_option( 'disable_admin_bar', true );
-		AMP_Theme_Support::add_hooks();
-		$this->assertEquals( 100, has_filter( 'show_admin_bar', '__return_false' ) );
-	}
-
-	/**
 	 * Test register_widgets().
 	 *
 	 * @covers AMP_Theme_Support::register_widgets()


### PR DESCRIPTION
Fixes #2322.

A theme's stylesheets should never be excluded in favor of the admin bar CSS. Similarly, print stylesheets should never be included at the expense of plugin stylesheets. This PR introduces prioritization when determining which stylesheets to include and which to exclude when the tree shaker is not able to reduce the total CSS to the 50KB limit. The changes here should result in a drastic reduction in the frequency of a theme appearing completely broken when viewing in Native/Transitional modes.

The stylesheet priorities are:

1. Parent theme (non-print) stylesheets
1. Child theme (non-print) stylesheets
1. Core stylesheets used by themes (for blocks)
1. Plugin (non-print) stylesheets
1. Stylesheets from `wp-includes`
1. Additional CSS from Customizer
1. Styles added by blocks and widgets
1. Dashicons
1. Print stylesheets
1. Admin bar CSS

If it so happens that the Admin Bar CSS is excluded, then the HTML element for the admin bar as well as its associated CSS are both excluded.

Since the admin bar is automatically excluded, there is now no need for the option and it is removed:

![image](https://user-images.githubusercontent.com/134745/57799390-cc6fd880-7703-11e9-89ff-2b4fb8d6b0e1.png)

# TODO

- [x] Add additional tests for prioritization.
- [x] Remove admin bar when either admin-bar-css or admin-bar-inline-css is excluded.

# Other items for follow-up

- Add indication that admin bar is hidden?
- How to indicate that CSS is truncated when admin bar is hidden?
- Ensure admin bar print style is added as inline.
- Include any CSS stylesheet which has admin-bar as dependency?
- Or skip sanitizing the admin bar at all? Exempt processing of any stylesheet that targets admin bar selectors.
- Hide admin bar when doing Validation request.
- What to do about dashicons.
- Tree Shaker must exempt admin-bar.css
- Omit dashicons from tree Shaker and processing if there are no dashicon classes used in the document?
- Remove admin bar before sanitizers are run, and the restore after all run. Add dirty styles rule for admin bar CSS when authenticated.
