### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://amp-wp.org
  * Author: AMP Project Contributors
  * Author URI: https://github.com/ampproject/amp-wp/graphs/contributors
- * Version: 1.2-RC1
+ * Version: 1.2.0
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -209,7 +209,7 @@ if ( ! empty( $_amp_load_errors->errors ) ) {
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '1.2-RC1' );
+define( 'AMP__VERSION', '1.2.0' );
 
 /**
  * Print admin notice if plugin installed with incorrect slug (which impacts WordPress's auto-update system).

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Enable AMP on your WordPress site, the WordPress way.
 **Tags:** [amp](https://wordpress.org/plugins/tags/amp), [framework](https://wordpress.org/plugins/tags/framework), [components](https://wordpress.org/plugins/tags/components), [performance](https://wordpress.org/plugins/tags/performance), [mobile](https://wordpress.org/plugins/tags/mobile), [stories](https://wordpress.org/plugins/tags/stories)  
 **Requires at least:** 4.9  
 **Tested up to:** 5.2  
-**Stable tag:** 1.1.3  
+**Stable tag:** 1.2.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Requires PHP:** 5.4  
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: google, xwp, automattic, westonruter, swissspidy, stubgo, ryankien
 Tags: amp, framework, components, performance, mobile, stories
 Requires at least: 4.9
 Tested up to: 5.2
-Stable tag: 1.1.3
+Stable tag: 1.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Requires PHP: 5.4


### PR DESCRIPTION
Follows the release checklist to bump the plugin version and stable tag.

After merge this needs to be cherry picked into the 1.2 branch.