### PR TITLE
Improve validation of the nodes in the head

### DIFF
--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -184,7 +184,7 @@ class AMP_DOM_Utils {
 	 * @param DOMElement $body BODY element.
 	 */
 	private static function move_invalid_head_nodes_to_body( $head, $body ) {
-		// Walking backwards is to make it easier to prepend them to the body in the expected order.
+		// Walking backwards makes it easier to move elements in the expected order.
 		$node = $head->lastChild;
 		while ( $node ) {
 			$next_sibling = $node->previousSibling;

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -180,9 +180,6 @@ class AMP_DOM_Utils {
 	 * Apparently PHP's DOM is more lenient when parsing HTML to allow nodes in the HEAD which do not belong. A proper
 	 * HTML5 parser should rather prematurely short-circuit the HEAD when it finds an illegal element.
 	 *
-	 * @link https://github.com/ampproject/amphtml/blob/445d6e3be8a5063e2738c6f90fdcd57f2b6208be/validator/engine/htmlparser.js#L83-L100
-	 * @link https://www.w3.org/TR/html5/document-metadata.html
-	 *
 	 * @param DOMElement $head HEAD element.
 	 * @param DOMElement $body BODY element.
 	 */
@@ -191,18 +188,30 @@ class AMP_DOM_Utils {
 		$node = $head->lastChild;
 		while ( $node ) {
 			$next_sibling = $node->previousSibling;
-			$is_valid     = (
-				$node instanceof DOMElement && in_array( $node->nodeName, self::$elements_allowed_in_head, true )
-				||
-				$node instanceof DOMText && preg_match( '/^\s*$/', $node->nodeValue )
-				||
-				$node instanceof DOMComment
-			);
-			if ( ! $is_valid ) {
+			if ( ! self::is_valid_head_node( $node ) ) {
 				$body->insertBefore( $head->removeChild( $node ), $body->firstChild );
 			}
 			$node = $next_sibling;
 		}
+	}
+
+	/**
+	 * Determine whether a node can be in the head.
+	 *
+	 * @link https://github.com/ampproject/amphtml/blob/445d6e3be8a5063e2738c6f90fdcd57f2b6208be/validator/engine/htmlparser.js#L83-L100
+	 * @link https://www.w3.org/TR/html5/document-metadata.html
+	 *
+	 * @param DOMNode $node Node.
+	 * @return bool Whether valid head node.
+	 */
+	public static function is_valid_head_node( DOMNode $node ) {
+		return (
+			$node instanceof DOMElement && in_array( $node->nodeName, self::$elements_allowed_in_head, true )
+			||
+			$node instanceof DOMText && preg_match( '/^\s*$/', $node->nodeValue ) // Whitespace text nodes are OK.
+			||
+			$node instanceof DOMComment
+		);
 	}
 
 	/**

--- a/tests/test-amp-script-sanitizer.php
+++ b/tests/test-amp-script-sanitizer.php
@@ -19,13 +19,21 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function get_noscript_data() {
 		return array(
-			'document_write'  => array(
-				'Has script? <script>document.write("Yep!")</script><noscript>Nope!</noscript>',
-				'Has script? <!--noscript-->Nope!<!--/noscript-->',
+			'document_write'      => array(
+				'<html><head></head><body>Has script? <script>document.write("Yep!")</script><noscript>Nope!</noscript></body></html>',
+				'<html><head></head><body>Has script? <!--noscript-->Nope!<!--/noscript--></body></html>',
 			),
-			'nested_elements' => array(
-				'<noscript>before <em><strong>middle</strong> end</em></noscript>',
-				'<!--noscript-->before <em><strong>middle</strong> end</em><!--/noscript-->',
+			'nested_elements'     => array(
+				'<html><head></head><body><noscript>before <em><strong>middle</strong> end</em></noscript></body></html>',
+				'<html><head></head><body><!--noscript-->before <em><strong>middle</strong> end</em><!--/noscript--></body></html>',
+			),
+			'head_noscript_style' => array(
+				'<html><head><noscript><style>body{color:red}</style></noscript></head><body></body></html>',
+				'<html><head><!--noscript--><style>body{color:red}</style><!--/noscript--></head><body></body></html>',
+			),
+			'head_noscript_span'  => array(
+				'<html><head><noscript><span>No script</span></noscript></head><body></body></html>',
+				'<html><head></head><body><!--noscript--><span>No script</span><!--/noscript--></body></html>',
 			),
 		);
 	}
@@ -39,13 +47,13 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers AMP_Script_Sanitizer::sanitize()
 	 */
 	public function test_noscript_promotion( $source, $expected = null ) {
-		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
+		$dom = AMP_DOM_Utils::get_dom( $source );
 		$this->assertSame( 1, $dom->getElementsByTagName( 'noscript' )->length );
 		$sanitizer = new AMP_Script_Sanitizer( $dom );
 		$sanitizer->sanitize();
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$whitelist_sanitizer->sanitize();
-		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+		$content = AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
 		$this->assertEquals( $expected, $content );
 	}
 

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -347,4 +347,138 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $dom->documentElement->lastChild, $p->parentNode );
 		$this->assertEquals( 'Hello world', $p->textContent );
 	}
+
+	/**
+	 * Get head node data.
+	 *
+	 * @return array Head node data.
+	 */
+	public function get_head_node_data() {
+		$dom = new DOMDocument();
+		return array(
+			array(
+				AMP_DOM_Utils::create_node( $dom, 'title', array() ),
+				true,
+			),
+			array(
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'base',
+					array( 'href' => '/' )
+				),
+				true,
+			),
+			array(
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'script',
+					array( 'src' => 'http://example.com/test.js' )
+				),
+				true,
+			),
+			array(
+				AMP_DOM_Utils::create_node( $dom, 'style', array( 'media' => 'print' ) ),
+				true,
+			),
+			array(
+				AMP_DOM_Utils::create_node( $dom, 'noscript', array() ),
+				true,
+			),
+			array(
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					array(
+						'rel'  => 'stylesheet',
+						'href' => 'https://example.com/foo.css',
+					)
+				),
+				true,
+			),
+			array(
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'meta',
+					array(
+						'name'    => 'foo',
+						'content' => 'https://example.com/foo.css',
+					)
+				),
+				true,
+			),
+			array(
+				$dom->createTextNode( " \n\t" ),
+				true,
+			),
+			array(
+				$dom->createTextNode( 'no' ),
+				false,
+			),
+			array(
+				$dom->createComment( 'hello world' ),
+				true,
+			),
+			array(
+				$dom->createProcessingInstruction( 'test' ),
+				false,
+			),
+			array(
+				$dom->createCDATASection( 'nope' ),
+				false,
+			),
+			array(
+				$dom->createEntityReference( 'bad' ),
+				false,
+			),
+			array(
+				$dom->createElementNS( 'http://www.w3.org/2000/svg', 'svg' ),
+				false,
+			),
+			array(
+				AMP_DOM_Utils::create_node( $dom, 'span', array() ),
+				false,
+			),
+		);
+	}
+
+	/**
+	 * Test is_valid_head_node().
+	 *
+	 * @dataProvider get_head_node_data
+	 * @covers \AMP_DOM_Utils::is_valid_head_node()
+	 *
+	 * @param DOMNode $node  Node.
+	 * @param bool    $valid Expected valid.
+	 */
+	public function test_is_valid_head_node( $node, $valid ) {
+		$this->assertEquals( $valid, AMP_DOM_Utils::is_valid_head_node( $node ) );
+	}
+
+	/**
+	 * Test that invalid head nodes are moved to body.
+	 *
+	 * @covers \AMP_DOM_Utils::move_invalid_head_nodes_to_body()
+	 */
+	public function test_invalid_head_nodes() {
+
+		// Text node.
+		$html = '<html><head>text</head><body><span>end</span></body></html>';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertNull( $dom->getElementsByTagName( 'head' )->item( 0 )->firstChild );
+		$body_first_child = $dom->getElementsByTagName( 'body' )->item( 0 )->firstChild;
+		$this->assertInstanceOf( 'DOMElement', $body_first_child );
+		$this->assertEquals( 'text', $body_first_child->textContent );
+
+		// Valid nodes.
+		$html = '<html><head><!--foo--><title>a</title><base href="/"><meta name="foo" content="bar"><link rel="test" href="/"><style></style><noscript><img src="http://example.com/foo.png"></noscript><script></script></head><body></body></html>';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertEquals( 8, $dom->getElementsByTagName( 'head' )->item( 0 )->childNodes->length );
+		$this->assertNull( $dom->getElementsByTagName( 'body' )->item( 0 )->firstChild );
+
+		// Invalid nodes.
+		$html = '<html><head><?pi ?><span></span><div></div><p>hi</p><img src="https://example.com"><iframe src="/"></iframe></head><body></body></html>';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertNull( $dom->getElementsByTagName( 'head' )->item( 0 )->firstChild );
+		$this->assertEquals( 6, $dom->getElementsByTagName( 'body' )->item( 0 )->childNodes->length );
+	}
 }

--- a/tests/test-class-amp-dom-utils.php
+++ b/tests/test-class-amp-dom-utils.php
@@ -309,4 +309,42 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 		$output = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $body, $output );
 	}
+
+	/**
+	 * Test that HEAD and BODY elements are always present.
+	 *
+	 * @covers \AMP_DOM_Utils::get_dom()
+	 */
+	public function test_ensuring_head_body() {
+		$html = '<html><body><p>Hello</p></body></html>';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertEquals( 'head', $dom->documentElement->firstChild->nodeName );
+		$this->assertEquals( 0, $dom->documentElement->firstChild->childNodes->length );
+		$this->assertEquals( 'body', $dom->documentElement->lastChild->nodeName );
+		$this->assertEquals( $dom->documentElement->lastChild, $dom->getElementsByTagName( 'p' )->item( 0 )->parentNode );
+
+		$html = '<html><head><title>foo</title></head></html>';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertEquals( 'head', $dom->documentElement->firstChild->nodeName );
+		$this->assertEquals( $dom->documentElement->firstChild, $dom->getElementsByTagName( 'title' )->item( 0 )->parentNode );
+		$this->assertEquals( 'body', $dom->documentElement->lastChild->nodeName );
+		$this->assertEquals( 0, $dom->documentElement->lastChild->childNodes->length );
+
+		$html = '<html><head><title>foo</title></head><p>no body</p></html>';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertEquals( 'head', $dom->documentElement->firstChild->nodeName );
+		$this->assertEquals( $dom->documentElement->firstChild, $dom->getElementsByTagName( 'title' )->item( 0 )->parentNode );
+		$p = $dom->getElementsByTagName( 'p' )->item( 0 );
+		$this->assertEquals( $dom->documentElement->lastChild, $p->parentNode );
+		$this->assertEquals( 'no body', $p->textContent );
+
+		$html = 'Hello world';
+		$dom  = AMP_DOM_Utils::get_dom( $html );
+		$this->assertEquals( 'head', $dom->documentElement->firstChild->nodeName );
+		$this->assertEquals( 0, $dom->documentElement->firstChild->childNodes->length );
+		$this->assertEquals( 'body', $dom->documentElement->lastChild->nodeName );
+		$p = $dom->getElementsByTagName( 'p' )->item( 0 );
+		$this->assertEquals( $dom->documentElement->lastChild, $p->parentNode );
+		$this->assertEquals( 'Hello world', $p->textContent );
+	}
 }

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1569,6 +1569,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<html amp><head><meta charset="utf-8"><meta property="og:site_name" content="AMP Site"></head><body></body></html>',
 				null, // No change.
 			),
+			'head_with_valid_amp_illegal_parent'      => array(
+				'<html amp><head><meta charset="utf-8"><amp-analytics id="75a1fdc3143c" type="googleanalytics"><script type="application/json">{"vars":{"account":"UA-XXXXXX-1"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}</script></amp-analytics></head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"></head><body><amp-analytics id="75a1fdc3143c" type="googleanalytics"><script type="application/json">{"vars":{"account":"UA-XXXXXX-1"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}</script></amp-analytics></body></html>',
+				array( 'amp-analytics' ),
+			),
+			'head_with_invalid_nodes'                 => array(
+				'<html amp><head><meta charset="utf-8"><META NAME="foo" CONTENT="bar"><bad>bad!</bad> other</head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"><meta name="foo" content="bar"></head><body>bad!<p> other</p></body></html>',
+			),
 		);
 
 		// Also include the body tests.


### PR DESCRIPTION
This PR prevents users from invalidating their pages by accidentally putting disallowed elements in the `head`. HTML has a fixed set of elements that are allowed in the `head` and if any other element is encountered (or a text node) then this is interpreted by browsers as an implicit closing of the `head` and the opening of the `body`. Nevertheless, the PHP DOM parser does not exhibit this behavior. So by moving such nodes to the `body` automatically then the PHP handling behaves more like the browser.

* Prevent AMP validation errors from leaking to the frontend due to disallowed `head` nodes being present.
* Move invalid `head` nodes to the `body`.
* Ensure `head` and `body` are present.
* When unwrapping `noscript` elements in the `head`, move children to `body` if not allowed in `head`.

Fixes #2419.  See #2418.