### PR TITLE
[WIP] Amp-Stories Fit Text - Swap flex vertical centering by classic inline-block style

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -51,12 +51,26 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	display: inline-block;
 }
 
+.wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .amp-fit-text-wrapper {
+	position: relative;
+	line-height: 350px;
+}
+
 .wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .is-amp-fit-text {
-	line-height: 1.15;
-	display: flex;
-	flex-direction: column;
-	flex-wrap: nowrap;
-	justify-content: center;
+	display: inline-block;
+	vertical-align: middle;
+	line-height: normal;
+}
+
+.wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .is-amp-fit-text::before {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background: inherit;
+	z-index: -1;
 }
 
 .wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text,

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -51,9 +51,8 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	display: inline-block;
 }
 
-.wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .amp-fit-text-wrapper {
+.wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text {
 	position: relative;
-	line-height: 350px;
 }
 
 .wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .is-amp-fit-text {


### PR DESCRIPTION
Fixes #2342 
To Do:
@miina - can you add a amp-fit-text-wrapper around is-amp-fit-text to avoid applying some rules to some too generic of wrappers?