### PR TITLE
Do not try to download Chromium by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ cache:
     - $HOME/phpunit-bin
     - $HOME/deployment-targets
 
+env: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
 install:
   - nvm install 8.11.4 && nvm use 8.11.4
   - composer install


### PR DESCRIPTION
This happens because the wordpress/scripts package depends on Puppeteer, which results in attempts to download Chromium when running `npm install`.

Once we use Puppeteer for end-to-end tests that can be run on Travis, we can enable the download again just for that stage. Until then, setting `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` should make Travis jobs a bit faster.

Related: #2363, https://github.com/WordPress/gutenberg/pull/15712