### PR TITLE
Omit validation results from At a Glance if Website not enabled

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -172,8 +172,10 @@ class AMP_Validated_URL_Post_Type {
 	public static function add_admin_hooks() {
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_post_list_screen_scripts' ) );
 
-		add_filter( 'dashboard_glance_items', array( __CLASS__, 'filter_dashboard_glance_items' ) );
-		add_action( 'rightnow_end', array( __CLASS__, 'print_dashboard_glance_styles' ) );
+		if ( AMP_Options_Manager::is_website_experience_enabled() ) {
+			add_filter( 'dashboard_glance_items', array( __CLASS__, 'filter_dashboard_glance_items' ) );
+			add_action( 'rightnow_end', array( __CLASS__, 'print_dashboard_glance_styles' ) );
+		}
 
 		// Edit post screen hooks.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_edit_post_screen_scripts' ) );


### PR DESCRIPTION
Amends #2550.

# Before

When the Website experience is disabled, the AMP error count is shown on the Dashboard “At a Glance” widget:

![image](https://user-images.githubusercontent.com/134745/59310880-a256fb00-8c5c-11e9-92c2-880427d62aa2.png)

# After

This PR prevents that from being included if Website is not enabled:

![image](https://user-images.githubusercontent.com/134745/59310869-979c6600-8c5c-11e9-8602-aa94996351d3.png)

This aligns the behavior with the AMP admin screen, where when Website is enabled you can see:

![image](https://user-images.githubusercontent.com/134745/59311008-f235c200-8c5c-11e9-8bf7-ef7bec45814f.png)

But when disabled:

![image](https://user-images.githubusercontent.com/134745/59311037-02e63800-8c5d-11e9-9059-b92c95260954.png)

The compatibility tool should not be displayed in the UI when website is not enabled.
