### PR TITLE
Add missing prop types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,6 @@
     "Set": true
   },
   "rules": {
-    "react/prop-types": 1
+    "react/prop-types": 2
   }
 }

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -414,6 +414,7 @@ class PageEdit extends Component {
 }
 
 PageEdit.propTypes = {
+	clientId: PropTypes.string.isRequired,
 	attributes: PropTypes.shape( {
 		anchor: PropTypes.string,
 		backgroundColors: PropTypes.string,
@@ -433,6 +434,8 @@ PageEdit.propTypes = {
 	media: PropTypes.object,
 	allowedBlocks: PropTypes.arrayOf( PropTypes.string ).isRequired,
 	totalAnimationDuration: PropTypes.number.isRequired,
+	getBlockOrder: PropTypes.func.isRequired,
+	moveBlockToPosition: PropTypes.func.isRequired,
 };
 
 export default compose(


### PR DESCRIPTION
Introduced in #2443.

From now on, there will be errors (not `erros` 🤦‍♂ ) instead of warnings for missing prop types.