### PR TITLE
Remove admin-bar class name from body when admin bar element removed due to excessive CSS

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2683,6 +2683,17 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		if ( ! $included ) {
+			// Remove admin-bar class from body element.
+			// @todo It would be nice if any style rules which refer to .admin-bar could also be removed, but this would mean retroactively going back over the CSS again and re-shaking it.
+			$body = $this->dom->getElementsByTagName( 'body' )->item( 0 );
+			if ( $body instanceof DOMElement && $body->hasAttribute( 'class' ) ) {
+				$body->setAttribute(
+					'class',
+					preg_replace( '/(^|\s)admin-bar(\s|$)/', ' ', $body->getAttribute( 'class' ) )
+				);
+			}
+
+			// Remove admin bar element.
 			$comment_text = sprintf(
 				/* translators: %s: CSS selector for admin bar element  */
 				__( 'Admin bar (%s) was removed to preserve AMP validity due to excessive CSS.', 'amp' ),

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -2305,7 +2305,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$render_template = function () {
 			ob_start();
 			?>
-			<!DOCTYPE html><html><head><meta charset="utf-8"><?php wp_head(); ?></head><body><?php wp_footer(); ?></body></html>
+			<!DOCTYPE html><html><head><meta charset="utf-8"><?php wp_head(); ?></head><body <?php body_class(); ?>><?php wp_footer(); ?></body></html>
 			<?php
 			return ob_get_clean();
 		};
@@ -2313,6 +2313,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		return array(
 			'admin_bar_included' => array(
 				function () use ( $render_template ) {
+					$this->go_to( home_url() );
 					show_admin_bar( true );
 					_wp_admin_bar_init();
 					switch_theme( 'twentyten' );
@@ -2342,6 +2343,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					 */
 					$this->assertInstanceOf( 'DOMElement', $original_dom->getElementById( 'wpadminbar' ), 'Expected admin bar element to be present originally.' );
 					$this->assertInstanceOf( 'DOMElement', $original_dom->getElementById( 'admin-bar-css' ), 'Expected admin bar CSS to be present originally.' );
+					$this->assertContains( 'admin-bar', $original_dom->getElementsByTagName( 'body' )->item( 0 )->getAttribute( 'class' ) );
 					$this->assertContains( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
 
 					$this->assertContains( '.is-style-outline .wp-block-button__link', $amphtml_source, 'Expected block-library/style.css' );
@@ -2350,6 +2352,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$this->assertNotContains( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to not be present.' );
 					$this->assertNotContains( 'earlyprintstyle', $amphtml_source, 'Expected early print style to not be present.' );
 					$this->assertNotContains( 'admin-bar-inline-style', $amphtml_source, 'Expected admin-bar.css inline style to not be present.' );
+					$this->assertNotContains( 'admin-bar', $amphtml_dom->getElementsByTagName( 'body' )->item( 0 )->getAttribute( 'class' ) );
 					$this->assertEmpty( $amphtml_dom->getElementById( 'wpadminbar' ) );
 				},
 			),


### PR DESCRIPTION
Themes have styles specific for when the admin bar is shown:

```
twentyseventeen/style.css
1734:.admin-bar .wp-custom-header-video-button {
3505:	.admin-bar .site-navigation-fixed.navigation-top {
3743:	.admin-bar.twentyseventeen-front-page.has-header-image .custom-header-media,
3744:	.admin-bar.twentyseventeen-front-page.has-header-video .custom-header-media,
3745:	.admin-bar.home.blog.has-header-image .custom-header-media,
3746:	.admin-bar.home.blog.has-header-video .custom-header-media {
4161:	.admin-bar .site-navigation-fixed.navigation-top,
4162:	.admin-bar .site-navigation-hidden.navigation-top {

twentysixteen/style.css
2775:	body:not(.custom-background-image).admin-bar:before {
2981:	body:not(.custom-background-image).admin-bar:before {

twentynineteen/style-rtl.css
3280:.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
3286:.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
3291:  .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
3295:  .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {

twentynineteen/style.css
3280:.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
3286:.admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {
3291:  .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true {
3295:  .admin-bar .main-navigation .main-menu .menu-item-has-children.off-canvas .sub-menu.expanded-true .sub-menu.expanded-true {

twentyfourteen/style.css
3571:	.admin-bar.masthead-fixed .site-header {
```

With #2346 the admin bar is now removed if the admin bar CSS is excessive. However, this removal did not include the removal of the `admin-bar` class from the body element. The results can be undesirable:

> <img width="630" alt="Screen Shot 2019-05-23 at 14 11 12" src="https://user-images.githubusercontent.com/134745/58287125-1d677880-7d65-11e9-8d65-e93c471edc5c.png">

The `admin-bar` class needs to be removed from the `body` in addition to the `wpadminbar` element being removed from the DOM. With that change applied, the result is as expected:

> <img width="570" alt="Screen Shot 2019-05-23 at 14 11 34" src="https://user-images.githubusercontent.com/134745/58287173-3708c000-7d65-11e9-9820-22af5bb1dfdb.png">

As noted in the comments, it would be nice if the style rules could be removed which have selectors referencing `.admin-bar`. But this would require doing a second pass at tree shaking, and it doesn't seem worthwhile since the number of styles removed is small.