### PR TITLE
Use shorthand Fragment syntax everywhere

### DIFF
--- a/assets/src/block-editor/blocks/amp-brid-player/index.js
+++ b/assets/src/block-editor/blocks/amp-brid-player/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -91,7 +90,7 @@ export const settings =	{
 			url = `http://cdn.brid.tv/live/partners/${ dataPartner }`;
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'Brid Player Settings', 'amp' ) }>
 						<TextControl
@@ -135,7 +134,7 @@ export const settings =	{
 						</Placeholder>
 					)
 				}
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-ima-video/index.js
+++ b/assets/src/block-editor/blocks/amp-ima-video/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -83,7 +82,7 @@ export const settings = {
 			dataSet = true;
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'IMA Video Settings', 'amp' ) }>
 						<TextControl
@@ -117,7 +116,7 @@ export const settings = {
 						</Placeholder>
 					)
 				}
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-jwplayer/index.js
+++ b/assets/src/block-editor/blocks/amp-jwplayer/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -83,7 +82,7 @@ export const settings = {
 			}
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'JW Player Settings', 'amp' ) }>
 						<TextControl
@@ -112,7 +111,7 @@ export const settings = {
 						</Placeholder>
 					)
 				}
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-latest-stories/edit.js
+++ b/assets/src/block-editor/blocks/amp-latest-stories/edit.js
@@ -10,10 +10,7 @@ import { isUndefined, pickBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import {
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	PanelBody,
 	Placeholder,
@@ -69,7 +66,7 @@ class LatestStoriesEdit extends Component {
 		const hasStories = Array.isArray( latestStories ) && latestStories.length;
 		if ( ! hasStories ) {
 			return (
-				<Fragment>
+				<>
 					{ inspectorControls }
 					<Placeholder
 						icon="admin-post"
@@ -80,20 +77,20 @@ class LatestStoriesEdit extends Component {
 							__( 'No stories found.', 'amp' )
 						}
 					</Placeholder>
-				</Fragment>
+				</>
 			);
 		}
 
 		const serverSideAttributes = Object.assign( {}, attributes, { useCarousel: false } );
 
 		return (
-			<Fragment>
+			<>
 				{ inspectorControls }
 				<ServerSideRender
 					block={ blockName }
 					attributes={ serverSideAttributes }
 				/>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/src/block-editor/blocks/amp-o2-player/index.js
+++ b/assets/src/block-editor/blocks/amp-o2-player/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -89,7 +88,7 @@ export const settings = {
 			url = `https://delivery.vidible.tv/htmlembed/pid=${ dataPid }/`;
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'O2 Player Settings', 'amp' ) }>
 						<TextControl
@@ -128,7 +127,7 @@ export const settings = {
 						</Placeholder>
 					)
 				}
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-ooyala-player/index.js
+++ b/assets/src/block-editor/blocks/amp-ooyala-player/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -86,7 +85,7 @@ export const settings = {
 			url = `http://cf.c.ooyala.com/${ dataEmbedCode }`;
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'Ooyala settings', 'amp' ) }>
 						<TextControl
@@ -122,7 +121,7 @@ export const settings = {
 						<p>{ __( 'Add required data to use the block.', 'amp' ) }</p>
 					</Placeholder>
 				) }
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-reach-player/index.js
+++ b/assets/src/block-editor/blocks/amp-reach-player/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -69,7 +68,7 @@ export const settings = {
 			url = 'https://media-cdn.beachfrontreach.com/acct_1/video/';
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'Reach settings', 'amp' ) }>
 						<TextControl
@@ -88,7 +87,7 @@ export const settings = {
 						</Placeholder>
 					)
 				}
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-springboard-player/index.js
+++ b/assets/src/block-editor/blocks/amp-springboard-player/index.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { Fragment } from '@wordpress/element';
 import {
 	PanelBody,
 	TextControl,
@@ -95,7 +94,7 @@ export const settings = {
 			url = 'https://cms.springboardplatform.com/embed_iframe/';
 		}
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'Springboard Player Settings', 'amp' ) }>
 						<TextControl
@@ -144,7 +143,7 @@ export const settings = {
 						</Placeholder>
 					)
 				}
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/blocks/amp-timeago/index.js
+++ b/assets/src/block-editor/blocks/amp-timeago/index.js
@@ -13,7 +13,6 @@ import {
 	PanelBody,
 	TextControl,
 } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -95,7 +94,7 @@ export const settings = {
 		];
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelBody title={ __( 'AMP Timeago Settings', 'amp' ) }>
 						<DateTimePicker
@@ -123,7 +122,7 @@ export const settings = {
 					/>
 				</BlockControls>
 				<time dateTime={ attributes.dateTime }>{ timeAgo }</time>
-			</Fragment>
+			</>
 		);
 	},
 

--- a/assets/src/block-editor/helpers/index.js
+++ b/assets/src/block-editor/helpers/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, _x } from '@wordpress/i18n';
-import { cloneElement, RawHTML, Fragment } from '@wordpress/element';
+import { cloneElement, RawHTML } from '@wordpress/element';
 import { TextControl, SelectControl, ToggleControl, Notice, PanelBody, FontSizePicker } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { select } from '@wordpress/data';
@@ -400,10 +400,10 @@ export const filterBlocksEdit = ( BlockEdit ) => {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<BlockEdit { ...props } />
 				{ inspectorControls }
-			</Fragment>
+			</>
 		);
 	};
 };
@@ -576,7 +576,7 @@ const setUpTextBlocksInspectorControls = ( props ) => {
 				/>
 			</PanelBody>
 			{ ampFitText && (
-				<Fragment>
+				<>
 					<TextControl
 						label={ __( 'Height', 'amp' ) }
 						value={ height }
@@ -634,7 +634,7 @@ const setUpTextBlocksInspectorControls = ( props ) => {
 							} }
 						/>
 					</PanelBody>
-				</Fragment>
+				</>
 			) }
 		</InspectorControls>
 	);

--- a/assets/src/block-editor/plugins/amp-toggle.js
+++ b/assets/src/block-editor/plugins/amp-toggle.js
@@ -9,7 +9,7 @@ import { errorMessages } from 'amp-block-editor-data';
  */
 import { __ } from '@wordpress/i18n';
 import { FormToggle, Notice } from '@wordpress/components';
-import { Fragment, RawHTML } from '@wordpress/element';
+import { RawHTML } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
 import { compose, withInstanceId } from '@wordpress/compose';
@@ -30,7 +30,7 @@ import { isAMPEnabled } from '../helpers';
  */
 function AMPToggle( { isEnabled, onChange } ) {
 	return (
-		<Fragment>
+		<>
 			<PluginPostStatusInfo>
 				{ ! errorMessages.length && <label htmlFor="amp-enabled">{ __( 'Enable AMP', 'amp' ) }</label> }
 				{
@@ -59,7 +59,7 @@ function AMPToggle( { isEnabled, onChange } ) {
 					)
 				}
 			</PluginPostStatusInfo>
-		</Fragment>
+		</>
 	);
 }
 

--- a/assets/src/components/animation-controls.js
+++ b/assets/src/components/animation-controls.js
@@ -3,7 +3,6 @@
  */
 import { withSelect } from '@wordpress/data';
 import { RangeControl, SelectControl } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -39,7 +38,7 @@ const AnimationControls = ( {
 	} );
 
 	return (
-		<Fragment>
+		<>
 			<SelectControl
 				label={ __( 'Animation Type', 'amp' ) }
 				value={ animationType }
@@ -53,7 +52,7 @@ const AnimationControls = ( {
 				} }
 			/>
 			{ animationType && (
-				<Fragment>
+				<>
 					<RangeControl
 						label={ __( 'Duration (ms)', 'amp' ) }
 						value={ animationDuration }
@@ -75,9 +74,9 @@ const AnimationControls = ( {
 						options={ animatedBlocks() }
 						onChange={ onAnimationAfterChange }
 					/>
-				</Fragment>
+				</>
 			) }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/src/components/block-navigation/item.js
+++ b/assets/src/components/block-navigation/item.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { compose } from '@wordpress/compose';
 import { Button, Draggable, DropZone } from '@wordpress/components';
-import { Fragment, Component } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -106,7 +106,7 @@ class BlockNavigationItem extends Component {
 				>
 					{
 						( { onDraggableStart, onDraggableEnd } ) => (
-							<Fragment>
+							<>
 								<DropZone
 									className={ this.state.isDragging ? 'is-dragging-block' : undefined }
 									onDrop={ this.onDrop }
@@ -129,7 +129,7 @@ class BlockNavigationItem extends Component {
 										accessibilityText={ isSelected && __( '(selected block)', 'amp' ) }
 									/>
 								</Button>
-							</Fragment>
+							</>
 						)
 					}
 				</Draggable>

--- a/assets/src/components/block-preview-label.js
+++ b/assets/src/components/block-preview-label.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { getBlockType } from '@wordpress/blocks';
 import { BlockIcon } from '@wordpress/block-editor';
 import { withSelect } from '@wordpress/data';
@@ -10,12 +9,12 @@ import { __ } from '@wordpress/i18n';
 
 const BlockPreviewLabel = ( { content, icon, displayIcon = true, alignIcon = 'left', accessibilityText } ) => {
 	return (
-		<Fragment>
+		<>
 			{ displayIcon && 'left' === alignIcon && <BlockIcon icon={ icon } /> }
 			{ content.length > 20 ? `${ content.substr( 0, 20 ) }…` : content }
 			{ accessibilityText && <span className="screen-reader-text">{ accessibilityText }</span> }
 			{ displayIcon && 'right' === alignIcon && <BlockIcon icon={ icon } /> }
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/src/components/editor-carousel/index.js
+++ b/assets/src/components/editor-carousel/index.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -63,7 +63,7 @@ class EditorCarousel extends Component {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<div className="amp-story-editor-carousel-navigation">
 					<IconButton
 						icon="arrow-left-alt2"
@@ -89,7 +89,7 @@ class EditorCarousel extends Component {
 						disabled={ null === nextPage }
 					/>
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/src/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/components/higher-order/with-amp-story-settings.js
@@ -16,7 +16,6 @@ import {
 } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import {
 	IconButton,
@@ -240,7 +239,7 @@ export default createHigherOrderComponent(
 			const isEmptyImageBlock = isImageBlock && ( ! attributes.url || ! attributes.url.length );
 
 			return (
-				<Fragment>
+				<>
 					{ isMovableBlock && (
 						<StoryBlockMover
 							clientId={ props.clientId }
@@ -503,7 +502,7 @@ export default createHigherOrderComponent(
 							</PanelBody>
 						</InspectorControls>
 					) }
-				</Fragment>
+				</>
 			);
 		} );
 	},

--- a/assets/src/components/higher-order/with-call-to-action-validation.js
+++ b/assets/src/components/higher-order/with-call-to-action-validation.js
@@ -7,7 +7,6 @@ import { withSelect, withDispatch } from '@wordpress/data';
 import { Warning } from '@wordpress/editor';
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 
 const enhance = compose(
 	/**
@@ -77,7 +76,7 @@ export default createHigherOrderComponent( ( BlockEdit ) => {
 		}
 
 		return (
-			<Fragment>
+			<>
 				<div style={ { minHeight: '60px' } }>
 					<BlockEdit key="block-edit" { ...props } />
 				</div>
@@ -88,7 +87,7 @@ export default createHigherOrderComponent( ( BlockEdit ) => {
 						__( 'This block can not be used on the first page.', 'amp' )
 					}
 				</Warning>
-			</Fragment>
+			</>
 		);
 	} );
 }, 'withCallToActionValidation' );

--- a/assets/src/components/higher-order/with-featured-image-notice.js
+++ b/assets/src/components/higher-order/with-featured-image-notice.js
@@ -3,7 +3,6 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Notice } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -29,7 +28,7 @@ export default createHigherOrderComponent(
 			}
 
 			return (
-				<Fragment>
+				<>
 					<Notice
 						status="notice"
 						isDismissible={ false }
@@ -43,7 +42,7 @@ export default createHigherOrderComponent(
 						} ) }
 					</Notice>
 					<PostFeaturedImage { ...props } />
-				</Fragment>
+				</>
 			);
 		};
 	},

--- a/assets/src/components/higher-order/with-page-number.js
+++ b/assets/src/components/higher-order/with-page-number.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 
@@ -59,7 +58,7 @@ export default createHigherOrderComponent(
 			}
 
 			return (
-				<Fragment>
+				<>
 					<div className="amp-story-page-number">
 						{
 							/* translators: %s: Page number */
@@ -67,7 +66,7 @@ export default createHigherOrderComponent(
 						}
 					</div>
 					<BlockEdit { ...props } />
-				</Fragment>
+				</>
 			);
 		} );
 	},

--- a/assets/src/components/higher-order/with-story-featured-image-notice.js
+++ b/assets/src/components/higher-order/with-story-featured-image-notice.js
@@ -3,7 +3,6 @@
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { Notice } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -30,7 +29,7 @@ export default createHigherOrderComponent(
 			}
 
 			return (
-				<Fragment>
+				<>
 					<Notice
 						status="warning"
 						isDismissible={ false }
@@ -44,7 +43,7 @@ export default createHigherOrderComponent(
 						} ) }
 					</Notice>
 					<PostFeaturedImage { ...props } />
-				</Fragment>
+				</>
 			);
 		};
 	},

--- a/assets/src/components/higher-order/with-validation-error-notice.js
+++ b/assets/src/components/higher-order/with-validation-error-notice.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { Notice } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { createHigherOrderComponent } from '@wordpress/compose';
@@ -45,7 +44,7 @@ export default createHigherOrderComponent(
 			];
 
 			return (
-				<Fragment>
+				<>
 					<Notice
 						status="warning"
 						isDismissible={ false }
@@ -75,7 +74,7 @@ export default createHigherOrderComponent(
 						</details>
 					</Notice>
 					<BlockEdit { ...props } />
-				</Fragment>
+				</>
 			);
 		} );
 	},

--- a/assets/src/components/higher-order/with-video-poster-image-notice.js
+++ b/assets/src/components/higher-order/with-video-poster-image-notice.js
@@ -4,7 +4,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { select } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
 import { Notice } from '@wordpress/components';
 
 /**
@@ -41,7 +40,7 @@ export default createHigherOrderComponent(
 			}
 
 			return (
-				<Fragment>
+				<>
 					<Notice
 						status="error"
 						isDismissible={ false }
@@ -49,7 +48,7 @@ export default createHigherOrderComponent(
 						{ __( 'A poster is required for videos in stories.', 'amp' ) }
 					</Notice>
 					<MediaUpload { ...props } />
-				</Fragment>
+				</>
 			);
 		};
 	},

--- a/assets/src/components/layout-controls.js
+++ b/assets/src/components/layout-controls.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { Notice, SelectControl, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -22,7 +21,7 @@ export default ( props ) => {
 	const showWidthNotice = ! width && 'fixed' === ampLayout;
 
 	return (
-		<Fragment>
+		<>
 			<SelectControl
 				label={ __( 'Layout', 'amp' ) }
 				value={ ampLayout }
@@ -63,6 +62,6 @@ export default ( props ) => {
 				value={ height }
 				onChange={ ( value ) => ( setAttributes( { height: value } ) ) }
 			/>
-		</Fragment>
+		</>
 	);
 };

--- a/assets/src/components/pre-publish-panel.js
+++ b/assets/src/components/pre-publish-panel.js
@@ -3,7 +3,6 @@
  */
 import { Notice } from '@wordpress/components';
 import { PluginPrePublishPanel } from '@wordpress/edit-post';
-import { Fragment } from '@wordpress/element';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -25,7 +24,7 @@ const PrePublishPanel = ( { featuredMedia, dimensions, required } ) => {
 	}
 
 	return (
-		<Fragment>
+		<>
 			<PluginPrePublishPanel
 				title={ __( 'Featured Image', 'amp' ) }
 				initialOpen="true"
@@ -43,7 +42,7 @@ const PrePublishPanel = ( { featuredMedia, dimensions, required } ) => {
 					} ) }
 				</Notice>
 			</PluginPrePublishPanel>
-		</Fragment>
+		</>
 	);
 };
 

--- a/assets/src/components/reorderer/item.js
+++ b/assets/src/components/reorderer/item.js
@@ -3,7 +3,7 @@
  */
 import { compose } from '@wordpress/compose';
 import { Draggable, DropZone } from '@wordpress/components';
-import { Fragment, Component } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 
 /**
@@ -99,7 +99,7 @@ class ReordererItem extends Component {
 				>
 					{
 						( { onDraggableStart, onDraggableEnd } ) => (
-							<Fragment>
+							<>
 								<DropZone
 									className={ this.state.isDragging ? 'is-dragging-page' : undefined }
 									onDrop={ this.onDrop }
@@ -117,7 +117,7 @@ class ReordererItem extends Component {
 										<BlockPreview { ...page } />
 									</div>
 								</div>
-							</Fragment>
+							</>
 						)
 					}
 				</Draggable>

--- a/assets/src/components/story-controls/index.js
+++ b/assets/src/components/story-controls/index.js
@@ -8,7 +8,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { IconButton, Button } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -22,7 +21,7 @@ import './edit.css';
 function StoryControls( { isReordering, startReordering, saveOrder, resetOrder } ) {
 	if ( isReordering ) {
 		return (
-			<Fragment>
+			<>
 				<IconButton
 					className="amp-story-controls-reorder-cancel"
 					onClick={ resetOrder }
@@ -38,12 +37,12 @@ function StoryControls( { isReordering, startReordering, saveOrder, resetOrder }
 				>
 					{ __( 'Save Changes', 'amp' ) }
 				</Button>
-			</Fragment>
+			</>
 		);
 	}
 
 	return (
-		<Fragment>
+		<>
 			<TemplateInserter />
 			<IconButton
 				className="amp-story-controls-reorder"
@@ -51,7 +50,7 @@ function StoryControls( { isReordering, startReordering, saveOrder, resetOrder }
 				label={ __( 'Reorder Pages', 'amp' ) }
 				onClick={ startReordering }
 			/>
-		</Fragment>
+		</>
 	);
 }
 

--- a/assets/src/components/validation-error-message.js
+++ b/assets/src/components/validation-error-message.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Fragment } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -22,24 +21,24 @@ export default ( { message, code, node_name: nodeName, parent_name: parentName }
 
 	if ( 'invalid_element' === code && nodeName ) {
 		return (
-			<Fragment>
+			<>
 				{ __( 'Invalid element: ', 'amp' ) }
 				<code>{ nodeName }</code>
-			</Fragment>
+			</>
 		);
 	} else if ( 'invalid_attribute' === code && nodeName ) {
 		return (
-			<Fragment>
+			<>
 				{ __( 'Invalid attribute: ', 'amp' ) }
 				<code>{ parentName ? sprintf( '%s[%s]', parentName, nodeName ) : nodeName }</code>
-			</Fragment>
+			</>
 		);
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ __( 'Error code: ', 'amp' ) }
 			<code>{ code || __( 'unknown', 'amp' ) }</code>
-		</Fragment>
+		</>
 	);
 };

--- a/assets/src/components/with-meta-block-edit.js
+++ b/assets/src/components/with-meta-block-edit.js
@@ -11,7 +11,7 @@ import {
 	AlignmentToolbar,
 	BlockControls,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { dateI18n, __experimentalGetSettings as getDateSettings } from '@wordpress/date';
@@ -77,7 +77,7 @@ class MetaBlockEdit extends Component {
 		const ContentTag = tagName;
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<AlignmentToolbar
 						value={ align }
@@ -103,7 +103,7 @@ class MetaBlockEdit extends Component {
 				>
 					{ blockContent || placeholder }
 				</ContentTag>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -8,10 +8,7 @@ import uuid from 'uuid/v4';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Component,
-	Fragment,
-} from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	Dashicon,
 	IconButton,
@@ -62,7 +59,7 @@ class CallToActionEdit extends Component {
 		} = attributes;
 
 		return (
-			<Fragment>
+			<>
 				<div className={ className } ref={ this.bindRef }>
 					<RichText
 						placeholder={ __( 'Add text…', 'amp' ) }
@@ -97,7 +94,7 @@ class CallToActionEdit extends Component {
 						<IconButton icon="editor-break" label={ __( 'Apply', 'amp' ) } type="submit" />
 					</form>
 				) }
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -15,7 +15,7 @@ import {
 	MediaUpload,
 	MediaUploadCheck,
 } from '@wordpress/block-editor';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	PanelBody,
 	Button,
@@ -197,7 +197,7 @@ class EditPage extends Component {
 		const colorSettings = this.getOverlayColorSettings();
 
 		return (
-			<Fragment>
+			<>
 				<InspectorControls>
 					<PanelColorSettings
 						title={ __( 'Background Color', 'amp' ) }
@@ -232,7 +232,7 @@ class EditPage extends Component {
 						/>
 					</PanelColorSettings>
 					<PanelBody title={ __( 'Background Media', 'amp' ) }>
-						<Fragment>
+						<>
 							<BaseControl>
 								<MediaUploadCheck fallback={ instructions }>
 									<MediaUpload
@@ -315,7 +315,7 @@ class EditPage extends Component {
 								</MediaUploadCheck>
 							) }
 							{ mediaUrl && (
-								<Fragment>
+								<>
 									{ /* Note: FocalPointPicker is only available in Gutenberg 5.1+ */ }
 									{ IMAGE_BACKGROUND_TYPE === mediaType && FocalPointPicker && (
 										<FocalPointPicker
@@ -325,9 +325,9 @@ class EditPage extends Component {
 											onChange={ ( value ) => setAttributes( { focalPoint: value } ) }
 										/>
 									) }
-								</Fragment>
+								</>
 							) }
-						</Fragment>
+						</>
 					</PanelBody>
 					<PanelBody title={ __( 'Page Settings', 'amp' ) }>
 						<SelectControl
@@ -366,7 +366,7 @@ class EditPage extends Component {
 					) }
 					<InnerBlocks template={ TEMPLATE } allowedBlocks={ allowedBlocks } />
 				</div>
-			</Fragment>
+			</>
 		);
 	}
 }

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -7,7 +7,7 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, Fragment } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import {
 	RichText,
 	BlockControls,
@@ -105,7 +105,7 @@ class TextBlockEdit extends Component {
 		const appliedBackgroundColor = getBackgroundColorWithOpacity( colors, backgroundColor, customBackgroundColor, opacity );
 
 		return (
-			<Fragment>
+			<>
 				<BlockControls>
 					<AlignmentToolbar
 						value={ align }
@@ -138,7 +138,7 @@ class TextBlockEdit extends Component {
 					} ) }
 					placeholder={ placeholder || __( 'Write text…', 'amp' ) }
 				/>
-			</Fragment>
+			</>
 		);
 	}
 }


### PR DESCRIPTION
This removes the need for explicit imports, as these are handled by Babel.

This has been made possible by an upstream change in Gutenberg, see https://github.com/WordPress/gutenberg/pull/15120. Example:

```jsx
function MyComponent( props ) {
  return <>
    <h1>Hello!</h1>
    <h2>👋</h2>
  </>;
}

/* ⬇️ After transform ⬇️ */

import { createElement, Fragment } from '@wordpress/element';
function MyComponent( props ) {
  return <>
    <h1>Hello!</h1>
    <h2>👋</h2>
  </>;
}
```