### PR TITLE
Update min and max font sizes to match amp-fit-text

### DIFF
--- a/assets/src/common/constants.js
+++ b/assets/src/common/constants.js
@@ -1,2 +1,3 @@
-export const MIN_FONT_SIZE = 14;
-export const MAX_FONT_SIZE = 54;
+// See https://github.com/ampproject/amphtml/blob/e7a1b3ff97645ec0ec482192205134bd0735943c/extensions/amp-fit-text/0.1/amp-fit-text.js#L81-L85
+export const MIN_FONT_SIZE = 6;
+export const MAX_FONT_SIZE = 72;

--- a/assets/src/stories-editor/constants.js
+++ b/assets/src/stories-editor/constants.js
@@ -33,9 +33,6 @@ export const STORY_PAGE_INNER_HEIGHT = 553;
 export const MIN_BLOCK_WIDTH = 40;
 export const MIN_BLOCK_HEIGHT = 30;
 
-export const MIN_FONT_SIZE = 8;
-export const MAX_FONT_SIZE = 54;
-
 export const ALLOWED_TOP_LEVEL_BLOCKS = [
 	'amp/amp-story-page',
 	'core/block', // Reusable blocks.

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -36,9 +36,11 @@ import {
 	STORY_PAGE_INNER_HEIGHT,
 	MEDIA_INNER_BLOCKS,
 	BLOCKS_WITH_TEXT_SETTINGS,
+} from '../constants';
+import {
 	MAX_FONT_SIZE,
 	MIN_FONT_SIZE,
-} from '../constants';
+} from '../../common/constants';
 import { getMinimumFeaturedImageDimensions, getBackgroundColorWithOpacity } from '../../common/helpers';
 
 const { ampStoriesFonts } = window;

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -1107,6 +1107,8 @@ const getBlockInnerTextElement = ( block ) => {
 			return document.querySelector( `#block-${ clientId } .block-editor-rich-text__editable.is-amp-fit-text` );
 
 		case 'amp/amp-story-post-title':
+		case 'amp/amp-story-post-author':
+		case 'amp/amp-story-post-date':
 			const slug = name.replace( '/', '-' );
 			return document.querySelector( `#block-${ clientId } .wp-block-${ slug }` );
 	}
@@ -1149,6 +1151,8 @@ export const maybeUpdateFontSize = ( block ) => {
 			break;
 
 		case 'amp/amp-story-post-title':
+		case 'amp/amp-story-post-author':
+		case 'amp/amp-story-post-date':
 			const metaBlockElement = getBlockInnerTextElement( block );
 
 			if ( metaBlockElement && ampFitText ) {


### PR DESCRIPTION
Since amp-fit-text is also used in the regular block editor, it makes sense to use the same values in both environments.

See #2189.