### PR TITLE
Improve behavior for selected blocks

### DIFF
--- a/assets/src/components/rotatable-box/edit.css
+++ b/assets/src/components/rotatable-box/edit.css
@@ -16,13 +16,23 @@
 }
 
 .block-editor-block-list__block .rotatable-box-wrap {
-	box-shadow: -1px 0 rgba(66, 88, 99, .4);
-	width: 0;
-	height: 25px;
 	position: absolute;
-	bottom: -40px;
-	margin-left: 50%;
+	right: -14px;
+	bottom: -25px;
+	left: calc(50% - 15px);
+	width: 30px;
+	height: 25px;
+}
+
+.block-editor-block-list__block .rotatable-box-wrap:before {
+	display: block;
+	content: "";
+	cursor: inherit;
 	border-left: 1px solid theme( outlines );
+	box-shadow: inset -3px 0 0 0 #555d66;
+	height: 40px;
+	width: 0;
+	margin: 0 auto;
 }
 
 .block-editor-block-list__block .rotatable-box-wrap .rotatable-box-wrap__handle {
@@ -31,7 +41,7 @@
 	transition: opacity .3s;
 	position: absolute;
 	bottom: -20px;
-	left: calc(50% - 26px);
+	left: calc(50% - 25px);
 	width: 50px;
 	height: 24px;
 	padding: 4px;

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -114,6 +114,9 @@
 }
 
 .editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-selected,
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-typing,
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-focused,
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-dragging,
 .editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-rotating {
 	z-index: 100;
 }

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -117,6 +117,11 @@
 	z-index: 100;
 }
 
+.block-editor-block-list__layout .block-editor-block-list__block.is-selected > .block-editor-block-list__block-edit:before {
+	box-shadow: none;
+	border-left: 1px solid rgba(66,88,99,.4);
+}
+
 /*
  * Make all the inner blocks positioned with absolute.
  */

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -112,6 +112,11 @@
 	margin-bottom: 0;
 }
 
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-selected,
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-rotating {
+	z-index: 100;
+}
+
 /*
  * Make all the inner blocks positioned with absolute.
  */

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -30,7 +30,8 @@
 	margin: 0 auto;
 }
 
-.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-selected {
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-selected,
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-rotating {
 	z-index: 100;
 }
 

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -30,6 +30,10 @@
 	margin: 0 auto;
 }
 
+.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-selected {
+	z-index: 100;
+}
+
 .editor-styles-wrapper #amp-story-editor .wp-block .wp-block[data-type="amp/amp-story-text"] {
 	width: initial;
 }

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -30,11 +30,6 @@
 	margin: 0 auto;
 }
 
-.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-selected,
-.editor-styles-wrapper #amp-story-editor .wp-block .wp-block.is-rotating {
-	z-index: 100;
-}
-
 .editor-styles-wrapper #amp-story-editor .wp-block .wp-block[data-type="amp/amp-story-text"] {
 	width: initial;
 }


### PR DESCRIPTION
* When selecting or rotating a block, it will always be the first and foremost block (z-index change).  
  This makes it easier to quickly edit a block without having to temporarily move it to the foreground for editing.
* Increases the area surrounding the rotation handle.  
  Makes it easier to move the cursor to the handle, without accidentally leaving the block container.
* Removes the thick left border for selected block.  
  This specific Gutenberg styling does not really apply to our movable blocks.

**Screenshots:**

![Screenshot 2019-05-29 at 13 23 07](https://user-images.githubusercontent.com/841956/58558315-c3612a00-8220-11e9-940c-cf77dbadf3ec.png)
![Screenshot 2019-05-29 at 13 23 10](https://user-images.githubusercontent.com/841956/58558323-c8be7480-8220-11e9-9774-0630662196e0.png)
![Screenshot 2019-05-29 at 13 44 26](https://user-images.githubusercontent.com/841956/58558330-cbb96500-8220-11e9-871e-a0d707fcb0b0.png)
