### PR TITLE
Improve display of duplicated pages

### DIFF
--- a/assets/src/stories-editor/index.js
+++ b/assets/src/stories-editor/index.js
@@ -280,16 +280,13 @@ store.subscribe( () => {
 	 * Prevent an issue where duplicated page blocks had the same anchor attribute, and didn't look right on the front-end.
 	 * @see https://github.com/ampproject/amp-wp/issues/2510
 	 */
-	const usedAnchors = [];
 	const conditionallyUpdateAnchor = ( block ) => {
 		if ( ! has( block, [ 'attributes', 'anchor' ] ) ) {
 			return;
 		}
 
-		if ( usedAnchors.includes( block.attributes.anchor ) ) {
+		if ( block.attributes.anchor !== block.clientId ) {
 			updateBlockAttributes( block.clientId, { anchor: block.clientId } );
-		} else {
-			usedAnchors.push( block.attributes.anchor );
 		}
 	};
 

--- a/assets/src/stories-editor/index.js
+++ b/assets/src/stories-editor/index.js
@@ -277,7 +277,7 @@ store.subscribe( () => {
 	}
 
 	/*
-	 * Prevent an issue where cloned pages had the same anchor attribute, and didn't look right on the front-end.
+	 * Prevent an issue where duplicated page blocks had the same anchor attribute, and didn't look right on the front-end.
 	 * @see https://github.com/ampproject/amp-wp/issues/2510
 	 */
 	const usedAnchors = [];

--- a/assets/src/stories-editor/index.js
+++ b/assets/src/stories-editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { has } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
@@ -63,6 +68,7 @@ const {
 	getBlockRootClientId,
 	getBlockOrder,
 	getBlock,
+	getBlocks,
 	getBlockAttributes,
 } = select( 'core/block-editor' );
 
@@ -268,6 +274,28 @@ store.subscribe( () => {
 				ampAnimationDelay: delay,
 			} );
 		}
+	}
+
+	/*
+	 * Prevent an issue where cloned pages had the same anchor attribute, and didn't look right on the front-end.
+	 * @see https://github.com/ampproject/amp-wp/issues/2510
+	 */
+	const usedAnchors = [];
+	const conditionallyUpdateAnchor = ( block ) => {
+		if ( ! has( block, [ 'attributes', 'anchor' ] ) ) {
+			return;
+		}
+
+		if ( usedAnchors.includes( block.attributes.anchor ) ) {
+			updateBlockAttributes( block.clientId, { anchor: block.clientId } );
+		} else {
+			usedAnchors.push( block.attributes.anchor );
+		}
+	};
+
+	const blocksToVerifyAnchor = getBlocks();
+	for ( const blockToVerifyAnchor of blocksToVerifyAnchor ) {
+		conditionallyUpdateAnchor( blockToVerifyAnchor );
 	}
 } );
 


### PR DESCRIPTION
# Before
The `amp-story-page[id]` was the same in both the duplicated page and the original page (thanks to @swissspidy for pointing to the `anchor` attribute in #2510).

<img width="1434" alt="before-here" src="https://user-images.githubusercontent.com/4063887/59073242-e11b3880-888b-11e9-8c03-307ae5ee9006.png">

This [is set from the anchor attribute](https://github.com/ampproject/amp-wp/blob/bf82129e1636ecb945f0675f951112b1d74e5cdd/assets/src/stories-editor/blocks/amp-story-page/save.js#L51) in the block.

# After
So if the `anchor` attribute is the same for two pages, this resets it on the duplicated one to the same as its `clientId`:

![duplicating-blocks](https://user-images.githubusercontent.com/4063887/59072988-af55a200-888a-11e9-8cdd-ff58cc692950.gif)

Fixes #2510