### PR TITLE
Consistently import components from block-editor package

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -17,7 +17,7 @@ import {
 import {
 	URLInput,
 	RichText,
-} from '@wordpress/editor';
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/assets/src/stories-editor/blocks/amp-story-cta/save.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/save.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/assets/src/stories-editor/blocks/amp-story-cta/test/index.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/test/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
+import '@wordpress/editor'; // So the data store is registered.
 
 /**
  * Internal dependencies

--- a/assets/src/stories-editor/blocks/amp-story-post-author/test/index.js
+++ b/assets/src/stories-editor/blocks/amp-story-post-author/test/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
+import '@wordpress/editor'; // So the data store is registered.
 
 /**
  * Internal dependencies

--- a/assets/src/stories-editor/blocks/amp-story-post-date/test/index.js
+++ b/assets/src/stories-editor/blocks/amp-story-post-date/test/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
+import '@wordpress/editor'; // So the data store is registered.
 
 /**
  * Internal dependencies

--- a/assets/src/stories-editor/blocks/amp-story-post-title/test/index.js
+++ b/assets/src/stories-editor/blocks/amp-story-post-title/test/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { addFilter, removeFilter } from '@wordpress/hooks';
+import '@wordpress/editor'; // So the data store is registered.
 
 /**
  * Internal dependencies

--- a/assets/src/stories-editor/components/higher-order/with-call-to-action-validation.js
+++ b/assets/src/stories-editor/components/higher-order/with-call-to-action-validation.js
@@ -4,7 +4,7 @@
 import { getBlockType } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { Warning } from '@wordpress/editor';
+import { Warning } from '@wordpress/block-editor';
 import { createHigherOrderComponent, compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 


### PR DESCRIPTION
These are currently proxied through the editor package, which is the deprecated way of importing them.