### PR TITLE
Ensure respecting limits for amp-fit-text, too.

### DIFF
--- a/assets/src/components/resizable-box/index.js
+++ b/assets/src/components/resizable-box/index.js
@@ -78,10 +78,9 @@ const EnhancedResizableBox = ( props ) => {
 				let appliedWidth = width + deltaW;
 				let appliedHeight = height + deltaH;
 
-				if ( textElement ) {
-					appliedWidth = appliedWidth < lastWidth ? lastWidth : appliedWidth;
-					appliedHeight = appliedHeight < lastHeight ? lastHeight : appliedHeight;
-				}
+				// Ensure the measures not crossing limits.
+				appliedWidth = appliedWidth < lastWidth ? lastWidth : appliedWidth;
+				appliedHeight = appliedHeight < lastHeight ? lastHeight : appliedHeight;
 
 				onResizeStop( {
 					width: parseInt( appliedWidth, 10 ),


### PR DESCRIPTION
Fixes #2456.

Ensures that a negative or too small width/height is not assigned due to following the cursor only.