### PR TITLE
Fix Text block's padding and related resizing issues

### DIFF
--- a/assets/css/amp-stories-editor.css
+++ b/assets/css/amp-stories-editor.css
@@ -105,6 +105,20 @@
 	height: 100%;
 }
 
+.wp-block[data-type="core/video"] .block-mover,
+.wp-block[data-type="core/video"] .block-mover div {
+	height: 100%;
+}
+
+.wp-block[data-type="core/video"] .block-mover .editor-rich-text.block-editor-rich-text,
+.wp-block[data-type="core/video"] .block-mover .editor-rich-text.block-editor-rich-text div {
+	height: initial;
+}
+
+.wp-block[data-type="core/video"] .wp-block-video {
+	margin: 0;
+}
+
 .wp-block-code textarea {
 	white-space: nowrap;
 }

--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -11,10 +11,18 @@ amp-story-grid-layer[template="fill"] .wp-block-image {
 	padding: 7px !important;
 }
 
+/* with amp-fit-text */
 .wp-block-amp-amp-story-post-author,
 .wp-block-amp-amp-story-post-title,
 .wp-block-amp-amp-story-post-date {
 	display: flex;
+}
+
+/* no amp-fit-text */
+.wp-block-amp-amp-story-post-author.amp-text-content,
+.wp-block-amp-amp-story-post-title.amp-text-content,
+.wp-block-amp-amp-story-post-date.amp-text-content {
+	display: block;
 }
 
 .wp-block-amp-amp-story-cta.aligncenter {

--- a/assets/src/stories-editor/blocks/amp-story-post-author/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-post-author/edit.css
@@ -12,6 +12,10 @@
 	justify-content: center;
 }
 
+.wp-block[data-type="amp/amp-story-post-author"] .wp-block-amp-amp-story-post-author:not(.is-amp-fit-text) {
+	display: block;
+}
+
 .wp-block[data-type="amp/amp-story-post-author"] .wp-block-amp-amp-story-post-author.is-amp-fit-text.is-measuring-fontsize {
 	height: initial !important;
 	width: initial !important;

--- a/assets/src/stories-editor/blocks/amp-story-post-date/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-post-date/edit.css
@@ -12,6 +12,10 @@
 	justify-content: center;
 }
 
+.wp-block[data-type="amp/amp-story-post-date"] .wp-block-amp-amp-story-post-date:not(.is-amp-fit-text) {
+	display: block;
+}
+
 .wp-block[data-type="amp/amp-story-post-date"] .wp-block-amp-amp-story-post-date.is-amp-fit-text.is-measuring-fontsize {
 	height: initial !important;
 	width: initial !important;

--- a/assets/src/stories-editor/blocks/amp-story-post-title/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-post-title/edit.css
@@ -13,6 +13,10 @@
 	font-weight: 700;
 }
 
+.wp-block[data-type="amp/amp-story-post-title"] .wp-block-amp-amp-story-post-title:not(.is-amp-fit-text) {
+	display: block;
+}
+
 .wp-block[data-type="amp/amp-story-post-title"] .wp-block-amp-amp-story-post-title.is-amp-fit-text.is-measuring-fontsize {
 	height: initial !important;
 	width: initial !important;

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -58,6 +58,10 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	line-height: 1.15;
 }
 
+.wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .wp-block-amp-amp-story-text {
+	width: 100%;
+}
+
 .wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .is-amp-fit-text.is-measuring-fontsize {
 	height: initial !important;
 	width: initial !important;

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -7,7 +7,6 @@
  */
 .wp-block-amp-story-text .block-editor-rich-text__editable {
 	padding: 7px !important;
-	width: 100%;
 }
 
 .wp-block[data-type="amp/amp-story-text"] .amp-story-resize-container .components-resizable-box__handle-right {

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -82,7 +82,3 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 .wp-block[data-type="amp/amp-story-text"] .block-mover div {
 	height: 100%;
 }
-
-.wp-block-amp-story-text {
-	line-height: initial;
-}

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -59,11 +59,6 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	line-height: 1.15;
 }
 
-.wp-block-amp-story-text-wrapper:not(.with-line-height),
-.wp-block-amp-story-text-wrapper:not(.with-line-height) * {
-	height: 100%;
-}
-
 .wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .is-amp-fit-text.is-measuring-fontsize {
 	height: initial !important;
 	width: initial !important;
@@ -86,4 +81,8 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 .wp-block[data-type="amp/amp-story-text"] .block-mover,
 .wp-block[data-type="amp/amp-story-text"] .block-mover div {
 	height: 100%;
+}
+
+.wp-block-amp-story-text {
+	line-height: initial;
 }

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -7,6 +7,7 @@
  */
 .wp-block-amp-story-text .block-editor-rich-text__editable {
 	padding: 7px !important;
+	width: 100%;
 }
 
 .wp-block[data-type="amp/amp-story-text"] .amp-story-resize-container .components-resizable-box__handle-right {
@@ -56,10 +57,6 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	display: inline-block;
 	vertical-align: middle;
 	line-height: 1.15;
-}
-
-.wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .wp-block-amp-amp-story-text {
-	width: 100%;
 }
 
 .wp-block[data-type="amp/amp-story-text"] .wp-block-amp-story-text .is-amp-fit-text.is-measuring-fontsize {

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -106,13 +106,16 @@ class TextBlockEdit extends Component {
 		const { colors } = select( 'core/block-editor' ).getSettings();
 		const appliedBackgroundColor = getBackgroundColorWithOpacity( colors, backgroundColor, customBackgroundColor, opacity );
 
-		const wrapperStyle = ampFitText && content.length ? { lineHeight: height + 'px', backgroundColor: appliedBackgroundColor } : null;
+		const wrapperStyle = { backgroundColor: appliedBackgroundColor };
+		if ( ampFitText && content.length ) {
+			wrapperStyle.lineHeight = height + 'px';
+		}
 
 		const styleClasses = [];
 		let wrapperClass = 'wp-block-amp-story-text-wrapper';
 
 		// We need to assign the block styles to the wrapper, too.
-		if ( ampFitText && attributes.className && attributes.className.length ) {
+		if ( attributes.className && attributes.className.length ) {
 			const classNames = attributes.className.split( ' ' );
 			classNames.forEach( ( value ) => {
 				if ( value.includes( 'is-style' ) ) {
@@ -146,7 +149,6 @@ class TextBlockEdit extends Component {
 						onReplace={ this.onReplace }
 						onSplit={ () => {} }
 						style={ {
-							backgroundColor: ampFitText ? undefined : appliedBackgroundColor,
 							color: textColor.color,
 							fontSize: ampFitText ? autoFontSize + 'px' : userFontSize,
 							textAlign: align,
@@ -154,8 +156,6 @@ class TextBlockEdit extends Component {
 						} }
 						className={ classnames( className, {
 							'has-text-color': textColor.color,
-							'has-background': ampFitText ? undefined : backgroundColor.color,
-							[ backgroundColor.class ]: ampFitText ? undefined : backgroundColor.class,
 							[ textColor.class ]: textColor.class,
 							[ fontSize.class ]: ampFitText ? undefined : fontSize.class,
 							'is-amp-fit-text': ampFitText,

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -160,11 +160,16 @@ const EnhancedResizableBox = ( props ) => {
 				if ( textElement && isReducing ) {
 					// If we have a rotated block, let's assign the width and height for measuring.
 					// Without assigning the new measure, the calculation would be incorrect due to angle.
-					// Text block is handled differently since the text block's content doesn't have 100% width/height.
-					if ( angle && ! isText ) {
-						textElement.style.width = appliedWidth + 'px';
-						textElement.style.height = appliedHeight + 'px';
+					// Text block is handled differently since the text block's content shouldn't have full width while measuring.
+					if ( angle ) {
+						if ( ! isText ) {
+							textElement.style.width = appliedWidth + 'px';
+							textElement.style.height = appliedHeight + 'px';
+						} else if ( isText && ! ampFitText ) {
+							textElement.style.width = 'initial';
+						}
 					}
+
 					const scrollWidth = isText ? textElement.scrollWidth + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollWidth;
 					const scrollHeight = isText ? textElement.scrollHeight + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollHeight;
 					if ( appliedWidth < scrollWidth || appliedHeight < scrollHeight ) {
@@ -172,9 +177,13 @@ const EnhancedResizableBox = ( props ) => {
 						appliedHeight = lastHeight;
 					}
 					// If we have rotated block, let's restore the correct measures.
-					if ( angle && ! isText ) {
-						textElement.style.width = 'initial';
-						textElement.style.height = '100%';
+					if ( angle ) {
+						if ( ! isText ) {
+							textElement.style.width = 'initial';
+							textElement.style.height = '100%';
+						} else if ( isText && ! ampFitText ) {
+							textElement.style.width = '100%';
+						}
 					}
 				}
 
@@ -182,8 +191,15 @@ const EnhancedResizableBox = ( props ) => {
 					const radianAngle = getRadianFromDeg( angle );
 
 					// Compare position between the initial and after resizing.
-					const initialPosition = getBlockPositioning( width, height, radianAngle );
-					const resizedPosition = getBlockPositioning( appliedWidth, appliedHeight, radianAngle );
+					let initialPosition, resizedPosition;
+					// If it's a text block, we shouldn't consider the added padding for measuring.
+					if ( isText ) {
+						initialPosition = getBlockPositioning( width - ( TEXT_BLOCK_PADDING * 2 ), height - ( TEXT_BLOCK_PADDING * 2 ), radianAngle );
+						resizedPosition = getBlockPositioning( appliedWidth - ( TEXT_BLOCK_PADDING * 2 ), appliedHeight - ( TEXT_BLOCK_PADDING * 2 ), radianAngle );
+					} else {
+						initialPosition = getBlockPositioning( width, height, radianAngle );
+						resizedPosition = getBlockPositioning( appliedWidth, appliedHeight, radianAngle );
+					}
 					const diff = {
 						left: resizedPosition.left - initialPosition.left,
 						top: resizedPosition.top - initialPosition.top,

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -158,22 +158,11 @@ const EnhancedResizableBox = ( props ) => {
 				const isReducing = 0 > deltaW || 0 > deltaH;
 
 				if ( textElement && isReducing ) {
-					// If we have a rotated block, let's assign the width and height for measuring.
-					// Without assigning the new measure, the calculation would be incorrect due to angle.
-					if ( angle ) {
-						textElement.style.width = appliedWidth - ( TEXT_BLOCK_BORDER * 2 ) + 'px';
-						textElement.style.height = appliedHeight - ( TEXT_BLOCK_BORDER * 2 ) + 'px';
-					}
 					const scrollWidth = isText ? textElement.scrollWidth + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollWidth;
 					const scrollHeight = isText ? textElement.scrollHeight + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollHeight;
 					if ( appliedWidth < scrollWidth || appliedHeight < scrollHeight ) {
 						appliedWidth = lastWidth;
 						appliedHeight = lastHeight;
-					}
-					// If we have rotated block, let's restore the correct measures.
-					if ( angle ) {
-						textElement.style.width = 'initial';
-						textElement.style.height = '100%';
 					}
 				}
 

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -161,8 +161,8 @@ const EnhancedResizableBox = ( props ) => {
 					// If we have a rotated block, let's assign the width and height for measuring.
 					// Without assigning the new measure, the calculation would be incorrect due to angle.
 					if ( angle ) {
-						textElement.style.width = appliedWidth + 'px';
-						textElement.style.height = appliedHeight + 'px';
+						textElement.style.width = appliedWidth - ( TEXT_BLOCK_BORDER * 2 ) + 'px';
+						textElement.style.height = appliedHeight - ( TEXT_BLOCK_BORDER * 2 ) + 'px';
 					}
 					const scrollWidth = isText ? textElement.scrollWidth + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollWidth;
 					const scrollHeight = isText ? textElement.scrollHeight + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollHeight;

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -21,7 +21,7 @@ import {
 	getRadianFromDeg,
 } from '../../helpers';
 
-import { BLOCKS_WITH_TEXT_SETTINGS, TEXT_BLOCK_BORDER } from '../../constants';
+import { BLOCKS_WITH_TEXT_SETTINGS, TEXT_BLOCK_BORDER, TEXT_BLOCK_PADDING } from '../../constants';
 
 let lastSeenX = 0,
 	lastSeenY = 0,
@@ -56,6 +56,11 @@ const EnhancedResizableBox = ( props ) => {
 	const isImage = 'core/image' === blockName;
 	const isBlockWithText = BLOCKS_WITH_TEXT_SETTINGS.includes( blockName ) || 'core/code' === blockName;
 	const isText = 'amp/amp-story-text' === blockName;
+
+	if ( isText ) {
+		height += TEXT_BLOCK_PADDING * 2;
+		width += TEXT_BLOCK_PADDING * 2;
+	}
 
 	const textBlockBorderInPercentageTop = getPercentageFromPixels( 'y', TEXT_BLOCK_BORDER );
 	const textBlockBorderInPercentageLeft = getPercentageFromPixels( 'x', TEXT_BLOCK_BORDER );
@@ -94,8 +99,8 @@ const EnhancedResizableBox = ( props ) => {
 				const positionLeft = ! isText ? Number( elementLeft.toFixed( 2 ) ) : Number( ( elementLeft + textBlockBorderInPercentageLeft ).toFixed( 2 ) );
 
 				onResizeStop( {
-					width: parseInt( appliedWidth, 10 ),
-					height: parseInt( appliedHeight, 10 ),
+					width: isText ? parseInt( appliedWidth, 10 ) - ( TEXT_BLOCK_PADDING * 2 ) : parseInt( appliedWidth, 10 ),
+					height: isText ? parseInt( appliedHeight, 10 ) - ( TEXT_BLOCK_PADDING * 2 ) : parseInt( appliedHeight, 10 ),
 					positionTop,
 					positionLeft,
 				} );
@@ -159,7 +164,9 @@ const EnhancedResizableBox = ( props ) => {
 						textElement.style.width = appliedWidth + 'px';
 						textElement.style.height = appliedHeight + 'px';
 					}
-					if ( appliedWidth < textElement.scrollWidth || appliedHeight < textElement.scrollHeight ) {
+					const scrollWidth = isText ? textElement.scrollWidth + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollWidth;
+					const scrollHeight = isText ? textElement.scrollHeight + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollHeight;
+					if ( appliedWidth < scrollWidth || appliedHeight < scrollHeight ) {
 						appliedWidth = lastWidth;
 						appliedHeight = lastHeight;
 					}

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -137,7 +137,7 @@ const EnhancedResizableBox = ( props ) => {
 					textElement = null;
 				}
 
-				if ( ampFitText && 'amp/amp-story-text' === blockName ) {
+				if ( ampFitText && isText ) {
 					textBlockWrapper = blockElement.querySelector( '.with-line-height' );
 				} else {
 					textBlockWrapper = null;
@@ -205,7 +205,7 @@ const EnhancedResizableBox = ( props ) => {
 				lastHeight = appliedHeight;
 
 				if ( textBlockWrapper && ampFitText ) {
-					textBlockWrapper.style.lineHeight = appliedHeight + 'px';
+					textBlockWrapper.style.lineHeight = isText ? appliedHeight - ( TEXT_BLOCK_PADDING * 2 ) + 'px' : appliedHeight + 'px';
 				}
 
 				// If it's image, let's change the width and height of the image, too.

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -158,11 +158,23 @@ const EnhancedResizableBox = ( props ) => {
 				const isReducing = 0 > deltaW || 0 > deltaH;
 
 				if ( textElement && isReducing ) {
+					// If we have a rotated block, let's assign the width and height for measuring.
+					// Without assigning the new measure, the calculation would be incorrect due to angle.
+					// Text block is handled differently since the text block's content doesn't have 100% width/height.
+					if ( angle && ! isText ) {
+						textElement.style.width = appliedWidth + 'px';
+						textElement.style.height = appliedHeight + 'px';
+					}
 					const scrollWidth = isText ? textElement.scrollWidth + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollWidth;
 					const scrollHeight = isText ? textElement.scrollHeight + ( TEXT_BLOCK_BORDER * 2 ) : textElement.scrollHeight;
 					if ( appliedWidth < scrollWidth || appliedHeight < scrollHeight ) {
 						appliedWidth = lastWidth;
 						appliedHeight = lastHeight;
+					}
+					// If we have rotated block, let's restore the correct measures.
+					if ( angle && ! isText ) {
+						textElement.style.width = 'initial';
+						textElement.style.height = '100%';
 					}
 				}
 

--- a/assets/src/stories-editor/constants.js
+++ b/assets/src/stories-editor/constants.js
@@ -237,3 +237,4 @@ export const AMP_STORY_FONT_IMAGES = {
 };
 
 export const TEXT_BLOCK_BORDER = 5;
+export const TEXT_BLOCK_PADDING = 7;

--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -39,6 +39,7 @@ import {
 	BLOCKS_WITH_TEXT_SETTINGS,
 	MEGABYTE_IN_BYTES,
 	VIDEO_ALLOWED_MEGABYTES_PER_SECOND,
+	TEXT_BLOCK_BORDER,
 } from '../constants';
 import {
 	MAX_FONT_SIZE,
@@ -1173,7 +1174,7 @@ export const maybeUpdateFontSize = ( block ) => {
 			const element = getBlockInnerTextElement( block );
 
 			if ( element && ampFitText && content.length ) {
-				const fitFontSize = calculateFontSize( element, height, width, MAX_FONT_SIZE, MIN_FONT_SIZE );
+				const fitFontSize = calculateFontSize( element, height + TEXT_BLOCK_BORDER, width + TEXT_BLOCK_BORDER, MAX_FONT_SIZE, MIN_FONT_SIZE );
 
 				if ( fitFontSize && autoFontSize !== fitFontSize ) {
 					updateBlockAttributes( clientId, { autoFontSize: fitFontSize } );


### PR DESCRIPTION
Fixes #2620.

Aims to fix the following issues:
- Text content going over the edge of its wrapper.
- Resizing rotated Text block not working properly.

Also fixes #2629.

- Fixes aligning meta blocks in both the editor and on the frontend