### PR TITLE
Remove requirement that curl multi functions exist

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -40,11 +40,10 @@ $_amp_required_extensions = array(
 	// Required by FasterImage.
 	'curl'   => array(
 		'functions' => array(
+			'curl_close',
 			'curl_error',
+			'curl_exec',
 			'curl_init',
-			'curl_multi_add_handle',
-			'curl_multi_exec',
-			'curl_multi_init',
 			'curl_setopt',
 		),
 	),


### PR DESCRIPTION
Now that `FasterImage` has fallback support for when cURL Multi is disabled (see https://github.com/willwashburn/fasterimage/pull/18 and https://github.com/ampproject/amp-wp/pull/2422), we can remove these functions from being a dependency for the AMP plugin to work.

This partly reverts https://github.com/ampproject/amp-wp/pull/2319 to address this feedback: https://github.com/ampproject/amp-wp/pull/2183#issuecomment-491506514

Eventually the plugin should integrate with Site Health to warn when the functions are not available, since performance is slowed greatly. See https://github.com/ampproject/amp-wp/issues/2199.

Builds for testing:

* [amp.zip](https://github.com/ampproject/amp-wp/files/3219588/amp.zip) - 1.2-beta1-20190525T175231Z-b5d52025
* [amp.zip](https://github.com/ampproject/amp-wp/files/3219591/amp.zip) - 1.1.2-alpha-20190525T175731Z-a0c29aa4