### PR TITLE
Move amp-analytics under amp-story from body

### DIFF
--- a/includes/templates/single-amp_story.php
+++ b/includes/templates/single-amp_story.php
@@ -65,14 +65,13 @@ the_post();
 			<?php
 			amp_print_story_auto_ads();
 			the_content();
+			amp_print_analytics( '' );
 			?>
 		</amp-story>
 
 		<?php
 		// Note that \AMP_Story_Post_Type::filter_frontend_print_styles_array() will limit which styles are printed.
 		print_late_styles();
-
-		amp_print_analytics( '' );
 		?>
 	</body>
 </html>

--- a/tests/test-tag-and-attribute-sanitizer.php
+++ b/tests/test-tag-and-attribute-sanitizer.php
@@ -318,6 +318,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 							<i>bad</i>
 							<amp-story-bookend src="bookendv1.json" layout="nodisplay"></amp-story-bookend>
 							<i>bad</i>
+							<amp-analytics id="75a1fdc3143c" type="googleanalytics"><script type="application/json">{"vars":{"account":"UA-XXXXXX-1"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}</script></amp-analytics>
 						</amp-story>
 						'
 					);


### PR DESCRIPTION
Turns out that while `amp-analytics` is allowed in Stories, it must be a child of `amp-story` or `amp-story-page`, instead of the `body`. 

Interestingly, the validating sanitizer does not catch this problem so the validation error leaks through to the frontend. I'm not sure how that constraint is being specified in the validator. But that's something to look at later.