### PR TITLE
Fix font size oddities

### DIFF
--- a/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
@@ -410,9 +410,6 @@ export default createHigherOrderComponent(
 									checked={ ampFitText }
 									onChange={ () => {
 										setAttributes( { ampFitText: ! ampFitText } );
-										if ( ! ampFitText ) {
-											setFontSize( attributes.autoFontSize );
-										}
 									} }
 								/>
 								{ ! ampFitText && (

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -116,6 +116,8 @@ const EnhancedResizableBox = ( props ) => {
 							textElement = blockElement.querySelector( '.wp-block-amp-amp-story-post-date' );
 							break;
 					}
+				} else {
+					textElement = null;
 				}
 
 				if ( ampFitText && 'amp/amp-story-text' === blockName ) {


### PR DESCRIPTION
Fixes #2366.

- Uses the stored custom font size when switching off from amp-fit-text instead of assigning the amp-fit-text font size to text.
- Fixes amp-fit-text not allowing resizing smaller after it had been turned off previously.