### PR TITLE
Add looping for video headers; extend tree-shaking for amp-video-* class names

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2375,6 +2375,7 @@ class AMP_Theme_Support {
 			'height'   => $video_settings['height'],
 			'layout'   => 'responsive',
 			'autoplay' => '',
+			'loop'     => '',
 			'id'       => 'wp-custom-header-video',
 		];
 
@@ -2405,8 +2406,6 @@ class AMP_Theme_Support {
 						'data-param-playsinline'    => '1', // Prevent fullscreen playback on iOS.
 						'data-param-disablekb'      => '1', // Disable keyboard conttrols.
 						'data-param-fs'             => '0', // Suppress full screen button.
-						'data-param-loop'           => '1', // Loop video playback.
-						'data-param-playlist'       => $youtube_id, // Currently needed to make looping work. See <https://developers.google.com/youtube/player_parameters#loop> and <https://github.com/ampproject/amphtml/pull/22856>.
 					]
 				)
 			);
@@ -2416,8 +2415,7 @@ class AMP_Theme_Support {
 				array_merge(
 					$video_attributes,
 					[
-						'src'  => $video_settings['videoUrl'],
-						'loop' => '',
+						'src' => $video_settings['videoUrl'],
 					]
 				)
 			);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2409,6 +2409,9 @@ class AMP_Theme_Support {
 					]
 				)
 			);
+
+			// Hide equalizer video animation.
+			$video_markup .= '<style>#wp-custom-header-video .amp-video-eq { display:none; }</style>';
 		} else {
 			$video_markup = AMP_HTML_Utils::build_tag(
 				'amp-video',

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2394,10 +2394,19 @@ class AMP_Theme_Support {
 				array_merge(
 					$video_attributes,
 					[
-						'data-videoid'        => $youtube_id,
-						'data-param-rel'      => '0', // Don't show related videos.
-						'data-param-showinfo' => '0', // Don't show video title at the top.
-						'data-param-controls' => '0', // Don't show video controls.
+						'data-videoid'              => $youtube_id,
+
+						// For documentation on the params, see <https://developers.google.com/youtube/player_parameters>.
+						'data-param-rel'            => '0', // Don't show related videos.
+						'data-param-showinfo'       => '0', // Don't show video title at the top.
+						'data-param-controls'       => '0', // Don't show video controls.
+						'data-param-iv_load_policy' => '3', // Suppress annotations.
+						'data-param-modestbranding' => '1', // Show modest branding.
+						'data-param-playsinline'    => '1', // Prevent fullscreen playback on iOS.
+						'data-param-disablekb'      => '1', // Disable keyboard conttrols.
+						'data-param-fs'             => '0', // Suppress full screen button.
+						'data-param-loop'           => '1', // Loop video playback.
+						'data-param-playlist'       => $youtube_id, // Currently needed to make looping work. See <https://developers.google.com/youtube/player_parameters#loop> and <https://github.com/ampproject/amphtml/pull/22856>.
 					]
 				)
 			);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2407,7 +2407,8 @@ class AMP_Theme_Support {
 				array_merge(
 					$video_attributes,
 					[
-						'src' => $video_settings['videoUrl'],
+						'src'  => $video_settings['videoUrl'],
+						'loop' => '',
 					]
 				)
 			);

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -273,6 +273,32 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private $selector_mappings = [];
 
 	/**
+	 * Elements in extensions which use the video-manager, and thus the video-autoplay.css.
+	 *
+	 * @var array
+	 */
+	private $video_autoplay_elements = [
+		'amp-3q-player',
+		'amp-brid-player',
+		'amp-brightcove',
+		'amp-dailymotion',
+		'amp-delight-player',
+		'amp-gfycat',
+		'amp-ima-video',
+		'amp-mowplayer',
+		'amp-nexxtv-player',
+		'amp-ooyala-player',
+		'amp-powr-player',
+		'amp-story-auto-ads',
+		'amp-video',
+		'amp-video-iframe',
+		'amp-vimeo',
+		'amp-viqeo-player',
+		'amp-wistia-player',
+		'amp-youtube',
+	];
+
+	/**
 	 * Get error codes that can be raised during parsing of CSS.
 	 *
 	 * This is used to determine which validation errors should be taken into account
@@ -508,6 +534,16 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					return false;
 				}
 				continue;
+			}
+
+			// Class names for extensions which use the video-manager, and thus video-autoplay.css.
+			if ( 'amp-video-' === substr( $class_name, 0, 10 ) ) {
+				foreach ( $this->video_autoplay_elements as $video_autoplay_element ) {
+					if ( $this->has_used_tag_names( [ $video_autoplay_element ] ) ) {
+						continue 2;
+					}
+				}
+				return false;
 			}
 
 			/*

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -448,6 +448,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .amp-geo-group-foo { color: peru; } </style>
 					<style> .amp-iso-country-us { color: oldlace; } </style>
 					<style> .non-existent { color: black; } </style>
+					<style> .amp-video-eq { display: none; } </style>
 					</head><body><p>Hello!</p></body></html>
 				',
 				[
@@ -476,6 +477,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .amp-geo-no-group { color: ghostwhite; } </style>
 					<style> .amp-geo-group-foo { color: peru; } </style>
 					<style> .amp-iso-country-us { color: oldlace; } </style>
+					<style> .amp-video-eq { display: none; } </style>
 					<style> .non-existent { color: black; } </style>
 					</head>
 					<body>
@@ -510,6 +512,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.amp-geo-no-group{color:ghostwhite}',
 					'.amp-geo-group-foo{color:peru}',
 					'.amp-iso-country-us{color:oldlace}',
+					'.amp-video-eq{display:none}',
 					'', // Because no non-existent.
 				],
 				[],

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1970,7 +1970,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// There's a YouTube URL as the header video.
 		set_theme_mod( 'external_header_video', 'https://www.youtube.com/watch?v=a8NScvBhVnc' );
 		$this->assertEquals(
-			$mock_image . '<amp-youtube media="(min-width: 900px)" width="0" height="0" layout="responsive" autoplay id="wp-custom-header-video" data-videoid="a8NScvBhVnc" data-param-rel="0" data-param-showinfo="0" data-param-controls="0"></amp-youtube>',
+			$mock_image . '<amp-youtube media="(min-width: 900px)" width="0" height="0" layout="responsive" autoplay loop id="wp-custom-header-video" data-videoid="a8NScvBhVnc" data-param-rel="0" data-param-showinfo="0" data-param-controls="0" data-param-iv_load_policy="3" data-param-modestbranding="1" data-param-playsinline="1" data-param-disablekb="1" data-param-fs="0"></amp-youtube>',
 			AMP_Theme_Support::amend_header_image_with_video_header( $mock_image )
 		);
 	}

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1970,7 +1970,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// There's a YouTube URL as the header video.
 		set_theme_mod( 'external_header_video', 'https://www.youtube.com/watch?v=a8NScvBhVnc' );
 		$this->assertEquals(
-			$mock_image . '<amp-youtube media="(min-width: 900px)" width="0" height="0" layout="responsive" autoplay loop id="wp-custom-header-video" data-videoid="a8NScvBhVnc" data-param-rel="0" data-param-showinfo="0" data-param-controls="0" data-param-iv_load_policy="3" data-param-modestbranding="1" data-param-playsinline="1" data-param-disablekb="1" data-param-fs="0"></amp-youtube>',
+			$mock_image . '<amp-youtube media="(min-width: 900px)" width="0" height="0" layout="responsive" autoplay loop id="wp-custom-header-video" data-videoid="a8NScvBhVnc" data-param-rel="0" data-param-showinfo="0" data-param-controls="0" data-param-iv_load_policy="3" data-param-modestbranding="1" data-param-playsinline="1" data-param-disablekb="1" data-param-fs="0"></amp-youtube><style>#wp-custom-header-video .amp-video-eq { display:none; }</style>',
 			AMP_Theme_Support::amend_header_image_with_video_header( $mock_image )
 		);
 	}


### PR DESCRIPTION
Theme support for the video header is lacking in the plugin. In particular, the video header is failing to loop. This fixes that.

To test, use a theme that supports video headers (e.g. Twenty Seventeen). Make sure you select a short MP4 video and a short YouTube video, for example https://www.youtube.com/watch?v=qbGbDNYArTU

Note that in order for the video header to appear in AMP, you _must_ currently also select a video header _image_. This is because the AMP video is injected via the `get_header_image_tag` filter which only applies if a header image is assigned.

The ability to loop YouTube videos recently was made more seamless via https://github.com/ampproject/amphtml/pull/22858. Note there is still a momentary flicker of the title: https://github.com/ampproject/amphtml/issues/22855#issuecomment-511674431.

# Changes

- Add missing `loop` attribute on MP4 video header loops in AMP.
- Ensure YouTube video header loops in AMP (see https://github.com/ampproject/amphtml/issues/22855); this mostly works, but the looping is not perfect as can be seen in this comparison video: https://youtu.be/8PZGJf3dtwM
- Update AMP validator spec once https://github.com/ampproject/amphtml/pull/22858 live and use new `loop` attribute instead of `data-param-loop` and `data-param-playlist`. See https://github.com/ampproject/amp-wp/pull/2816.
- Hide video autoplay equalizer animation in bottom-right corner of video header in AMP.
- Update tree-shaker to prevent removing style rules with `amp-video-*` class names when any AMP component using the video-loader is present, and thus any styles in [`video-autoplay.css`](https://github.com/ampproject/amphtml/blob/568c032d0c5bf6538c61dd546d43be0969c0ceb4/css/video-autoplay.css).

# Out of scope

- Fix video header so not dependent on header image being selected.