### PR TITLE
Improve detection for theme being installed in unit test

### DIFF
--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -2376,8 +2376,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		if ( version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
 			$this->markTestSkipped( 'Requires WordPress 5.0.' );
 		}
-
-		if ( ! wp_get_theme( 'twentyten' )->exists() ) {
+		global $wp_theme_directories; // Note that get_theme_roots() does not work, for some reason.
+		$theme_exists = false;
+		foreach ( $wp_theme_directories as $theme_root ) {
+			$theme_exists = wp_get_theme( 'twentyten', $theme_root )->exists();
+			if ( $theme_exists ) {
+				break;
+			}
+		}
+		if ( ! $theme_exists ) {
 			$this->markTestSkipped( 'Requires Twenty Ten to be installed.' );
 		}
 


### PR DESCRIPTION
I found on my Lando env that `\AMP_Style_Sanitizer_Test::test_prioritized_stylesheets()` was being skipped, even though I have Twenty Ten installed. This appears to be because in this env there are multiple theme roots, and the core theme root is not the default.

Amends ba891ce09cb2b9fea1117bf7830ed23ed1b4ac79 from #2408.