### PR TITLE
Improve CTA block focus handling

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -87,7 +87,6 @@ class CallToActionEdit extends Component {
 							color: textColor.color,
 							fontSize: fontSize.size ? fontSize.size + 'px' : undefined,
 						} }
-						keepPlaceholderOnFocus
 					/>
 				</div>
 				{ isSelected && (
@@ -98,6 +97,7 @@ class CallToActionEdit extends Component {
 						<URLInput
 							value={ url }
 							onChange={ ( value ) => setAttributes( { url: value } ) }
+							autoFocus={ false /* eslint-disable-line jsx-a11y/no-autofocus */ }
 						/>
 						<IconButton icon="editor-break" label={ __( 'Apply', 'amp' ) } type="submit" />
 					</form>


### PR DESCRIPTION
* Do not keep placeholder when focusing on button
* Do not auto-focus on URL input when selecting the CTA block.

Fixes #2520.
Fixes #2521.