### PR TITLE
Add RSS feed link for Stories

### DIFF
--- a/includes/admin/class-amp-story-templates.php
+++ b/includes/admin/class-amp-story-templates.php
@@ -32,7 +32,7 @@ class AMP_Story_Templates {
 	 * Init.
 	 */
 	public function init() {
-		if ( ! post_type_exists( 'amp_story' ) ) {
+		if ( ! post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			return;
 		}
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -324,8 +324,6 @@ class AMP_Story_Post_Type {
 		);
 
 		add_action( 'wp_head', array( __CLASS__, 'print_feed_link' ) );
-
-		self::maybe_flush_rewrite_rules();
 	}
 
 	/**
@@ -1361,29 +1359,6 @@ class AMP_Story_Post_Type {
 		}
 
 		return ob_get_clean();
-	}
-
-	/**
-	 * Flushes rewrite rules if it hasn't been done yet after having AMP Stories Post type.
-	 */
-	public static function maybe_flush_rewrite_rules() {
-		$current_rules = get_option( 'rewrite_rules' );
-
-		// If we're not using permalinks.
-		if ( empty( $current_rules ) ) {
-			return;
-		}
-
-		// Check if the rewrite rule for showing preview exists for different permalink settings.
-		$story_rules = array_filter(
-			array_keys( $current_rules ),
-			function( $rule ) {
-				return 0 === strpos( $rule, self::REWRITE_SLUG ) || false !== strpos( $rule, '/' . self::REWRITE_SLUG . '/' );
-			}
-		);
-		if ( empty( $story_rules ) ) {
-			flush_rewrite_rules( false );
-		}
 	}
 
 	/**

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -1387,15 +1387,11 @@ class AMP_Story_Post_Type {
 	}
 
 	/**
-	 * Add RSS feed link for stories, if theme supports automatic-feed-links.
+	 * Add RSS feed link for stories.
 	 *
 	 * @since 1.2
 	 */
 	public static function print_feed_link() {
-		if ( ! current_theme_supports( 'automatic-feed-links' ) ) {
-			return;
-		}
-
 		$post_type_object = get_post_type_object( self::POST_TYPE_SLUG );
 		$feed_url         = add_query_arg(
 			'post_type',

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -323,6 +323,8 @@ class AMP_Story_Post_Type {
 			}
 		);
 
+		add_action( 'wp_head', array( __CLASS__, 'print_feed_link' ) );
+
 		self::maybe_flush_rewrite_rules();
 	}
 
@@ -1382,6 +1384,30 @@ class AMP_Story_Post_Type {
 		if ( empty( $story_rules ) ) {
 			flush_rewrite_rules( false );
 		}
+	}
+
+	/**
+	 * Add RSS feed link for stories, if theme supports automatic-feed-links.
+	 *
+	 * @since 1.2
+	 */
+	public static function print_feed_link() {
+		if ( ! current_theme_supports( 'automatic-feed-links' ) ) {
+			return;
+		}
+
+		$post_type_object = get_post_type_object( self::POST_TYPE_SLUG );
+		$feed_url         = add_query_arg(
+			'post_type',
+			self::POST_TYPE_SLUG,
+			get_feed_link()
+		);
+		printf(
+			'<link rel="alternate" type="%s" title="%s" href="%s">',
+			esc_attr( feed_content_type() ),
+			esc_attr( $post_type_object->labels->name ),
+			esc_url( $feed_url )
+		);
 	}
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -85,11 +85,22 @@ class AMP_Options_Manager {
 		sort( $old_experiences );
 		sort( $new_experiences );
 		if ( $old_post_types !== $new_post_types || $old_experiences !== $new_experiences ) {
+
+			// Ensure story post type registration is up to date prior to flushing rewrite rules.
+			$story_post_type = get_post_type_object( AMP_Story_Post_Type::POST_TYPE_SLUG );
+			if ( self::is_stories_experience_enabled() && ! $story_post_type ) {
+				AMP_Story_Post_Type::register();
+			} elseif ( ! self::is_stories_experience_enabled() && $story_post_type ) {
+				$story_post_type->remove_rewrite_rules();
+				unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
+			}
+
+			// Flush rewrite rules, with ensuring up to date for website experience.
 			if ( self::is_website_experience_enabled() ) {
 				add_rewrite_endpoint( amp_get_slug(), EP_PERMALINK );
 				flush_rewrite_rules( false );
 			} else {
-				amp_deactivate();
+				amp_deactivate(); // This will call flush_rewrite_rules( false ).
 			}
 		}
 	}

--- a/tests/test-class-amp-story-post-type.php
+++ b/tests/test-class-amp-story-post-type.php
@@ -16,6 +16,10 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		if ( ! AMP_Story_Post_Type::has_required_block_capabilities() ) {
+			$this->markTestSkipped( 'The function register_block_type() is not present, so the AMP Story post type was not registered.' );
+		}
+
 		if ( class_exists( 'WP_Block_Type_Registry' ) ) {
 			foreach ( WP_Block_Type_Registry::get_instance()->get_all_registered() as $block ) {
 				if ( 'amp/' === substr( $block->name, 0, 4 ) ) {
@@ -129,10 +133,6 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Post_Type::enqueue_embed_styling()
 	 */
 	public function test_enqueue_embed_styling() {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'The function register_block_type() is not present, so the AMP Story post type was not registered.' );
-		}
-
 		AMP_Story_Post_Type::register();
 
 		// None of the conditional is satisfied, so this should not enqueue the stylesheet.
@@ -157,10 +157,6 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 */
 	public function test_override_story_embed_callback() {
 		global $wp_rewrite;
-
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'The function register_block_type() is not present, so the AMP Story post type was not registered.' );
-		}
 
 		AMP_Story_Post_Type::register();
 
@@ -223,10 +219,6 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Post_Type::register_block_latest_stories()
 	 */
 	public function test_register_block_latest_stories() {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'The function register_block_type() is not present, so the block was not registered.' );
-		}
-
 		AMP_Story_Post_Type::register_block_latest_stories();
 
 		set_current_screen( 'edit.php' );
@@ -272,9 +264,6 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers \AMP_Story_Post_Type::render_block_latest_stories()
 	 */
 	public function test_render_block_latest_stories() {
-		if ( ! function_exists( 'register_block_type' ) ) {
-			$this->markTestSkipped( 'The function register_block_type() is not present, so the AMP Story post type was not registered.' );
-		}
 		AMP_Story_Post_Type::register();
 
 		$attributes = array(

--- a/tests/test-class-amp-story-post-type.php
+++ b/tests/test-class-amp-story-post-type.php
@@ -38,6 +38,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		global $wp_rewrite;
 
 		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
+		unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
 
 		$wp_rewrite->set_permalink_structure( false );
 		unset( $_SERVER['HTTPS'] );
@@ -51,11 +52,15 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers \AMP_Story_Post_Type::register()
 	 */
 	public function test_requires_opt_in() {
+		unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
+
 		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
-
 		AMP_Story_Post_Type::register();
-
 		$this->assertFalse( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Story_Post_Type::register();
+		$this->assertTrue( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) );
 	}
 
 	/**
@@ -156,6 +161,8 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		if ( ! function_exists( 'register_block_type' ) ) {
 			$this->markTestSkipped( 'The function register_block_type() is not present, so the AMP Story post type was not registered.' );
 		}
+
+		AMP_Story_Post_Type::register();
 
 		/*
 		 * It looks like embedding custom post types does not work with the plain permalink structure.

--- a/tests/test-class-amp-story-templates.php
+++ b/tests/test-class-amp-story-templates.php
@@ -28,6 +28,7 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 			}
 		}
 
+		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
 		AMP_Story_Post_Type::register();
 	}
 


### PR DESCRIPTION
At the moment in order for a search engine to discover the AMP Stories published on a site, a user must either:

0. Link to a story with regular hyperlink
1. Link to a story via post embed
2. Use the Latest Stories block
3. Install an XML Sitemap plugin (until [part of core](https://make.wordpress.org/core/2019/06/12/xml-sitemaps-feature-project-proposal/))

If a user hasn't done these things, in order to ensure stories are discoverable by search engines, the AMP plugin should add an RSS feed specific for stories.

This PR adds an RSS link for Stories like the following:

```html
<link rel="alternate" type="application/rss+xml" title="Stories" href="https://example.com/feed/?post_type=amp_story">
```

----

This PR also eliminates `AMP_Story_Post_Type::maybe_flush_rewrite_rules()` by adding story-awareness to `AMP_Options_Manager::maybe_flush_rewrite_rules()`, which eliminates the inefficiency of checking rewrite rules for every request. Now it will just flush rewrite rules upon toggling the Stories experience.