### PR TITLE
Update AMP validator spec to v1905292322390

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -358,7 +358,9 @@ def ParseRules(out_dir):
 
 				# Handle the special $REFERENCE_POINT tag
 				if '$REFERENCE_POINT' == tag_spec.tag_name:
-					reference_points[ tag_spec.spec_name ] = GetTagSpec(tag_spec, attr_lists)
+					gotten_tag_spec = GetTagSpec(tag_spec, attr_lists)
+					if gotten_tag_spec is not None:
+						reference_points[ tag_spec.spec_name ] = gotten_tag_spec
 					continue
 
 				# If we made it here, then start adding the tag_spec

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -17210,7 +17210,6 @@ class AMP_Allowed_Tags_Generated {
 				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
 			),
 		),
-		'AMP-VIDEO-IFRAME > I-AMPHTML-SIZER [style]' => NULL,
 		'AMP-VIDEO-IFRAME > [placeholder]' => array(
 			'attr_spec_list' => array(
 				'placeholder' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 859;
+	private static $spec_file_revision = 882;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -38,15 +38,31 @@ class AMP_Allowed_Tags_Generated {
 			'button',
 			'caption',
 			'cite',
+			'circle',
+			'clippath',
 			'code',
 			'data',
+			'defs',
 			'del',
+			'desc',
 			'dfn',
 			'div',
+			'ellipse',
 			'em',
+			'fecolormatrix',
+			'fecomposite',
+			'feflood',
+			'fegaussianblur',
+			'femerge',
+			'femergenode',
+			'feoffset',
 			'figcaption',
 			'figure',
+			'filter',
 			'footer',
+			'g',
+			'glyph',
+			'glyphref',
 			'h1',
 			'h2',
 			'h3',
@@ -55,19 +71,32 @@ class AMP_Allowed_Tags_Generated {
 			'h6',
 			'header',
 			'hgroup',
+			'hkern',
 			'hr',
 			'i',
+			'image',
 			'ins',
 			'kbd',
 			'li',
+			'line',
+			'lineargradient',
 			'main',
+			'marker',
 			'mark',
+			'mask',
+			'metadata',
 			'nav',
 			'noscript',
 			'ol',
 			'p',
+			'path',
+			'pattern',
 			'pre',
+			'polygon',
+			'polyline',
+			'radialgradient',
 			'q',
+			'rect',
 			'rp',
 			'rt',
 			'rtc',
@@ -76,15 +105,27 @@ class AMP_Allowed_Tags_Generated {
 			'samp',
 			'section',
 			'small',
+			'solidcolor',
 			'span',
 			'strong',
 			'sub',
 			'sup',
+			'svg',
+			'switch',
+			'symbol',
+			'text',
+			'textpath',
+			'tref',
+			'tspan',
+			'title',
 			'time',
 			'tr',
 			'u',
 			'ul',
+			'use',
 			'var',
+			'view',
+			'vkern',
 			'wbr',
 		),
 		'amp-story-grid-layer-allowed-descendants' => array(
@@ -116,21 +157,37 @@ class AMP_Allowed_Tags_Generated {
 			'blockquote',
 			'br',
 			'caption',
+			'circle',
 			'cite',
+			'clippath',
 			'code',
 			'col',
 			'colgroup',
 			'data',
 			'dd',
+			'defs',
 			'del',
+			'desc',
 			'dfn',
 			'div',
 			'dl',
 			'dt',
+			'ellipse',
 			'em',
+			'fecolormatrix',
+			'fecomposite',
+			'feflood',
+			'fegaussianblur',
+			'femerge',
+			'femergenode',
+			'feoffset',
 			'figcaption',
 			'figure',
+			'filter',
 			'footer',
+			'g',
+			'glyph',
+			'glyphref',
 			'h1',
 			'h2',
 			'h3',
@@ -139,19 +196,32 @@ class AMP_Allowed_Tags_Generated {
 			'h6',
 			'header',
 			'hgroup',
+			'hkern',
 			'hr',
 			'i',
+			'image',
 			'ins',
 			'kbd',
 			'li',
+			'line',
+			'lineargradient',
 			'main',
 			'mark',
+			'marker',
+			'mask',
+			'metadata',
 			'nav',
 			'noscript',
 			'ol',
 			'p',
+			'path',
+			'pattern',
+			'polygon',
+			'polyline',
 			'pre',
 			'q',
+			'radialgradient',
+			'rect',
 			'rp',
 			'rt',
 			'rtc',
@@ -160,23 +230,35 @@ class AMP_Allowed_Tags_Generated {
 			'samp',
 			'section',
 			'small',
+			'solidcolor',
 			'source',
 			'span',
 			'strong',
 			'sub',
 			'sup',
+			'svg',
+			'switch',
+			'symbol',
 			'table',
 			'tbody',
 			'td',
+			'text',
+			'textpath',
 			'tfoot',
 			'th',
 			'thead',
 			'time',
+			'title',
 			'tr',
 			'track',
+			'tref',
+			'tspan',
 			'u',
 			'ul',
+			'use',
 			'var',
+			'view',
+			'vkern',
 			'wbr',
 		),
 		'amp-story-page-attachment-allowed-descendants' => array(
@@ -258,21 +340,37 @@ class AMP_Allowed_Tags_Generated {
 			'br',
 			'button',
 			'caption',
+			'circle',
 			'cite',
+			'clippath',
 			'code',
 			'col',
 			'colgroup',
 			'data',
 			'dd',
+			'defs',
 			'del',
+			'desc',
 			'dfn',
 			'div',
 			'dl',
 			'dt',
+			'ellipse',
 			'em',
+			'fecolormatrix',
+			'fecomposite',
+			'feflood',
+			'fegaussianblur',
+			'femerge',
+			'femergenode',
+			'feoffset',
 			'figcaption',
 			'figure',
+			'filter',
 			'footer',
+			'g',
+			'glyph',
+			'glyphref',
 			'h1',
 			'h2',
 			'h3',
@@ -281,18 +379,31 @@ class AMP_Allowed_Tags_Generated {
 			'h6',
 			'header',
 			'hgroup',
+			'hkern',
 			'hr',
 			'i',
+			'image',
 			'ins',
 			'kbd',
 			'li',
+			'line',
+			'lineargradient',
 			'main',
 			'mark',
+			'marker',
+			'mask',
+			'metadata',
 			'nav',
 			'ol',
 			'p',
+			'path',
+			'pattern',
+			'polygon',
+			'polyline',
 			'pre',
 			'q',
+			'radialgradient',
+			'rect',
 			'rp',
 			'rt',
 			'rtc',
@@ -301,23 +412,35 @@ class AMP_Allowed_Tags_Generated {
 			'samp',
 			'section',
 			'small',
+			'solidcolor',
 			'source',
 			'span',
 			'strong',
 			'sub',
 			'sup',
+			'svg',
+			'switch',
+			'symbol',
 			'table',
 			'tbody',
 			'td',
+			'text',
+			'textpath',
 			'tfoot',
 			'th',
 			'thead',
 			'time',
+			'title',
 			'tr',
 			'track',
+			'tref',
+			'tspan',
 			'u',
 			'ul',
+			'use',
 			'var',
+			'view',
+			'vkern',
 			'wbr',
 		),
 	);
@@ -386,7 +509,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#links',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#links',
 				),
 			),
 		),
@@ -542,7 +665,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-accordion',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-accordion',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-accordion',
 				),
 			),
 		),
@@ -562,7 +685,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-action-macro',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-action-macro',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-action-macro',
 				),
 			),
 		),
@@ -614,7 +737,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-ad',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
 				),
 			),
 			array(
@@ -675,7 +798,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-ad with data-multi-size attribute',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
 				),
 			),
 			array(
@@ -733,7 +856,48 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-ad with data-enable-refresh attribute',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+				),
+			),
+		),
+		'amp-ad-custom' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
+					),
+					'disallowed_ancestor' => array(
+						'amp-app-banner',
+					),
+					'requires_extension' => array(
+						'amp-ad-custom',
+					),
 				),
 			),
 		),
@@ -803,7 +967,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-analytics',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-analytics',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics',
 				),
 			),
 		),
@@ -850,7 +1014,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-anim',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-anim',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-anim',
 				),
 			),
 		),
@@ -917,7 +1081,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-apester-media',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-apester-media',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-apester-media',
 				),
 			),
 		),
@@ -945,7 +1109,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-app-banner',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-app-banner',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-app-banner',
 					'unique' => true,
 				),
 			),
@@ -1012,7 +1176,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-audio',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
 				),
 			),
 			array(
@@ -1065,7 +1229,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-audio',
 					),
 					'spec_name' => 'amp-story >> amp-audio',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
 				),
 			),
 		),
@@ -1089,7 +1253,63 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-auto-ads',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-auto-ads',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-auto-ads',
+				),
+			),
+		),
+		'amp-autocomplete' => array(
+			array(
+				'attr_spec_list' => array(
+					'[src]' => array(),
+					'filter' => array(
+						'value_casei' => array(
+							'custom',
+							'fuzzy',
+							'none',
+							'prefix',
+							'substring',
+							'token-prefix',
+						),
+					),
+					'filter-expr' => array(
+						'requires_extension' => array(
+							'amp-bind',
+						),
+					),
+					'filter-value' => array(),
+					'highlight-user-entry' => array(),
+					'max-entries' => array(),
+					'media' => array(),
+					'min-characters' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'value_url' => array(
+							'allow_relative' => true,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+					'submit-on-enter' => array(),
+					'suggest-first' => array(),
+					'template' => array(),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
+					'mandatory_ancestor' => 'form',
+					'requires_extension' => array(
+						'amp-autocomplete',
+					),
+					'spec_name' => 'amp-autocomplete',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-autocomplete',
 				),
 			),
 		),
@@ -1170,7 +1390,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-base-carousel',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-base-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel',
 				),
 			),
 			array(
@@ -1264,7 +1484,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-lightbox-gallery',
 					),
 					'spec_name' => 'AMP-BASE-CAROUSEL [lightbox]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-base-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-base-carousel',
 				),
 			),
 		),
@@ -1326,7 +1546,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-bind',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-bind',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bind',
 				),
 			),
 		),
@@ -1375,7 +1595,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-bodymovin-animation',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-bodymovin-animation',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bodymovin-animation',
 				),
 			),
 		),
@@ -1424,7 +1644,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-brid-player',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-brid-player',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-brid-player',
 				),
 			),
 		),
@@ -1472,7 +1692,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-brightcove',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-brightcove',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-brightcove',
 				),
 			),
 		),
@@ -1549,7 +1769,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-call-tracking',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-call-tracking',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-call-tracking',
 				),
 			),
 		),
@@ -1607,7 +1827,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-carousel',
 					),
 					'spec_name' => 'AMP-CAROUSEL [type=slides]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
 				),
 			),
 			array(
@@ -1660,7 +1880,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-carousel',
 					),
 					'spec_name' => 'AMP-CAROUSEL [type=carousel]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
 				),
 			),
 			array(
@@ -1730,7 +1950,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-lightbox-gallery',
 					),
 					'spec_name' => 'AMP-CAROUSEL [lightbox] [type=slides]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
 				),
 			),
 			array(
@@ -1797,7 +2017,38 @@ class AMP_Allowed_Tags_Generated {
 						'amp-lightbox-gallery',
 					),
 					'spec_name' => 'AMP-CAROUSEL [lightbox] [type=carousel]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-carousel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
+				),
+			),
+		),
+		'amp-connatix-player' => array(
+			array(
+				'attr_spec_list' => array(
+					'data-player-id' => array(
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-connatix-player',
+					),
+					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-connatix-player',
 				),
 			),
 		),
@@ -1918,7 +2169,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-dailymotion',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-dailymotion',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-dailymotion',
 				),
 			),
 		),
@@ -2491,7 +2742,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-ad',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
 				),
 			),
 			array(
@@ -2552,7 +2803,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_name' => 'amp-embed with data-multi-size attribute',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
 				),
 			),
 		),
@@ -2584,7 +2835,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-embedly-card',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-embedly-card',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-embedly-card',
 				),
 			),
 		),
@@ -2615,7 +2866,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-experiment',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-experiment',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
 					'unique' => true,
 				),
 			),
@@ -2898,7 +3149,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-gfycat',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-gfycat',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-gfycat',
 				),
 			),
 		),
@@ -2924,7 +3175,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-gist',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-gist',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-gist',
 				),
 			),
 		),
@@ -2965,7 +3216,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-google-document-embed',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-google-document-embed',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-google-document-embed',
 				),
 			),
 		),
@@ -2995,7 +3246,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-hulu',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-hulu',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-hulu',
 				),
 			),
 		),
@@ -3131,7 +3382,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-ima-video',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ima-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ima-video',
 				),
 			),
 		),
@@ -3194,7 +3445,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-image-slider',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-image-slider',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
 				),
 			),
 		),
@@ -3247,7 +3498,7 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
 				),
 			),
 		),
@@ -3461,7 +3712,7 @@ class AMP_Allowed_Tags_Generated {
 							5,
 						),
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-layout',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-layout',
 				),
 			),
 		),
@@ -3749,7 +4000,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page with inline config',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
 					'unique' => true,
 				),
 			),
@@ -3777,7 +4028,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page with src attribute',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
 					'unique' => true,
 				),
 			),
@@ -3807,7 +4058,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page [type=adsense]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
 					'unique' => true,
 				),
 			),
@@ -4044,7 +4295,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-pinterest',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-pinterest',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-pinterest',
 				),
 			),
 		),
@@ -4084,7 +4335,7 @@ class AMP_Allowed_Tags_Generated {
 							1,
 						),
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-pixel',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-pixel',
 				),
 			),
 		),
@@ -4203,7 +4454,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-powr-player',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-powr-player',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-powr-player',
 				),
 			),
 		),
@@ -4337,7 +4588,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-riddle-quiz',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-riddle-quiz',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-riddle-quiz',
 				),
 			),
 		),
@@ -4379,6 +4630,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-script',
 					),
+					'unique' => true,
 				),
 			),
 		),
@@ -4474,7 +4726,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-sidebar',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
 				),
 			),
 			array(
@@ -4490,7 +4742,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-sidebar',
 					),
 					'spec_name' => 'amp-story >> amp-sidebar',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-sidebar',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
 				),
 			),
 		),
@@ -4745,7 +4997,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-bind',
 					),
 					'spec_name' => 'amp-state',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-bind',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bind',
 				),
 			),
 		),
@@ -4906,7 +5158,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-story-auto-ads',
 					),
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story-auto-ads.md',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads',
 					'unique' => true,
 				),
 			),
@@ -5089,7 +5341,43 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-timeago',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-timeago',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-timeago',
+				),
+			),
+		),
+		'amp-truncate-text' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'overflow-style' => array(
+						'value' => array(
+							'right',
+							'default',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
+					'requires_extension' => array(
+						'amp-truncate-text',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-truncate-text',
 				),
 			),
 		),
@@ -5146,6 +5434,33 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-twitter',
 					),
+				),
+			),
+		),
+		'amp-user-location' => array(
+			array(
+				'attr_spec_list' => array(
+					'id' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'requires_extension' => array(
+						'amp-user-location',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
 				),
 			),
 		),
@@ -5305,7 +5620,7 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 						'amp-story',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
 				),
 			),
 			array(
@@ -5416,7 +5731,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video',
 					),
 					'spec_name' => 'amp-story >> amp-video',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
 				),
 			),
 		),
@@ -5494,7 +5809,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video-iframe',
 					),
 					'spec_name' => 'AMP-VIDEO-IFRAME[poster]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video-iframe',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe',
 				),
 			),
 			array(
@@ -5573,7 +5888,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-video-iframe',
 					),
 					'spec_name' => 'AMP-VIDEO-IFRAME with [placeholder]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video-iframe',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe',
 				),
 			),
 		),
@@ -5736,6 +6051,13 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
+					'service-worker-scope' => array(
+						'value_url' => array(
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
 					'service-worker-url' => array(
 						'mandatory' => true,
 						'value_url' => array(
@@ -5755,7 +6077,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-web-push',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-web-push',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-web-push',
 				),
 			),
 		),
@@ -5786,7 +6108,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-web-push',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-web-push',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-web-push',
 				),
 			),
 		),
@@ -5855,7 +6177,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-yotpo',
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-yotpo',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo',
 				),
 			),
 		),
@@ -5943,7 +6265,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-audio',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
 				),
 			),
 		),
@@ -6019,7 +6341,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => 'html',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -6167,7 +6489,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6257,7 +6579,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6293,7 +6615,7 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 		),
@@ -6382,7 +6704,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6417,7 +6739,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6570,7 +6892,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-image-slider',
 					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [first]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-image-slider',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
 				),
 			),
 			array(
@@ -6582,7 +6904,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-image-slider',
 					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [second]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-image-slider',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
 				),
 			),
 		),
@@ -6682,7 +7004,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6774,7 +7096,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6864,7 +7186,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -6947,7 +7269,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7033,7 +7355,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7116,7 +7438,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7134,7 +7456,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7220,7 +7542,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7348,7 +7670,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7564,7 +7886,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7651,7 +7973,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7753,7 +8075,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7811,7 +8133,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => 'html',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -7846,7 +8168,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -7862,7 +8184,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory' => true,
 					'mandatory_parent' => '!doctype',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -7916,7 +8238,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-iframe',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-iframe',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-iframe',
 				),
 			),
 		),
@@ -8024,7 +8346,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -8072,7 +8394,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-img',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
 				),
 			),
 		),
@@ -8140,7 +8462,7 @@ class AMP_Allowed_Tags_Generated {
 					'width' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 			array(
@@ -8211,7 +8533,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form [method=post]',
 					'spec_name' => 'INPUT [type=file]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 			array(
@@ -8277,7 +8599,26 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'form [method=post]',
 					'spec_name' => 'INPUT [type=password]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'search',
+							'text',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-autocomplete',
+					'requires_extension' => array(
+						'amp-autocomplete',
+						'amp-form',
+					),
+					'spec_name' => 'amp-autocomplete > input',
 				),
 			),
 			array(
@@ -8320,6 +8661,9 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 					),
 					'mask-output' => array(),
+					'mask-trim-zeros' => array(
+						'value_regex' => '\\d+',
+					),
 					'max' => array(),
 					'maxlength' => array(),
 					'min' => array(),
@@ -8352,7 +8696,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask] (custom mask)',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
 				),
 			),
 			array(
@@ -8429,7 +8773,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=payment-card]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
 				),
 			),
 			array(
@@ -8506,7 +8850,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-dd-mm-yyyy]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
 				),
 			),
 			array(
@@ -8583,7 +8927,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-mm-dd-yyyy]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
 				),
 			),
 			array(
@@ -8660,7 +9004,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-mm-yy]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
 				),
 			),
 			array(
@@ -8737,7 +9081,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-inputmask',
 					),
 					'spec_name' => 'input [mask=date-yyyy-mm-dd]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-inputmask',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inputmask',
 				),
 			),
 		),
@@ -8771,7 +9115,7 @@ class AMP_Allowed_Tags_Generated {
 					'for' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 		),
@@ -8875,7 +9219,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -8979,7 +9323,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -9009,7 +9353,7 @@ class AMP_Allowed_Tags_Generated {
 						'template',
 					),
 					'spec_name' => 'link rel=',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9048,7 +9392,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=canonical',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -9086,7 +9430,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=manifest',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9118,7 +9462,7 @@ class AMP_Allowed_Tags_Generated {
 						'template',
 					),
 					'spec_name' => 'link rel=preload',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9147,7 +9491,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'link rel=stylesheet for fonts',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#custom-fonts',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#custom-fonts',
 				),
 			),
 			array(
@@ -9177,7 +9521,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'link itemprop=sameAs',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9203,7 +9547,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'link itemprop=',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9229,7 +9573,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'spec_name' => 'link property=',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 		),
@@ -9335,7 +9679,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -9423,7 +9767,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -9442,7 +9786,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta charset=utf-8',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -9476,7 +9820,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=viewport',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -9504,7 +9848,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=X-UA-Compatible',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9524,7 +9868,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=apple-itunes-app',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9566,7 +9910,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-3p-iframe-src',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ad',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
 				),
 			),
 			array(
@@ -9726,7 +10070,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Type',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9745,7 +10089,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=content-language',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9764,7 +10108,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=pics-label',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9783,7 +10127,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=imagetoolbar',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9805,7 +10149,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Style-Type',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9827,7 +10171,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=Content-Script-Type',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9846,7 +10190,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=origin-trial',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9865,7 +10209,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=resource-type',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9888,7 +10232,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'head',
 					'spec_name' => 'meta http-equiv=x-dns-prefetch-control',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#html-tags',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags',
 				),
 			),
 			array(
@@ -9942,7 +10286,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10012,7 +10356,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'noscript enclosure for boilerplate',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites',
 					'unique' => true,
 				),
 			),
@@ -10060,7 +10404,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'select',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 		),
@@ -10077,7 +10421,7 @@ class AMP_Allowed_Tags_Generated {
 					'value' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 		),
@@ -10183,7 +10527,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10292,7 +10636,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10301,7 +10645,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(),
 				'tag_spec' => array(
 					'mandatory_parent' => 'noscript',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
 				),
 			),
 		),
@@ -10386,7 +10730,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10471,7 +10815,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10609,7 +10953,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10705,7 +11049,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -10778,7 +11122,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js script',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#required-markup',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
 			),
@@ -11119,6 +11463,32 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-ad-custom',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+					'spec_name' => 'amp-ad-custom extension .js script',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-ad',
 						'requires_usage' => 2,
@@ -11205,7 +11575,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-analytics',
 					),
 					'spec_name' => 'amp-analytics extension .json script',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-analytics',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics',
 				),
 			),
 			array(
@@ -11407,6 +11777,56 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-autocomplete',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'nonce' => array(),
+					'type' => array(
+						'dispatch_key' => 3,
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/json',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-autocomplete',
+					'requires_extension' => array(
+						'amp-autocomplete',
+					),
+					'spec_name' => 'amp-autocomplete JSON',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-base-carousel',
 						'version' => array(
 							'0.1',
@@ -11483,7 +11903,7 @@ class AMP_Allowed_Tags_Generated {
 						'regex' => '<!--',
 					),
 					'max_bytes' => 100000,
-					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/components/dynamic/amp-bind#state',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-bind#state',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-state',
@@ -11491,7 +11911,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-bind',
 					),
 					'spec_name' => 'amp-bind extension .json script',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-bind',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-bind',
 				),
 			),
 			array(
@@ -11644,6 +12064,31 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-carousel',
 						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-connatix-player',
 						'version' => array(
 							'0.1',
 							'latest',
@@ -11925,11 +12370,13 @@ class AMP_Allowed_Tags_Generated {
 						'error_message' => 'html comments',
 						'regex' => '<!--',
 					),
+					'max_bytes' => 15000,
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-experiment#configuration',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-experiment',
 					'spec_name' => 'amp-experiment extension .json script',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-experiment',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
 				),
 			),
 			array(
@@ -12216,7 +12663,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-geo',
 					),
 					'spec_name' => 'amp-geo extension .json script',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-geo',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-geo',
 				),
 			),
 			array(
@@ -12839,7 +13286,7 @@ class AMP_Allowed_Tags_Generated {
 						'deprecated_version' => array(
 							'0.1',
 						),
-						'is_custom_template' => true,
+						'extension_type' => 2,
 						'name' => 'amp-mustache',
 						'requires_usage' => 2,
 						'version' => array(
@@ -12929,7 +13376,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-next-page',
 					),
 					'spec_name' => 'amp-next-page extension .json configuration',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-next-page',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
 				),
 			),
 			array(
@@ -13551,7 +13998,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-story-auto-ads',
 					),
 					'spec_name' => 'amp-story-auto-ads config script',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/amp-story-auto-ads.md',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads',
 				),
 			),
 			array(
@@ -13758,6 +14205,31 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-truncate-text',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-twitter',
 						'requires_usage' => 2,
@@ -13766,6 +14238,57 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-user-location',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'nonce' => array(),
+					'type' => array(
+						'dispatch_key' => 3,
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/json',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-user-location',
+					'requires_extension' => array(
+						'amp-user-location',
+					),
+					'spec_name' => 'amp-user-location extension .json script',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
 				),
 			),
 			array(
@@ -14050,7 +14573,7 @@ class AMP_Allowed_Tags_Generated {
 							'latest',
 						),
 					),
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-yotpo',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo',
 				),
 			),
 			array(
@@ -14139,7 +14662,7 @@ class AMP_Allowed_Tags_Generated {
 					'size' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 		),
@@ -14235,7 +14758,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -14260,7 +14783,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'picture',
 					'spec_name' => 'picture > source',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-img',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-img',
 				),
 			),
 			array(
@@ -14282,7 +14805,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-video',
 					'spec_name' => 'amp-video > source',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
 				),
 			),
 			array(
@@ -14304,7 +14827,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-audio',
 					'spec_name' => 'amp-audio > source',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
 				),
 			),
 			array(
@@ -14327,7 +14850,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'audio',
 					'spec_name' => 'audio > source',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-audio',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-audio',
 				),
 			),
 			array(
@@ -14350,7 +14873,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'video',
 					'spec_name' => 'video > source',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
 				),
 			),
 			array(
@@ -14403,7 +14926,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'lineargradient',
 					'spec_name' => 'lineargradient > stop',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 			array(
@@ -14418,7 +14941,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'radialgradient',
 					'spec_name' => 'radialgradient > stop',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -14484,12 +15007,12 @@ class AMP_Allowed_Tags_Generated {
 						'validate_keyframes' => false,
 					),
 					'max_bytes' => 50000,
-					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#maximum-size',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'style amp-custom',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#stylesheets',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets',
 					'unique' => true,
 				),
 			),
@@ -14511,7 +15034,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'head > style[amp-boilerplate]',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites',
 					'unique' => true,
 				),
 			),
@@ -14534,7 +15057,7 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_ancestor' => 'head',
 					'mandatory_parent' => 'noscript',
 					'spec_name' => 'noscript > style[amp-boilerplate]',
-					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/spec/amp-boilerplate.md',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amp-boilerplate?format=websites',
 					'unique' => true,
 				),
 			),
@@ -14567,7 +15090,7 @@ class AMP_Allowed_Tags_Generated {
 						'validate_keyframes' => true,
 					),
 					'max_bytes' => 500000,
-					'max_bytes_spec_url' => 'https://www.ampproject.org/docs/reference/spec#keyframes-stylesheet',
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#keyframes-stylesheet',
 				),
 				'tag_spec' => array(
 					'mandatory_parent' => 'body',
@@ -14688,7 +15211,7 @@ class AMP_Allowed_Tags_Generated {
 					'zoomandpan' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -14769,7 +15292,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -14850,7 +15373,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -15083,7 +15606,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -15093,6 +15616,7 @@ class AMP_Allowed_Tags_Generated {
 					'[autocomplete]' => array(),
 					'[autofocus]' => array(),
 					'[cols]' => array(),
+					'[defaulttext]' => array(),
 					'[disabled]' => array(),
 					'[maxlength]' => array(),
 					'[minlength]' => array(),
@@ -15137,7 +15661,7 @@ class AMP_Allowed_Tags_Generated {
 					'wrap' => array(),
 				),
 				'tag_spec' => array(
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-form',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-form',
 				),
 			),
 		),
@@ -15240,7 +15764,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -15304,7 +15828,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
 					'spec_name' => 'svg title',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -15666,7 +16190,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'amp-ima-video',
 					'spec_name' => 'amp-ima-video > track[kind=subtitles]',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-ima-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-ima-video',
 				),
 			),
 		),
@@ -15766,7 +16290,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -15855,7 +16379,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -15978,7 +16502,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -16014,7 +16538,7 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-video',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
 				),
 			),
 		),
@@ -16036,7 +16560,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -16058,7 +16582,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'svg',
-					'spec_url' => 'https://www.ampproject.org/docs/reference/spec#svg',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#svg',
 				),
 			),
 		),
@@ -16219,6 +16743,7 @@ class AMP_Allowed_Tags_Generated {
 		'resource' => array(),
 		'rev' => array(),
 		'role' => array(),
+		'slot' => array(),
 		'style' => array(
 			'blacklisted_value_regex' => '(!\\s*important|<!--)',
 		),
@@ -16346,7 +16871,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-LIVE-LIST [items]',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#items',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#items',
 			),
 		),
 		'AMP-LIVE-LIST [items] item' => array(
@@ -16363,7 +16888,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [items] item',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#items',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#items',
 			),
 		),
 		'AMP-LIVE-LIST [pagination]' => array(
@@ -16374,7 +16899,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [pagination]',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#pagination',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#pagination',
 			),
 		),
 		'AMP-LIVE-LIST [update]' => array(
@@ -16385,7 +16910,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [update]',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-live-list#update',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#update',
 			),
 		),
 		'AMP-NEXT-PAGE > [separator]' => array(
@@ -16433,7 +16958,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-SELECTOR option',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-selector',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-selector',
 			),
 		),
 		'AMP-STORY-CTA-LAYER animate-in' => array(
@@ -16485,7 +17010,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-STORY-CTA-LAYER animate-in',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
 			),
 		),
 		'AMP-STORY-GRID-LAYER animate-in' => array(
@@ -16556,7 +17081,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-STORY-GRID-LAYER animate-in',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
 			),
 		),
 		'AMP-STORY-GRID-LAYER default' => array(
@@ -16682,9 +17207,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'spec_name' => 'AMP-STORY-GRID-LAYER default',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-story',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-story',
 			),
 		),
+		'AMP-VIDEO-IFRAME > I-AMPHTML-SIZER [style]' => NULL,
 		'AMP-VIDEO-IFRAME > [placeholder]' => array(
 			'attr_spec_list' => array(
 				'placeholder' => array(
@@ -16693,7 +17219,7 @@ class AMP_Allowed_Tags_Generated {
 			),
 			'tag_spec' => array(
 				'spec_name' => 'AMP-VIDEO-IFRAME > [placeholder]',
-				'spec_url' => 'https://www.ampproject.org/docs/reference/components/amp-video-iframe',
+				'spec_url' => 'https://amp.dev/documentation/components/amp-video-iframe',
 			),
 		),
 	);

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -284,6 +284,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 								<amp-story-grid-layer template="fill">
 									<amp-img id="object1" animate-in="rotate-in-left" src="https://example.ampproject.org/helloworld/bg1.jpg" width="900" height="1600">
 									</amp-img>
+									<!-- Note: The viewbox attribute must currently be lower-case due to https://github.com/ampproject/amp-wp/issues/2045 -->
+									<svg viewbox="0 0 100 100"><circle cx="50" cy="50" r="50"></circle></svg>
 								</amp-story-grid-layer>
 								<amp-story-grid-layer template="vertical">
 									<h1 animate-in="fly-in-left" animate-in-duration="0.5s" animate-in-delay="0.4s" animate-in-after="object1">Hello, amp-story!</h1>
@@ -1291,7 +1293,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			),
 
 			'amp-input-mask' => array(
-				'<form method="post" class="p2" action-xhr="/components/amp-inputmask/postal" target="_top"><label>Postal code: <input name="code" mask="L0L_0L0" placeholder="A1A 1A1"></label><input type="submit"><div submit-success><template type="amp-mustache"><p>You submitted: {{code}}</p></template></div></form>',
+				'<form method="post" class="p2" action-xhr="/components/amp-inputmask/postal" target="_top"><label>Postal code: <input name="code" mask="L0L_0L0" mask-trim-zeros="3" placeholder="A1A 1A1"></label><input type="submit"><div submit-success><template type="amp-mustache"><p>You submitted: {{code}}</p></template></div></form>',
 				null,
 				array( 'amp-form', 'amp-inputmask', 'amp-mustache' ),
 			),
@@ -1302,10 +1304,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array(),
 			),
 
-			'amp_textarea_with_autoexpand' => array(
-				'<textarea name="with-autoexpand" autoexpand></textarea>',
+			'amp_textarea_with_autoexpand_and_defaulttext' => array(
+				'<textarea name="with-autoexpand" autoexpand [defaulttext]="hello" [text]="goodbye">hello</textarea>',
 				null,
-				array( 'amp-form' ),
+				array( 'amp-form', 'amp-bind' ),
 			),
 
 			'amp-viqeo-player' => array(
@@ -1478,6 +1480,50 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				array( 'amp-geo' ),
 				array( 'duplicate_element' ),
 			),
+
+			'amp-autocomplete' => array(
+				'
+					<form method="post" action-xhr="/form/echo-json/post" target="_blank" on="submit-success:AMP.setState({result: event.response})">
+						<amp-autocomplete id="autocomplete" filter="substring" min-characters="0">
+							<input type="text" id="input">
+							<script type="application/json" id="script">
+							{ "items" : ["apple", "banana", "orange"] }
+							</script>
+						</amp-autocomplete>
+					</form>
+				',
+				null,
+				array( 'amp-form', 'amp-autocomplete' ),
+			),
+
+			'amp-connatix-player' => array(
+				'<amp-connatix-player data-player-id="03ef71d8-0941-4bff-94f2-74ca3580b497" layout="responsive" width="16" height="9"></amp-connatix-player>',
+				null,
+				array( 'amp-connatix-player' ),
+			),
+
+			'amp-truncate-text' => array(
+				'
+					<amp-truncate-text layout="fixed" height="3em" width="20em">
+						Some text that may get truncated.
+						<button slot="expand">See more</button>
+						<button slot="collapse">See less</button>
+					</amp-truncate-text>
+				',
+				null,
+				array( 'amp-truncate-text' ),
+			),
+
+			'amp-user-location' => array(
+				'
+					<button on="tap: location.request()">Use my location</button>
+					<amp-user-location id="location" on="approve:AMP.setState({located: true})" layout="nodisplay">
+					</amp-user-location>
+				',
+				null,
+				array( 'amp-user-location' ),
+			),
+
 		);
 	}
 

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -1436,10 +1436,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 							<button id="img">Insert &lt;img&gt;</button>
 						</div>
 					</amp-script>
-					
-					<amp-script layout="container" src="https://example.com/examples/amp-script/empty.js">
-						<div class="root">should be empty</div>
-					</amp-script>
 				',
 				null,
 				array( 'amp-script' ),
@@ -1448,6 +1444,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'
 					<amp-script src="https://example.com/examples/amp-script/todomvc.ssr.js" layout="container">
 						<div><header class="header"><h1>todos</h1><input class="new-todo" placeholder="What needs to be done?" autofocus="true"></header></div>
+					</amp-script>
+				',
+				null,
+				array( 'amp-script' ),
+			),
+
+			'amp-script-4' => array(
+				'
+					<amp-script layout="container" src="https://example.com/examples/amp-script/empty.js">
+						<div class="root">should be empty</div>
 					</amp-script>
 				',
 				null,


### PR DESCRIPTION
Previously #2297.

- [x] Run `./bin/amphtml-update.sh`
- [x] Examine diff for changelog
- [x] Update spec generator as needed based on spec format changes
- [x] Modify validating sanitizer based on changes to spec, if needed
- [x] Add tests for key changes
- [x] ~Add support for components requiring an origin trial token.~ See #2551.


# Changelog

* Allow SVG inside of Stories
* Introduce `amp-ad-custom` (docs for this seem absent)
* Introduce [`amp-autocomplete`](https://amp.dev/documentation/components/amp-autocomplete) with  its dedicated `input` field
* Introduce [`amp-connatix-player`](https://amp.dev/documentation/components/amp-connatix-player?format=websites)
* Introduce [`amp-truncate-text`](https://amp.dev/documentation/components/amp-truncate-text?format=websites), add `slot` to globally allowed attributes.
* Introduce [`amp-user-location`](https://amp.dev/documentation/components/amp-user-location?format=websites)
* Add [`mask-trim-zeros`](https://amp.dev/documentation/components/amp-inputmask?format=websites#mask-trim-zeros) to `input` for `amp-inputmask`
* Add amp-bind `[defaulttext]` attribute to `textarea` (https://github.com/ampproject/amphtml/issues/21053)
* Update `amp-script`:
  * This is the first update to the spec after `amp-script` has been uncommented from the validator (https://github.com/ampproject/amphtml/pull/22413)
  * Add `unique` constraint.
