### PR TITLE
Don't export the Latest Stories data in the AMP Story editor

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -570,6 +570,10 @@ class AMP_Story_Post_Type {
 	 * Export data used for Latest Stories block.
 	 */
 	public static function export_latest_stories_block_editor_data() {
+		if ( self::POST_TYPE_SLUG === get_current_screen()->post_type ) {
+			return;
+		}
+
 		$url = add_query_arg(
 			'ver',
 			wp_styles()->registered[ self::STORY_CARD_CSS_SLUG ]->ver,

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -146,8 +146,18 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertEquals( amp_get_asset_url( 'js/' . AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE . '.js' ), $block_script->src );
 		$this->assertEquals( AMP__VERSION, $block_script->ver );
 
-		// Test Stories integration.
+		/*
+		 * Test Stories integration.
+		 * The current screen is the AMP Story editor, so the data for the Latest Stories block should not be present, as it's not needed there.
+		 */
+		register_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
+		set_current_screen( AMP_Story_Post_Type::POST_TYPE_SLUG );
 		AMP_Story_Post_Type::register_story_card_styling( wp_styles() );
+		AMP_Story_Post_Type::export_latest_stories_block_editor_data();
+		$this->assertFalse( isset( wp_scripts()->registered[ AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ]->extra['before'] ) );
+
+		// The current screen is the editor for a normal post, so the data for the Latest Stories block should be present.
+		set_current_screen( 'post.php' );
 		AMP_Story_Post_Type::export_latest_stories_block_editor_data();
 		$this->assertContains( 'ampLatestStoriesBlockData', implode( '', wp_scripts()->registered[ AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ]->extra['before'] ) );
 	}

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -39,6 +39,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		global $wp_scripts, $wp_styles;
 		$wp_scripts = null;
 		$wp_styles  = null;
+		unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
As @swissspidy [pointed out](https://github.com/ampproject/amp-wp/pull/2355#issuecomment-494325262), this data isn't needed in that case.

This uses a [similar conditional](https://github.com/ampproject/amp-wp/blob/85f8c1ffe31e154f8553e89553affdf4b2ac8bf6/includes/class-amp-story-post-type.php#L411-L413) to that in `enqueue_block_editor_styles()`.