### PR TITLE
Adjust styling for the block navigation.

### DIFF
--- a/assets/src/stories-editor/components/block-navigation/edit.css
+++ b/assets/src/stories-editor/components/block-navigation/edit.css
@@ -18,7 +18,7 @@
 	}
 }
 
-@media (max-width: 1100px) and (min-width: 1001px) {
+@media (min-width: 1001px) and (max-width: 1100px) {
 
 	.is-sidebar-opened .editor-block-list__layout {
 		margin-right: -100px;

--- a/assets/src/stories-editor/components/block-navigation/edit.css
+++ b/assets/src/stories-editor/components/block-navigation/edit.css
@@ -12,20 +12,30 @@
 }
 
 @media (max-width: 1200px) {
+
 	.is-sidebar-opened #amp-story-block-navigation {
 		left: 0;
 	}
 }
 
-@media (max-width: 1100px) and (min-width: 961px) {
+@media (max-width: 1100px) and (min-width: 1001px) {
+
 	.is-sidebar-opened .editor-block-list__layout {
 		margin-right: -100px;
 	}
 }
 
 @media (min-width: 961px) {
+
 	#amp-story-block-navigation {
 		display: block;
+	}
+}
+
+@media (min-width: 961px) and (max-width: 1000px) {
+
+	.is-sidebar-opened #amp-story-block-navigation {
+		display: none;
 	}
 }
 

--- a/assets/src/stories-editor/components/block-navigation/edit.css
+++ b/assets/src/stories-editor/components/block-navigation/edit.css
@@ -4,14 +4,26 @@
 	left: 45px;
 	top: 75px;
 	width: 300px;
+	min-width: 115px;
 	z-index: 80;
 	list-style-type: none;
 	padding: 0;
 	margin: 0;
 }
 
-@media (min-width: 961px) {
+@media (max-width: 1200px) {
+	.is-sidebar-opened #amp-story-block-navigation {
+		left: 0;
+	}
+}
 
+@media (max-width: 1100px) and (min-width: 961px) {
+	.is-sidebar-opened .editor-block-list__layout {
+		margin-right: -100px;
+	}
+}
+
+@media (min-width: 961px) {
 	#amp-story-block-navigation {
 		display: block;
 	}


### PR DESCRIPTION
Fixes #2578.

Adjusts styling for block navigation to avoid it from looking "broken".