### PR TITLE
Always allow switching to Reader mode, but default to mode defined by theme

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -311,21 +311,18 @@ class AMP_Theme_Support {
 
 			$is_paired = ! empty( $args[ self::PAIRED_FLAG ] );
 
-			self::$support_added_via_theme = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
+			self::$support_added_via_theme  = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
+			self::$support_added_via_option = $theme_support_option;
 
-			/*
-			 * If the theme has transitional support, allow the user to opt for AMP-first mode via an option, since a theme
-			 * in transitional mode entails that it supports serving templates as both AMP and non-AMP, and this it is
-			 * able to serve AMP-first pages just as well as paired pages. Otherwise, consider that the the mode was
-			 * not set at all via option.
-			 */
+			// Make sure the user option can override what the theme has specified.
 			if ( $is_paired && self::STANDARD_MODE_SLUG === $theme_support_option ) {
 				$args[ self::PAIRED_FLAG ] = false;
 				add_theme_support( self::SLUG, $args );
-				self::$support_added_via_option = $theme_support_option;
+			} elseif ( ! $is_paired && self::TRANSITIONAL_MODE_SLUG === $theme_support_option ) {
+				$args[ self::PAIRED_FLAG ] = true;
+				add_theme_support( self::SLUG, $args );
 			} elseif ( self::READER_MODE_SLUG === $theme_support_option ) {
 				remove_theme_support( self::SLUG );
-				self::$support_added_via_option = $theme_support_option;
 			}
 		} elseif ( self::READER_MODE_SLUG !== $theme_support_option ) {
 			$is_paired = ( self::TRANSITIONAL_MODE_SLUG === $theme_support_option );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -71,6 +71,14 @@ class AMP_Theme_Support {
 	const TRANSITIONAL_MODE_SLUG = 'transitional';
 
 	/**
+	 * Slug identifying reader website mode.
+	 *
+	 * @since 1.2
+	 * @var string
+	 */
+	const READER_MODE_SLUG = 'reader';
+
+	/**
 	 * Flag used in args passed to add_theme_support('amp') to indicate transitional mode supported.
 	 *
 	 * @since 1.2
@@ -248,7 +256,7 @@ class AMP_Theme_Support {
 			$theme_support = self::get_support_mode_added_via_theme();
 		}
 		if ( ! $theme_support ) {
-			$theme_support = 'disabled';
+			$theme_support = self::READER_MODE_SLUG;
 		}
 		return $theme_support;
 	}
@@ -311,12 +319,15 @@ class AMP_Theme_Support {
 			 * able to serve AMP-first pages just as well as paired pages. Otherwise, consider that the the mode was
 			 * not set at all via option.
 			 */
-			self::$support_added_via_option = ( $is_paired && self::STANDARD_MODE_SLUG === $theme_support_option ) ? self::STANDARD_MODE_SLUG : null;
-			if ( self::STANDARD_MODE_SLUG === self::$support_added_via_option ) {
+			if ( $is_paired && self::STANDARD_MODE_SLUG === $theme_support_option ) {
 				$args[ self::PAIRED_FLAG ] = false;
-				add_theme_support( 'amp', $args );
+				add_theme_support( self::SLUG, $args );
+				self::$support_added_via_option = $theme_support_option;
+			} elseif ( self::READER_MODE_SLUG === $theme_support_option ) {
+				remove_theme_support( self::SLUG );
+				self::$support_added_via_option = $theme_support_option;
 			}
-		} elseif ( 'disabled' !== $theme_support_option ) {
+		} elseif ( self::READER_MODE_SLUG !== $theme_support_option ) {
 			$is_paired = ( self::TRANSITIONAL_MODE_SLUG === $theme_support_option );
 			add_theme_support(
 				self::SLUG,

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -128,7 +128,18 @@ class AMP_Options_Manager {
 		} elseif ( 'paired' === $options['theme_support'] ) {
 			$options['theme_support'] = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
 		} elseif ( 'disabled' === $options['theme_support'] ) {
-			$options['theme_support'] = AMP_Theme_Support::READER_MODE_SLUG;
+			/*
+			 * Prior to 1.2, the theme support slug for Reader mode was 'disabled'. This would be saved in options for
+			 * themes that had 'amp' theme support defined. Also prior to 1.2, the user could not switch between modes
+			 * when the theme had 'amp' theme support. The result is that a site running 1.1 could be AMP-first and then
+			 * upon upgrading to 1.2, be switched to Reader mode. So when migrating the old 'disabled' slug to the new
+			 * value, we need to make sure we use the default theme support slug as it has been determined above. If the
+			 * site has non-paired 'amp' theme support and the theme support slug is 'disabled' then it should here be
+			 * set to 'standard' as opposed to 'reader', and the same goes for paired 'amp' theme support, as it should
+			 * become 'transitional'. Otherwise, if the theme lacks 'amp' theme support, then this will become the
+			 * default 'reader' mode.
+			 */
+			$options['theme_support'] = $defaults['theme_support'];
 		}
 
 		return $options;

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -292,13 +292,13 @@ class AMP_Options_Menu {
 
 		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 			<?php if ( AMP_Theme_Support::READER_MODE_SLUG === AMP_Theme_Support::get_support_mode() ) : ?>
-				<?php if ( $builtin_support || AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
-					<div class="notice notice-success notice-alt inline">
-						<p><?php esc_html_e( 'Your active theme is known to work well in standard or transitional mode.', 'amp' ); ?></p>
-					</div>
-				<?php elseif ( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
+				<?php if ( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
 					<div class="notice notice-success notice-alt inline">
 						<p><?php esc_html_e( 'Your active theme is known to work well in standard mode.', 'amp' ); ?></p>
+					</div>
+				<?php elseif ( $builtin_support || AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
+					<div class="notice notice-success notice-alt inline">
+						<p><?php esc_html_e( 'Your active theme is known to work well in standard or transitional mode.', 'amp' ); ?></p>
 					</div>
 				<?php endif; ?>
 			<?php endif; ?>
@@ -319,17 +319,15 @@ class AMP_Options_Menu {
 				<dd>
 					<?php echo wp_kses_post( $standard_description ); ?>
 				</dd>
-				<?php if ( AMP_Theme_Support::STANDARD_MODE_SLUG !== AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
-					<dt>
-						<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>" <?php disabled( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ); ?> <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>
-						<label for="theme_support_transitional">
-							<strong><?php esc_html_e( 'Transitional', 'amp' ); ?></strong>
-						</label>
-					</dt>
-					<dd>
-						<?php echo wp_kses_post( $transitional_description ); ?>
-					</dd>
-				<?php endif; ?>
+				<dt>
+					<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>
+					<label for="theme_support_transitional">
+						<strong><?php esc_html_e( 'Transitional', 'amp' ); ?></strong>
+					</label>
+				</dt>
+				<dd>
+					<?php echo wp_kses_post( $transitional_description ); ?>
+				</dd>
 				<dt>
 					<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::READER_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::READER_MODE_SLUG ); ?>>
 					<label for="theme_support_disabled">

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -289,41 +289,39 @@ class AMP_Options_Menu {
 
 		$builtin_support = in_array( get_template(), AMP_Core_Theme_Sanitizer::get_supported_themes(), true );
 		?>
-		<?php if ( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
-			<div class="notice notice-info notice-alt inline">
-				<p><?php esc_html_e( 'Your active theme has built-in AMP support.', 'amp' ); ?></p>
-			</div>
-			<p>
-				<?php echo wp_kses_post( $standard_description ); ?>
-			</p>
-			<p>
-				<?php echo wp_kses_post( $ecosystem_description ); ?>
-			</p>
-		<?php else : ?>
-			<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
-				<?php if ( $builtin_support ) : ?>
+
+		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+			<?php if ( AMP_Theme_Support::READER_MODE_SLUG === AMP_Theme_Support::get_support_mode() ) : ?>
+				<?php if ( $builtin_support || AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
 					<div class="notice notice-success notice-alt inline">
 						<p><?php esc_html_e( 'Your active theme is known to work well in standard or transitional mode.', 'amp' ); ?></p>
 					</div>
+				<?php elseif ( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
+					<div class="notice notice-success notice-alt inline">
+						<p><?php esc_html_e( 'Your active theme is known to work well in standard mode.', 'amp' ); ?></p>
+					</div>
 				<?php endif; ?>
+			<?php endif; ?>
 
-				<?php if ( ! AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
-					<p>
-						<?php echo wp_kses_post( $ecosystem_description ); ?>
-					</p>
-				<?php endif; ?>
-				<dl>
+			<?php if ( ! AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
+				<p>
+					<?php echo wp_kses_post( $ecosystem_description ); ?>
+				</p>
+			<?php endif; ?>
+
+			<dl>
+				<dt>
+					<input type="radio" id="theme_support_standard" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>>
+					<label for="theme_support_standard">
+						<strong><?php esc_html_e( 'Standard', 'amp' ); ?></strong>
+					</label>
+				</dt>
+				<dd>
+					<?php echo wp_kses_post( $standard_description ); ?>
+				</dd>
+				<?php if ( AMP_Theme_Support::STANDARD_MODE_SLUG !== AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
 					<dt>
-						<input type="radio" id="theme_support_standard" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>>
-						<label for="theme_support_standard">
-							<strong><?php esc_html_e( 'Standard', 'amp' ); ?></strong>
-						</label>
-					</dt>
-					<dd>
-						<?php echo wp_kses_post( $standard_description ); ?>
-					</dd>
-					<dt>
-						<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>
+						<input type="radio" id="theme_support_transitional" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>" <?php disabled( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ); ?> <?php checked( $theme_support, AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); ?>>
 						<label for="theme_support_transitional">
 							<strong><?php esc_html_e( 'Transitional', 'amp' ); ?></strong>
 						</label>
@@ -331,59 +329,57 @@ class AMP_Options_Menu {
 					<dd>
 						<?php echo wp_kses_post( $transitional_description ); ?>
 					</dd>
-					<?php if ( ! AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
-						<dt>
-							<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="disabled" <?php checked( $theme_support, 'disabled' ); ?>>
-							<label for="theme_support_disabled">
-								<strong><?php esc_html_e( 'Reader', 'amp' ); ?></strong>
-							</label>
-						</dt>
-						<dd>
-							<?php echo wp_kses_post( $reader_description ); ?>
-
-							<?php if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) && wp_count_posts( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG )->publish > 0 ) : ?>
-								<div class="notice notice-info inline notice-alt">
-									<p>
-										<?php
-										echo wp_kses_post(
-											sprintf(
-												/* translators: %1: link to invalid URLs. 2: link to validation errors. */
-												__( 'View current site compatibility results for standard and transitional modes: %1$s and %2$s.', 'amp' ),
-												sprintf(
-													'<a href="%s">%s</a>',
-													esc_url( add_query_arg( 'post_type', AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, admin_url( 'edit.php' ) ) ),
-													esc_html( get_post_type_object( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG )->labels->name )
-												),
-												sprintf(
-													'<a href="%s">%s</a>',
-													esc_url(
-														add_query_arg(
-															array(
-																'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-																'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-															),
-															admin_url( 'edit-tags.php' )
-														)
-													),
-													esc_html( get_taxonomy( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG )->labels->name )
-												)
-											)
-										);
-										?>
-									</p>
-								</div>
-							<?php endif; ?>
-						</dd>
-					<?php endif; ?>
-				</dl>
-
-				<?php if ( AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
-					<p>
-						<?php echo wp_kses_post( $ecosystem_description ); ?>
-					</p>
 				<?php endif; ?>
-			</fieldset>
-		<?php endif; ?>
+				<dt>
+					<input type="radio" id="theme_support_disabled" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[theme_support]' ); ?>" value="<?php echo esc_attr( AMP_Theme_Support::READER_MODE_SLUG ); ?>" <?php checked( $theme_support, AMP_Theme_Support::READER_MODE_SLUG ); ?>>
+					<label for="theme_support_disabled">
+						<strong><?php esc_html_e( 'Reader', 'amp' ); ?></strong>
+					</label>
+				</dt>
+				<dd>
+					<?php echo wp_kses_post( $reader_description ); ?>
+
+					<?php if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) && wp_count_posts( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG )->publish > 0 ) : ?>
+						<div class="notice notice-info inline notice-alt">
+							<p>
+								<?php
+								echo wp_kses_post(
+									sprintf(
+										/* translators: %1: link to invalid URLs. 2: link to validation errors. */
+										__( 'View current site compatibility results for standard and transitional modes: %1$s and %2$s.', 'amp' ),
+										sprintf(
+											'<a href="%s">%s</a>',
+											esc_url( add_query_arg( 'post_type', AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, admin_url( 'edit.php' ) ) ),
+											esc_html( get_post_type_object( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG )->labels->name )
+										),
+										sprintf(
+											'<a href="%s">%s</a>',
+											esc_url(
+												add_query_arg(
+													array(
+														'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
+														'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
+													),
+													admin_url( 'edit-tags.php' )
+												)
+											),
+											esc_html( get_taxonomy( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG )->labels->name )
+										)
+									)
+								);
+								?>
+							</p>
+						</div>
+					<?php endif; ?>
+				</dd>
+			</dl>
+
+			<?php if ( AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
+				<p>
+					<?php echo wp_kses_post( $ecosystem_description ); ?>
+				</p>
+			<?php endif; ?>
+		</fieldset>
 		<?php
 	}
 
@@ -447,7 +443,7 @@ class AMP_Options_Menu {
 			<?php endif; ?>
 
 			<script>
-			(function( $, standardModeSlug ) {
+			(function( $, standardModeSlug, readerModeSlug ) {
 				const getThemeSupportMode = () => {
 					const checkedInput = $( 'input[type=radio][name="amp-options[theme_support]"]:checked' );
 					if ( 0 === checkedInput.length ) {
@@ -456,17 +452,21 @@ class AMP_Options_Menu {
 					return checkedInput.val();
 				};
 
-				var updateHiddenClasses = function() {
+				const updateHiddenClasses = function() {
 					const themeSupportMode = getThemeSupportMode();
 					$( '.amp-auto-accept-sanitize' ).toggleClass( 'hidden', standardModeSlug === themeSupportMode );
-					$( '.amp-validation-field' ).toggleClass( 'hidden', 'disabled' === themeSupportMode );
+					$( '.amp-validation-field' ).toggleClass( 'hidden', readerModeSlug === themeSupportMode );
 					$( '.amp-auto-accept-sanitize-canonical' ).toggleClass( 'hidden', standardModeSlug !== themeSupportMode );
 				};
 
 				$( 'input[type=radio][name="amp-options[theme_support]"]' ).change( updateHiddenClasses );
 
 				updateHiddenClasses();
-			})( jQuery, <?php echo wp_json_encode( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?> );
+			})(
+				jQuery,
+				<?php echo wp_json_encode( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>,
+				<?php echo wp_json_encode( AMP_Theme_Support::READER_MODE_SLUG ); ?>
+			);
 			</script>
 		</fieldset>
 		<?php

--- a/tests/test-amp-helper-functions.php
+++ b/tests/test-amp-helper-functions.php
@@ -314,6 +314,8 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				'template_dir' => './',
 			)
 		);
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
+		AMP_Theme_Support::read_theme_support();
 		AMP_Theme_Support::init();
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
 			array(

--- a/tests/test-amp-style-sanitizer.php
+++ b/tests/test-amp-style-sanitizer.php
@@ -20,6 +20,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		global $wp_styles, $wp_scripts;
 		$wp_styles  = null;
 		$wp_scripts = null;
+		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
 	}
 
 	/**

--- a/tests/test-class-amp-options-manager.php
+++ b/tests/test-class-amp-options-manager.php
@@ -13,6 +13,15 @@
 class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 	/**
+	 * Set up.
+	 */
+	public function setUp() {
+		parent::setUp();
+		remove_theme_support( AMP_Theme_Support::SLUG );
+		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
+	}
+
+	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
 	public function tearDown() {
@@ -104,7 +113,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEquals(
 			array(
 				'experiences'              => array( AMP_Options_Manager::WEBSITE_EXPERIENCE ),
-				'theme_support'            => 'disabled',
+				'theme_support'            => AMP_Theme_Support::READER_MODE_SLUG,
 				'supported_post_types'     => array( 'post' ),
 				'analytics'                => array(),
 				'auto_accept_sanitization' => true,
@@ -294,7 +303,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		// Test when 'all_templates_supported' is not selected, and theme support is also disabled.
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
-		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post' ) );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
@@ -307,7 +316,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		remove_post_type_support( 'foo', AMP_Post_Type_Support::SLUG );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'foo' ) );
-		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::check_supported_post_type_update_errors();
 		$settings_errors = get_settings_errors();
 		$this->assertCount( 1, $settings_errors );
@@ -474,7 +483,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 
 		$page_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
 		AMP_Options_Manager::update_option( 'supported_post_types', array( 'page' ) );
-		AMP_Options_Manager::update_option( 'theme_support', 'disabled' );
+		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::READER_MODE_SLUG );
 		AMP_Options_Manager::handle_updated_theme_support_option();
 		$amp_settings_errors = get_settings_errors( AMP_Options_Manager::OPTION_NAME );
 		$new_error           = end( $amp_settings_errors );

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -158,11 +158,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Theme_Support::read_theme_support();
 		$this->assertSame( AMP_Theme_Support::READER_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 
-		// Test that Standard mode in theme overrides Transitional mode set via option.
+		// Test that Standard mode in theme does not override Transitional mode set via option (user option prevails).
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
 		AMP_Theme_Support::read_theme_support();
-		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
+		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 
 		// Test that standard via option trumps transitional in theme.
 		$args = array(
@@ -187,15 +187,15 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
 
-		// Test that standard via theme always trumps transitional via option.
+		// Test that standard via theme does not trump transitional option.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG ); // Will be ignored since standard in theme overrides transitional option.
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
-		$this->assertNull( AMP_Theme_Support::get_support_mode_added_via_option() );
+		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_theme() );
-		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
-		$this->assertEquals( array( AMP_Theme_Support::PAIRED_FLAG => false ), AMP_Theme_Support::get_theme_support_args() );
+		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
+		$this->assertEquals( array( AMP_Theme_Support::PAIRED_FLAG => true ), AMP_Theme_Support::get_theme_support_args() );
 
 		// Test that no support via theme can be overridden with option.
 		remove_theme_support( AMP_Theme_Support::SLUG );

--- a/tests/test-class-amp-widget-archives.php
+++ b/tests/test-class-amp-widget-archives.php
@@ -26,6 +26,7 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
+		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		wp_maybe_load_widgets();
 		AMP_Theme_Support::init();

--- a/tests/test-class-amp-widget-categories.php
+++ b/tests/test-class-amp-widget-categories.php
@@ -27,6 +27,7 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		add_theme_support( AMP_Theme_Support::SLUG );
+		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
 		wp_maybe_load_widgets();
 		AMP_Theme_Support::init();
 		$this->widget = new AMP_Widget_Categories();

--- a/tests/validation/test-class-amp-validation-manager.php
+++ b/tests/validation/test-class-amp-validation-manager.php
@@ -99,6 +99,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 				}
 			}
 		}
+		delete_option( AMP_Options_Manager::OPTION_NAME ); // Make sure default reader mode option does not override theme support being added.
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up on #2550.

When using a core theme, a notice is displayed encouraging a user to switch to Standard or Transitional mode:

![image](https://user-images.githubusercontent.com/134745/59463406-c4768780-8dda-11e9-9037-b41f9f5ba18a.png)

If using a non-core theme without any special theme support, it looks like:

![image](https://user-images.githubusercontent.com/134745/59463453-dc4e0b80-8dda-11e9-8881-7fc6f95e7fe2.png)

However, when using a theme like [Neve](https://wordpress.org/themes/neve/) which has built-in paired AMP support, the Reader mode option is removed:

![image](https://user-images.githubusercontent.com/134745/59461738-ebcb5580-8dd6-11e9-806e-819f643714fa.png)

The user can still switch to Transitional mode (see #2312), but the Reader mode is gone. 

Additionally, if a theme is active which is AMP-first (non-paired `amp` theme support declared), then they see no options at all:

![image](https://user-images.githubusercontent.com/134745/59461836-2503c580-8dd7-11e9-8a12-89c8349f0f7c.png)

This can be undesirable because while the theme itself has `amp` support, the plugins being used by the theme may very well not. For such sites, having the option to stay in Reader mode is important until AMP-compatible plugins can be activated. As it stands today, the lack of Reader mode availability could cause theme makers hesitate from adding AMP compatibility, since it limits the options available to their users. It could cause users to either switch to a different theme if they want AMP, or turn off AMP if they really want the theme. 

So we should let Reader mode always be an available option. Nevertheless, upon activating the AMP plugin and the theme has `amp` support, then the default option should be Standard when `paired`  flag is present and Transitional when `paired` flag is present. As explained in #2312, if `paired` is absent then the Transitional mode should still not be made available.

This is related to #1384: Default to transitional mode with auto-sanitization for new activations, and to native mode when compatible theme/plugins active.

# Proposed Changes

No change for when a core theme is being used, continuing to default to Reader mode or when using a theme that lacks `amp` theme support.

However, when switching to a theme like Neve which has `paired` theme support, then for _existing_ plugin activations (which had previously been on Reader) then the Reader mode remains active and a green notice is displayed encouraging them to switch:

![image](https://user-images.githubusercontent.com/134745/59463740-862d9800-8ddb-11e9-9ebc-c5a7f5797cc6.png)

For _new_ AMP plugin activations, the default mode is Transitional, and again the Reader mode is still presented as an option (the notice is removed because the user switched):

![image](https://user-images.githubusercontent.com/134745/59463818-aeb59200-8ddb-11e9-95bf-29caaec36183.png)

Similarly, if the user has activated a theme that has `amp` theme support without the `paired` flag (i.e. an AMP-first theme), then upon switching to such a theme from an _existing_ Reader mode install they would see defaulting to Reader with a notice:

![image](https://user-images.githubusercontent.com/134745/59468260-723b6380-8de6-11e9-9110-3a805b73203c.png)

And _brand new_ AMP plugin activations would default to Standard for themes that have non-paried `amp` theme support, but with the ability to switch to Reader:

![image](https://user-images.githubusercontent.com/134745/59468303-88492400-8de6-11e9-9672-dafb619d43c0.png)