### PR TITLE
Change block sidebar calculation to work for smaller screens

### DIFF
--- a/assets/src/components/block-navigation/edit.css
+++ b/assets/src/components/block-navigation/edit.css
@@ -52,10 +52,10 @@
 	--block-settings-sidebar-width: 280px;
 	--admin-menu-expanded-sidebar-width: 160px;
 	--admin-menu-collapsed-sidebar-width: 36px;
-	--amp-story-content-width: 328px;
+	--amp-story-content-width: 334px;
 	--block-editor-horizontal-margin: 40px;
 	--scrollbar-width: 20px;
-	--block-navigation-right-margin: 20px;
+	--block-navigation-right-margin: 50px;
 }
 
 /* Navigator in the context of the open sidebar, settings hidden. */

--- a/assets/src/components/block-navigation/edit.css
+++ b/assets/src/components/block-navigation/edit.css
@@ -53,9 +53,9 @@
 	--admin-menu-expanded-sidebar-width: 160px;
 	--admin-menu-collapsed-sidebar-width: 36px;
 	--amp-story-content-width: 334px;
-	--block-editor-horizontal-margin: 40px;
+	--block-editor-horizontal-margin: 50px;
 	--scrollbar-width: 20px;
-	--block-navigation-right-margin: 50px;
+	--block-navigation-right-margin: 45px;
 }
 
 /* Navigator in the context of the open sidebar, settings hidden. */


### PR DESCRIPTION
Fixes #2403.

Corrects the page width to consider the borders as well + adjusts the block navigation margin and correct the editor margins.

Note that what seems to be missing from the calculations is the space between the editor's right margin and the active page's right edge, however, not sure how to calculate this so changed the block navigation margin instead.