### PR TITLE
Fix layout of Gallery as amp-carousel

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -204,6 +204,9 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			return '';
 		}
 
+		$max_width  = 0;
+		$max_height = 0;
+
 		$images = array();
 		foreach ( $args['images'] as $props ) {
 			$image_atts = array(
@@ -212,6 +215,8 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 				'height' => $props['height'],
 				'layout' => 'responsive',
 			);
+			$max_width  = max( $max_width, $props['width'] );
+			$max_height = max( $max_height, $props['height'] );
 			if ( ! empty( $args['lightbox'] ) ) {
 				$image_atts['lightbox'] = '';
 				$image_atts['on']       = 'tap:' . AMP_Img_Sanitizer::AMP_IMAGE_LIGHTBOX_ID;
@@ -239,8 +244,8 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		return AMP_HTML_Utils::build_tag(
 			'amp-carousel',
 			array(
-				'width'  => $this->args['width'],
-				'height' => $this->args['height'],
+				'width'  => $max_width,
+				'height' => $max_height,
 				'type'   => 'slides',
 				'layout' => 'responsive',
 			),

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -128,13 +128,16 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			list( $width, $height ) = $this->get_carousel_dimensions( $node );
+
 			$amp_carousel = AMP_DOM_Utils::create_node(
 				$this->dom,
 				'amp-carousel',
 				array(
-					'height' => $this->get_carousel_height( $node ),
+					'width'  => $width,
+					'height' => $height,
 					'type'   => 'slides',
-					'layout' => 'fixed-height',
+					'layout' => 'responsive',
 				)
 			);
 			foreach ( $images as $image ) {
@@ -150,15 +153,20 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	 * Get carousel height by containing images.
 	 *
 	 * @param DOMElement $element The UL element.
-	 * @return int Height.
+	 * @return array {
+	 *     Dimensions.
+	 *
+	 *     @type int $width  Width.
+	 *     @type int $height Height.
+	 * }
 	 */
-	protected function get_carousel_height( $element ) {
+	protected function get_carousel_dimensions( $element ) {
 		$images     = $element->getElementsByTagName( 'amp-img' );
 		$num_images = $images->length;
 		$max_height = 0;
 		$max_width  = 0;
 		if ( 0 === $num_images ) {
-			return self::FALLBACK_HEIGHT;
+			return array( self::FALLBACK_WIDTH, self::FALLBACK_HEIGHT );
 		}
 		foreach ( $images as $image ) {
 			/**
@@ -170,17 +178,13 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 			if ( is_numeric( $image_height ) ) {
 				$max_height = max( $max_height, $image_height );
 			}
-			$image_width = $image->getAttribute( 'height' );
+			$image_width = $image->getAttribute( 'width' );
 			if ( is_numeric( $image_width ) ) {
 				$max_width = max( $max_width, $image_width );
 			}
 		}
 
-		if ( ! empty( $this->args['content_max_width'] ) && $max_height > 0 && $max_width > $this->args['content_max_width'] ) {
-			$max_height = ( $max_width * $this->args['content_max_width'] ) / $max_height;
-		}
-
-		return ! $max_height ? self::FALLBACK_HEIGHT : $max_height;
+		return array( $max_width, $max_height );
 	}
 
 	/**

--- a/tests/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/test-class-amp-gallery-block-sanitizer.php
@@ -39,7 +39,7 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_carousel'              => array(
 				'<ul class="wp-block-gallery" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel height="400" type="slides" layout="fixed-height"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></amp-carousel>',
 			),
 
 			'data_amp_with_lightbox'              => array(
@@ -48,8 +48,8 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'data_amp_with_lightbox_and_carousel' => array(
-				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel height="400" type="slides" layout="fixed-height"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="1234" height="567"></amp-img></a></figure></li></ul>',
+				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><amp-img src="http://example.com/img.png" width="1234" height="567" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			),
 		);
 	}
@@ -93,12 +93,12 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_lightbox'              => array(
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel height="400" type="slides" layout="fixed-height"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			),
 
 			'data_amp_with_lightbox_and_carousel' => array(
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel height="400" type="slides" layout="fixed-height"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			),
 		);
 	}


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/problem-with-the-gallery-2/

The gallery was incorrectly using the `fixed-height` for the Gallery block and it wasn't obtaining the width/height properly. The Gallery shortcode was not being output with the dimensions of the images inside, but rather fixed dimensions for all embeds.

So this PR ensures that both the `gallery` shortcode and the Gallery block use the `responsive` layout, and that the `width`/`height` of the `amp-carousel` is the max `width`/`height` of the images contained therein.

The results are much improved:

# Before

![image](https://user-images.githubusercontent.com/134745/58906709-5be42800-86c1-11e9-973b-3afaaeaaa180.png)

![image](https://user-images.githubusercontent.com/134745/58906749-74ecd900-86c1-11e9-9a99-99d7f73e549a.png)

# After

![image](https://user-images.githubusercontent.com/134745/58906797-99e14c00-86c1-11e9-9c50-4e7165c6a649.png)

![image](https://user-images.githubusercontent.com/134745/58906834-b7161a80-86c1-11e9-9028-a668535d365e.png)

# Testing builds

* [amp.zip](https://github.com/ampproject/amp-wp/files/3254125/amp.zip) - 1.2-beta2-20190604T191520Z-f964e1ee
* [amp.zip](https://github.com/ampproject/amp-wp/files/3254136/amp.zip) - 1.1.4-alpha-20190604T191932Z-72acd5bb

