### PR TITLE
Prevent sending response through post-processor if Content-Type is not text/html

### DIFF
--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -22,6 +22,8 @@ class AMP_HTTP {
 	/**
 	 * Headers sent (or attempted to be sent).
 	 *
+	 * This is used primarily for the benefit of unit testing. Otherwise, `headers_list()` should be used.
+	 *
 	 * @since 1.0
 	 * @see AMP_HTTP::send_header()
 	 * @var array[]
@@ -489,5 +491,24 @@ class AMP_HTTP {
 		);
 
 		return null;
+	}
+
+	/**
+	 * Get the Content-Type for the response.
+	 *
+	 * @since 1.2
+	 *
+	 * @return string Content type.
+	 */
+	public static function get_response_content_type() {
+		$content_type = ini_get( 'default_mimetype' );
+		foreach ( headers_list() as $header ) {
+			list( $name, $value ) = explode( ':', $header, 2 );
+			if ( 'content-type' === strtolower( $name ) ) {
+				$content_type = trim( $value );
+				break;
+			}
+		}
+		return $content_type;
 	}
 }

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1725,7 +1725,8 @@ class AMP_Theme_Support {
 			);
 		}
 
-		if ( '<' !== substr( ltrim( $response ), 0, 1 ) ) {
+		// Abort if the response was not HTML.
+		if ( 'text/html' !== substr( AMP_HTTP::get_response_content_type(), 0, 9 ) || '<' !== substr( ltrim( $response ), 0, 1 ) ) {
 			return $response;
 		}
 

--- a/tests/test-class-amp-http.php
+++ b/tests/test-class-amp-http.php
@@ -599,4 +599,13 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 			$response['message']
 		);
 	}
+
+	/**
+	 * Test get_response_content_type().
+	 *
+	 * @covers \AMP_HTTP::get_response_content_type()
+	 */
+	public function test_get_response_content_type() {
+		$this->assertSame( ini_get( 'default_mimetype' ), AMP_HTTP::get_response_content_type() );
+	}
 }


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/how-to-exclude-sitemap-xml-page-from-amp/

On a native mode site, when PHP generates a response that contains XML the output is erroneously sent through the post-processor for conversion to AMP. This breaks the [Google Sitemap Generator](https://wordpress.org/plugins/google-sitemap-generator/) plugin, among presumably many others that use PHP to generate XML. (Note that RSS feeds are exempted from this because `is_amp_endpoint()` checks `is_feed()`.)

# Before

> ![image](https://user-images.githubusercontent.com/134745/59050378-0c2b6b00-883f-11e9-9ee7-b269ac0430ef.png)

```html
<!DOCTYPE html>
<html amp="">
<head>
	<meta charset="utf-8">
	<meta name="viewport" content="width=device-width">
	<meta name="amp-to-amp-navigation" content="AMP-Redirect-To; AMP.navigateTo">
	<link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
	<script type="application/ld+json">{
		"@context": "http:\/\/schema.org",
		"publisher": {
			"@type": "Organization",
			"name": "WordPress Develop",
			"logo": {
				"@type": "ImageObject",
				"url": "https:\/\/wordpressdev.lndo.site\/content\/uploads\/2019\/02\/cropped-1200px-American_bison_k5680-1-5-32x32.jpg",
				"width": 32,
				"height": 32
			}
		}
	}</script>
	<link rel="canonical" href="https://wordpressdev.lndo.site/sitemap.xml/">
</head>
<body>
https://wordpressdev.lndo.site/sitemap-misc.xml2019-06-02T05:37:57+00:00https://wordpressdev.lndo.site/sitemap-pt-post-2019-06.xml2019-06-02T05:37:57+00:00https://wordpressdev.lndo.site/sitemap-pt-post-2019-05.xml2019-05-31T17:07:35+00:00https://wordpressdev.lndo.site/sitemap-pt-post-2019-04.xml2019-04-29T02:43:48+00:00https://wordpressdev.lndo.site/sitemap-pt-post-2019-03.xml2019-05-28T00:22:12+00:00https://wordpressdev.lndo.site/sitemap-pt-post-2019-02.xml2019-05-01T20:31:47+00:00https://wordpressdev.lndo.site/sitemap-pt-page-2019-05.xml2019-05-30T18:40:44+00:00https://wordpressdev.lndo.site/sitemap-pt-page-2019-03.xml2019-03-12T20:25:17+00:00https://wordpressdev.lndo.site/sitemap-pt-page-2019-02.xml2019-03-09T06:22:38+00:00
<!-- <p>Please edit wp-db.inc.php in wp-includes and set SAVEQUERIES to true if you want to see the queries.</p> -->
<!-- Request ID: 7f4b5e7cf17f187f8e00286bcd8bbb96; Queries for sitemap: 5; Total queries: 37; Seconds: 0.01; Memory for sitemap: 0MB; Total memory: 2MB --></body>
</html>
```

# After

> ![image](https://user-images.githubusercontent.com/134745/59050449-2e24ed80-883f-11e9-8511-0e48a414094f.png)

```xml
<?xml version="1.0" encoding="UTF-8"?><?xml-stylesheet type="text/xsl" href="https://wordpressdev.lndo.site/content/plugins/google-sitemap-generator/sitemap.xsl"?><!-- sitemap-generator-url="http://www.arnebrachhold.de" sitemap-generator-version="4.1.0" -->
<!-- generated-on="2019-06-06 4:40 pm" -->
<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
              xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-misc.xml</loc>
        <lastmod>2019-06-02T05:37:57+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-post-2019-06.xml</loc>
        <lastmod>2019-06-02T05:37:57+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-post-2019-05.xml</loc>
        <lastmod>2019-05-31T17:07:35+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-post-2019-04.xml</loc>
        <lastmod>2019-04-29T02:43:48+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-post-2019-03.xml</loc>
        <lastmod>2019-05-28T00:22:12+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-post-2019-02.xml</loc>
        <lastmod>2019-05-01T20:31:47+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-page-2019-05.xml</loc>
        <lastmod>2019-05-30T18:40:44+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-page-2019-03.xml</loc>
        <lastmod>2019-03-12T20:25:17+00:00</lastmod>
    </sitemap>
    <sitemap>
        <loc>https://wordpressdev.lndo.site/sitemap-pt-page-2019-02.xml</loc>
        <lastmod>2019-03-09T06:22:38+00:00</lastmod>
    </sitemap>
</sitemapindex><!-- <p>Please edit wp-db.inc.php in wp-includes and set SAVEQUERIES to true if you want to see the queries.</p> --> <!-- Request ID: 4c135986bf1cb0309275b738560b54de; Queries for sitemap: 5; Total queries: 37; Seconds: 0.01; Memory for sitemap: 0MB; Total memory: 2MB -->
```

# Testing Build

[amp.zip](https://github.com/ampproject/amp-wp/files/3262587/amp.zip) - v1.2-beta2-20190606T164319Z-8ee62b0d
