### PR TITLE
Add amp_story_supports_landscape filter for initial opt-in to landscape support for stories

### DIFF
--- a/includes/templates/single-amp_story.php
+++ b/includes/templates/single-amp_story.php
@@ -40,6 +40,17 @@ the_post();
 		?>
 		<amp-story
 			standalone
+			<?php
+			/**
+			 * Filters whether the story supports landscape.
+			 *
+			 * @param bool    $supports_landscape Whether supports landscape. Currently false by default, but this will change in the future (e.g. via user toggle).
+			 * @param wp_Post $post               The current amp_story post object.
+			 */
+			if ( apply_filters( 'amp_story_supports_landscape', false, get_post() ) ) {
+				echo 'supports-landscape';
+			}
+			?>
 			publisher-logo-src="<?php echo esc_url( $publisher_logo_src ); ?>"
 			publisher="<?php echo esc_attr( $publisher ); ?>"
 			title="<?php the_title_attribute(); ?>"


### PR DESCRIPTION
With this change, a site can opt-in to landscape (desktop) support for stories via:

```php
add_filter( 'amp_story_supports_landscape', '__return_true' );
```

In the future we'll need to do more for adjusting assets for landscape as well. See #2409.