### PR TITLE
Suppress admin bar from being shown during validation requests

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -207,6 +207,15 @@ class AMP_Validation_Manager {
 		add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_menu_items' ), 101 );
 
 		if ( self::$should_locate_sources ) {
+			/*
+			 * Always suppress the admin bar from being shown when performing a validation request. This ensures that
+			 * user-initiated validation requests perform the same as validation requests initiated by the WP-CLI
+			 * command `wp amp validate-site`, which does so as an unauthenticated user. Unauthenticated users should
+			 * not be shown the admin bar, and normal site visitors who read AMP content (such as via an AMP Cache) are
+			 * not authenticated, so it doesn't make sense to include the admin bar when doing validation.
+			 */
+			add_filter( 'show_admin_bar', '__return_false', PHP_INT_MAX );
+
 			self::add_validation_error_sourcing();
 		}
 	}


### PR DESCRIPTION
This change always suppresses the admin bar from being shown when performing a validation request. This ensures that user-initiated validation requests perform the same as validation requests initiated by the WP-CLI command `wp amp validate-site`, which does so as an unauthenticated user. Unauthenticated users should not be shown the admin bar, and normal site visitors who read AMP content (such as via an AMP Cache) are not authenticated, so it doesn't make sense to include the admin bar when doing validation.

This will further prevent confusion when saving a post and there being validation errors reported, but when the user goes to the post on the frontend they see no problem because the admin bar would have been hidden entirely already via #2346.

This does not change what the user sees when browsing AMP pages served by WordPress.

See #1921.

# Before

> ![image](https://user-images.githubusercontent.com/134745/58979621-4afbeb00-8783-11e9-91b0-975942000aaa.png)

> ![image](https://user-images.githubusercontent.com/134745/58979594-3881b180-8783-11e9-8889-e33c17bf2a41.png)

# After

> ![image](https://user-images.githubusercontent.com/134745/58979728-8bf3ff80-8783-11e9-93ae-c54d07137b1b.png)

> ![image](https://user-images.githubusercontent.com/134745/58979687-72eb4e80-8783-11e9-86e0-e2fa7209b6d8.png)
