### PR TITLE
Improve form handling when submission handler does no redirection

### DIFF
--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -29,14 +29,19 @@ body amp-audio:not([controls]) {
 	height: auto;
 }
 
+/*
+ * Style the default template messages for submit-success, submit-error, and submitting. These elements are inserted
+ * by the form sanitizer when a POST form lacks the action-xhr attribute.
+ */
 .amp-wp-default-form-message > p {
 	margin: 1em 0;
 	padding: 0.5em;
 }
-.amp-wp-default-form-message[submitting] > p {
+.amp-wp-default-form-message[submitting] > p,
+.amp-wp-default-form-message[submit-success] > p.amp-wp-form-redirecting {
 	font-style: italic;
 }
-.amp-wp-default-form-message[submit-success] > p {
+.amp-wp-default-form-message[submit-success] > p:not(.amp-wp-form-redirecting) {
 	border: solid 1px green;
 	background-color: lightgreen;
 	color: black;

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -37,19 +37,22 @@ body amp-audio:not([controls]) {
 	margin: 1em 0;
 	padding: 0.5em;
 }
+
 .amp-wp-default-form-message[submitting] > p,
 .amp-wp-default-form-message[submit-success] > p.amp-wp-form-redirecting {
 	font-style: italic;
 }
+
 .amp-wp-default-form-message[submit-success] > p:not(.amp-wp-form-redirecting) {
-	border: solid 1px green;
-	background-color: lightgreen;
-	color: black;
+	border: solid 1px #008000;
+	background-color: #90ee90;
+	color: #000;
 }
+
 .amp-wp-default-form-message[submit-error] > p {
-	border: solid 1px red;
-	background-color: lightpink;
-	color: black;
+	border: solid 1px #f00;
+	background-color: #ffb6c1;
+	color: #000;
 }
 
 /* Prevent showing empty success message in the case of an AMP-Redirect-To response header. */

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -28,3 +28,24 @@ body amp-audio:not([controls]) {
 	display: inline-block;
 	height: auto;
 }
+
+.amp-wp-default-form-message > div {
+	margin: 1em 0;
+	padding: 0.5em;
+}
+.amp-wp-default-form-message[submitting] > div {
+	font-style: italic;
+}
+.amp-wp-default-form-message[submit-success] > div {
+	border: solid 1px green;
+	background-color: lightgreen;
+}
+.amp-wp-default-form-message[submit-error] > div {
+	border: solid 1px red;
+	background-color: lightpink;
+}
+
+/* Prevent showing empty success message in the case of an AMP-Redirect-To response header. */
+.amp-wp-default-form-message[submit-success] > div:empty {
+	display: none;
+}

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -29,23 +29,25 @@ body amp-audio:not([controls]) {
 	height: auto;
 }
 
-.amp-wp-default-form-message > div {
+.amp-wp-default-form-message > p {
 	margin: 1em 0;
 	padding: 0.5em;
 }
-.amp-wp-default-form-message[submitting] > div {
+.amp-wp-default-form-message[submitting] > p {
 	font-style: italic;
 }
-.amp-wp-default-form-message[submit-success] > div {
+.amp-wp-default-form-message[submit-success] > p {
 	border: solid 1px green;
 	background-color: lightgreen;
+	color: black;
 }
-.amp-wp-default-form-message[submit-error] > div {
+.amp-wp-default-form-message[submit-error] > p {
 	border: solid 1px red;
 	background-color: lightpink;
+	color: black;
 }
 
 /* Prevent showing empty success message in the case of an AMP-Redirect-To response header. */
-.amp-wp-default-form-message[submit-success] > div:empty {
+.amp-wp-default-form-message[submit-success] > p:empty {
 	display: none;
 }

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -414,7 +414,7 @@ class AMP_HTTP {
 		// Message will be shown in template defined by AMP_Theme_Support::amend_comment_form().
 		wp_send_json(
 			array(
-				'error' => amp_wp_kses_mustache( $error ),
+				'message' => amp_wp_kses_mustache( $error ),
 			)
 		);
 	}

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -372,7 +372,12 @@ class AMP_HTTP {
 		self::send_header( 'AMP-Redirect-To', $absolute_location );
 		self::send_header( 'Access-Control-Expose-Headers', 'AMP-Redirect-To', array( 'replace' => false ) );
 
-		wp_send_json_success();
+		wp_send_json(
+			array(
+				'message' => __( 'Redirecting…', 'amp' ),
+			),
+			200
+		);
 	}
 
 	/**

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -325,12 +325,11 @@ class AMP_HTTP {
 		add_filter( 'comment_post_redirect', array( __CLASS__, 'filter_comment_post_redirect' ), PHP_INT_MAX, 2 );
 
 		// Add die handler for AMP error display, most likely due to problem with comment.
-		add_filter(
-			'wp_die_handler',
-			function () {
-				return array( __CLASS__, 'handle_wp_die' );
-			}
-		);
+		$handle_wp_die = function () {
+			return array( __CLASS__, 'handle_wp_die' );
+		};
+		add_filter( 'wp_die_json_handler', $handle_wp_die );
+		add_filter( 'wp_die_handler', $handle_wp_die ); // Needed for WP<5.1.
 	}
 
 	/**

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -374,7 +374,8 @@ class AMP_HTTP {
 
 		wp_send_json(
 			array(
-				'message' => __( 'Redirecting…', 'amp' ),
+				'message'     => __( 'Redirecting…', 'amp' ),
+				'redirecting' => true, // Make sure that the submit-success doesn't get styled as success since redirection _could_ be to error page.
 			),
 			200
 		);

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -12,6 +12,14 @@
 class AMP_HTTP {
 
 	/**
+	 * Query var which is submitted with a form which had an action attribute which was automatically converted into action-xhr.
+	 *
+	 * @see \AMP_Form_Sanitizer::sanitize()
+	 * @var string
+	 */
+	const ACTION_XHR_CONVERTED_QUERY_VAR = '_wp_amp_action_xhr_converted';
+
+	/**
 	 * Headers sent (or attempted to be sent).
 	 *
 	 * @since 1.0
@@ -130,7 +138,7 @@ class AMP_HTTP {
 	public static function purge_amp_query_vars() {
 		$query_vars = array(
 			'__amp_source_origin',
-			'_wp_amp_action_xhr_converted',
+			self::ACTION_XHR_CONVERTED_QUERY_VAR,
 			'amp_latest_update_time',
 			'amp_last_check_time',
 		);
@@ -302,7 +310,7 @@ class AMP_HTTP {
 	 */
 	public static function handle_xhr_request() {
 		$is_amp_xhr = (
-			! empty( self::$purged_amp_query_vars['_wp_amp_action_xhr_converted'] )
+			! empty( self::$purged_amp_query_vars[ self::ACTION_XHR_CONVERTED_QUERY_VAR ] )
 			&&
 			( ! empty( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] )
 		);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1078,7 +1078,7 @@ class AMP_Theme_Support {
 		</div>
 		<div submit-error>
 			<template type="amp-mustache">
-				<p class="amp-comment-submit-error">{{{error}}}</p>
+				<p class="amp-comment-submit-error">{{{message}}}</p>
 			</template>
 		</div>
 		<?php

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1720,6 +1720,8 @@ class AMP_Theme_Support {
 		$is_form_submission = (
 			isset( AMP_HTTP::$purged_amp_query_vars[ AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&&
+			wp_is_json_request()
+			&&
 			isset( $_SERVER['REQUEST_METHOD'] )
 			&&
 			'POST' === $_SERVER['REQUEST_METHOD']
@@ -1727,12 +1729,8 @@ class AMP_Theme_Support {
 		if ( $is_form_submission && null === json_decode( $response ) && json_last_error() && ( ( $status_code >= 200 && $status_code < 300 ) || $status_code >= 400 ) ) {
 			return wp_json_encode(
 				array(
-					'message' => sprintf(
-						/* translators: %1$d: the HTTP response code, %2$s: the status description */
-						__( 'Server responded with status code %1$d: %2$s', 'amp' ),
-						$status_code,
-						get_status_header_desc( $status_code )
-					),
+					'status_code' => $status_code,
+					'status_text' => get_status_header_desc( $status_code ),
 				)
 			);
 		}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1731,7 +1731,7 @@ class AMP_Theme_Support {
 						/* translators: %1$d: the HTTP response code, %2$s: the status description */
 						__( 'Server responded with status code %1$d: %2$s', 'amp' ),
 						$status_code,
-						esc_html( get_status_header_desc( $status_code ) )
+						get_status_header_desc( $status_code )
 					),
 				)
 			);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1709,13 +1709,14 @@ class AMP_Theme_Support {
 		$is_form_submission = (
 			isset( AMP_HTTP::$purged_amp_query_vars[ AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&&
-			wp_is_json_request()
-			&&
 			isset( $_SERVER['REQUEST_METHOD'] )
 			&&
 			'POST' === $_SERVER['REQUEST_METHOD']
 		);
-		if ( $is_form_submission && null === json_decode( $response ) && json_last_error() && ( ( $status_code >= 200 && $status_code < 300 ) || $status_code >= 400 ) ) {
+		if ( $is_form_submission && null === json_decode( $response ) && json_last_error() && ( is_bool( $status_code ) || ( $status_code >= 200 && $status_code < 300 ) || $status_code >= 400 ) ) {
+			if ( is_bool( $status_code ) ) {
+				$status_code = 200; // Not a web server environment.
+			}
 			return wp_json_encode(
 				array(
 					'status_code' => $status_code,

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1063,24 +1063,13 @@ class AMP_Theme_Support {
 	}
 
 	/**
-	 * Adds the form submit success and fail templates.
+	 * Amend the comment form with the redirect_to field to persist the AMP page after submission.
 	 */
 	public static function amend_comment_form() {
 		?>
 		<?php if ( is_singular() && ! amp_is_canonical() ) : ?>
 			<input type="hidden" name="redirect_to" value="<?php echo esc_url( amp_get_permalink( get_the_ID() ) ); ?>">
 		<?php endif; ?>
-
-		<div submit-success>
-			<template type="amp-mustache">
-				<p>{{{message}}}</p>
-			</template>
-		</div>
-		<div submit-error>
-			<template type="amp-mustache">
-				<p class="amp-comment-submit-error">{{{message}}}</p>
-			</template>
-		</div>
 		<?php
 	}
 

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -156,7 +156,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 			$template = $this->dom->createElement( 'template' );
 			$div->setAttribute( 'class', 'amp-wp-default-form-message' );
 			if ( 'submitting' === $attribute ) {
-				$mustache = $this->dom->createTextNode( esc_html__( 'Submitting…', 'amp' ) );
+				$mustache = $this->dom->createTextNode( __( 'Submitting…', 'amp' ) );
 			} else {
 				$mustache = $this->dom->createTextNode( '{{{message}}}' );
 			}

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -94,6 +94,9 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 				if ( ! $xhr_action ) {
 					// Record that action was converted to action-xhr.
 					$action_url = add_query_arg( AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR, 1, $action_url );
+					if ( ! amp_is_canonical() ) {
+						$action_url = add_query_arg( amp_get_slug(), '', $action_url );
+					}
 					$node->setAttribute( 'action-xhr', $action_url );
 					// Append success/error handlers if not found.
 					$this->ensure_response_message_elements( $node );

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -92,8 +92,8 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 			} elseif ( 'post' === $method ) {
 				$node->removeAttribute( 'action' );
 				if ( ! $xhr_action ) {
-					// record that action was converted tp action-xhr.
-					$action_url = add_query_arg( '_wp_amp_action_xhr_converted', 1, $action_url );
+					// Record that action was converted tp action-xhr.
+					$action_url = add_query_arg( AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR, 1, $action_url );
 					$node->setAttribute( 'action-xhr', $action_url );
 					// Append error handler if not found.
 					$this->ensure_submit_error_element( $node );

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -161,6 +161,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 				$template->appendChild( $p );
 			} else {
 				$p = $this->dom->createElement( 'p' );
+				$p->setAttribute( 'class', '{{#redirecting}}amp-wp-form-redirecting{{/redirecting}}' );
 				$p->appendChild( $this->dom->createTextNode( '{{#message}}{{{message}}}{{/message}}' ) );
 
 				// Show generic message for HTTP success/failure.

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -173,7 +173,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 					$p->appendChild( $this->dom->createTextNode( __( 'It appears your submission was successful.', 'amp' ) ) );
 					$reason = __( 'Even though the server responded OK, it is possible the submission was not processed.' );
 				}
-				$reason .= ' ' . __( 'Please contact the developer for the form processor to better integrate with this form.', 'amp' );
+				$reason .= ' ' . __( 'Please contact the developer of this form processor to improve this message.', 'amp' );
 
 				$p->appendChild( $this->dom->createTextNode( ' ' ) );
 				$small = $this->dom->createElement( 'small' );

--- a/tests/test-amp-form-sanitizer.php
+++ b/tests/test-amp-form-sanitizer.php
@@ -29,6 +29,8 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
+		$form_templates = '<div class="amp-wp-default-form-message" submit-error=""><template type="amp-mustache">{{{message}}}</template></div><div class="amp-wp-default-form-message" submit-success=""><template type="amp-mustache">{{{message}}}</template></div><div class="amp-wp-default-form-message" submitting=""><template type="amp-mustache">Submitting…</template></div>';
+
 		return array(
 			'no_form' => array(
 				'<p>Lorem Ipsum Demet Delorit.</p>',
@@ -48,7 +50,7 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'form_with_post_method_http_action_and_no_target' => array(
 				'<form method="post" action="http://example.org/example-page/"></form>',
-				'<form method="post" action-xhr="//example.org/example-page/?_wp_amp_action_xhr_converted=1" target="_top"><div submit-error=""><template type="amp-mustache">{{{error}}}</template></div></form>',
+				'<form method="post" action-xhr="//example.org/example-page/?_wp_amp_action_xhr_converted=1" target="_top">' . $form_templates . '</form>',
 			),
 			'form_with_post_method_http_action_and_blank_target' => array(
 				'<form method="post" action-xhr="http://example.org/example-page/" target="_blank"></form>',
@@ -60,23 +62,23 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'form_with_post_method_https_action_and_custom_target' => array(
 				'<form method="post" action="https://example.org/" target="some_other_target"></form>',
-				'<form method="post" target="_blank" action-xhr="https://example.org/?_wp_amp_action_xhr_converted=1"><div submit-error=""><template type="amp-mustache">{{{error}}}</template></div></form>',
+				'<form method="post" target="_blank" action-xhr="https://example.org/?_wp_amp_action_xhr_converted=1">' . $form_templates . '</form>',
 			),
 			'jetpack_contact_form' => array(
 				'<form action="https://src.wordpress-develop.test/contact/#contact-form-9" method="post" class="contact-form commentsblock"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p></form>',
-				'<form method="post" class="contact-form commentsblock" action-xhr="https://src.wordpress-develop.test/contact/?_wp_amp_action_xhr_converted=1#contact-form-9" target="_top"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p><div submit-error=""><template type="amp-mustache">{{{error}}}</template></div></form>',
+				'<form method="post" class="contact-form commentsblock" action-xhr="https://src.wordpress-develop.test/contact/?_wp_amp_action_xhr_converted=1#contact-form-9" target="_top"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p>' . $form_templates . '</form>',
 			),
 			'form_with_upload' => array(
 				'<form action="https://src.wordpress-develop.test/upload/" method="post"><input type="file" name="upload"><button type="submit">Submit</button></form>',
-				'<form method="post" action-xhr="https://src.wordpress-develop.test/upload/?_wp_amp_action_xhr_converted=1" target="_top"><input type="file" name="upload"><button type="submit">Submit</button><div submit-error=""><template type="amp-mustache">{{{error}}}</template></div></form>',
+				'<form method="post" action-xhr="https://src.wordpress-develop.test/upload/?_wp_amp_action_xhr_converted=1" target="_top"><input type="file" name="upload"><button type="submit">Submit</button>' . $form_templates . '</form>',
 			),
 			'form_with_password' => array(
 				'<form action="https://src.wordpress-develop.test/login/" method="post"><input type="password" name="password"><button type="submit">Submit</button></form>',
-				'<form method="post" action-xhr="https://src.wordpress-develop.test/login/?_wp_amp_action_xhr_converted=1" target="_top"><input type="password" name="password"><button type="submit">Submit</button><div submit-error=""><template type="amp-mustache">{{{error}}}</template></div></form>',
+				'<form method="post" action-xhr="https://src.wordpress-develop.test/login/?_wp_amp_action_xhr_converted=1" target="_top"><input type="password" name="password"><button type="submit">Submit</button>' . $form_templates . '</form>',
 			),
 			'form_with_relative_action_url' => array(
 				'<form method="post" action="/login/"></form>',
-				'<form method="post" action-xhr="//example.org/login/?_wp_amp_action_xhr_converted=1" target="_top"><div submit-error=""><template type="amp-mustache">{{{error}}}</template></div></form>',
+				'<form method="post" action-xhr="//example.org/login/?_wp_amp_action_xhr_converted=1" target="_top">' . $form_templates . '</form>',
 			),
 		);
 	}

--- a/tests/test-amp-form-sanitizer.php
+++ b/tests/test-amp-form-sanitizer.php
@@ -29,7 +29,11 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		$form_templates = '<div class="amp-wp-default-form-message" submit-error=""><template type="amp-mustache">{{{message}}}</template></div><div class="amp-wp-default-form-message" submit-success=""><template type="amp-mustache">{{{message}}}</template></div><div class="amp-wp-default-form-message" submitting=""><template type="amp-mustache">Submitting…</template></div>';
+		$form_template_pattern = (
+			preg_quote( '<div class="amp-wp-default-form-message" submit-error=""><template type="amp-mustache">', '#' ) . '.+?</template></div>' .
+			preg_quote( '<div class="amp-wp-default-form-message" submit-success=""><template type="amp-mustache">', '#' ) . '.+?</template></div>' .
+			preg_quote( '<div class="amp-wp-default-form-message" submitting=""><template type="amp-mustache">', '#' ) . '.+?</template></div>'
+		);
 
 		return array(
 			'no_form' => array(
@@ -50,7 +54,7 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'form_with_post_method_http_action_and_no_target' => array(
 				'<form method="post" action="http://example.org/example-page/"></form>',
-				'<form method="post" action-xhr="//example.org/example-page/?_wp_amp_action_xhr_converted=1" target="_top">' . $form_templates . '</form>',
+				'#' . preg_quote( '<form method="post" action-xhr="//example.org/example-page/?_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
 			),
 			'form_with_post_method_http_action_and_blank_target' => array(
 				'<form method="post" action-xhr="http://example.org/example-page/" target="_blank"></form>',
@@ -62,23 +66,23 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 			),
 			'form_with_post_method_https_action_and_custom_target' => array(
 				'<form method="post" action="https://example.org/" target="some_other_target"></form>',
-				'<form method="post" target="_blank" action-xhr="https://example.org/?_wp_amp_action_xhr_converted=1">' . $form_templates . '</form>',
+				'#' . preg_quote( '<form method="post" target="_blank" action-xhr="https://example.org/?_wp_amp_action_xhr_converted=1">', '#' ) . $form_template_pattern . '</form>#s',
 			),
 			'jetpack_contact_form' => array(
 				'<form action="https://src.wordpress-develop.test/contact/#contact-form-9" method="post" class="contact-form commentsblock"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p></form>',
-				'<form method="post" class="contact-form commentsblock" action-xhr="https://src.wordpress-develop.test/contact/?_wp_amp_action_xhr_converted=1#contact-form-9" target="_top"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p>' . $form_templates . '</form>',
+				'#' . preg_quote( '<form method="post" class="contact-form commentsblock" action-xhr="https://src.wordpress-develop.test/contact/?_wp_amp_action_xhr_converted=1#contact-form-9" target="_top"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p>', '#' ) . $form_template_pattern . '</form>#s',
 			),
 			'form_with_upload' => array(
 				'<form action="https://src.wordpress-develop.test/upload/" method="post"><input type="file" name="upload"><button type="submit">Submit</button></form>',
-				'<form method="post" action-xhr="https://src.wordpress-develop.test/upload/?_wp_amp_action_xhr_converted=1" target="_top"><input type="file" name="upload"><button type="submit">Submit</button>' . $form_templates . '</form>',
+				'#' . preg_quote( '<form method="post" action-xhr="https://src.wordpress-develop.test/upload/?_wp_amp_action_xhr_converted=1" target="_top"><input type="file" name="upload"><button type="submit">Submit</button>', '#' ) . $form_template_pattern . '</form>#s',
 			),
 			'form_with_password' => array(
 				'<form action="https://src.wordpress-develop.test/login/" method="post"><input type="password" name="password"><button type="submit">Submit</button></form>',
-				'<form method="post" action-xhr="https://src.wordpress-develop.test/login/?_wp_amp_action_xhr_converted=1" target="_top"><input type="password" name="password"><button type="submit">Submit</button>' . $form_templates . '</form>',
+				'#' . preg_quote( '<form method="post" action-xhr="https://src.wordpress-develop.test/login/?_wp_amp_action_xhr_converted=1" target="_top"><input type="password" name="password"><button type="submit">Submit</button>', '#' ) . $form_template_pattern . '</form>#s',
 			),
 			'form_with_relative_action_url' => array(
 				'<form method="post" action="/login/"></form>',
-				'<form method="post" action-xhr="//example.org/login/?_wp_amp_action_xhr_converted=1" target="_top">' . $form_templates . '</form>',
+				'#' . preg_quote( '<form method="post" action-xhr="//example.org/login/?_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
 			),
 		);
 	}
@@ -94,6 +98,9 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 		if ( is_null( $expected ) ) {
 			$expected = $source;
 		}
+		if ( '#' !== $expected[0] ) {
+			$expected = '#' . preg_quote( $expected, '#' ) . '#s';
+		}
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 
 		$sanitizer = new AMP_Form_Sanitizer( $dom );
@@ -105,7 +112,7 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
 
-		$this->assertEquals( $expected, $content );
+		$this->assertRegExp( $expected, $content );
 	}
 
 	/**

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -374,8 +374,8 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	 * @covers AMP_HTTP::handle_xhr_request()
 	 */
 	public function test_handle_xhr_request() {
-		$_GET['_wp_amp_action_xhr_converted'] = 1;
-		$_SERVER['REQUEST_METHOD']            = 'POST';
+		$_GET[ AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR ] = 1;
+		$_SERVER['REQUEST_METHOD']                        = 'POST';
 		AMP_HTTP::purge_amp_query_vars();
 		AMP_HTTP::handle_xhr_request();
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'wp_redirect', array( 'AMP_HTTP', 'intercept_post_request_redirect' ) ) );

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -516,12 +516,12 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 
 		ob_start();
 		AMP_HTTP::handle_wp_die( 'string' );
-		$this->assertEquals( '{"error":"string"}', ob_get_clean() );
+		$this->assertEquals( '{"message":"string"}', ob_get_clean() );
 
 		ob_start();
 		$error = new WP_Error( 'code', 'The Message' );
 		AMP_HTTP::handle_wp_die( $error );
-		$this->assertEquals( '{"error":"The Message"}', ob_get_clean() );
+		$this->assertEquals( '{"message":"The Message"}', ob_get_clean() );
 	}
 
 	/**

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -404,11 +404,13 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 			}
 		);
 
+		$redirecting_json = wp_json_encode( array( 'message' => __( 'Redirecting…' ) ) );
+
 		// Test redirecting to full URL with HTTPS protocol.
 		AMP_HTTP::$headers_sent = array();
 		ob_start();
 		AMP_HTTP::intercept_post_request_redirect( $url );
-		$this->assertEquals( '{"success":true}', ob_get_clean() );
+		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
 			array(
 				'name'        => 'AMP-Redirect-To',
@@ -433,7 +435,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		ob_start();
 		$url = home_url( '/', 'http' );
 		AMP_HTTP::intercept_post_request_redirect( $url );
-		$this->assertEquals( '{"success":true}', ob_get_clean() );
+		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
 			array(
 				'name'        => 'AMP-Redirect-To',
@@ -457,7 +459,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		AMP_HTTP::$headers_sent = array();
 		ob_start();
 		AMP_HTTP::intercept_post_request_redirect( '/new-location/' );
-		$this->assertEquals( '{"success":true}', ob_get_clean() );
+		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
 			array(
 				'name'        => 'AMP-Redirect-To',
@@ -473,7 +475,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		ob_start();
 		$url = home_url( '/new-location/' );
 		AMP_HTTP::intercept_post_request_redirect( substr( $url, strpos( $url, ':' ) + 1 ) );
-		$this->assertEquals( '{"success":true}', ob_get_clean() );
+		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
 			array(
 				'name'        => 'AMP-Redirect-To',
@@ -488,7 +490,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		AMP_HTTP::$headers_sent = array();
 		ob_start();
 		AMP_HTTP::intercept_post_request_redirect( '' );
-		$this->assertEquals( '{"success":true}', ob_get_clean() );
+		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
 			array(
 				'name'        => 'AMP-Redirect-To',

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -404,7 +404,12 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 			}
 		);
 
-		$redirecting_json = wp_json_encode( array( 'message' => __( 'Redirecting…' ) ) );
+		$redirecting_json = wp_json_encode(
+			array(
+				'message'     => __( 'Redirecting…', 'amp' ),
+				'redirecting' => true,
+			)
+		);
 
 		// Test redirecting to full URL with HTTPS protocol.
 		AMP_HTTP::$headers_sent = array();

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -924,8 +924,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::amend_comment_form();
 		$output = ob_get_clean();
 		$this->assertNotContains( '<input type="hidden" name="redirect_to"', $output );
-		$this->assertContains( '<div submit-success>', $output );
-		$this->assertContains( '<div submit-error>', $output );
 
 		// Test transitional AMP.
 		add_theme_support(
@@ -939,8 +937,6 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::amend_comment_form();
 		$output = ob_get_clean();
 		$this->assertContains( '<input type="hidden" name="redirect_to"', $output );
-		$this->assertContains( '<div submit-success>', $output );
-		$this->assertContains( '<div submit-error>', $output );
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1508,6 +1508,22 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test prepare_response when submitting form.
+	 *
+	 * @covers AMP_Theme_Support::prepare_response()
+	 */
+	public function test_prepare_response_for_submitted_form() {
+		AMP_HTTP::$purged_amp_query_vars[ AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR ] = true;
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+
+		$response = AMP_Theme_Support::prepare_response( '<p>¡Tienes éxito!</p>' );
+		$this->assertEquals( '{"status_code":200,"status_text":"OK"}', $response );
+
+		unset( AMP_HTTP::$purged_amp_query_vars[ AMP_HTTP::ACTION_XHR_CONVERTED_QUERY_VAR ] );
+		unset( $_SERVER['REQUEST_METHOD'] );
+	}
+
+	/**
 	 * Test post-processor cache effectiveness in AMP_Theme_Support::prepare_response().
 	 */
 	public function test_post_processor_cache_effectiveness() {


### PR DESCRIPTION
This follows up on #911/#923.

When a plugin adds a form to the page and the handling of the form submission does not redirect to a success page, the current behavior of the AMP plugin is to just not show any indication at all that a submission was made. The `amp-form` client-side fails because the `POST` response contains an HTML page as opposed to the expected JSON. This is bad because many forms in WordPress process submissions without redirections, leaving them to appear as broken. (In contrast, when `wp_redirect()` is done, then `\AMP_HTTP::intercept_post_request_redirect()` will automatically send the `AMP-Redirect-To` response header, taking the user to the intended success/failure page.)

To improve the experience, when processing a form submission (which didn't have `action-xhr` to begin with) we need to detect when the `POST` form handler is responding with an HTML body rather than a redirect, and in this case, try to serve some JSON that will populate the `submit-success` and `submit-error` message templates, based on whether the form handler returns a 200 or 400+ status code. When a 200 status is returned then a generic success message should be displayed, and when a 400+ status code is returned then a generic error message should be displayed. A challenge here is that form processors may detect an error but they still return with a 200 code, which we can't really do anything about.

The ideal is still that a theme/plugin developer adds direct support for forms by adding `action-xhr` to the `form` elements, sending JSON responses, and adding `div[submitting]`, `div[submit-success]`, and `div[submit-error]` message templates. But this improves compatibility with themes/plugins that have not yet done this. 

To test this PR, use this test plugin that has a `[test_form_post]` shortcode: https://gist.github.com/westonruter/6c0eb253972ccdfc31f841629e2f4344

# Before

No message is displayed at all when `200` response: 

> ![image](https://user-images.githubusercontent.com/134745/58378464-2b75ee80-7f49-11e9-8b2e-a228ab21deb3.png)

Nor in an error response:

> ![image](https://user-images.githubusercontent.com/134745/58378539-35e4b800-7f4a-11e9-86cd-b022aa1553d8.png)

# After

A new `submitting` message is displayed:

> ![image](https://user-images.githubusercontent.com/134745/58378477-60824100-7f49-11e9-85ba-7bea596ecb73.png)

And upon a 200 response, a generic success message is displayed:

> <img width="845" alt="Screen Shot 2019-06-01 at 22 41 00" src="https://user-images.githubusercontent.com/134745/58757272-608cbe80-84be-11e9-838c-82dfa61fc733.png">

And when a 200 response happens but the page is redirecting, a “Redirecting…” message is displayed without the success styling since it could be redirecting to an error page:

> <img width="659" alt="Screen Shot 2019-06-01 at 22 43 19" src="https://user-images.githubusercontent.com/134745/58757845-190b3000-84c8-11e9-9a42-3bdfd5883309.png">

If there is a `400`+ error response, then the `submit-error` message is displayed:

> ![image](https://user-images.githubusercontent.com/134745/58757277-79956f80-84be-11e9-9dbb-df44a004a0af.png)

## Comment Form

There is a new “Submitting” message here as well:

> <img width="853" alt="Screen Shot 2019-05-27 at 10 14 18" src="https://user-images.githubusercontent.com/134745/58432656-4d19c780-8068-11e9-99c9-ca85a62b75f3.png">

The `submit-error` is now styled in the same way as the generic form conversion:

> ![image](https://user-images.githubusercontent.com/134745/58756591-14d31880-84b0-11e9-8e44-a3b3c5a5eadf.png)

Note the `ERROR:` prefix text is [coming from WordPress itself](https://github.com/WordPress/wordpress-develop/blob/d22572a5a5c985c450893edb0f780e4e0d337b6f/src/wp-includes/comment.php#L3310).

# Todo

- [x] Should status codes be indicated in the generic responses?
- [x] Is the default styling for the form messages OK?
- [x] Improve styling for comment form error message.
- [x] Ensure no regressions for comments.
- [x] Ensure that invalid comment submission responses return with error codes. See https://core.trac.wordpress.org/ticket/47393
- [x] Do not style redirection as green success.
- [x] Test with existing form plugins.
  - [x] Jetpack Contact Forms
  - [x] Contact Form 7 (with [helper plugin](https://gist.github.com/westonruter/3501016b0d44af45d878067b1856e023))