### PR TITLE
Enforce unique constraints from validator

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1840,7 +1840,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			if ( ! in_array( $child_element->nodeName, $allowed_descendants, true ) ) {
 				$this->remove_invalid_child( $child_element );
 			} else {
-				$this->remove_disallowed_descendants( $child, $allowed_descendants );
+				$this->remove_disallowed_descendants( $child_element, $allowed_descendants );
 			}
 		}
 	}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -61,6 +61,13 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	protected $rev_alternate_attr_name_lookup = array();
 
 	/**
+	 * Mapping of JSON-serialized tag spec to the number of instances encountered in the document.
+	 *
+	 * @var array
+	 */
+	protected $visited_unique_tag_specs = array();
+
+	/**
 	 * Stack.
 	 *
 	 * @since 0.5
@@ -508,6 +515,22 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				$layouts = wp_array_slice_assoc( AMP_Rule_Spec::$layout_enum, $tag_spec['amp_layout']['supported_layouts'] );
 
 				$merged_attr_spec_list['layout'][ AMP_Rule_Spec::VALUE_REGEX_CASEI ] = '(' . implode( '|', $layouts ) . ')';
+			}
+		}
+
+		// Enforce unique constraint.
+		if ( ! empty( $tag_spec['unique'] ) ) {
+			$removed      = false;
+			$tag_spec_key = wp_json_encode( $tag_spec );
+			if ( ! empty( $this->visited_unique_tag_specs[ $node->nodeName ][ $tag_spec_key ] ) ) {
+				$removed = $this->remove_invalid_child(
+					$node,
+					array( 'code' => 'duplicate_element' )
+				);
+			}
+			$this->visited_unique_tag_specs[ $node->nodeName ][ $tag_spec_key ] = true;
+			if ( $removed ) {
+				return;
 			}
 		}
 


### PR DESCRIPTION
Fixes #1580.

The sanitizer is not currently enforcing a unique constraint, resulting in validation errors leaking to the frontend when, for example:

* `meta[charset]` appears more than once: https://wordpress.org/support/topic/amp-error-for-google-webmaster-tools/
* `meta[name=viewport]` appears more than once: https://wordpress.org/support/topic/the-tag-meta-nameviewport-appears-more-than-once-in-the-document-3/
* `amp-geo` appears more than once: #1580.

It is straightforward to implement this constraint by merely keeping track of whether or not a given tag spec with the `unique` constraint has been encountered for a given element. If so, then the element should raise a validation error for removal.

# Before

Given the [Page Speed](https://wordpress.org/themes/page-speed/) theme: 

![image](https://user-images.githubusercontent.com/134745/58513566-96dfdc00-8154-11e9-9487-4e94fd532126.png)

# After

![image](https://user-images.githubusercontent.com/134745/58513618-aced9c80-8154-11e9-97d6-be1a3fd5d1d7.png)

![image](https://user-images.githubusercontent.com/134745/58513638-b8d95e80-8154-11e9-904b-931de45428d4.png)

# Addendum

Static analysis revealed a variable which may not have been defined, so this is fixed in a917b39.
