### PR TITLE
Improve selection of background video

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -43,6 +43,7 @@ import {
 	addBackgroundColorToOverlay,
 	getCallToActionBlock,
 	isVideoSizeExcessive,
+	getVideoBytesPerSecond,
 } from '../../helpers';
 import {
 	ALLOWED_CHILD_BLOCKS,
@@ -53,6 +54,7 @@ import {
 	POSTER_ALLOWED_MEDIA_TYPES,
 	MAX_IMAGE_SIZE_SLUG,
 	VIDEO_ALLOWED_MEGABYTES_PER_SECOND,
+	MEGABYTE_IN_BYTES,
 } from '../../constants';
 import './edit.css';
 
@@ -254,6 +256,7 @@ class PageEdit extends Component {
 
 		const colorSettings = this.getOverlayColorSettings();
 		const isExcessiveVideoSize = VIDEO_BACKGROUND_TYPE === mediaType && isVideoSizeExcessive( media );
+		const videoBytesPerSecond = VIDEO_BACKGROUND_TYPE === mediaType ? getVideoBytesPerSecond( media ) : -1;
 
 		return (
 			<>
@@ -300,6 +303,12 @@ class PageEdit extends Component {
 											/* translators: %d: the number of recommended megabytes per second */
 											__( 'A video size of less than %d MB per second is recommended.', 'amp' ),
 											VIDEO_ALLOWED_MEGABYTES_PER_SECOND
+										)
+									}
+									{
+										videoBytesPerSecond > 0 && ' ' + sprintf(
+											__( 'The selected video is %d MB per second.', 'amp' ),
+											Math.round( videoBytesPerSecond / MEGABYTE_IN_BYTES )
 										)
 									}
 								</Notice>

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -307,6 +307,7 @@ class PageEdit extends Component {
 									}
 									{
 										videoBytesPerSecond > 0 && ' ' + sprintf(
+											/* translators: %d: the number of actual megabytes per second */
 											__( 'The selected video is %d MB per second.', 'amp' ),
 											Math.round( videoBytesPerSecond / MEGABYTE_IN_BYTES )
 										)

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -256,7 +256,7 @@ class PageEdit extends Component {
 
 		const colorSettings = this.getOverlayColorSettings();
 		const isExcessiveVideoSize = VIDEO_BACKGROUND_TYPE === mediaType && isVideoSizeExcessive( media );
-		const videoBytesPerSecond = VIDEO_BACKGROUND_TYPE === mediaType ? getVideoBytesPerSecond( media ) : -1;
+		const videoBytesPerSecond = VIDEO_BACKGROUND_TYPE === mediaType ? getVideoBytesPerSecond( media ) : null;
 
 		return (
 			<>
@@ -306,7 +306,7 @@ class PageEdit extends Component {
 										)
 									}
 									{
-										videoBytesPerSecond > 0 && ' ' + sprintf(
+										videoBytesPerSecond && ' ' + sprintf(
 											/* translators: %d: the number of actual megabytes per second */
 											__( 'The selected video is %d MB per second.', 'amp' ),
 											Math.round( videoBytesPerSecond / MEGABYTE_IN_BYTES )

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -312,7 +312,7 @@ class PageEdit extends Component {
 										value={ mediaId }
 										render={ ( { open } ) => (
 											<Button isDefault isLarge onClick={ open } className="editor-amp-story-page-background">
-												{ mediaUrl ? __( 'Edit Media', 'amp' ) : __( 'Select Media', 'amp' ) }
+												{ mediaUrl ? __( 'Change Media', 'amp' ) : __( 'Select Media', 'amp' ) }
 											</Button>
 										) }
 									/>

--- a/assets/src/stories-editor/constants.js
+++ b/assets/src/stories-editor/constants.js
@@ -106,7 +106,7 @@ export const ALLOWED_BLOCKS = [
 
 export const IMAGE_BACKGROUND_TYPE = 'image';
 export const VIDEO_BACKGROUND_TYPE = 'video';
-export const ALLOWED_MEDIA_TYPES = [ 'image', 'video' ];
+export const ALLOWED_MEDIA_TYPES = [ 'image', 'video/mp4' ];
 export const POSTER_ALLOWED_MEDIA_TYPES = [ 'image' ];
 export const MEDIA_INNER_BLOCKS = [ 'core/video', 'core/audio' ];
 export const MAX_IMAGE_SIZE_SLUG = 'amp_story_page';

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -1426,6 +1426,19 @@ export const getCallToActionBlock = ( pageClientId ) => {
 };
 
 /**
+ * Gets the number of megabytes per second for the video.
+ *
+ * @param {Object} media The media object of the video.
+ * @return {number} Number of megabytes per second, or -1 if media details unavailable.
+ */
+export const getVideoBytesPerSecond = ( media ) => {
+	if ( ! has( media, [ 'media_details', 'filesize' ] ) || ! has( media, [ 'media_details', 'length' ] ) ) {
+		return -1;
+	}
+	return media.media_details.filesize / media.media_details.length;
+};
+
+/**
  * Gets whether the video file size is over a certain amount of MB per second.
  *
  * @param {Object} media The media object of the video.

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -1429,11 +1429,11 @@ export const getCallToActionBlock = ( pageClientId ) => {
  * Gets the number of megabytes per second for the video.
  *
  * @param {Object} media The media object of the video.
- * @return {number} Number of megabytes per second, or -1 if media details unavailable.
+ * @return {number|null} Number of megabytes per second, or null if media details unavailable.
  */
 export const getVideoBytesPerSecond = ( media ) => {
 	if ( ! has( media, [ 'media_details', 'filesize' ] ) || ! has( media, [ 'media_details', 'length' ] ) ) {
-		return -1;
+		return null;
 	}
 	return media.media_details.filesize / media.media_details.length;
 };


### PR DESCRIPTION
* Limit video filetype to MP4
* Update “Edit Media“ to “Change Media” in button.
* Update warning to indicate the MB per second of the selected video. See https://github.com/ampproject/amp-wp/issues/2560#issuecomment-501117194.