### PR TITLE
Re-calculate font sizes of text block in more cases

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -40,12 +40,16 @@ class TextBlockEdit extends Component {
 			height,
 			width,
 			content,
+			ampFitText,
+			ampFontFamily,
 		} = attributes;
 
 		if (
 			prevProps.attributes.height === height &&
 			prevProps.attributes.width === width &&
-			prevProps.attributes.content === content
+			prevProps.attributes.content === content &&
+			prevProps.attributes.ampFitText === ampFitText &&
+			prevProps.attributes.ampFontFamily === ampFontFamily
 		) {
 			return;
 		}
@@ -179,6 +183,7 @@ TextBlockEdit.propTypes = {
 		autoFontSize: PropTypes.number,
 		tagName: PropTypes.string,
 		opacity: PropTypes.number,
+		ampFontFamily: PropTypes.string,
 	} ).isRequired,
 	isSelected: PropTypes.bool.isRequired,
 	onReplace: PropTypes.func.isRequired,


### PR DESCRIPTION
This way it also runs when the content changes, ampFitText is toggled, or the font family is changed.

**UNTESTED:** I am not sure if these changes even make sense.