### PR TITLE
Fix editing of draggable blocks in Safari

### DIFF
--- a/assets/src/stories-editor/components/block-mover/draggable.js
+++ b/assets/src/stories-editor/components/block-mover/draggable.js
@@ -116,9 +116,10 @@ class Draggable extends Component {
 		 * On dragging, the browser creates an image of the target, for example, the entire text block.
 		 * But there's already a clone below that's rotated in case the block is rotated,
 		 * and this can create a non-rotated duplicate of that.
-		 * So override this with an empty image.
+		 * So override this with a transparent image.
 		 */
 		const dragImage = new Image();
+		dragImage.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=';
 		event.dataTransfer.setDragImage( dragImage, 0, 0 );
 
 		event.dataTransfer.setData( 'text', JSON.stringify( transferData ) );

--- a/assets/src/stories-editor/components/block-mover/edit.css
+++ b/assets/src/stories-editor/components/block-mover/edit.css
@@ -21,6 +21,10 @@
 	margin: 0 auto;
 }
 
+.wp-block [draggable="true"] {
+	-webkit-user-select: auto;
+}
+
 .wp-block [draggable="true"]:hover {
 	cursor: grab;
 }


### PR DESCRIPTION
# Before
As @MackenzieHartung pointed out in #2612, it wasn't possible to type in any `[draggable]` element in Safari, meaning the Text block wasn't usable.

# After
This uses @miina's idea of `-webkit-user-select` for the `[draggable]` element that wraps the blocks.

This fixed the issue in Safari, at least in brief testing. Dragging also still works in Chrome and Firefox, after quick testing.

Fixes #2612