### PR TITLE
Refactor AMP modes

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -517,7 +517,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *
  *      add_theme_support( AMP_Theme_Support::SLUG );
  *
- * This will serve templates in native AMP, allowing you to use AMP components in your theme templates.
+ * This will serve templates in AMP-first, allowing you to use AMP components in your theme templates.
  * If you want to make available in transitional mode, where templates are served in AMP or non-AMP documents, do:
  *
  *      add_theme_support( AMP_Theme_Support::SLUG, array(
@@ -530,7 +530,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *          'template_dir' => 'amp',
  *      ) );
  *
- * If you want to have AMP-specific templates in addition to serving native AMP, do:
+ * If you want to have AMP-specific templates in addition to serving AMP-first, do:
  *
  *      add_theme_support( AMP_Theme_Support::SLUG, array(
  *          'paired'       => false,
@@ -553,7 +553,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *      ) );
  *
  * @see AMP_Theme_Support::read_theme_support()
- * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is native and there is not separate AMP URL current URL.
+ * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is AMP-first and there is not separate AMP URL current URL.
  */
 function amp_is_canonical() {
 	if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {

--- a/amp.php
+++ b/amp.php
@@ -278,7 +278,7 @@ function amp_deactivate() {
 		}
 	}
 
-	flush_rewrite_rules();
+	flush_rewrite_rules( false );
 }
 
 /*

--- a/amp.php
+++ b/amp.php
@@ -343,6 +343,7 @@ function amp_init() {
 	add_action( 'admin_init', 'AMP_Options_Manager::register_settings' );
 	add_action( 'wp_loaded', 'amp_add_options_menu' );
 	add_action( 'wp_loaded', 'amp_admin_pointer' );
+	add_action( 'wp_loaded', 'amp_post_meta_box' ); // Used in both Website and Stories experiences.
 
 	if ( AMP_Options_Manager::is_website_experience_enabled() ) {
 		add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
@@ -351,7 +352,6 @@ function amp_init() {
 		add_action( 'parse_query', 'amp_correct_query_when_is_front_page' );
 		add_action( 'admin_bar_menu', 'amp_add_admin_bar_view_link', 100 );
 		add_action( 'wp_loaded', 'amp_editor_core_blocks' );
-		add_action( 'wp_loaded', 'amp_post_meta_box' );
 		add_filter( 'request', 'amp_force_query_var_value' );
 
 		// Add actions for reader mode templates.

--- a/amp.php
+++ b/amp.php
@@ -561,8 +561,8 @@ function amp_is_canonical() {
 	}
 
 	$args = AMP_Theme_Support::get_theme_support_args();
-	if ( isset( $args['paired'] ) ) {
-		return empty( $args['paired'] );
+	if ( isset( $args[ AMP_Theme_Support::PAIRED_FLAG ] ) ) {
+		return empty( $args[ AMP_Theme_Support::PAIRED_FLAG ] );
 	}
 
 	// If there is a template_dir, then transitional mode is implied.

--- a/amp.php
+++ b/amp.php
@@ -553,7 +553,7 @@ function amp_correct_query_when_is_front_page( WP_Query $query ) {
  *      ) );
  *
  * @see AMP_Theme_Support::read_theme_support()
- * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is AMP-first and there is not separate AMP URL current URL.
+ * @return boolean Whether this is in AMP 'canonical' mode, that is whether it is AMP-first and there is not a separate (paired) AMP URL.
  */
 function amp_is_canonical() {
 	if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {

--- a/assets/src/block-editor/index.js
+++ b/assets/src/block-editor/index.js
@@ -16,20 +16,23 @@ import './store';
 
 const { ampLatestStoriesBlockData } = window;
 
-addFilter( 'blocks.registerBlockType', 'ampEditorBlocks/addAttributes', addAMPAttributes );
-addFilter( 'blocks.getSaveElement', 'ampEditorBlocks/filterSave', filterBlocksSave );
-addFilter( 'editor.BlockEdit', 'ampEditorBlocks/filterEdit', filterBlocksEdit, 20 );
-addFilter( 'blocks.getSaveContent.extraProps', 'ampEditorBlocks/addExtraAttributes', addAMPExtraProps );
-addFilter( 'editor.PostFeaturedImage', 'ampEditorBlocks/withFeaturedImageNotice', withFeaturedImageNotice );
-addFilter( 'editor.MediaUpload', 'ampEditorBlocks/addCroppedFeaturedImage', ( InitialMediaUpload ) => withCroppedFeaturedImage( InitialMediaUpload, getMinimumFeaturedImageDimensions() ) );
+// Add filters if AMP for Website experience is enabled.
+if ( select( 'amp/block-editor' ).isWebsiteEnabled() ) {
+	addFilter( 'blocks.registerBlockType', 'ampEditorBlocks/addAttributes', addAMPAttributes );
+	addFilter( 'blocks.getSaveElement', 'ampEditorBlocks/filterSave', filterBlocksSave );
+	addFilter( 'editor.BlockEdit', 'ampEditorBlocks/filterEdit', filterBlocksEdit, 20 );
+	addFilter( 'blocks.getSaveContent.extraProps', 'ampEditorBlocks/addExtraAttributes', addAMPExtraProps );
+	addFilter( 'editor.PostFeaturedImage', 'ampEditorBlocks/withFeaturedImageNotice', withFeaturedImageNotice );
+	addFilter( 'editor.MediaUpload', 'ampEditorBlocks/addCroppedFeaturedImage', ( InitialMediaUpload ) => withCroppedFeaturedImage( InitialMediaUpload, getMinimumFeaturedImageDimensions() ) );
 
-const plugins = require.context( './plugins', true, /.*\.js$/ );
+	const plugins = require.context( './plugins', true, /.*\.js$/ );
 
-plugins.keys().forEach( ( modulePath ) => {
-	const { name, render, icon } = plugins( modulePath );
+	plugins.keys().forEach( ( modulePath ) => {
+		const { name, render, icon } = plugins( modulePath );
 
-	registerPlugin( name, { icon, render } );
-} );
+		registerPlugin( name, { icon, render } );
+	} );
+}
 
 /*
  * If there's no theme support, unregister blocks that are only meant for AMP.
@@ -52,14 +55,24 @@ const blocks = require.context( './blocks', true, /(?<!test\/)index\.js$/ );
 blocks.keys().forEach( ( modulePath ) => {
 	const { name, settings } = blocks( modulePath );
 
-	// Prevent registering latest-stories block if not enabled.
-	if ( 'amp/amp-latest-stories' === name && typeof ampLatestStoriesBlockData === 'undefined' ) {
-		return;
-	}
+	const isLatestStoriesBlock = 'amp/amp-latest-stories' === name;
 
-	const blockRequiresAmp = AMP_DEPENDENT_BLOCKS.includes( name );
+	const shouldRegister = (
+		(
+			select( 'amp/block-editor' ).isWebsiteEnabled() &&
+			(
+				( ! isLatestStoriesBlock && select( 'amp/block-editor' ).isStandardMode() && AMP_DEPENDENT_BLOCKS.includes( name ) ) ||
+				( isLatestStoriesBlock && select( 'amp/block-editor' ).isStoriesEnabled() )
+			)
+		) ||
+		(
+			select( 'amp/block-editor' ).isStoriesEnabled() &&
+			isLatestStoriesBlock &&
+			typeof ampLatestStoriesBlockData !== 'undefined'
+		)
+	);
 
-	if ( ! blockRequiresAmp || select( 'amp/block-editor' ).isNativeAMP() ) {
+	if ( shouldRegister ) {
 		registerBlockType( name, settings );
 	}
 } );

--- a/assets/src/block-editor/index.js
+++ b/assets/src/block-editor/index.js
@@ -14,17 +14,16 @@ import { addAMPAttributes, addAMPExtraProps, filterBlocksEdit, filterBlocksSave 
 import { getMinimumFeaturedImageDimensions } from '../common/helpers';
 import './store';
 
+const {
+	isWebsiteEnabled,
+	isStoriesEnabled,
+	isStandardMode,
+} = select( 'amp/block-editor' );
+
 const { ampLatestStoriesBlockData } = window;
 
 // Add filters if AMP for Website experience is enabled.
-if ( select( 'amp/block-editor' ).isWebsiteEnabled() ) {
-	addFilter( 'blocks.registerBlockType', 'ampEditorBlocks/addAttributes', addAMPAttributes );
-	addFilter( 'blocks.getSaveElement', 'ampEditorBlocks/filterSave', filterBlocksSave );
-	addFilter( 'editor.BlockEdit', 'ampEditorBlocks/filterEdit', filterBlocksEdit, 20 );
-	addFilter( 'blocks.getSaveContent.extraProps', 'ampEditorBlocks/addExtraAttributes', addAMPExtraProps );
-	addFilter( 'editor.PostFeaturedImage', 'ampEditorBlocks/withFeaturedImageNotice', withFeaturedImageNotice );
-	addFilter( 'editor.MediaUpload', 'ampEditorBlocks/addCroppedFeaturedImage', ( InitialMediaUpload ) => withCroppedFeaturedImage( InitialMediaUpload, getMinimumFeaturedImageDimensions() ) );
-
+if ( isWebsiteEnabled() ) {
 	const plugins = require.context( './plugins', true, /.*\.js$/ );
 
 	plugins.keys().forEach( ( modulePath ) => {
@@ -32,6 +31,13 @@ if ( select( 'amp/block-editor' ).isWebsiteEnabled() ) {
 
 		registerPlugin( name, { icon, render } );
 	} );
+
+	addFilter( 'blocks.registerBlockType', 'ampEditorBlocks/addAttributes', addAMPAttributes );
+	addFilter( 'blocks.getSaveElement', 'ampEditorBlocks/filterSave', filterBlocksSave );
+	addFilter( 'editor.BlockEdit', 'ampEditorBlocks/filterEdit', filterBlocksEdit, 20 );
+	addFilter( 'blocks.getSaveContent.extraProps', 'ampEditorBlocks/addExtraAttributes', addAMPExtraProps );
+	addFilter( 'editor.PostFeaturedImage', 'ampEditorBlocks/withFeaturedImageNotice', withFeaturedImageNotice );
+	addFilter( 'editor.MediaUpload', 'ampEditorBlocks/addCroppedFeaturedImage', ( InitialMediaUpload ) => withCroppedFeaturedImage( InitialMediaUpload, getMinimumFeaturedImageDimensions() ) );
 }
 
 /*
@@ -59,16 +65,10 @@ blocks.keys().forEach( ( modulePath ) => {
 
 	const shouldRegister = (
 		(
-			select( 'amp/block-editor' ).isWebsiteEnabled() &&
-			(
-				( ! isLatestStoriesBlock && select( 'amp/block-editor' ).isStandardMode() && AMP_DEPENDENT_BLOCKS.includes( name ) ) ||
-				( isLatestStoriesBlock && select( 'amp/block-editor' ).isStoriesEnabled() )
-			)
+			isWebsiteEnabled() && isStandardMode() && AMP_DEPENDENT_BLOCKS.includes( name )
 		) ||
 		(
-			select( 'amp/block-editor' ).isStoriesEnabled() &&
-			isLatestStoriesBlock &&
-			typeof ampLatestStoriesBlockData !== 'undefined'
+			isStoriesEnabled() && isLatestStoriesBlock && typeof ampLatestStoriesBlockData !== 'undefined'
 		)
 	);
 

--- a/assets/src/block-editor/store/selectors.js
+++ b/assets/src/block-editor/store/selectors.js
@@ -26,7 +26,7 @@ export function hasThemeSupport( state ) {
  *
  * @param {Object} state Editor state.
  *
- * @return {boolean} Whether the current site uses AMP first.
+ * @return {boolean} Whether the current site is AMP first.
  */
 export function isStandardMode( state ) {
 	return Boolean( state.isStandardMode );

--- a/assets/src/block-editor/store/selectors.js
+++ b/assets/src/block-editor/store/selectors.js
@@ -22,16 +22,36 @@ export function hasThemeSupport( state ) {
 }
 
 /**
- * Returns whether the current site uses AMP first (as opposed to paired).
- *
- * @todo Rename to isStandardAMP or isAMPFirst?
+ * Returns whether the current site is in Standard mode (AMP first) as opposed to Transitional (paired).
  *
  * @param {Object} state Editor state.
  *
  * @return {boolean} Whether the current site uses AMP first.
  */
-export function isNativeAMP( state ) {
-	return Boolean( state.isNativeAMP );
+export function isStandardMode( state ) {
+	return Boolean( state.isStandardMode );
+}
+
+/**
+ * Returns whether the website experience is enabled.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether website experienced enabled.
+ */
+export function isWebsiteEnabled( state ) {
+	return Boolean( state.isWebsiteEnabled );
+}
+
+/**
+ * Returns whether the stories experience is enabled.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Whether stories experienced enabled.
+ */
+export function isStoriesEnabled( state ) {
+	return Boolean( state.isStoriesEnabled );
 }
 
 export function getDefaultStatus( state ) {

--- a/assets/src/block-editor/store/selectors.js
+++ b/assets/src/block-editor/store/selectors.js
@@ -22,11 +22,13 @@ export function hasThemeSupport( state ) {
 }
 
 /**
- * Returns whether the current site uses native AMP.
+ * Returns whether the current site uses AMP first (as opposed to paired).
+ *
+ * @todo Rename to isStandardAMP or isAMPFirst?
  *
  * @param {Object} state Editor state.
  *
- * @return {boolean} Whether the current site uses native AMP.
+ * @return {boolean} Whether the current site uses AMP first.
  */
 export function isNativeAMP( state ) {
 	return Boolean( state.isNativeAMP );

--- a/assets/src/block-editor/store/selectors.js
+++ b/assets/src/block-editor/store/selectors.js
@@ -10,11 +10,11 @@ export function hasThemeSupport( state ) {
 }
 
 /**
- * Returns whether the current site is in Standard mode (AMP first) as opposed to Transitional (paired).
+ * Returns whether the current site is in Standard mode (AMP-first) as opposed to Transitional (paired).
  *
  * @param {Object} state Editor state.
  *
- * @return {boolean} Whether the current site is AMP first.
+ * @return {boolean} Whether the current site is AMP-first.
  */
 export function isStandardMode( state ) {
 	return Boolean( state.isStandardMode );

--- a/assets/src/block-editor/store/selectors.js
+++ b/assets/src/block-editor/store/selectors.js
@@ -1,16 +1,4 @@
 /**
- * Returns the block validation errors for a given clientId.
- *
- * @param {Object} state    Editor state.
- * @param {string} clientId Block client ID.
- *
- * @return {Array} Block validation errors.
- */
-export function getBlockValidationErrors( state, clientId ) {
-	return state.errorsByClientId[ clientId ] || [];
-}
-
-/**
  * Returns whether the current theme has AMP support.
  *
  * @param {Object} state Editor state.
@@ -54,10 +42,24 @@ export function isStoriesEnabled( state ) {
 	return Boolean( state.isStoriesEnabled );
 }
 
+/**
+ * Returns the default AMP status.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string} The default AMP status.
+ */
 export function getDefaultStatus( state ) {
 	return state.defaultStatus;
 }
 
+/**
+ * Returns the possible AMP statuses.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string[]} The possible AMP statuses, 'enabled' and 'disabled'.
+ */
 export function getPossibleStatuses( state ) {
 	return state.possibleStatuses;
 }

--- a/assets/src/block-editor/store/test/selectors.js
+++ b/assets/src/block-editor/store/test/selectors.js
@@ -2,11 +2,47 @@
  * Internal dependencies
  */
 import {
+	hasThemeSupport,
+	isStandardMode,
+	isWebsiteEnabled,
+	isStoriesEnabled,
 	getDefaultStatus,
 	getPossibleStatuses,
 } from '../selectors';
 
 describe( 'selectors', () => {
+	describe( 'hasThemeSupport', () => {
+		it( 'should return whether the theme has AMP support', () => {
+			const state = { hasThemeSupport: false };
+
+			expect( hasThemeSupport( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isStandardMode', () => {
+		it( 'should return whether standard mode is enabled', () => {
+			const state = { isStandardMode: true };
+
+			expect( isStandardMode( state ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'isWebsiteEnabled', () => {
+		it( 'should return whether the website format is enabled', () => {
+			const state = { isWebsiteEnabled: false };
+
+			expect( isWebsiteEnabled( state ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isStoriesEnabled', () => {
+		it( 'should return whether the stories format is enabled', () => {
+			const state = { isStoriesEnabled: false };
+
+			expect( isStoriesEnabled( state ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'getDefaultStatus', () => {
 		it( 'should return the default AMP status', () => {
 			const state = { defaultStatus: 'enabled' };

--- a/assets/src/block-validation/helpers/index.js
+++ b/assets/src/block-validation/helpers/index.js
@@ -154,6 +154,7 @@ export const updateValidationErrors = () => {
 export const maybeDisplayNotice = () => {
 	const { getValidationErrors, isSanitizationAutoAccepted, getReviewLink } = select( 'amp/block-validation' );
 	const { createWarningNotice } = dispatch( 'core/notices' );
+	const { getCurrentPost } = select( 'core/editor' );
 
 	const validationErrors = getValidationErrors();
 	const validationErrorCount = validationErrors.length;
@@ -174,54 +175,56 @@ export const maybeDisplayNotice = () => {
 	const blockValidationErrors = validationErrors.filter( ( { clientId } ) => clientId );
 	const blockValidationErrorCount = blockValidationErrors.length;
 
-	if ( blockValidationErrorCount > 0 ) {
-		noticeMessage += ' ' + sprintf(
-			/* translators: %s: number of block errors. */
-			_n(
-				'%s issue is directly due to content here.',
-				'%s issues are directly due to content here.',
-				blockValidationErrorCount,
-				'amp'
-			),
-			blockValidationErrorCount
-		);
-	} else if ( validationErrors.length === 1 ) {
-		noticeMessage += ' ' + __( 'The issue is not directly due to content here.', 'amp' );
-	} else {
-		noticeMessage += ' ' + __( 'The issues are not directly due to content here.', 'amp' );
-	}
-
-	noticeMessage += ' ';
-
-	if ( isSanitizationAutoAccepted() ) {
-		const rejectedBlockValidationErrors = blockValidationErrors.filter( ( error ) => {
-			return (
-				VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
-				VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
+	if ( 'amp_story' !== getCurrentPost().type ) {
+		if ( blockValidationErrorCount > 0 ) {
+			noticeMessage += ' ' + sprintf(
+				/* translators: %s: number of block errors. */
+				_n(
+					'%s issue is directly due to content here.',
+					'%s issues are directly due to content here.',
+					blockValidationErrorCount,
+					'amp'
+				),
+				blockValidationErrorCount
 			);
-		} );
-
-		const rejectedValidationErrors = validationErrors.filter( ( error ) => {
-			return (
-				VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
-				VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
-			);
-		} );
-
-		const totalRejectedErrorsCount = rejectedBlockValidationErrors.length + rejectedValidationErrors.length;
-
-		if ( totalRejectedErrorsCount === 0 ) {
-			noticeMessage += __( 'However, your site is configured to automatically accept sanitization of the offending markup.', 'amp' );
+		} else if ( validationErrors.length === 1 ) {
+			noticeMessage += ' ' + __( 'The issue is not directly due to content here.', 'amp' );
 		} else {
-			noticeMessage += _n(
-				'Your site is configured to automatically accept sanitization errors, but this error could be from when auto-acceptance was not selected, or from manually rejecting an error.',
-				'Your site is configured to automatically accept sanitization errors, but these errors could be from when auto-acceptance was not selected, or from manually rejecting an error.',
-				validationErrors.length,
-				'amp'
-			);
+			noticeMessage += ' ' + __( 'The issues are not directly due to content here.', 'amp' );
 		}
-	} else {
-		noticeMessage += __( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
+
+		noticeMessage += ' ';
+
+		if ( isSanitizationAutoAccepted() ) {
+			const rejectedBlockValidationErrors = blockValidationErrors.filter( ( error ) => {
+				return (
+					VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
+					VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
+				);
+			} );
+
+			const rejectedValidationErrors = validationErrors.filter( ( error ) => {
+				return (
+					VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
+					VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
+				);
+			} );
+
+			const totalRejectedErrorsCount = rejectedBlockValidationErrors.length + rejectedValidationErrors.length;
+
+			if ( totalRejectedErrorsCount === 0 ) {
+				noticeMessage += __( 'However, your site is configured to automatically accept sanitization of the offending markup.', 'amp' );
+			} else {
+				noticeMessage += _n(
+					'Your site is configured to automatically accept sanitization errors, but this error could be from when auto-acceptance was not selected, or from manually rejecting an error.',
+					'Your site is configured to automatically accept sanitization errors, but these errors could be from when auto-acceptance was not selected, or from manually rejecting an error.',
+					validationErrors.length,
+					'amp'
+				);
+			}
+		} else {
+			noticeMessage += __( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
+		}
 	}
 
 	const options = {

--- a/assets/src/block-validation/store/selectors.js
+++ b/assets/src/block-validation/store/selectors.js
@@ -35,7 +35,7 @@ export function getReviewLink( state ) {
 /**
  * Returns whether sanitization errors are auto-accepted.
  *
- * Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in Native mode.
+ * Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in Standard mode.
  *
  * @param {Object} state Editor state.
  *

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -87,7 +87,7 @@ class AMP_Admin_Pointers {
 						if ( 'toplevel_page_amp-options' === $hook_suffix ) {
 							return false;
 						}
-						return ! AMP_Options_Manager::get_option( 'enable_amp_stories' );
+						return ! AMP_Options_Manager::is_stories_experience_enabled();
 					},
 				)
 			),
@@ -104,7 +104,7 @@ class AMP_Admin_Pointers {
 						if ( 'edit.php' === $hook_suffix && AMP_Story_Post_Type::POST_TYPE_SLUG === filter_input( INPUT_GET, 'post_type' ) ) {
 							return false;
 						}
-						return AMP_Story_Post_Type::has_required_block_capabilities() && AMP_Options_Manager::get_option( 'enable_amp_stories' );
+						return AMP_Options_Manager::is_stories_experience_enabled();
 					},
 				)
 			),

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -64,7 +64,7 @@ class AMP_Admin_Pointers {
 					'selector'        => '#toplevel_page_amp-options',
 					'heading'         => __( 'AMP', 'amp' ),
 					'subheading'      => __( 'New AMP Template Modes', 'amp' ),
-					'description'     => __( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Native&#8221; modes.', 'amp' ),
+					'description'     => __( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Standard&#8221; modes.', 'amp' ),
 					'position'        => array(
 						'align' => 'middle',
 					),

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -44,11 +44,11 @@ class AMP_Editor_Blocks {
 			add_filter( 'wp_kses_allowed_html', array( $this, 'whitelist_block_atts_in_wp_kses_allowed_html' ), 10, 2 );
 
 			/*
-			 * Dirty AMP is required when a site is in AMP first mode but not all templates are being served
+			 * Dirty AMP is required when a site is in AMP-first mode but not all templates are being served
 			 * as AMP. In particular, if a single post is using AMP-specific Gutenberg Blocks which make
 			 * use of AMP components, and the singular template is served as AMP but the blog page is not,
 			 * then the non-AMP blog page need to load the AMP runtime scripts so that the AMP components
-			 * in the posts displayed there will be rendered properly. This is only relevant on AMP first
+			 * in the posts displayed there will be rendered properly. This is only relevant on AMP-first
 			 * sites because the AMP Gutenberg blocks are only made available in that mode; they are not
 			 * presented in the Gutenberg inserter in transitional mode. In general, using AMP components in
 			 * non-AMP documents is still not officially supported, so it's occurrence is being minimized

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -44,11 +44,11 @@ class AMP_Editor_Blocks {
 			add_filter( 'wp_kses_allowed_html', array( $this, 'whitelist_block_atts_in_wp_kses_allowed_html' ), 10, 2 );
 
 			/*
-			 * Dirty AMP is required when a site is in native mode but not all templates are being served
+			 * Dirty AMP is required when a site is in AMP first mode but not all templates are being served
 			 * as AMP. In particular, if a single post is using AMP-specific Gutenberg Blocks which make
 			 * use of AMP components, and the singular template is served as AMP but the blog page is not,
 			 * then the non-AMP blog page need to load the AMP runtime scripts so that the AMP components
-			 * in the posts displayed there will be rendered properly. This is only relevant on native AMP
+			 * in the posts displayed there will be rendered properly. This is only relevant on AMP first
 			 * sites because the AMP Gutenberg blocks are only made available in that mode; they are not
 			 * presented in the Gutenberg inserter in transitional mode. In general, using AMP components in
 			 * non-AMP documents is still not officially supported, so it's occurrence is being minimized

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -230,8 +230,10 @@ class AMP_Post_Meta_Box {
 			'possibleStatuses' => array( self::ENABLED_STATUS, self::DISABLED_STATUS ),
 			'defaultStatus'    => $enabled_status,
 			'errorMessages'    => $error_messages,
+			'isWebsiteEnabled' => AMP_Options_Manager::is_website_experience_enabled(),
+			'isStoriesEnabled' => AMP_Options_Manager::is_stories_experience_enabled(),
 			'hasThemeSupport'  => current_theme_supports( AMP_Theme_Support::SLUG ),
-			'isNativeAMP'      => amp_is_canonical(),
+			'isStandardMode'   => amp_is_canonical(),
 		);
 
 		wp_localize_script(

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -21,7 +21,7 @@ define( 'AMP_CUSTOMIZER_QUERY_VAR', 'customize_amp' );
  * And this does not need to toggle between the AMP and normal display.
  */
 function amp_init_customizer() {
-	if ( amp_is_canonical() ) {
+	if ( amp_is_canonical() || ! AMP_Options_Manager::is_website_experience_enabled() ) {
 		return;
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -318,7 +318,7 @@ function is_amp_endpoint() {
 		return $has_amp_query_var;
 	}
 
-	// When there is no query var and AMP is not canonical/native, then this is definitely not an AMP endpoint.
+	// When there is no query var and AMP is not canonical (AMP first), then this is definitely not an AMP endpoint.
 	if ( ! $has_amp_query_var && ! amp_is_canonical() ) {
 		return false;
 	}
@@ -375,7 +375,7 @@ function amp_get_boilerplate_code() {
  */
 function amp_add_generator_metadata() {
 	if ( amp_is_canonical() ) {
-		$mode = 'native';
+		$mode = 'native'; // aka 'standard'.
 	} elseif ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		$mode = 'transitional';
 	} else {

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -318,7 +318,7 @@ function is_amp_endpoint() {
 		return $has_amp_query_var;
 	}
 
-	// When there is no query var and AMP is not canonical (AMP first), then this is definitely not an AMP endpoint.
+	// When there is no query var and AMP is not canonical (AMP-first), then this is definitely not an AMP endpoint.
 	if ( ! $has_amp_query_var && ! amp_is_canonical() ) {
 		return false;
 	}

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -374,14 +374,22 @@ function amp_get_boilerplate_code() {
  * @since 1.0 Add template mode.
  */
 function amp_add_generator_metadata() {
-	if ( amp_is_canonical() ) {
-		$mode = 'native'; // aka 'standard'.
+	$content = sprintf( 'AMP Plugin v%s', AMP__VERSION );
+
+	if ( ! AMP_Options_Manager::is_website_experience_enabled() ) {
+		$mode = 'none';
+	} elseif ( amp_is_canonical() ) {
+		$mode = 'standard';
 	} elseif ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 		$mode = 'transitional';
 	} else {
 		$mode = 'reader';
 	}
-	printf( '<meta name="generator" content="%s">', esc_attr( sprintf( 'AMP Plugin v%s; mode=%s', AMP__VERSION, $mode ) ) );
+	$content .= sprintf( '; mode=%s', $mode );
+
+	$content .= sprintf( '; experiences=%s', implode( ',', AMP_Options_Manager::get_option( 'experiences' ) ) );
+
+	printf( '<meta name="generator" content="%s">', esc_attr( $content ) );
 }
 
 /**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -243,7 +243,7 @@ function post_supports_amp( $post ) {
  * to determine the queried object is able to be served as AMP. If 'amp' theme support is not
  * present, this function returns true just if the query var is present. If theme support is
  * present, then it returns true in transitional mode if an AMP template is available and the query
- * var is present, or else in native mode if just the template is available.
+ * var is present, or else in standard mode if just the template is available.
  *
  * @return bool Whether it is the AMP endpoint.
  * @global string $pagenow

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -120,7 +120,7 @@ class AMP_Story_Post_Type {
 	 * @return void
 	 */
 	public static function register() {
-		if ( ! AMP_Options_Manager::get_option( 'enable_amp_stories' ) || ! self::has_required_block_capabilities() ) {
+		if ( ! AMP_Options_Manager::is_stories_experience_enabled() || ! self::has_required_block_capabilities() ) {
 			return;
 		}
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -495,11 +495,13 @@ class AMP_Story_Post_Type {
 	 * @return array Modified editor settings.
 	 */
 	public static function filter_block_editor_settings( $editor_settings, $post ) {
-		if ( self::POST_TYPE_SLUG === $post->post_type ) {
-			unset( $editor_settings['fontSizes'], $editor_settings['colors'] );
+		if ( self::POST_TYPE_SLUG !== get_current_screen()->post_type ) {
+			return $editor_settings;
 		}
 
-		if ( get_current_screen()->is_block_editor && isset( $editor_settings['styles'] ) ) {
+		unset( $editor_settings['fontSizes'], $editor_settings['colors'] );
+
+		if ( isset( $editor_settings['styles'] ) ) {
 			foreach ( $editor_settings['styles'] as $key => $style ) {
 
 				// If the baseURL is not set or if the URL doesn't include theme styles, move to next.
@@ -518,6 +520,7 @@ class AMP_Story_Post_Type {
 				}
 			}
 		}
+
 		return $editor_settings;
 	}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -306,7 +306,7 @@ class AMP_Theme_Support {
 			self::$support_added_via_theme = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
 
 			/*
-			 * If the theme has transitional support, allow the user to opt for AMP first mode via an option, since a theme
+			 * If the theme has transitional support, allow the user to opt for AMP-first mode via an option, since a theme
 			 * in transitional mode entails that it supports serving templates as both AMP and non-AMP, and this it is
 			 * able to serve AMP-first pages just as well as paired pages. Otherwise, consider that the the mode was
 			 * not set at all via option.
@@ -411,7 +411,7 @@ class AMP_Theme_Support {
 
 		if ( amp_is_canonical() || is_singular( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			/*
-			 * When AMP first/canonical, then when there is an /amp/ endpoint or ?amp URL param,
+			 * When AMP-first/canonical, then when there is an /amp/ endpoint or ?amp URL param,
 			 * then a redirect needs to be done to the URL without any AMP indicator in the URL.
 			 * Permanent redirect is used for unauthenticated users since switching between modes
 			 * should happen infrequently. For admin users, this is kept temporary to allow them
@@ -2119,7 +2119,7 @@ class AMP_Theme_Support {
 
 		if ( $blocking_error_count > 0 && ! AMP_Validation_Manager::should_validate_response() ) {
 			/*
-			 * In AMP first, strip html@amp attribute to prevent GSC from complaining about a validation error
+			 * In AMP-first, strip html@amp attribute to prevent GSC from complaining about a validation error
 			 * already surfaced inside of WordPress. This is intended to not serve dirty AMP, but rather a
 			 * non-AMP document (intentionally not valid AMP) that contains the AMP runtime and AMP components.
 			 */

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -154,7 +154,7 @@ class AMP_Theme_Support {
 
 		self::$init_start_time = microtime( true );
 
-		if ( current_theme_supports( self::SLUG ) ) {
+		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( self::SLUG ) ) {
 			// Ensure extra theme support for core themes is in place.
 			AMP_Core_Theme_Sanitizer::extend_theme_support();
 
@@ -168,7 +168,7 @@ class AMP_Theme_Support {
 			 * action to template_redirect--the wp action--is used instead.
 			 */
 			add_action( 'wp', array( __CLASS__, 'finish_init' ), PHP_INT_MAX );
-		} elseif ( AMP_Options_Manager::get_option( 'enable_amp_stories' ) ) {
+		} elseif ( AMP_Options_Manager::is_stories_experience_enabled() ) {
 			add_action(
 				'wp',
 				function () {

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -200,7 +200,7 @@ class AMP_Theme_Support {
 	 * Get the theme support mode added via admin option.
 	 *
 	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'native' or 'paired'.
-	 *@see AMP_Theme_Support::read_theme_support()
+	 * @see AMP_Theme_Support::read_theme_support()
 	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
 	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
 	 *
@@ -214,7 +214,7 @@ class AMP_Theme_Support {
 	 * Get the theme support mode added via admin option.
 	 *
 	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'native' or 'paired'.
-	 *@see AMP_Theme_Support::read_theme_support()
+	 * @see AMP_Theme_Support::read_theme_support()
 	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
 	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
 	 *
@@ -228,7 +228,7 @@ class AMP_Theme_Support {
 	 * Get theme support mode.
 	 *
 	 * @return string Theme support mode.
-	 *@see AMP_Theme_Support::read_theme_support()
+	 * @see AMP_Theme_Support::read_theme_support()
 	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
 	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
 	 *

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -55,15 +55,15 @@ class AMP_Theme_Support {
 	const CACHE_MISS_URL_OPTION = 'amp_cache_miss_url';
 
 	/**
-	 * Slug identifying native mode.
+	 * Slug identifying standard website mode.
 	 *
 	 * @since 1.2
 	 * @var string
 	 */
-	const NATIVE_MODE_SLUG = 'native';
+	const STANDARD_MODE_SLUG = 'native'; // aka 'standard'.
 
 	/**
-	 * Slug identifying transitional mode.
+	 * Slug identifying transitional website mode.
 	 *
 	 * @since 1.2
 	 * @var string
@@ -199,12 +199,12 @@ class AMP_Theme_Support {
 	/**
 	 * Get the theme support mode added via admin option.
 	 *
-	 * @since 1.2
-	 * @see AMP_Theme_Support::read_theme_support()
-	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
-	 * @see AMP_Theme_Support::NATIVE_MODE_SLUG
-	 *
 	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'native' or 'paired'.
+	 *@see AMP_Theme_Support::read_theme_support()
+	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
+	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
+	 *
+	 * @since 1.2
 	 */
 	public static function get_support_mode_added_via_option() {
 		return self::$support_added_via_option;
@@ -213,12 +213,12 @@ class AMP_Theme_Support {
 	/**
 	 * Get the theme support mode added via admin option.
 	 *
-	 * @since 1.2
-	 * @see AMP_Theme_Support::read_theme_support()
-	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
-	 * @see AMP_Theme_Support::NATIVE_MODE_SLUG
-	 *
 	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'native' or 'paired'.
+	 *@see AMP_Theme_Support::read_theme_support()
+	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
+	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
+	 *
+	 * @since 1.2
 	 */
 	public static function get_support_mode_added_via_theme() {
 		return self::$support_added_via_theme;
@@ -227,12 +227,12 @@ class AMP_Theme_Support {
 	/**
 	 * Get theme support mode.
 	 *
-	 * @since 1.2
-	 * @see AMP_Theme_Support::read_theme_support()
-	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
-	 * @see AMP_Theme_Support::NATIVE_MODE_SLUG
-	 *
 	 * @return string Theme support mode.
+	 *@see AMP_Theme_Support::read_theme_support()
+	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
+	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
+	 *
+	 * @since 1.2
 	 */
 	public static function get_support_mode() {
 		$theme_support = self::get_support_mode_added_via_option();
@@ -295,16 +295,16 @@ class AMP_Theme_Support {
 
 			$is_paired = ! empty( $args['paired'] );
 
-			self::$support_added_via_theme = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::NATIVE_MODE_SLUG;
+			self::$support_added_via_theme = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
 
 			/*
-			 * If the theme has transitional support, allow the user to opt for native mode via an option, since a theme
+			 * If the theme has transitional support, allow the user to opt for AMP first mode via an option, since a theme
 			 * in transitional mode entails that it supports serving templates as both AMP and non-AMP, and this it is
 			 * able to serve AMP-first pages just as well as paired pages. Otherwise, consider that the the mode was
 			 * not set at all via option.
 			 */
-			self::$support_added_via_option = ( $is_paired && self::NATIVE_MODE_SLUG === $theme_support_option ) ? self::NATIVE_MODE_SLUG : null;
-			if ( self::NATIVE_MODE_SLUG === self::$support_added_via_option ) {
+			self::$support_added_via_option = ( $is_paired && self::STANDARD_MODE_SLUG === $theme_support_option ) ? self::STANDARD_MODE_SLUG : null;
+			if ( self::STANDARD_MODE_SLUG === self::$support_added_via_option ) {
 				$args['paired'] = false;
 				add_theme_support( 'amp', $args );
 			}
@@ -316,9 +316,9 @@ class AMP_Theme_Support {
 					'paired' => $is_paired,
 				)
 			);
-			self::$support_added_via_option = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::NATIVE_MODE_SLUG;
+			self::$support_added_via_option = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
 		} elseif ( AMP_Validation_Manager::is_theme_support_forced() ) {
-			self::$support_added_via_option = self::NATIVE_MODE_SLUG;
+			self::$support_added_via_option = self::STANDARD_MODE_SLUG;
 			add_theme_support( self::SLUG );
 		}
 	}
@@ -403,7 +403,7 @@ class AMP_Theme_Support {
 
 		if ( amp_is_canonical() || is_singular( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			/*
-			 * When AMP native/canonical, then when there is an /amp/ endpoint or ?amp URL param,
+			 * When AMP first/canonical, then when there is an /amp/ endpoint or ?amp URL param,
 			 * then a redirect needs to be done to the URL without any AMP indicator in the URL.
 			 * Permanent redirect is used for unauthenticated users since switching between modes
 			 * should happen infrequently. For admin users, this is kept temporary to allow them
@@ -2111,7 +2111,7 @@ class AMP_Theme_Support {
 
 		if ( $blocking_error_count > 0 && ! AMP_Validation_Manager::should_validate_response() ) {
 			/*
-			 * In native AMP, strip html@amp attribute to prevent GSC from complaining about a validation error
+			 * In AMP first, strip html@amp attribute to prevent GSC from complaining about a validation error
 			 * already surfaced inside of WordPress. This is intended to not serve dirty AMP, but rather a
 			 * non-AMP document (intentionally not valid AMP) that contains the AMP runtime and AMP components.
 			 */

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -60,7 +60,7 @@ class AMP_Theme_Support {
 	 * @since 1.2
 	 * @var string
 	 */
-	const STANDARD_MODE_SLUG = 'native'; // aka 'standard'.
+	const STANDARD_MODE_SLUG = 'standard';
 
 	/**
 	 * Slug identifying transitional website mode.
@@ -68,7 +68,15 @@ class AMP_Theme_Support {
 	 * @since 1.2
 	 * @var string
 	 */
-	const TRANSITIONAL_MODE_SLUG = 'paired';
+	const TRANSITIONAL_MODE_SLUG = 'transitional';
+
+	/**
+	 * Flag used in args passed to add_theme_support('amp') to indicate transitional mode supported.
+	 *
+	 * @since 1.2
+	 * @var string
+	 */
+	const PAIRED_FLAG = 'paired';
 
 	/**
 	 * Sanitizer classes.
@@ -128,7 +136,7 @@ class AMP_Theme_Support {
 	/**
 	 * Theme support mode that was added via option.
 	 *
-	 * This should be either null (reader), 'native', or 'transitional'.
+	 * This should be either null (reader), 'standard', or 'transitional'.
 	 *
 	 * @since 1.0
 	 * @var null|string
@@ -138,7 +146,7 @@ class AMP_Theme_Support {
 	/**
 	 * Theme support mode which was added via the theme.
 	 *
-	 * This should be either null (reader), 'native', or 'transitional'.
+	 * This should be either null (reader), 'standard', or 'transitional'.
 	 *
 	 * @var null|string
 	 */
@@ -199,7 +207,7 @@ class AMP_Theme_Support {
 	/**
 	 * Get the theme support mode added via admin option.
 	 *
-	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'native' or 'paired'.
+	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'standard' or 'transitional'.
 	 * @see AMP_Theme_Support::read_theme_support()
 	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
 	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
@@ -213,7 +221,7 @@ class AMP_Theme_Support {
 	/**
 	 * Get the theme support mode added via admin option.
 	 *
-	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'native' or 'paired'.
+	 * @return null|string Support added via option, with null meaning Reader, and otherwise being 'standard' or 'transitional'.
 	 * @see AMP_Theme_Support::read_theme_support()
 	 * @see AMP_Theme_Support::TRANSITIONAL_MODE_SLUG
 	 * @see AMP_Theme_Support::STANDARD_MODE_SLUG
@@ -263,7 +271,7 @@ class AMP_Theme_Support {
 			$args = self::get_theme_support_args();
 
 			// Validate theme support usage.
-			$keys = array( 'template_dir', 'comments_live_list', 'paired', 'templates_supported', 'available_callback', 'service_worker', 'nav_menu_toggle', 'nav_menu_dropdown' );
+			$keys = array( 'template_dir', 'comments_live_list', self::PAIRED_FLAG, 'templates_supported', 'available_callback', 'service_worker', 'nav_menu_toggle', 'nav_menu_dropdown' );
 
 			if ( count( array_diff( array_keys( $args ), $keys ) ) !== 0 ) {
 				_doing_it_wrong(
@@ -293,7 +301,7 @@ class AMP_Theme_Support {
 				);
 			}
 
-			$is_paired = ! empty( $args['paired'] );
+			$is_paired = ! empty( $args[ self::PAIRED_FLAG ] );
 
 			self::$support_added_via_theme = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
 
@@ -305,15 +313,15 @@ class AMP_Theme_Support {
 			 */
 			self::$support_added_via_option = ( $is_paired && self::STANDARD_MODE_SLUG === $theme_support_option ) ? self::STANDARD_MODE_SLUG : null;
 			if ( self::STANDARD_MODE_SLUG === self::$support_added_via_option ) {
-				$args['paired'] = false;
+				$args[ self::PAIRED_FLAG ] = false;
 				add_theme_support( 'amp', $args );
 			}
 		} elseif ( 'disabled' !== $theme_support_option ) {
-			$is_paired = ( 'paired' === $theme_support_option );
+			$is_paired = ( self::TRANSITIONAL_MODE_SLUG === $theme_support_option );
 			add_theme_support(
 				self::SLUG,
 				array(
-					'paired' => $is_paired,
+					self::PAIRED_FLAG => $is_paired,
 				)
 			);
 			self::$support_added_via_option = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
@@ -339,7 +347,7 @@ class AMP_Theme_Support {
 		$support = get_theme_support( self::SLUG );
 		if ( true === $support ) {
 			return array(
-				'paired' => false,
+				self::PAIRED_FLAG => false,
 			);
 		}
 		if ( ! isset( $support[0] ) || ! is_array( $support[0] ) ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -68,7 +68,7 @@ class AMP_Options_Manager {
 	}
 
 	/**
-	 * Flush rewrite rules if the supported_post_types have changed.
+	 * Flush rewrite rules if the supported_post_types or experiences have changed.
 	 *
 	 * @since 0.6.2
 	 *
@@ -80,8 +80,17 @@ class AMP_Options_Manager {
 		$new_post_types = isset( $new_options['supported_post_types'] ) ? $new_options['supported_post_types'] : array();
 		sort( $old_post_types );
 		sort( $new_post_types );
-		if ( $old_post_types !== $new_post_types ) {
-			flush_rewrite_rules( false );
+		$old_experiences = isset( $old_options['experiences'] ) ? $old_options['experiences'] : array();
+		$new_experiences = isset( $new_options['experiences'] ) ? $new_options['experiences'] : array();
+		sort( $old_experiences );
+		sort( $new_experiences );
+		if ( $old_post_types !== $new_post_types || $old_experiences !== $new_experiences ) {
+			if ( self::is_website_experience_enabled() ) {
+				add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
+				flush_rewrite_rules( false );
+			} else {
+				amp_deactivate();
+			}
 		}
 	}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -196,7 +196,7 @@ class AMP_Options_Manager {
 		$recognized_theme_supports = array(
 			'disabled',
 			'paired',
-			'native',
+			'native', // aka 'standard'.
 		);
 		if ( isset( $new_options['theme_support'] ) && in_array( $new_options['theme_support'], $recognized_theme_supports, true ) ) {
 			$options['theme_support'] = $new_options['theme_support'];
@@ -311,7 +311,7 @@ class AMP_Options_Manager {
 			return;
 		}
 
-		// If all templates are supported then skip check since all post types are also supported. This option only applies with native/transitional theme support.
+		// If all templates are supported then skip check since all post types are also supported. This option only applies with standard/transitional theme support.
 		if ( self::get_option( 'all_templates_supported', false ) && 'disabled' !== self::get_option( 'theme_support' ) ) {
 			return;
 		}
@@ -713,8 +713,8 @@ class AMP_Options_Manager {
 		}
 
 		switch ( $template_mode ) {
-			case 'native':
-				$message = esc_html__( 'Native mode activated!', 'amp' );
+			case 'native': // aka 'standard'.
+				$message = esc_html__( 'Standard mode activated!', 'amp' );
 				if ( $review_messages ) {
 					$message .= ' ' . join( ' ', $review_messages );
 				}
@@ -729,7 +729,7 @@ class AMP_Options_Manager {
 				$message = wp_kses_post(
 					sprintf(
 						/* translators: %s is an AMP URL */
-						__( 'Reader mode activated! View the <a href="%s">AMP version of a recent post</a>. It is recommended that you upgrade to Native or Transitional mode.', 'amp' ),
+						__( 'Reader mode activated! View the <a href="%s">AMP version of a recent post</a>. It is recommended that you upgrade to Standard or Transitional mode.', 'amp' ),
 						esc_url( $url )
 					)
 				);

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -114,6 +114,13 @@ class AMP_Options_Manager {
 			unset( $options['enable_amp_stories'] );
 		}
 
+		// Migrate theme support slugs.
+		if ( 'native' === $options['theme_support'] ) {
+			$options['theme_support'] = AMP_Theme_Support::STANDARD_MODE_SLUG;
+		} elseif ( 'paired' === $options['theme_support'] ) {
+			$options['theme_support'] = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
+		}
+
 		return $options;
 	}
 
@@ -195,8 +202,8 @@ class AMP_Options_Manager {
 		// Theme support.
 		$recognized_theme_supports = array(
 			'disabled',
-			'paired',
-			'native', // aka 'standard'.
+			AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+			AMP_Theme_Support::STANDARD_MODE_SLUG,
 		);
 		if ( isset( $new_options['theme_support'] ) && in_array( $new_options['theme_support'], $recognized_theme_supports, true ) ) {
 			$options['theme_support'] = $new_options['theme_support'];
@@ -593,13 +600,13 @@ class AMP_Options_Manager {
 		AMP_Post_Type_Support::add_post_type_support();
 
 		// Ensure theme support flags are set properly according to the new mode so that proper AMP URL can be generated.
-		$has_theme_support = ( 'native' === $template_mode || 'paired' === $template_mode );
+		$has_theme_support = ( AMP_Theme_Support::STANDARD_MODE_SLUG === $template_mode || AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode );
 		if ( $has_theme_support ) {
 			$theme_support = current_theme_supports( AMP_Theme_Support::SLUG );
 			if ( ! is_array( $theme_support ) ) {
 				$theme_support = array();
 			}
-			$theme_support['paired'] = 'paired' === $template_mode;
+			$theme_support['paired'] = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode;
 			add_theme_support( AMP_Theme_Support::SLUG, $theme_support );
 		} else {
 			remove_theme_support( AMP_Theme_Support::SLUG ); // So that the amp_get_permalink() will work for reader mode URL.
@@ -713,13 +720,13 @@ class AMP_Options_Manager {
 		}
 
 		switch ( $template_mode ) {
-			case 'native': // aka 'standard'.
+			case AMP_Theme_Support::STANDARD_MODE_SLUG:
 				$message = esc_html__( 'Standard mode activated!', 'amp' );
 				if ( $review_messages ) {
 					$message .= ' ' . join( ' ', $review_messages );
 				}
 				break;
-			case 'paired':
+			case AMP_Theme_Support::TRANSITIONAL_MODE_SLUG:
 				$message = esc_html__( 'Transitional mode activated!', 'amp' );
 				if ( $review_messages ) {
 					$message .= ' ' . join( ' ', $review_messages );

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -250,7 +250,7 @@ class AMP_Options_Menu {
 				})(
 					jQuery,
 					<?php echo wp_json_encode( AMP_Options_Manager::OPTION_NAME . '[experiences][]' ); ?>,
-					<?php echo wp_json_encode( __( 'You must select at least once experience.', 'amp' ) ); ?>
+					<?php echo wp_json_encode( __( 'You must select at least one experience.', 'amp' ) ); ?>
 				);
 			</script>
 		</fieldset>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -88,6 +88,17 @@ class AMP_Options_Menu {
 		);
 
 		add_settings_field(
+			'amp_stories',
+			__( 'Stories', 'amp' ),
+			array( $this, 'render_amp_stories' ),
+			AMP_Options_Manager::OPTION_NAME,
+			'general',
+			array(
+				'class' => 'amp-stories-field',
+			)
+		);
+
+		add_settings_field(
 			'validation',
 			__( 'Validation Handling', 'amp' ),
 			array( $this, 'render_validation_handling' ),
@@ -106,17 +117,6 @@ class AMP_Options_Menu {
 			'general',
 			array(
 				'class' => 'amp-template-support-field',
-			)
-		);
-
-		add_settings_field(
-			'amp_stories',
-			__( 'Stories', 'amp' ),
-			array( $this, 'render_amp_stories' ),
-			AMP_Options_Manager::OPTION_NAME,
-			'general',
-			array(
-				'class' => 'amp-stories-field',
 			)
 		);
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -181,7 +181,7 @@ class AMP_Options_Menu {
 					echo wp_kses_post(
 						sprintf(
 							/* translators: %s: Stories documentation URL. */
-							__( 'AMP is a simple and robust format to ensure your website is fast, user-first, and makes money. AMP provides long-term success for your web strategy with distribution across popular platforms and reduced operating and development costs. Read more about <a href="%s" target="_blank">AMP Websites</a>.', 'amp' ),
+							__( 'AMP is a powerful web components framework that helps you build fast, user-first websites that monetize well. AMP puts tons of advanced capabilities at your fingertips, effectively reducing the operating and development costs of your sites. Read more about <a href="%s" target="_blank">AMP Websites</a>.', 'amp' ),
 							esc_url( 'https://amp.dev/about/websites' )
 						)
 					);

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -275,7 +275,7 @@ class AMP_Options_Menu {
 
 		$builtin_support = in_array( get_template(), AMP_Core_Theme_Sanitizer::get_supported_themes(), true );
 		?>
-		<?php if ( AMP_Theme_Support::NATIVE_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
+		<?php if ( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
 			<div class="notice notice-info notice-alt inline">
 				<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
 			</div>
@@ -300,7 +300,7 @@ class AMP_Options_Menu {
 				<?php endif; ?>
 				<dl>
 					<dt>
-						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="native" <?php checked( $theme_support, AMP_Theme_Support::NATIVE_MODE_SLUG ); ?>>
+						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>>
 						<label for="theme_support_native">
 							<strong><?php esc_html_e( 'Standard', 'amp' ); ?></strong>
 						</label>
@@ -309,7 +309,7 @@ class AMP_Options_Menu {
 						<?php echo wp_kses_post( $native_description ); ?>
 					</dd>
 					<dt>
-						<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="paired" <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>
+						<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>
 						<label for="theme_support_transitional">
 							<strong><?php esc_html_e( 'Transitional', 'amp' ); ?></strong>
 						</label>
@@ -334,7 +334,7 @@ class AMP_Options_Menu {
 										echo wp_kses_post(
 											sprintf(
 												/* translators: %1: link to invalid URLs. 2: link to validation errors. */
-												__( 'View current site compatibility results for native and transitional modes: %1$s and %2$s.', 'amp' ),
+												__( 'View current site compatibility results for standard and transitional modes: %1$s and %2$s.', 'amp' ),
 												sprintf(
 													'<a href="%s">%s</a>',
 													esc_url( add_query_arg( 'post_type', AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, admin_url( 'edit.php' ) ) ),
@@ -376,7 +376,7 @@ class AMP_Options_Menu {
 	/**
 	 * Post types support section renderer.
 	 *
-	 * @todo If dirty AMP is ever allowed (that is, post-processed documents which can be served with non-sanitized valdation errors), then automatically forcing sanitization in native should be able to be turned off.
+	 * @todo If dirty AMP is ever allowed (that is, post-processed documents which can be served with non-sanitized valdation errors), then automatically forcing sanitization in standard mode should be able to be turned off.
 	 *
 	 * @since 1.0
 	 */
@@ -400,7 +400,7 @@ class AMP_Options_Menu {
 				<input type="hidden" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[auto_accept_sanitization]' ); ?>" value="<?php echo AMP_Options_Manager::get_option( 'auto_accept_sanitization' ) ? 'on' : ''; ?>">
 			<?php else : ?>
 				<div class="amp-auto-accept-sanitize-canonical notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'All new validation errors are automatically accepted when in native mode.', 'amp' ); ?></p>
+					<p><?php esc_html_e( 'All new validation errors are automatically accepted when in standard mode.', 'amp' ); ?></p>
 				</div>
 				<div class="amp-auto-accept-sanitize">
 					<p>
@@ -433,26 +433,26 @@ class AMP_Options_Menu {
 			<?php endif; ?>
 
 			<script>
-			(function( $, nativeModeSlug ) {
+			(function( $, standardModeSlug ) {
 				const getThemeSupportMode = () => {
 					const checkedInput = $( 'input[type=radio][name="amp-options[theme_support]"]:checked' );
 					if ( 0 === checkedInput.length ) {
-						return nativeModeSlug;
+						return standardModeSlug;
 					}
 					return checkedInput.val();
 				};
 
 				var updateHiddenClasses = function() {
 					const themeSupportMode = getThemeSupportMode();
-					$( '.amp-auto-accept-sanitize' ).toggleClass( 'hidden', nativeModeSlug === themeSupportMode );
+					$( '.amp-auto-accept-sanitize' ).toggleClass( 'hidden', standardModeSlug === themeSupportMode );
 					$( '.amp-validation-field' ).toggleClass( 'hidden', 'disabled' === themeSupportMode );
-					$( '.amp-auto-accept-sanitize-canonical' ).toggleClass( 'hidden', nativeModeSlug !== themeSupportMode );
+					$( '.amp-auto-accept-sanitize-canonical' ).toggleClass( 'hidden', standardModeSlug !== themeSupportMode );
 				};
 
 				$( 'input[type=radio][name="amp-options[theme_support]"]' ).change( updateHiddenClasses );
 
 				updateHiddenClasses();
-			})( jQuery, <?php echo wp_json_encode( AMP_Theme_Support::NATIVE_MODE_SLUG ); ?> );
+			})( jQuery, <?php echo wp_json_encode( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?> );
 			</script>
 		</fieldset>
 		<?php

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -502,13 +502,23 @@ class AMP_Options_Menu {
 		<?php endif; ?>
 
 		<fieldset id="supported_post_types_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
-			<?php $element_name = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]'; ?>
+			<?php
+			$element_name         = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]';
+			$supported_post_types = AMP_Options_Manager::get_option( 'supported_post_types' );
+			?>
 			<h4 class="title"><?php esc_html_e( 'Content Types', 'amp' ); ?></h4>
 			<p>
 				<?php esc_html_e( 'The following content types will be available as AMP:', 'amp' ); ?>
 			</p>
 			<ul>
 			<?php foreach ( array_map( 'get_post_type_object', AMP_Post_Type_Support::get_eligible_post_types() ) as $post_type ) : ?>
+				<?php
+				$checked = (
+					post_type_supports( $post_type->name, AMP_Post_Type_Support::SLUG )
+					||
+					( ! AMP_Options_Manager::is_website_experience_enabled() && in_array( $post_type->name, $supported_post_types, true ) )
+				);
+				?>
 				<li>
 					<?php $element_id = AMP_Options_Manager::OPTION_NAME . "-supported_post_types-{$post_type->name}"; ?>
 					<input
@@ -516,7 +526,7 @@ class AMP_Options_Menu {
 						id="<?php echo esc_attr( $element_id ); ?>"
 						name="<?php echo esc_attr( $element_name ); ?>"
 						value="<?php echo esc_attr( $post_type->name ); ?>"
-						<?php checked( post_type_supports( $post_type->name, AMP_Post_Type_Support::SLUG ) ); ?>
+						<?php checked( $checked ); ?>
 						>
 					<label for="<?php echo esc_attr( $element_id ); ?>">
 						<?php echo esc_html( $post_type->label ); ?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -266,7 +266,7 @@ class AMP_Options_Menu {
 		$theme_support = AMP_Theme_Support::get_support_mode();
 
 		/* translators: %s: URL to the documentation. */
-		$native_description = sprintf( __( 'The active theme integrates AMP as the framework for your site by using its templates and styles to render webpages. This means your site is <b>AMP-first</b> and your canonical URLs are AMP! Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
+		$standard_description = sprintf( __( 'The active theme integrates AMP as the framework for your site by using its templates and styles to render webpages. This means your site is <b>AMP-first</b> and your canonical URLs are AMP! Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
 		/* translators: %s: URL to the documentation. */
 		$transitional_description = sprintf( __( 'The active theme’s templates are used to generate non-AMP and AMP versions of your content, allowing for each canonical URL to have a corresponding (paired) AMP URL. This mode is useful to progressively transition towards a fully AMP-first site. Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
 		$reader_description       = __( 'Formerly called the <b>classic mode</b>, this mode generates paired AMP content using simplified templates which may not match the look-and-feel of your site. Only posts/pages can be served as AMP in Reader mode. No redirection is performed for mobile visitors; AMP pages are served by AMP consumption platforms.', 'amp' );
@@ -280,7 +280,7 @@ class AMP_Options_Menu {
 				<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
 			</div>
 			<p>
-				<?php echo wp_kses_post( $native_description ); ?>
+				<?php echo wp_kses_post( $standard_description ); ?>
 			</p>
 			<p>
 				<?php echo wp_kses_post( $ecosystem_description ); ?>
@@ -300,13 +300,13 @@ class AMP_Options_Menu {
 				<?php endif; ?>
 				<dl>
 					<dt>
-						<input type="radio" id="theme_support_native" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>>
-						<label for="theme_support_native">
+						<input type="radio" id="theme_support_standard" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>>
+						<label for="theme_support_standard">
 							<strong><?php esc_html_e( 'Standard', 'amp' ); ?></strong>
 						</label>
 					</dt>
 					<dd>
-						<?php echo wp_kses_post( $native_description ); ?>
+						<?php echo wp_kses_post( $standard_description ); ?>
 					</dd>
 					<dt>
 						<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2444,7 +2444,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			/*
-			 * On AMP first themes when there are new/rejected validation errors present, a parsed stylesheet may include
+			 * On AMP-first themes when there are new/rejected validation errors present, a parsed stylesheet may include
 			 * @import rules. These must be moved to the beginning to be honored.
 			 */
 			$css = $stylesheet_groups['custom']['import_front_matter'];

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2444,7 +2444,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			/*
-			 * On Native AMP themes when there are new/rejected validation errors present, a parsed stylesheet may include
+			 * On AMP first themes when there are new/rejected validation errors present, a parsed stylesheet may include
 			 * @import rules. These must be moved to the beginning to be honored.
 			 */
 			$css = $stylesheet_groups['custom']['import_front_matter'];

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1244,19 +1244,19 @@ class AMP_Validated_URL_Post_Type {
 		if ( 'post' !== get_current_screen()->base ) {
 			// Display admin notice according to the AMP mode.
 			if ( amp_is_canonical() ) {
-				$template_mode = 'native';
+				$template_mode = AMP_Theme_Support::STANDARD_MODE_SLUG;
 			} elseif ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-				$template_mode = 'paired';
+				$template_mode = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
 			} else {
 				$template_mode = 'reader';
 			}
 			$auto_sanitization = AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
 
-			if ( 'native' === $template_mode ) {
+			if ( AMP_Theme_Support::STANDARD_MODE_SLUG === $template_mode ) {
 				$message = __( 'The site is using standard AMP mode, the validation errors found are already automatically handled.', 'amp' );
-			} elseif ( 'paired' === $template_mode && $auto_sanitization ) {
+			} elseif ( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode && $auto_sanitization ) {
 				$message = __( 'The site is using transitional AMP mode with auto-sanitization turned on, the validation errors found are already automatically handled.', 'amp' );
-			} elseif ( 'paired' === $template_mode ) {
+			} elseif ( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode ) {
 				$message = sprintf(
 					/* translators: %s is a link to the AMP settings screen */
 					__( 'The site is using transitional AMP mode without auto-sanitization, the validation errors found require action and influence which pages are shown in AMP. For automatically handling the errors turn on auto-sanitization from <a href="%s">Validation Handling settings</a>.', 'amp' ),

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -592,7 +592,7 @@ class AMP_Validated_URL_Post_Type {
 	 * Normalize a URL for storage.
 	 *
 	 * This ensures that query vars like utm_* and the like will not cause duplicates.
-	 * The AMP query param is removed to facilitate switching between native and transitional.
+	 * The AMP query param is removed to facilitate switching between standard and transitional.
 	 * The URL scheme is also normalized to HTTPS to help with transition from HTTP to HTTPS.
 	 *
 	 * @param string $url URL.
@@ -1253,7 +1253,7 @@ class AMP_Validated_URL_Post_Type {
 			$auto_sanitization = AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
 
 			if ( 'native' === $template_mode ) {
-				$message = __( 'The site is using native AMP mode, the validation errors found are already automatically handled.', 'amp' );
+				$message = __( 'The site is using standard AMP mode, the validation errors found are already automatically handled.', 'amp' );
 			} elseif ( 'paired' === $template_mode && $auto_sanitization ) {
 				$message = __( 'The site is using transitional AMP mode with auto-sanitization turned on, the validation errors found are already automatically handled.', 'amp' );
 			} elseif ( 'paired' === $template_mode ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -837,13 +837,6 @@ class AMP_Validated_URL_Post_Type {
 			}
 		}
 
-		if ( isset( $old_validated_environment['options'] ) ) {
-			$differing_options = array_diff_assoc( $new_validated_environment['options'], $old_validated_environment['options'] );
-			if ( $differing_options ) {
-				$staleness['options'] = $differing_options;
-			}
-		}
-
 		return $staleness;
 	}
 
@@ -1749,10 +1742,6 @@ class AMP_Validated_URL_Post_Type {
 								echo ' ';
 							} elseif ( ! empty( $staleness['plugins'] ) ) {
 								esc_html_e( 'Different plugins were active when these results were obtained.', 'amp' );
-								echo ' ';
-							}
-							if ( ! empty( $staleness['options'] ) ) {
-								esc_html_e( 'Options have changed.', 'amp' );
 								echo ' ';
 							}
 							esc_html_e( 'Please recheck.', 'amp' );

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -661,6 +661,14 @@ class AMP_Validated_URL_Post_Type {
 			);
 		}
 
+		$is_story = (
+			isset( $args['queried_object'], $args['queried_object']['type'], $args['queried_object']['id'] )
+			&&
+			'post' === $args['queried_object']['type']
+			&&
+			AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type( $args['queried_object']['id'] )
+		);
+
 		/*
 		 * The details for individual validation errors is stored in the amp_validation_error taxonomy terms.
 		 * The post content just contains the slugs for these terms and the sources for the given instance of
@@ -714,7 +722,7 @@ class AMP_Validated_URL_Post_Type {
 								'term_group' => $sanitization['status'],
 							)
 						);
-					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted() ) {
+					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted() || $is_story ) {
 						$term_data['term_group'] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS;
 						wp_update_term(
 							$term_id,

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -160,7 +160,7 @@ class AMP_Validated_URL_Post_Type {
 	 */
 	public static function should_show_in_menu() {
 		global $pagenow;
-		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			return true;
 		}
 		return ( 'edit.php' === $pagenow && ( isset( $_GET['post_type'] ) && self::POST_TYPE_SLUG === $_GET['post_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -283,7 +283,7 @@ class AMP_Validation_Error_Taxonomy {
 	 */
 	public static function should_show_in_menu() {
 		global $pagenow;
-		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			return true;
 		}
 		return ( 'edit-tags.php' === $pagenow && ( isset( $_GET['taxonomy'] ) && self::TAXONOMY_SLUG === $_GET['taxonomy'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2029,7 +2029,7 @@ class AMP_Validation_Manager {
 		$enabled_status    = $status_and_errors['status'];
 
 		$data = array(
-			'isSanitizationAutoAccepted' => self::is_sanitization_auto_accepted(),
+			'isSanitizationAutoAccepted' => self::is_sanitization_auto_accepted() || AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type(),
 			'possibleStatuses'           => array( AMP_Post_Meta_Box::ENABLED_STATUS, AMP_Post_Meta_Box::DISABLED_STATUS ),
 			'defaultStatus'              => $enabled_status,
 		);

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -281,7 +281,7 @@ class AMP_Validation_Manager {
 	}
 
 	/**
-	 * Return whether sanitization is forcibly accepted, whether because in AMP first mode or via user option.
+	 * Return whether sanitization is forcibly accepted, whether because in AMP-first mode or via user option.
 	 *
 	 * @return bool Whether sanitization is forcibly accepted.
 	 */
@@ -303,7 +303,7 @@ class AMP_Validation_Manager {
 	 * - Parent admin item and first submenu item: link to non-AMP version.
 	 * - Second submenu item: link to validate the URL.
 	 *
-	 * When on AMP first response:
+	 * When on AMP-first response:
 	 * - Icon: CHECK MARK if no unaccepted validation errors on page, or WARNING SIGN if there are unaccepted validation errors.
 	 * - Parent admin and first submenu item: link to validate the URL.
 	 *
@@ -877,13 +877,13 @@ class AMP_Validation_Manager {
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
 
-		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in AMP first (standard) mode.
+		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in AMP-first.
 		if ( self::is_sanitization_auto_accepted() ) {
 			if ( ! $has_rejected_error ) {
 				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 			} else {
 				/*
-				 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-standard mode, it will redirect to a non-AMP page.
+				 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
 				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
 				 * In that case, this will block serving AMP.
 				 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.
@@ -1994,7 +1994,7 @@ class AMP_Validation_Manager {
 		/*
 		 * The AMP_Validation_Manager::post_supports_validation() method is not being used here because
 		 * a post's status for validation checking can change during the life of the editor, such as when
-		 * the user to toggle AMP back on after having turned it off, and then get the validation
+		 * the user toggles AMP back on after having turned it off, and then gets the validation
 		 * warnings appearing due to the amp-block-validation having been enqueued already.
 		 */
 		$should_enqueue_block_validation = (

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -173,7 +173,7 @@ class AMP_Validation_Manager {
 		AMP_Validation_Error_Taxonomy::register();
 
 		// Short-circuit if AMP is not supported as only the post types should be available.
-		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) && ! AMP_Options_Manager::get_option( 'enable_amp_stories' ) ) {
+		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) && ! AMP_Options_Manager::is_stories_experience_enabled() ) {
 			return;
 		}
 
@@ -183,7 +183,7 @@ class AMP_Validation_Manager {
 		add_action( 'rest_api_init', array( __CLASS__, 'add_rest_api_fields' ) );
 
 		// Add actions for checking theme support is present to determine plugin compatibility and show validation links in the admin bar.
-		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			// Actions and filters involved in validation.
 			add_action(
 				'activate_plugin',
@@ -254,11 +254,11 @@ class AMP_Validation_Manager {
 
 		// Story post type always supports validation.
 		if ( AMP_Story_Post_Type::POST_TYPE_SLUG === $post->post_type ) {
-			return true;
+			return AMP_Options_Manager::is_stories_experience_enabled();
 		}
 
-		// Prevent doing post validation in Reader mode.
-		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+		// Prevent doing post validation in Reader mode or if the Website experience is not enabled.
+		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) || ! AMP_Options_Manager::is_website_experience_enabled() ) {
 			return false;
 		}
 
@@ -2001,9 +2001,9 @@ class AMP_Validation_Manager {
 			self::has_cap()
 			&&
 			(
-				current_theme_supports( AMP_Theme_Support::SLUG )
+				( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) )
 				||
-				AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type()
+				( AMP_Options_Manager::is_stories_experience_enabled() && AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type() )
 			)
 		);
 		if ( ! $should_enqueue_block_validation ) {

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -281,7 +281,7 @@ class AMP_Validation_Manager {
 	}
 
 	/**
-	 * Return whether sanitization is forcibly accepted, whether because in native mode or via user option.
+	 * Return whether sanitization is forcibly accepted, whether because in AMP first mode or via user option.
 	 *
 	 * @return bool Whether sanitization is forcibly accepted.
 	 */
@@ -303,7 +303,7 @@ class AMP_Validation_Manager {
 	 * - Parent admin item and first submenu item: link to non-AMP version.
 	 * - Second submenu item: link to validate the URL.
 	 *
-	 * When on native AMP response:
+	 * When on AMP first response:
 	 * - Icon: CHECK MARK if no unaccepted validation errors on page, or WARNING SIGN if there are unaccepted validation errors.
 	 * - Parent admin and first submenu item: link to validate the URL.
 	 *
@@ -877,16 +877,16 @@ class AMP_Validation_Manager {
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
 
-		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in Native mode.
+		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in AMP first (standard) mode.
 		if ( self::is_sanitization_auto_accepted() ) {
 			if ( ! $has_rejected_error ) {
 				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 			} else {
 				/*
-				 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Native mode, it will redirect to a non-AMP page.
+				 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-standard mode, it will redirect to a non-AMP page.
 				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
 				 * In that case, this will block serving AMP.
-				 * This could also apply if this is in 'Native' mode and the user has rejected a validation error.
+				 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.
 				 */
 				esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 			}

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Features and capabilities provided by the plugin include:
 - **AMP-first Experiences support**: enabling full-site AMP experiences without sacrificing the flexibility of the platform, or the fidelity of content.
 - **Many Optimizations**: A myriad of code, performance, and developer experience improvements: from customization flexibility, to better UI flows, internationalization, accessibility, etc.
 
-The plugin can be configured to follow one of three different template modes: Native, Transitional, and Reader. When configured to operate in Reader and Transitional modes, a given post/page will have a canonical URL as well as a corresponding (paired) AMP URL. The AMP plugin is not serving as a mobile theme; it does not redirect mobile devices to the AMP version. Instead, the AMP version is served to mobile visitors when they find the content on platforms such as Twitter, Pinterest, Google Search, and others.
+The plugin can be configured to follow one of three different template modes: Standard, Transitional, and Reader. When configured to operate in Reader and Transitional modes, a given post/page will have a canonical URL as well as a corresponding (paired) AMP URL. The AMP plugin is not serving as a mobile theme; it does not redirect mobile devices to the AMP version. Instead, the AMP version is served to mobile visitors when they find the content on platforms such as Twitter, Pinterest, Google Search, and others.
 
 With the official AMP plugin for WordPress, the WordPress ecosystem is provided with the capabilities and tools it needs to build world-class AMP experiences without deviating from its standard, flexible, and well-known content creation workflow.
 
@@ -35,7 +35,7 @@ With the official AMP plugin for WordPress, the WordPress ecosystem is provided 
 
 1. Upload the folder to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
-3. If you currently use older versions of the plugin in `Reader` mode, it is strongly encouraged to migrate to `Transitional` or `Native` mode. Depending on your theme/plugins, some development work may be required.
+3. If you currently use older versions of the plugin in `Reader` mode, it is strongly encouraged to migrate to `Transitional` or `Standard` mode. Depending on your theme/plugins, some development work may be required.
 
 ## Getting Started ##
 
@@ -57,9 +57,9 @@ If you are a developer, we encourage you to [follow along](https://github.com/am
 
 ![Reader mode templates are still available, but they are are limited. Not only do they differ from the active theme, any validation errors are silently sanitized.](wp-assets/screenshot-3.png)
 
-### Switch from Reader mode to Transitional or Native mode in AMP settings screen. You may need to disable the admin bar in AMP if your theme has a larger amount of CSS.
+### Switch from Reader mode to Transitional or Standard mode in AMP settings screen. You may need to disable the admin bar in AMP if your theme has a larger amount of CSS.
 
-![Switch from Reader mode to Transitional or Native mode in AMP settings screen. You may need to disable the admin bar in AMP if your theme has a larger amount of CSS.](wp-assets/screenshot-4.png)
+![Switch from Reader mode to Transitional or Standard mode in AMP settings screen. You may need to disable the admin bar in AMP if your theme has a larger amount of CSS.](wp-assets/screenshot-4.png)
 
 ### Make the entire site available in AMP or pick specific post types and templates; you can also opt-out on per-post basis.
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Features and capabilities provided by the plugin include:
 - **AMP-first Experiences support**: enabling full-site AMP experiences without sacrificing the flexibility of the platform, or the fidelity of content.
 - **Many Optimizations**: A myriad of code, performance, and developer experience improvements: from customization flexibility, to better UI flows, internationalization, accessibility, etc.
 
-The plugin can be configured to follow one of three different template modes: Native, Transitional, and Reader. When configured to operate in Reader and Transitional modes, a given post/page will have a canonical URL as well as a corresponding (paired) AMP URL. The AMP plugin is not serving as a mobile theme; it does not redirect mobile devices to the AMP version. Instead, the AMP version is served to mobile visitors when they find the content on platforms such as Twitter, Pinterest, Google Search, and others.
+The plugin can be configured to follow one of three different template modes: Standard, Transitional, and Reader. When configured to operate in Reader and Transitional modes, a given post/page will have a canonical URL as well as a corresponding (paired) AMP URL. The AMP plugin is not serving as a mobile theme; it does not redirect mobile devices to the AMP version. Instead, the AMP version is served to mobile visitors when they find the content on platforms such as Twitter, Pinterest, Google Search, and others.
 
 With the official AMP plugin for WordPress, the WordPress ecosystem is provided with the capabilities and tools it needs to build world-class AMP experiences without deviating from its standard, flexible, and well-known content creation workflow.
 
@@ -31,7 +31,7 @@ With the official AMP plugin for WordPress, the WordPress ecosystem is provided 
 
 1. Upload the folder to the `/wp-content/plugins/` directory.
 2. Activate the plugin through the 'Plugins' menu in WordPress.
-3. If you currently use older versions of the plugin in `Reader` mode, it is strongly encouraged to migrate to `Transitional` or `Native` mode. Depending on your theme/plugins, some development work may be required.
+3. If you currently use older versions of the plugin in `Reader` mode, it is strongly encouraged to migrate to `Transitional` or `Standard` mode. Depending on your theme/plugins, some development work may be required.
 
 == Getting Started ==
 
@@ -44,7 +44,7 @@ If you are a developer, we encourage you to [follow along](https://github.com/am
 1. Theme support enables you to reuse the active theme's templates and stylesheets; all WordPress features (menus, widgets, comments) are available in AMP.
 2. Many themes can be served as AMP without any changes; the default experience is as if JavaScript is turned off in the browser since scripts are removed.
 3. Reader mode templates are still available, but they are are limited. Not only do they differ from the active theme, any validation errors are silently sanitized.
-4. Switch from Reader mode to Transitional or Native mode in AMP settings screen. You may need to disable the admin bar in AMP if your theme has a larger amount of CSS.
+4. Switch from Reader mode to Transitional or Standard mode in AMP settings screen. You may need to disable the admin bar in AMP if your theme has a larger amount of CSS.
 5. Make the entire site available in AMP or pick specific post types and templates; you can also opt-out on per-post basis.
 6. Plugin checks for AMP validity and will indicate when either: no issues are found, new issues need moderation, or issues block AMP from being served.
 7. The editor will surface validation issues during content authoring. The specific blocks with validation errors are indicated.

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -352,7 +352,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertFalse( is_amp_endpoint() );
 		remove_theme_support( AMP_Theme_Support::SLUG );
 
-		// Native theme support.
+		// Standard theme support.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( is_amp_endpoint() );
 

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -478,25 +478,37 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_add_generator_metadata() {
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		ob_start();
-		amp_add_generator_metadata();
-		$output = ob_get_clean();
+
+		$get_generator_tag = function() {
+			ob_start();
+			amp_add_generator_metadata();
+			return ob_get_clean();
+		};
+
+		$output = $get_generator_tag();
 		$this->assertContains( 'mode=reader', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
+		$this->assertContains( 'experiences=website', $output );
 
 		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
-		ob_start();
-		amp_add_generator_metadata();
-		$output = ob_get_clean();
+		$output = $get_generator_tag();
 		$this->assertContains( 'mode=transitional', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
 
 		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
-		ob_start();
-		amp_add_generator_metadata();
-		$output = ob_get_clean();
-		$this->assertContains( 'mode=native', $output );
+		$output = $get_generator_tag();
+		$this->assertContains( 'mode=standard', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
+
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		$output = $get_generator_tag();
+		$this->assertContains( 'mode=none', $output );
+		$this->assertContains( 'experiences=stories', $output );
+
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		$output = $get_generator_tag();
+		$this->assertContains( 'mode=standard', $output );
+		$this->assertContains( 'experiences=website,stories', $output );
 	}
 
 	/**

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -490,12 +490,12 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertContains( 'v' . AMP__VERSION, $output );
 		$this->assertContains( 'experiences=website', $output );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		$output = $get_generator_tag();
 		$this->assertContains( 'mode=transitional', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
 		$output = $get_generator_tag();
 		$this->assertContains( 'mode=standard', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
@@ -1004,7 +1004,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertNull( $admin_bar->get_node( 'amp' ) );
 
 		// Check that paired mode does add link.
-		add_theme_support( 'amp', array( 'paired' => true ) );
+		add_theme_support( 'amp', array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		$admin_bar = new WP_Admin_Bar();
 		amp_add_admin_bar_view_link( $admin_bar );
 		$item = $admin_bar->get_node( 'amp' );

--- a/tests/test-amp.php
+++ b/tests/test-amp.php
@@ -41,8 +41,8 @@ class Test_AMP extends WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired'       => false,
-				'template_dir' => 'amp-templates',
+				AMP_Theme_Support::PAIRED_FLAG => false,
+				'template_dir'                 => 'amp-templates',
 			)
 		);
 		$this->assertTrue( amp_is_canonical() );
@@ -50,7 +50,7 @@ class Test_AMP extends WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired' => true,
+				AMP_Theme_Support::PAIRED_FLAG => true,
 			)
 		);
 		$this->assertFalse( amp_is_canonical() );

--- a/tests/test-class-amp-cli.php
+++ b/tests/test-class-amp-cli.php
@@ -120,7 +120,7 @@ class Test_AMP_CLI extends \WP_UnitTestCase {
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );
 		AMP_CLI::$force_crawl_urls = false;
 
-		// In AMP first, the IDs should include all of the newly-created posts.
+		// In AMP-first, the IDs should include all of the newly-created posts.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );
 

--- a/tests/test-class-amp-cli.php
+++ b/tests/test-class-amp-cli.php
@@ -120,7 +120,7 @@ class Test_AMP_CLI extends \WP_UnitTestCase {
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );
 		AMP_CLI::$force_crawl_urls = false;
 
-		// In Native AMP, the IDs should include all of the newly-created posts.
+		// In AMP first, the IDs should include all of the newly-created posts.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );
 

--- a/tests/test-class-amp-cli.php
+++ b/tests/test-class-amp-cli.php
@@ -128,7 +128,7 @@ class Test_AMP_CLI extends \WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired' => true,
+				AMP_Theme_Support::PAIRED_FLAG => true,
 			)
 		);
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );

--- a/tests/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/test-class-amp-gallery-block-sanitizer.php
@@ -58,7 +58,7 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 	 * Test sanitizer.
 	 *
 	 * This only tests when theme support is present.
-	 * Like if Native or Transitional is selected in AMP Settings > Template Mode,
+	 * Like if Standard or Transitional is selected in AMP Settings > Template Mode,
 	 * or if this is added with add_theme_support( 'amp' ).
 	 * If there is no theme support, the sanitizer will have the argument array( 'carousel_required' => true ).
 	 *

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -183,7 +183,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertContains( $amp_status_markup, $output );
 		$this->assertContains( $checkbox_enabled, $output );
 
-		// This is in AMP first mode with a template that can be rendered.
+		// This is in AMP-first mode with a template that can be rendered.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		ob_start();
 		$this->instance->render_status( $post );
@@ -242,7 +242,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 			$this->instance->get_status_and_errors( $post )
 		);
 
-		// In AMP first, there also shouldn't be errors.
+		// In AMP-first, there also shouldn't be errors.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertEquals(
 			$expected_status_and_errors,

--- a/tests/test-class-amp-meta-box.php
+++ b/tests/test-class-amp-meta-box.php
@@ -183,7 +183,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$this->assertContains( $amp_status_markup, $output );
 		$this->assertContains( $checkbox_enabled, $output );
 
-		// This is in AMP native mode with a template that can be rendered.
+		// This is in AMP first mode with a template that can be rendered.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		ob_start();
 		$this->instance->render_status( $post );
@@ -242,7 +242,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 			$this->instance->get_status_and_errors( $post )
 		);
 
-		// In Native AMP, there also shouldn't be errors.
+		// In AMP first, there also shouldn't be errors.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertEquals(
 			$expected_status_and_errors,

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -88,6 +88,8 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	 *
 	 * @covers AMP_Options_Manager::get_options()
 	 * @covers AMP_Options_Manager::get_option()
+	 * @covers AMP_Options_Manager::is_website_experience_enabled()
+	 * @covers AMP_Options_Manager::is_stories_experience_enabled()
 	 * @covers AMP_Options_Manager::update_option()
 	 * @covers AMP_Options_Manager::validate_options()
 	 * @covers AMP_Theme_Support::reset_cache_miss_url_option()
@@ -101,6 +103,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		$this->assertEquals(
 			array(
+				'experiences'              => array( AMP_Options_Manager::WEBSITE_EXPERIENCE ),
 				'theme_support'            => 'disabled',
 				'supported_post_types'     => array( 'post' ),
 				'analytics'                => array(),
@@ -110,12 +113,14 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 				'enable_response_caching'  => true,
 				'version'                  => AMP__VERSION,
 				'story_templates_version'  => false,
-				'enable_amp_stories'       => false,
 			),
 			AMP_Options_Manager::get_options()
 		);
+		$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
+		$this->assertFalse( AMP_Options_Manager::is_stories_experience_enabled() );
 		$this->assertSame( false, AMP_Options_Manager::get_option( 'foo' ) );
 		$this->assertSame( 'default', AMP_Options_Manager::get_option( 'foo', 'default' ) );
+
 		// Test supported_post_types validation.
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post', 'page', 'attachment' ) );
 		$this->assertSame(
@@ -241,6 +246,13 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'enable_response_caching', true );
 		$this->assertFalse( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 		$this->assertEquals( 'http://example.org/test-post', get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
+
+		// Test that enabling Stories experience works.
+		if ( AMP_Story_Post_Type::has_required_block_capabilities() ) {
+			AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+			$this->assertFalse( AMP_Options_Manager::is_website_experience_enabled() );
+			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
+		}
 	}
 
 	/**

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -484,12 +484,12 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_updated_theme_support_option for native when there is one auto-accepted issue.
+	 * Test handle_updated_theme_support_option for standard when there is one auto-accepted issue.
 	 *
 	 * @covers AMP_Options_Manager::handle_updated_theme_support_option()
 	 * @covers \amp_admin_get_preview_permalink()
 	 */
-	public function test_handle_updated_theme_support_option_native_success_but_error() {
+	public function test_handle_updated_theme_support_option_standard_success_but_error() {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$post_id = $this->factory()->post->create( array( 'post_type' => 'post' ) );
@@ -517,7 +517,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		remove_filter( 'pre_http_request', $filter );
 		$amp_settings_errors = get_settings_errors( AMP_Options_Manager::OPTION_NAME );
 		$new_error           = end( $amp_settings_errors );
-		$this->assertStringStartsWith( 'Native mode activated!', $new_error['message'] );
+		$this->assertStringStartsWith( 'Standard mode activated!', $new_error['message'] );
 		$this->assertContains( esc_url( amp_get_permalink( $post_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a post since it is the only post type supported.' );
 		$invalid_url_posts = get_posts(
 			array(
@@ -532,12 +532,12 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_updated_theme_support_option for native when there is one auto-accepted issue.
+	 * Test handle_updated_theme_support_option for standard when there is one auto-accepted issue.
 	 *
 	 * @covers AMP_Options_Manager::handle_updated_theme_support_option()
 	 * @covers \amp_admin_get_preview_permalink()
 	 */
-	public function test_handle_updated_theme_support_option_native_validate_error() {
+	public function test_handle_updated_theme_support_option_standard_validate_error() {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$this->factory()->post->create( array( 'post_type' => 'post' ) );
 
@@ -555,7 +555,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		$amp_settings_errors = get_settings_errors( AMP_Options_Manager::OPTION_NAME );
 		$new_error           = end( $amp_settings_errors );
-		$this->assertStringStartsWith( 'Native mode activated!', $new_error['message'] );
+		$this->assertStringStartsWith( 'Standard mode activated!', $new_error['message'] );
 		$invalid_url_posts = get_posts(
 			array(
 				'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -274,14 +274,14 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		AMP_Post_Type_Support::add_post_type_support();
 
 		// Test when 'all_templates_supported' is selected.
-		AMP_Options_Manager::update_option( 'theme_support', 'native' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$this->assertEmpty( get_settings_errors() );
 
 		// Test when 'all_templates_supported' is not selected.
-		AMP_Options_Manager::update_option( 'theme_support', 'native' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		foreach ( get_post_types() as $post_type ) {
 			if ( 'foo' !== $post_type ) {
@@ -493,7 +493,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$post_id = $this->factory()->post->create( array( 'post_type' => 'post' ) );
-		AMP_Options_Manager::update_option( 'theme_support', 'native' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 
 		$filter = function() {
@@ -541,7 +541,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$this->factory()->post->create( array( 'post_type' => 'post' ) );
 
-		AMP_Options_Manager::update_option( 'theme_support', 'native' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 
 		$filter = function() {
@@ -576,7 +576,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 
 		$post_id = $this->factory()->post->create( array( 'post_type' => 'post' ) );
-		AMP_Options_Manager::update_option( 'theme_support', 'paired' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 
 		$filter = function() {

--- a/tests/test-class-amp-story-post-type.php
+++ b/tests/test-class-amp-story-post-type.php
@@ -9,6 +9,10 @@
  * Test AMP_Story_Post_Type.
  */
 class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
+
+	/**
+	 * Set up.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -22,7 +26,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		global $wp_styles;
 		$wp_styles = null;
-		AMP_Options_Manager::update_option( 'enable_amp_stories', true );
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
 	}
 
 	/**
@@ -33,7 +37,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	public function tearDown() {
 		global $wp_rewrite;
 
-		AMP_Options_Manager::update_option( 'enable_amp_stories', false );
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
 
 		$wp_rewrite->set_permalink_structure( false );
 		unset( $_SERVER['HTTPS'] );
@@ -42,10 +46,12 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test requires opt_in.
+	 *
 	 * @covers \AMP_Story_Post_Type::register()
 	 */
 	public function test_requires_opt_in() {
-		AMP_Options_Manager::update_option( 'enable_amp_stories', false );
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
 
 		AMP_Story_Post_Type::register();
 
@@ -325,7 +331,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		// This is an AMP story embed, but the markup doesn't have an <iframe>, so it shouldn't be changed.
 		$amp_story                   = $this->factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
-		$embed_markup_without_iframe = '<div class="wp-embed"><img src="https://example.com/baz.jpeg></div>';
+		$embed_markup_without_iframe = '<div class="wp-embed"><img alt=baz src="https://example.com/baz.jpeg></div>';
 		$this->assertEquals( $embed_markup_without_iframe, AMP_Story_Post_Type::change_embed_iframe_attributes( $embed_markup_without_iframe, $amp_story ) );
 
 		// This is an AMP story embed, so it should change the height.
@@ -338,7 +344,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	/**
 	 * Creates amp_story posts with featured images of given heights.
 	 *
-	 * @param array $featured_images[][] {
+	 * @param array $featured_images {
 	 *     The featured image dimensions.
 	 *
 	 *     @type int width

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -89,8 +89,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_read_theme_support_bad_args_array() {
 		$args = array(
-			'paired'            => false,
-			'invalid_param_key' => array(),
+			AMP_Theme_Support::PAIRED_FLAG => false,
+			'invalid_param_key'            => array(),
 		);
 		add_theme_support( AMP_Theme_Support::SLUG, $args );
 		AMP_Theme_Support::read_theme_support();
@@ -130,9 +130,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		// Test that standard via option trumps transitional in theme.
 		$args = array(
-			'templates_supported' => 'all',
-			'paired'              => true,
-			'comments_live_list'  => true,
+			'templates_supported'          => 'all',
+			AMP_Theme_Support::PAIRED_FLAG => true,
+			'comments_live_list'           => true,
 		);
 		add_theme_support( AMP_Theme_Support::SLUG, $args );
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG ); // Will override the theme support flag.
@@ -141,7 +141,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			array_merge(
 				$args,
 				array(
-					'paired' => false, // The 'native' user option overrides the theme flag.
+					AMP_Theme_Support::PAIRED_FLAG => false, // The standard user option overrides the theme flag.
 				)
 			),
 			AMP_Theme_Support::get_theme_support_args()
@@ -159,7 +159,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_theme() );
 		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
-		$this->assertEquals( array( 'paired' => false ), AMP_Theme_Support::get_theme_support_args() );
+		$this->assertEquals( array( AMP_Theme_Support::PAIRED_FLAG => false ), AMP_Theme_Support::get_theme_support_args() );
 
 		// Test that no support via theme can be overridden with option.
 		remove_theme_support( AMP_Theme_Support::SLUG );
@@ -197,8 +197,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired'       => true,
-				'template_dir' => 'amp',
+				AMP_Theme_Support::PAIRED_FLAG => true,
+				'template_dir'                 => 'amp',
 			)
 		);
 
@@ -221,8 +221,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired'       => false,
-				'template_dir' => 'amp',
+				AMP_Theme_Support::PAIRED_FLAG => false,
+				'template_dir'                 => 'amp',
 			)
 		);
 		$this->go_to( get_permalink( $post_id ) );
@@ -391,7 +391,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired' => true,
+				AMP_Theme_Support::PAIRED_FLAG => true,
 			)
 		);
 		add_filter(
@@ -1792,7 +1792,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired' => true,
+				AMP_Theme_Support::PAIRED_FLAG => true,
 			)
 		);
 		add_filter(

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -36,6 +36,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Validation_Manager::reset_validation_results();
 		unset( $GLOBALS['current_screen'] );
 		remove_theme_support( AMP_Theme_Support::SLUG );
+		AMP_Theme_Support::read_theme_support();
 	}
 
 	/**

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -128,14 +128,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_read_theme_support_and_support_args() {
 
-		// Test that native via option trumps transitional in theme.
+		// Test that standard via option trumps transitional in theme.
 		$args = array(
 			'templates_supported' => 'all',
 			'paired'              => true,
 			'comments_live_list'  => true,
 		);
 		add_theme_support( AMP_Theme_Support::SLUG, $args );
-		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::NATIVE_MODE_SLUG ); // Will override the theme support flag.
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG ); // Will override the theme support flag.
 		AMP_Theme_Support::read_theme_support();
 		$this->assertEquals(
 			array_merge(
@@ -146,27 +146,27 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			),
 			AMP_Theme_Support::get_theme_support_args()
 		);
-		$this->assertSame( AMP_Theme_Support::NATIVE_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
+		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_theme() );
-		$this->assertSame( AMP_Theme_Support::NATIVE_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
+		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 
-		// Test that native via theme always trumps transitional via option.
+		// Test that standard via theme always trumps transitional via option.
 		add_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); // Will be ignored since native in theme overrides transitional option.
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); // Will be ignored since standard in theme overrides transitional option.
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_option() );
-		$this->assertSame( AMP_Theme_Support::NATIVE_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_theme() );
-		$this->assertSame( AMP_Theme_Support::NATIVE_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
+		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_theme() );
+		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 		$this->assertEquals( array( 'paired' => false ), AMP_Theme_Support::get_theme_support_args() );
 
 		// Test that no support via theme can be overridden with option.
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::NATIVE_MODE_SLUG );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Theme_Support::read_theme_support();
 		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_theme() );
-		$this->assertSame( AMP_Theme_Support::NATIVE_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
+		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 
 		// Test that no support via theme can be overridden with option.
@@ -182,7 +182,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		$_GET[ AMP_Validation_Manager::VALIDATE_QUERY_VAR ] = AMP_Validation_Manager::get_amp_validate_nonce();
 		AMP_Theme_Support::read_theme_support();
-		$this->assertSame( AMP_Theme_Support::NATIVE_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
+		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_theme() );
 		$this->assertTrue( get_theme_support( AMP_Theme_Support::SLUG ) );
 	}
@@ -947,7 +947,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( is_singular() );
 
-		// Test native AMP.
+		// Test AMP first.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( amp_is_canonical() );
 		ob_start();
@@ -1521,11 +1521,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test prepare_response for native mode when some validation errors aren't auto-sanitized.
+	 * Test prepare_response for standard mode when some validation errors aren't auto-sanitized.
 	 *
 	 * @covers AMP_Theme_Support::prepare_response()
 	 */
-	public function test_prepare_response_native_mode_non_amp() {
+	public function test_prepare_response_standard_mode_non_amp() {
 		wp();
 		$original_html = $this->get_original_html();
 		add_filter( 'amp_validation_error_sanitized', '__return_false' ); // For testing purpose only. This should not normally be done.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -947,7 +947,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( is_singular() );
 
-		// Test AMP first.
+		// Test AMP-first.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( amp_is_canonical() );
 		ob_start();

--- a/tests/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/validation/test-class-amp-validated-url-post-type.php
@@ -172,7 +172,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_get_invalid_url_validation_errors() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create();
 		$this->assertEmpty( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( get_permalink( $post ) ) );
@@ -237,7 +237,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::get_invalid_url_post()
 	 */
 	public function test_get_invalid_url_post() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
 		$this->assertEquals( null, AMP_Validated_URL_Post_Type::get_invalid_url_post( get_permalink( $post ) ) );
@@ -284,7 +284,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::get_url_from_post()
 	 */
 	public function test_get_url_from_post() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
 
@@ -304,7 +304,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 			AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id )
 		);
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
 		$this->assertEquals(
 			get_permalink( $post ),
 			AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id )
@@ -336,7 +336,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_store_validation_errors() {
 		global $post;
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Validation_Manager::init();
 		$post = $this->factory()->post->create_and_get();
 
@@ -744,7 +744,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	public function test_handle_bulk_action() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Validation_Manager::init();
 
 		$invalid_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
@@ -875,7 +875,7 @@ class Test_AMP_Validated_URL_Post_Type extends \WP_UnitTestCase {
 	 */
 	public function test_handle_validate_request() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		AMP_Validation_Manager::init();
 

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -32,6 +32,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 	public function tearDown() {
 		$_REQUEST = array();
 		remove_theme_support( AMP_Theme_Support::SLUG );
+		AMP_Theme_Support::read_theme_support();
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
 		remove_all_filters( 'amp_validation_error_sanitized' );
 		remove_all_filters( 'terms_clauses' );

--- a/tests/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/validation/test-class-amp-validation-error-taxonomy.php
@@ -297,7 +297,7 @@ class Test_AMP_Validation_Error_Taxonomy extends \WP_UnitTestCase {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			array(
-				'paired' => false,
+				AMP_Theme_Support::PAIRED_FLAG => false,
 			)
 		);
 		$this->assertTrue( amp_is_canonical() );

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -159,7 +159,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::init()
 	 */
 	public function test_init_without_theme_or_stories_support() {
-		AMP_Options_Manager::update_option( 'enable_amp_stories', false );
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
@@ -172,7 +172,10 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::init()
 	 */
 	public function test_init_with_stories_and_without_theme_support() {
-		AMP_Options_Manager::update_option( 'enable_amp_stories', true );
+		if ( ! AMP_Story_Post_Type::has_required_block_capabilities() ) {
+			$this->markTestSkipped( 'Environment does not support Stories.' );
+		}
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
@@ -189,7 +192,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 
 		// Ensure that story posts can be validated even when theme support is absent.
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'enable_amp_stories', true );
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
 		AMP_Story_Post_Type::register();
 		if ( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			$post = $this->factory()->post->create( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -234,11 +234,11 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 	}
@@ -274,7 +274,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 
 		// Admin bar item available in AMP first mode.
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -284,7 +284,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
 
 		// Admin bar item available in paired mode.
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -295,7 +295,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 
 		// Admin bar item available in paired mode with validation errors.
 		$_GET[ AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR ] = 3;
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -404,7 +404,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	public function test_add_rest_api_fields() {
 
 		// Test in a transitional context.
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Validation_Manager::add_rest_api_fields();
 		$post_types_non_canonical = array_intersect(
@@ -451,7 +451,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::validate_url()
 	 */
 	public function test_get_amp_validity_rest_field() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
@@ -636,7 +636,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::print_edit_form_validation_status()
 	 */
 	public function test_print_edit_form_validation_status() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 
 		AMP_Validated_URL_Post_Type::register();
@@ -688,7 +688,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		 * as there are errors with 'New Rejected' status.
 		 */
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		ob_start();

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -276,7 +276,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		remove_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 
-		// Admin bar item available in AMP first mode.
+		// Admin bar item available in AMP-first mode.
 		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
@@ -420,7 +420,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		);
 		$this->assert_rest_api_field_present( $post_types_non_canonical );
 
-		// Test in a AMP first (canonical) context.
+		// Test in a AMP-first (canonical) context.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Validation_Manager::add_rest_api_fields();

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -273,7 +273,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		remove_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 
-		// Admin bar item available in native mode.
+		// Admin bar item available in AMP first mode.
 		add_theme_support( AMP_Theme_Support::SLUG, array( 'paired' => false ) );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
@@ -417,7 +417,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		);
 		$this->assert_rest_api_field_present( $post_types_non_canonical );
 
-		// Test in a Native AMP (canonical) context.
+		// Test in a AMP first (canonical) context.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Validation_Manager::add_rest_api_fields();
@@ -675,7 +675,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertContains( '<code>script</code>', $output );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 
-		// In 'Native' mode, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
+		// In 'Standard' mode, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		ob_start();
 		AMP_Validation_Manager::print_edit_form_validation_status( $post );
@@ -775,7 +775,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_block_data() {
-		if ( ! class_exists( 'WP_Block_Type_Registry' ) || 1 ) {
+		if ( ! class_exists( 'WP_Block_Type_Registry' ) ) {
 			$this->markTestSkipped( 'Gutenberg not active.' );
 		}
 		$latest_posts_block = WP_Block_Type_Registry::get_instance()->get_registered( 'core/latest-posts' );


### PR DESCRIPTION
This PR intends to refactor the AMP modes in the plugin in order to resolve three issues:

- [x] Fixes #2312: Always allow switching from Transitional to Native on sites that are defined with `add_theme_support('amp', ['paired' => true])`.
- [x] Fixes #2311: Restore suppression of validation error warnings appearing in Reader mode
- [x] Fixes #2470: Add functionality for users to chose AMP + Stories, AMP-only, Stories-only 
  - [x] Ensure availability of Latest Stories block and Story post embed.
  - [x] Include enabled experiences in generator tag, as well as website mode.
- [x] Fixes #2507: Phase out “Native” terminology in favor of “AMP-first”
  - [x] Rename historical references of `native` to `standard`, and `paired` to `transitional`.

# Always allow switching themes with built-in Transitional support to Native

When a theme had `add_theme_support( 'amp', array( 'paired' => true ) )` they would see:

> ![image](https://user-images.githubusercontent.com/134745/59151820-8e0dc680-89ee-11e9-99d4-a5e6d1ff19fc.png)

Now, they see this instead:

> ![image](https://user-images.githubusercontent.com/134745/59151833-bf869200-89ee-11e9-84da-089488180937.png)

This allows a theme which declares support for both AMP and non-AMP, to just opt to only serve AMP pages instead of being paired mode. This allows a theme like [Neve](https://wordpress.org/themes/neve/) to be used in either mode, even though it is defined as being `paired => true`.

Additionally, if they had `add_theme_support( 'amp' )` then before they would see:

> ![image](https://user-images.githubusercontent.com/134745/59151856-20ae6580-89ef-11e9-85b0-86014bd52534.png)

Now they see a slightly tweaked message:

> ![image](https://user-images.githubusercontent.com/134745/59151865-3459cc00-89ef-11e9-8f73-cbbf6668bf89.png)

Notice the link to the ecosystem page is moved to the bottom.

# Generator Tag

Given a site in transitional mode with both website and stories experiences enabled, the generator tag is now:

```html
<meta name="generator" content="AMP Plugin v1.2-beta2; mode=transitional; experiences=website,stories">
```

Note the new `experiences` param. If switching to standard (formerly native) mode, this is also reflected:

```html
<meta name="generator" content="AMP Plugin v1.2-beta2; mode=standard; experiences=website,stories">
```

If stories is disabled, then this is shown as:

```html
<meta name="generator" content="AMP Plugin v1.2-beta2; mode=standard; experiences=website">
html

If website is disabled but stories is enabled, then:

```html
<meta name="generator" content="AMP Plugin v1.2-beta2; mode=none; experiences=stories">
```