### PR TITLE
Set video poster with timeout

### DIFF
--- a/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/block-editor';
 import { getBlockType } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { compose, createHigherOrderComponent } from '@wordpress/compose';
+import { compose, createHigherOrderComponent, withSafeTimeout } from '@wordpress/compose';
 import {
 	IconButton,
 	PanelBody,
@@ -174,6 +174,7 @@ const enhance = compose(
 	applyFallbackStyles,
 	applyWithSelect,
 	applyWithDispatch,
+	withSafeTimeout,
 );
 
 export default createHigherOrderComponent(
@@ -210,6 +211,7 @@ export default createHigherOrderComponent(
 				sendBackward,
 				moveFront,
 				moveBack,
+				setTimeout,
 			} = props;
 
 			const isChildBlock = ALLOWED_CHILD_BLOCKS.includes( name );
@@ -242,7 +244,9 @@ export default createHigherOrderComponent(
 
 			// If we have a video set from an attachment but there is no poster, use the featured image of the video if available.
 			if ( isVideoBlock && videoFeaturedImage ) {
-				setAttributes( { poster: videoFeaturedImage.source_url } );
+				setTimeout( () => {
+					setAttributes( { poster: videoFeaturedImage.source_url } );
+				}, 100 );
 			}
 
 			const isEmptyImageBlock = isImageBlock && ( ! attributes.url || ! attributes.url.length );


### PR DESCRIPTION
Fixes #2517.

Note that his is quite the workaround to fix this bug.

I came to the conclusion that 2a430d4b19dc13bda3408f2ee987c485db3c4c7a was not the right approach as we shouldn't be doing this `setAttributes` call in `withAmpStorySettings` in the first place.

Ideally, we'd use a listener somewhere else, or query the DOM to see if the video player is already there (not so nice), or try to extend the video block's edit component if possible (which I doubt). The latter would be needed for #2530 too.