### PR TITLE
Increase default minimum block height for meta blocks

### DIFF
--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -150,7 +150,7 @@ const getDefaultMinimumBlockHeight = ( name ) => {
 
 		case 'amp/amp-story-post-author':
 		case 'amp/amp-story-post-date':
-			return 30;
+			return 50;
 
 		case 'amp/amp-story-post-title':
 			return 100;


### PR DESCRIPTION
See #2189.

Before:

<img width="289" alt="Screenshot 2019-05-21 at 22 22 22" src="https://user-images.githubusercontent.com/841956/58128126-34985000-7c17-11e9-8671-464800684515.png">


After:

<img width="310" alt="Screenshot 2019-05-21 at 22 23 15" src="https://user-images.githubusercontent.com/841956/58128118-2e09d880-7c17-11e9-9037-ffac196f8aa3.png">

(Improved padding for bottom two blocks)