### PR TITLE
Only add text block template for the default page in a story

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -460,7 +460,7 @@ class PageEdit extends Component {
 					{ backgroundColors.length > 0 && (
 						<div style={ overlayStyle } />
 					) }
-					<InnerBlocks template={ TEMPLATE } allowedBlocks={ allowedBlocks } />
+					<InnerBlocks allowedBlocks={ allowedBlocks } />
 				</div>
 			</>
 		);

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -58,10 +58,6 @@ import {
 } from '../../constants';
 import './edit.css';
 
-const TEMPLATE = [
-	[ 'amp/amp-story-text' ],
-];
-
 class PageEdit extends Component {
 	shouldComponentUpdate() {
 		this.ensureCTABeingLast();

--- a/assets/src/stories-editor/blocks/amp-story-page/test/__snapshots__/index.js.snap
+++ b/assets/src/stories-editor/blocks/amp-story-page/test/__snapshots__/index.js.snap
@@ -6,6 +6,14 @@ exports[`amp/amp-story-page block edit matches snapshot 1`] = `
 >
   <div
     class="editor-inner-blocks block-editor-inner-blocks"
-  />
+  >
+    <div
+      class="editor-block-list__layout block-editor-block-list__layout"
+    >
+      <div
+        class="block-list-appender"
+      />
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
When creating a new story, the first page has an empty text block in it.

When adding new pages, no text block is added to the page.

Fixes #2541.
Fixes #2632. Or at least almost.

The #2632 bug still happens for the default text block on the first page when creating a new story. This is an upstream issue in Gutenberg with templates.

I think this PR is a good compromise in the meantime until this issue gets fixed in Gutenberg.