### PR TITLE
Fix double opacity for text block

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -66,7 +66,7 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background: inherit;
+	background: none;
 	z-index: -1;
 	border-radius: inherit;
 }


### PR DESCRIPTION
Before:

<img width="775" alt="Screenshot 2019-06-12 at 20 27 33" src="https://user-images.githubusercontent.com/841956/59376536-96e4fc00-8d50-11e9-976e-78328bec9670.png">

After:

<img width="771" alt="Screenshot 2019-06-12 at 20 27 37" src="https://user-images.githubusercontent.com/841956/59376541-99dfec80-8d50-11e9-92e1-79b25bcae8df.png">
