### PR TITLE
Always perform CSS tree shaking, regardless of total size

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -27,7 +27,6 @@ class AMP_Options_Manager {
 		'supported_post_types'     => array( 'post' ),
 		'analytics'                => array(),
 		'auto_accept_sanitization' => true,
-		'accept_tree_shaking'      => true,
 		'all_templates_supported'  => true,
 		'supported_templates'      => array( 'is_singular' ),
 		'enable_response_caching'  => true,
@@ -135,7 +134,6 @@ class AMP_Options_Manager {
 		}
 
 		$options['auto_accept_sanitization'] = ! empty( $new_options['auto_accept_sanitization'] );
-		$options['accept_tree_shaking']      = ! empty( $new_options['accept_tree_shaking'] );
 		$options['enable_amp_stories']       = ! empty( $new_options['enable_amp_stories'] );
 
 		// Validate post type support.

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -270,15 +270,8 @@ class AMP_Options_Menu {
 					'code' => 'non_existent',
 				)
 			);
-			remove_filter( 'amp_validation_error_sanitized', array( 'AMP_Validation_Manager', 'filter_tree_shaking_validation_error_as_accepted' ) );
-			$tree_shaking_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization(
-				array(
-					'code' => AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE,
-				)
-			);
 
 			$forced_sanitization = 'with_filter' === $auto_sanitization['forced'];
-			$forced_tree_shaking = $forced_sanitization || 'with_filter' === $tree_shaking_sanitization['forced'];
 			?>
 
 			<?php if ( $forced_sanitization ) : ?>
@@ -320,22 +313,6 @@ class AMP_Options_Menu {
 				</div>
 			<?php endif; ?>
 
-			<?php if ( $forced_tree_shaking ) : ?>
-				<input type="hidden" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[accept_tree_shaking]' ); ?>" value="<?php echo AMP_Options_Manager::get_option( 'accept_tree_shaking' ) ? 'on' : ''; ?>">
-			<?php else : ?>
-				<div class="amp-tree-shaking">
-					<p>
-						<label for="accept_tree_shaking">
-							<input id="accept_tree_shaking" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[accept_tree_shaking]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'accept_tree_shaking' ) ); ?>>
-							<?php esc_html_e( 'Automatically remove CSS rules that are not relevant to a given page (tree shaking).', 'amp' ); ?>
-						</label>
-					</p>
-					<p class="description">
-						<?php esc_html_e( 'AMP limits the total amount of CSS to no more than 50KB; any more than this will cause a validation error. The need to tree shake the CSS is not done by default because in some situations (in particular for dynamic content) it can result in CSS rules being removed that are needed.', 'amp' ); ?>
-					</p>
-				</div>
-			<?php endif; ?>
-
 			<script>
 			(function( $ ) {
 				var getThemeSupportMode = function() {
@@ -346,21 +323,14 @@ class AMP_Options_Menu {
 					return checkedInput.val();
 				};
 
-				var updateTreeShakingHiddenClass = function() {
-					var checkbox = $( '#auto_accept_sanitization' );
-					$( '.amp-tree-shaking' ).toggleClass( 'hidden', checkbox.prop( 'checked' ) && 'native' !== getThemeSupportMode() );
-				};
-
 				var updateHiddenClasses = function() {
 					var themeSupportMode = getThemeSupportMode();
 					$( '.amp-auto-accept-sanitize' ).toggleClass( 'hidden', 'native' === themeSupportMode );
 					$( '.amp-validation-field' ).toggleClass( 'hidden', 'disabled' === themeSupportMode );
 					$( '.amp-auto-accept-sanitize-canonical' ).toggleClass( 'hidden', 'native' !== themeSupportMode );
-					updateTreeShakingHiddenClass();
 				};
 
 				$( 'input[type=radio][name="amp-options[theme_support]"]' ).change( updateHiddenClasses );
-				$( '#auto_accept_sanitization' ).change( updateTreeShakingHiddenClass );
 
 				updateHiddenClasses();
 			})( jQuery );

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -27,13 +27,6 @@ use \Sabberworm\CSS\CSSList\Document;
 class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
-	 * Error code for tree shaking.
-	 *
-	 * @var string
-	 */
-	const TREE_SHAKING_ERROR_CODE = 'removed_unused_css_rules';
-
-	/**
 	 * Error code for illegal at-rule.
 	 *
 	 * @var string
@@ -87,7 +80,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * Array of flags used to control sanitization.
 	 *
 	 * @var array {
-	 *      @type string   $remove_unused_rules        Enum 'never', 'sometimes' (default), 'always'. If total CSS is greater than max_bytes, whether to strip selectors (and then empty rules) when they are not found to be used in doc. A validation error will be emitted when stripping happens since it is not completely safe in the case of dynamic content.
 	 *      @type string[] $dynamic_element_selectors  Selectors for elements (or their ancestors) which contain dynamic content; selectors containing these will not be filtered.
 	 *      @type bool     $use_document_element       Whether the root of the document should be used rather than the body.
 	 *      @type bool     $require_https_src          Require HTTPS URLs.
@@ -95,7 +87,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type callable $validation_error_callback  Function to call when a validation error is encountered.
 	 *      @type bool     $should_locate_sources      Whether to locate the sources when reporting validation errors.
 	 *      @type string   $parsed_cache_variant       Additional value by which to vary parsed cache.
-	 *      @type bool     $accept_tree_shaking        Whether to accept tree-shaking by default and bypass a validation error.
 	 *      @type string   $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element. Can be 'always', 'never', or 'when_excessive'.
 	 * }
 	 */
@@ -107,7 +98,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = array(
-		'remove_unused_rules'       => 'sometimes',
 		'dynamic_element_selectors' => array(
 			'amp-list',
 			'amp-live-list',
@@ -116,7 +106,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		),
 		'should_locate_sources'     => false,
 		'parsed_cache_variant'      => null,
-		'accept_tree_shaking'       => false,
 		'include_manifest_comment'  => 'always',
 	);
 
@@ -298,7 +287,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			self::ILLEGAL_AT_RULE_ERROR_CODE,
 			'illegal_css_important',
 			'illegal_css_property',
-			self::TREE_SHAKING_ERROR_CODE,
 			'unrecognized_css',
 			'disallowed_file_extension',
 			'file_path_not_found',
@@ -2388,7 +2376,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Finalize stylesheets for style[amp-custom] and style[amp-keyframes] elements.
 	 *
-	 * Concatenate all pending stylesheets, remove unused rules if necessary, and add to style elements in doc.
+	 * Concatenate all pending stylesheets, remove unused rules, and add to AMP style elements in document.
 	 * Combine all amp-keyframe styles and add them to the end of the body.
 	 *
 	 * @since 1.0
@@ -2398,19 +2386,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$stylesheet_groups = array(
 			'custom'    => array(
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-custom.css */",
-				'total_size'          => 0,
 				'cdata_spec'          => $this->style_custom_cdata_spec,
 				'pending_stylesheets' => array(),
-				'remove_unused_rules' => $this->args['remove_unused_rules'],
 				'included_count'      => 0,
 				'import_front_matter' => '', // Extra @import statements that are prepended when fetch fails and validation error is rejected.
 			),
 			'keyframes' => array(
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-keyframes.css */",
-				'total_size'          => 0,
 				'cdata_spec'          => $this->style_keyframes_cdata_spec,
 				'pending_stylesheets' => array(),
-				'remove_unused_rules' => 'never', // Not relevant.
 				'included_count'      => 0,
 				'import_front_matter' => '',
 			),
@@ -2433,7 +2417,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$size += strlen( $part[1] ); // Declaration block.
 				}
 			}
-			$stylesheet_groups[ $pending_stylesheet['group'] ]['total_size'] += $size; // Used in finalize_stylesheet_group() to determine if tree shaking is needed.
 
 			if ( ! empty( $pending_stylesheet['imported_font_urls'] ) ) {
 				$imported_font_urls = array_merge( $imported_font_urls, $pending_stylesheet['imported_font_urls'] );
@@ -2819,25 +2802,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return int Number of included stylesheets in group.
 	 */
 	private function finalize_stylesheet_group( $group, $group_config ) {
-		$included_count    = 0;
-		$max_bytes         = $group_config['cdata_spec']['max_bytes'] - strlen( $group_config['source_map_comment'] );
-		$is_too_much_css   = $group_config['total_size'] > $max_bytes;
-		$should_tree_shake = (
-			'always' === $group_config['remove_unused_rules'] || (
-				$is_too_much_css
-				&&
-				'sometimes' === $group_config['remove_unused_rules']
-			)
-		);
-
-		if ( $is_too_much_css && $should_tree_shake && empty( $this->args['accept_tree_shaking'] ) ) {
-			$should_tree_shake = $this->should_sanitize_validation_error(
-				array(
-					'code' => self::TREE_SHAKING_ERROR_CODE,
-					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-				)
-			);
-		}
+		$included_count = 0;
+		$max_bytes      = $group_config['cdata_spec']['max_bytes'] - strlen( $group_config['source_map_comment'] );
 
 		$previously_seen_stylesheet_index = array();
 		$indices_by_stylesheet_element_id = array();
@@ -2861,53 +2827,50 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 
 				list( $selectors_parsed, $declaration_block ) = $stylesheet_part;
-				if ( $should_tree_shake ) {
-					$selectors = array();
-					foreach ( $selectors_parsed as $selector => $parsed_selector ) {
-						$should_include = (
+
+				$selectors = array();
+				foreach ( $selectors_parsed as $selector => $parsed_selector ) {
+					$should_include = (
+						(
+							// If all class names are used in the doc.
 							(
-								// If all class names are used in the doc.
-								(
-									empty( $parsed_selector[ self::SELECTOR_EXTRACTED_CLASSES ] )
-									||
-									$this->has_used_class_name( $parsed_selector[ self::SELECTOR_EXTRACTED_CLASSES ] )
-								)
-								&&
-								// If all IDs are used in the doc.
-								(
-									empty( $parsed_selector[ self::SELECTOR_EXTRACTED_IDS ] )
-									||
-									0 === count(
-										array_filter(
-											$parsed_selector[ self::SELECTOR_EXTRACTED_IDS ],
-											function( $id ) {
-												return ! $this->dom->getElementById( $id );
-											}
-										)
+								empty( $parsed_selector[ self::SELECTOR_EXTRACTED_CLASSES ] )
+								||
+								$this->has_used_class_name( $parsed_selector[ self::SELECTOR_EXTRACTED_CLASSES ] )
+							)
+							&&
+							// If all IDs are used in the doc.
+							(
+								empty( $parsed_selector[ self::SELECTOR_EXTRACTED_IDS ] )
+								||
+								0 === count(
+									array_filter(
+										$parsed_selector[ self::SELECTOR_EXTRACTED_IDS ],
+										function( $id ) {
+											return ! $this->dom->getElementById( $id );
+										}
 									)
 								)
-								&&
-								// If tag names are present in the doc.
-								(
-									empty( $parsed_selector[ self::SELECTOR_EXTRACTED_TAGS ] )
-									||
-									$this->has_used_tag_names( $parsed_selector[ self::SELECTOR_EXTRACTED_TAGS ] )
-								)
-								&&
-								// If all attribute names are used in the doc.
-								(
-									empty( $parsed_selector[ self::SELECTOR_EXTRACTED_ATTRIBUTES ] )
-									||
-									$this->has_used_attributes( $parsed_selector[ self::SELECTOR_EXTRACTED_ATTRIBUTES ] )
-								)
 							)
-						);
-						if ( $should_include ) {
-							$selectors[] = $selector;
-						}
+							&&
+							// If tag names are present in the doc.
+							(
+								empty( $parsed_selector[ self::SELECTOR_EXTRACTED_TAGS ] )
+								||
+								$this->has_used_tag_names( $parsed_selector[ self::SELECTOR_EXTRACTED_TAGS ] )
+							)
+							&&
+							// If all attribute names are used in the doc.
+							(
+								empty( $parsed_selector[ self::SELECTOR_EXTRACTED_ATTRIBUTES ] )
+								||
+								$this->has_used_attributes( $parsed_selector[ self::SELECTOR_EXTRACTED_ATTRIBUTES ] )
+							)
+						)
+					);
+					if ( $should_include ) {
+						$selectors[] = $selector;
 					}
-				} else {
-					$selectors = array_keys( $selectors_parsed );
 				}
 				$stylesheet_part = implode( ',', $selectors ) . $declaration_block;
 				$original_size  += strlen( $stylesheet_part );

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -797,9 +797,6 @@ class AMP_Validated_URL_Post_Type {
 		return array(
 			'theme'   => get_stylesheet(),
 			'plugins' => get_option( 'active_plugins', array() ),
-			'options' => array(
-				'accept_tree_shaking' => ( AMP_Options_Manager::get_option( 'accept_tree_shaking' ) || AMP_Options_Manager::get_option( 'auto_accept_sanitization' ) ),
-			),
 		);
 	}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -206,11 +206,6 @@ class AMP_Validation_Manager {
 
 		add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_menu_items' ), 101 );
 
-		// Add filter to auto-accept tree shaking validation error.
-		if ( AMP_Options_Manager::get_option( 'accept_tree_shaking' ) || AMP_Options_Manager::get_option( 'auto_accept_sanitization' ) ) {
-			add_filter( 'amp_validation_error_sanitized', array( __CLASS__, 'filter_tree_shaking_validation_error_as_accepted' ), 10, 2 );
-		}
-
 		if ( self::$should_locate_sources ) {
 			self::add_validation_error_sourcing();
 		}
@@ -238,20 +233,6 @@ class AMP_Validation_Manager {
 	 */
 	public static function is_sanitization_auto_accepted() {
 		return amp_is_canonical() || AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
-	}
-
-	/**
-	 * Filter a tree-shaking validation error as accepted for sanitization.
-	 *
-	 * @param bool  $sanitized Sanitized.
-	 * @param array $error     Error.
-	 * @return bool Sanitized.
-	 */
-	public static function filter_tree_shaking_validation_error_as_accepted( $sanitized, $error ) {
-		if ( AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE === $error['code'] ) {
-			$sanitized = true;
-		}
-		return $sanitized;
 	}
 
 	/**
@@ -761,8 +742,8 @@ class AMP_Validation_Manager {
 		);
 
 		/*
-		 * Ignore validation errors which are forcibly sanitized by filter. This includes tree shaking error
-		 * accepted by options and via AMP_Validation_Error_Taxonomy::accept_validation_errors()).
+		 * Ignore validation errors which are forcibly sanitized by filter. This includes errors accepted via
+		 * AMP_Validation_Error_Taxonomy::accept_validation_errors(), such as the acceptable_errors in core themes.
 		 * This was introduced in <https://github.com/ampproject/amp-wp/pull/1413> to prevent forcibly-sanitized
 		 * validation errors from being reported, to avoid noise and wasted storage. It was inadvertently
 		 * reverted in de7b04b but then restored as part of <https://github.com/ampproject/amp-wp/pull/1413>.
@@ -1742,7 +1723,6 @@ class AMP_Validation_Manager {
 			if ( ! empty( $css_validation_errors ) ) {
 				$sanitizers['AMP_Style_Sanitizer']['parsed_cache_variant'] = md5( wp_json_encode( $css_validation_errors ) );
 			}
-			$sanitizers['AMP_Style_Sanitizer']['accept_tree_shaking'] = AMP_Options_Manager::get_option( 'accept_tree_shaking' );
 		}
 
 		return $sanitizers;

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -164,16 +164,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'allowed_at_rules_retained' => array(
-				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style>',
-				'',
+				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
+				'<div></div>',
 				array(
 					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',
 				),
 			),
 
 			'selector_specificity' => array(
-				'<style>#child {color:red !important} #parent #child {color:pink !important} .foo { color:blue !important; } #me .foo { color: green !important; }</style><div id="parent"><span id="child" class="foo bar baz">one</span><span style="color: yellow;">two</span><span style="color: purple !important;">three</span></div>',
-				'<div id="parent"><span id="child" class="foo bar baz">one</span><span class="amp-wp-64b4fd4">two</span><span class="amp-wp-ab79d9e">three</span></div>',
+				'<style>#child {color:red !important} #parent #child {color:pink !important} .foo { color:blue !important; } #me .foo { color: green !important; }</style><div id="parent"><span id="child" class="foo bar baz">one</span><span style="color: yellow;">two</span><span style="color: purple !important;">three</span></div><div id="me"><span class="foo"></span></div>',
+				'<div id="parent"><span id="child" class="foo bar baz">one</span><span class="amp-wp-64b4fd4">two</span><span class="amp-wp-ab79d9e">three</span></div><div id="me"><span class="foo"></span></div>',
 				array(
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #child{color:red}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #parent #child{color:pink}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .foo{color:blue}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #me .foo{color:green}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-64b4fd4{color:yellow}',
@@ -220,8 +220,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'multi_selector_in_not_pseudo_class'         => array(
-				'<style>.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul { color:red; }</style><div class="widget"></div>',
-				'<div class="widget"></div>',
+				'<style>.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul { color:red; }</style><div class="widget"><ul></ul></div>',
+				'<div class="widget"><ul></ul></div>',
 				array(
 					'.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul{color:red}',
 				),
@@ -550,7 +550,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$error_codes = array();
 		$args        = array(
 			'use_document_element'      => true,
-			'remove_unused_rules'       => 'always',
 			'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 				$error_codes[] = $error['code'];
 			},
@@ -681,14 +680,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$dom  = AMP_DOM_Utils::get_dom( $html );
 
 		$sanitizer_classes = amp_get_content_sanitizers();
-		$sanitizer_classes['AMP_Style_Sanitizer']['remove_unused_rules'] = 'always';
-		$sanitized   = AMP_Content_Sanitizer::sanitize_document(
+		$sanitized         = AMP_Content_Sanitizer::sanitize_document(
 			$dom,
 			$sanitizer_classes,
 			array(
 				'use_document_element' => true,
 			)
 		);
+
 		$stylesheets = array_values( $sanitized['stylesheets'] );
 		$this->assertEquals( $output, $stylesheets[0] );
 	}
@@ -827,7 +826,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$dom  = AMP_DOM_Utils::get_dom( $html );
 
 		$sanitizer_classes = amp_get_content_sanitizers();
-		$sanitizer_classes['AMP_Style_Sanitizer']['remove_unused_rules'] = 'always';
 
 		$sanitized = AMP_Content_Sanitizer::sanitize_document(
 			$dom,
@@ -1025,7 +1023,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element'      => true,
-				'remove_unused_rules'       => 'never',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
@@ -1055,7 +1052,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element'      => true,
-				'remove_unused_rules'       => 'always',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
@@ -1070,28 +1066,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertContains( '.dashicons{', $actual_stylesheets[0] );
 		$this->assertContains( '.dashicons-admin-appearance:before{', $actual_stylesheets[0] );
 		$this->assertNotContains( '.dashicons-format-chat:before', $actual_stylesheets[0] );
-
-		// Test with rule-removal not forced, since dashicons alone is not larger than 50KB.
-		$dom         = AMP_DOM_Utils::get_dom( $html );
-		$error_codes = array();
-		$sanitizer   = new AMP_Style_Sanitizer(
-			$dom,
-			array(
-				'use_document_element'      => true,
-				'remove_unused_rules'       => 'sometimes',
-				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
-					$error_codes[] = $error['code'];
-				},
-			)
-		);
-		$sanitizer->sanitize();
-		$this->assertEquals( array(), $error_codes );
-		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
-		$this->assertContains( 'dashicons.woff") format("woff")', $actual_stylesheets[0] );
-		$this->assertNotContains( 'data:application/font-woff;', $actual_stylesheets[0] );
-		$this->assertContains( '.dashicons,.dashicons-before:before{', $actual_stylesheets[0] );
-		$this->assertContains( '.dashicons-admin-appearance:before{', $actual_stylesheets[0] );
-		$this->assertContains( '.dashicons-format-chat:before', $actual_stylesheets[0] );
 	}
 
 	/**
@@ -1173,7 +1147,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element'      => true,
-				'remove_unused_rules'       => 'always',
 				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
@@ -1190,7 +1163,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that auto-removal is performed when remove_unused_rules=sometimes (the default), and that excessive CSS will be removed entirely.
+	 * Test that auto-removal is performed and that excessive CSS will be removed entirely.
 	 *
 	 * @covers AMP_Style_Sanitizer::finalize_stylesheet_group()
 	 */
@@ -1262,25 +1235,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals(
-			array( 'removed_unused_css_rules', 'excessive_css' ),
-			$error_codes
-		);
-
-		// Make sure the accept_tree_shaking option results in no removed_unused_css_rules error being raised.
-		$error_codes = array();
-		$dom         = AMP_DOM_Utils::get_dom( $html );
-		$sanitizer   = new AMP_Style_Sanitizer(
-			$dom,
-			array(
-				'use_document_element'      => true,
-				'accept_tree_shaking'       => true,
-				'validation_error_callback' => function( $error ) use ( &$error_codes ) {
-					$error_codes[] = $error['code'];
-				},
-			)
-		);
-		$sanitizer->sanitize();
-		$this->assertEquals(
 			array( 'excessive_css' ),
 			$error_codes
 		);
@@ -1333,7 +1287,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				array_merge(
 					array(
 						'use_document_element'      => true,
-						'accept_tree_shaking'       => true,
 						'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 							$error_codes[] = $error['code'];
 						},
@@ -1368,31 +1321,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $error_codes );
 		$this->assertNotInstanceOf( 'DOMComment', $style->previousSibling );
 
-		// Test that it contains the comment with duplicate styles removed without tree shaking.
-		list( $style, $error_codes ) = $get_sanitized_dom(
-			array(
-				'include_manifest_comment' => 'always',
-				'remove_unused_rules'      => 'never',
-			),
-			false
-		);
-		$this->assertEmpty( $error_codes );
-		$this->assertInstanceOf( 'DOMComment', $style->previousSibling );
-		$comment = $style->previousSibling;
-		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
-		$this->assertNotContains( 'The following stylesheets are too large to be included', $comment->nodeValue );
-		$this->assertContains( '15 B: style.body', $comment->nodeValue );
-		$this->assertContains( '17 B: style.foo3', $comment->nodeValue, 'Expected the foo3 to persist because it has preceding identical stylesheets for foo1 and foo2.' );
-		$this->assertContains( '17 B: style.bard', $comment->nodeValue );
-		$this->assertNotContains( 'style.foo2', $comment->nodeValue );
-		$this->assertNotContains( 'style.foo1', $comment->nodeValue );
-		$this->assertContains( 'Total included size: 49 bytes (100% of 49 total after tree shaking', $comment->nodeValue );
-
 		// Test that it contains the comment with duplicate styles removed with tree shaking.
 		list( $style, $error_codes ) = $get_sanitized_dom(
 			array(
 				'include_manifest_comment' => 'always',
-				'remove_unused_rules'      => 'always',
 			),
 			false
 		);
@@ -1412,7 +1344,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		list( $style, $error_codes ) = $get_sanitized_dom(
 			array(
 				'include_manifest_comment' => 'when_excessive',
-				'remove_unused_rules'      => 'sometimes',
 			),
 			true
 		);
@@ -1926,7 +1857,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					admin_url( 'css/colors/../login.css' ),
 					includes_url( 'css/buttons.css' ),
 				),
-				'<style>div::after{content:"After login"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After login"}</style><div><input type="checkbox"><button class="wp-core-ui button"></button></div>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				0, // Zero HTTP requests.
 				null, // No preempting of request, as no external requests.
 				function ( WP_UnitTestCase $test, $stylesheet ) {
@@ -1949,7 +1880,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					admin_url( 'css/colors/../login.css' ),
 					'https://bogus.example.com/remote-also-does-not-exist.css',
 				),
-				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style><body class="locale-he-il"><div class="login message"></div><table class="form-table"><td></td></table></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				3, // Three HTTP requests (to bogus.example.com). The local-does-not-exist.css checks filesystem directly.
 				function ( $requested_url ) {
 					if ( false !== strpos( $requested_url, 'does-not-exist' ) ) {
@@ -1989,7 +1920,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					admin_url( 'css/colors/../login.css' ),
 					'https://bogus.example.com/remote-also-does-not-exist.css',
 				),
-				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style><body class="locale-he-il"><div class="login message"></div><table class="form-table"><td></td></table></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				3, // Three HTTP requests (to bogus.example.com). The local-does-not-exist.css checks filesystem directly.
 				function ( $requested_url ) {
 					if ( false !== strpos( $requested_url, 'does-not-exist' ) ) {
@@ -2030,7 +1961,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'dynamic_stylesheet_with_relative_import' => array(
 				includes_url( '/dynamic/import-buttons.php' ),
-				'<style>div::after{content:"After import-buttons"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After import-buttons"}</style><body class="wp-core-ui"><div><button class="button"></button></div></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				1,
 				function( $requested_url ) {
 					if ( false !== strpos( $requested_url, 'import-buttons.php' ) ) {
@@ -2048,7 +1979,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'dynamic_stylesheet_with_absolute_import' => array(
 				includes_url( '/dynamic/import-buttons.php' ),
-				'<style>div::after{content:"After import-buttons2"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After import-buttons2"}</style><body class="wp-core-ui"><div><button class="button"></button></div></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				1,
 				function( $requested_url ) {
 					if ( false !== strpos( $requested_url, 'import-buttons.php' ) ) {
@@ -2066,7 +1997,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'dynamic_stylesheet_with_nested_dynamic_stylesheet' => array(
 				includes_url( '/dynamic/import-buttons.php' ),
-				'<style>div::after{content:"After import-buttons2"}</style>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+				'<style>div::after{content:"After import-buttons2"}</style><body><div></div></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				2,
 				function( $requested_url ) {
 					$self_call_url = includes_url( '/dynamic/nested.php' );
@@ -2152,7 +2083,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element'      => true,
-				'remove_unused_rules'       => 'never',
 				'validation_error_callback' => 'AMP_Validation_Manager::add_validation_error',
 			)
 		);
@@ -2182,7 +2112,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$dom,
 			array(
 				'use_document_element' => true,
-				'remove_unused_rules'  => 'never',
 			)
 		);
 		$sanitizer->sanitize();
@@ -2323,7 +2252,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					add_action(
 						'wp_head',
 						function() {
-							printf( '<style media=print id="early-print-style">html:after { content:"earlyprintstyle %s"; }</style>', esc_html( str_repeat( 'a', 10000 ) ) );
+							printf( '<style media=print id="early-print-style">html:after { content:"earlyprintstyle %s"; }</style>', esc_html( str_repeat( 'a', 49990 ) ) );
 						},
 						-1000
 					);
@@ -2331,6 +2260,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					AMP_Theme_Support::add_hooks();
 					wp_add_inline_style( 'admin-bar', '.admin-bar-inline-style{ color:red }' );
 					wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+					add_action(
+						'wp_footer',
+						function() {
+							?>
+							<div class="is-style-outline"><button class="wp-block-button__link"></button></div>
+							<div class="wp-block-foo"><figcaption></figcaption></div>
+							<img src="https://example.com/example.jpg" width="100" height="200">
+							<?php
+						}
+					);
 
 					return $render_template();
 				},
@@ -2398,11 +2338,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$error_codes = array();
 		$args        = array(
 			'use_document_element'      => true,
-			'remove_unused_rules'       => 'never',
 			'validation_error_callback' => function( $error ) use ( &$error_codes ) {
 				$error_codes[] = $error['code'];
 			},
 		);
+
+		$sanitizer = new AMP_Img_Sanitizer( $amphtml_dom, $args );
+		$sanitizer->sanitize();
 
 		$sanitizer = new AMP_Style_Sanitizer( $amphtml_dom, $args );
 		$sanitizer->sanitize();

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -105,7 +105,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				'supported_post_types'     => array( 'post' ),
 				'analytics'                => array(),
 				'auto_accept_sanitization' => true,
-				'accept_tree_shaking'      => true,
 				'all_templates_supported'  => true,
 				'supported_templates'      => array( 'is_singular' ),
 				'enable_response_caching'  => true,

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -495,22 +495,15 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	public function test_get_validated_environment() {
 		switch_theme( 'twentysixteen' );
 		update_option( 'active_plugins', array( 'foo/foo.php', 'bar.php' ) );
-		AMP_Options_Manager::update_option( 'accept_tree_shaking', true );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$old_env = AMP_Validated_URL_Post_Type::get_validated_environment();
 		$this->assertArrayHasKey( 'theme', $old_env );
 		$this->assertArrayHasKey( 'plugins', $old_env );
-		$this->assertArrayHasKey( 'options', $old_env );
-		$this->assertArrayHasKey( 'accept_tree_shaking', $old_env['options'] );
-		$this->assertTrue( $old_env['options']['accept_tree_shaking'] );
 		$this->assertEquals( 'twentysixteen', $old_env['theme'] );
 
 		switch_theme( 'twentyseventeen' );
 		update_option( 'active_plugins', array( 'foo/foo.php', 'baz.php' ) );
-		AMP_Options_Manager::update_option( 'accept_tree_shaking', false );
 		$new_env = AMP_Validated_URL_Post_Type::get_validated_environment();
 		$this->assertNotEquals( $old_env, $new_env );
-		$this->assertFalse( $new_env['options']['accept_tree_shaking'] );
 		$this->assertEquals( 'twentyseventeen', $new_env['theme'] );
 	}
 

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -131,29 +131,16 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertEquals( 101, has_action( 'admin_bar_menu', array( self::TESTED_CLASS, 'add_admin_bar_menu_items' ) ) );
 
 		$this->assertFalse( has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
-		$this->assertEquals( 10, has_filter( 'amp_validation_error_sanitized', array( self::TESTED_CLASS, 'filter_tree_shaking_validation_error_as_accepted' ) ) );
 
-		// Make sure should_locate_sources arg is recognized, as is disabling of tree-shaking.
+		// Make sure should_locate_sources arg is recognized.
 		remove_all_filters( 'amp_validation_error_sanitized' );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		AMP_Options_Manager::update_option( 'accept_tree_shaking', false );
 		AMP_Validation_Manager::init(
 			array(
 				'should_locate_sources' => true,
 			)
 		);
 		$this->assertEquals( 10, has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
-		$this->assertFalse( has_filter( 'amp_validation_error_sanitized', array( self::TESTED_CLASS, 'filter_tree_shaking_validation_error_as_accepted' ) ) );
-	}
-
-	/**
-	 * Test filter_tree_shaking_validation_error_as_accepted.
-	 *
-	 * @covers AMP_Validation_Manager::filter_tree_shaking_validation_error_as_accepted()
-	 */
-	public function test_filter_tree_shaking_validation_error_as_accepted() {
-		$this->assertNull( AMP_Validation_Manager::filter_tree_shaking_validation_error_as_accepted( null, array( 'code' => 'foo' ) ) );
-		$this->assertTrue( AMP_Validation_Manager::filter_tree_shaking_validation_error_as_accepted( null, array( 'code' => AMP_Style_Sanitizer::TREE_SHAKING_ERROR_CODE ) ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2501.

Remove a lot of code that is now unnecessary with removal of optional tree shaking, since it turns out that this option is obsolete.