### PR TITLE
Guard against race condition when importing story templates after version bump

### DIFF
--- a/includes/admin/class-amp-story-templates.php
+++ b/includes/admin/class-amp-story-templates.php
@@ -105,8 +105,8 @@ class AMP_Story_Templates {
 		if ( self::STORY_TEMPLATES_VERSION === AMP_Options_Manager::get_option( 'story_templates_version' ) ) {
 			return;
 		}
-		$this->import_story_templates();
 		AMP_Options_Manager::update_option( 'story_templates_version', self::STORY_TEMPLATES_VERSION );
+		$this->import_story_templates();
 	}
 
 	/**


### PR DESCRIPTION
Since importing story templates can take a couple seconds, this will prevent a race condition where a second set of stories are imported before the first set is completed importing.