### PR TITLE
Show CTA block in Block Navigation

### DIFF
--- a/assets/src/stories-editor/components/block-navigation/edit.css
+++ b/assets/src/stories-editor/components/block-navigation/edit.css
@@ -34,6 +34,12 @@
 
 #amp-story-block-navigation .block-editor-block-navigation__list {
 	list-style-type: none;
+	margin-bottom: 15px;
+}
+
+#amp-story-block-navigation .editor-block-navigation__list__static {
+	margin: 0;
+	padding: 0;
 }
 
 #amp-story-block-navigation .components-icon-button .dashicon {

--- a/assets/src/stories-editor/components/block-navigation/index.js
+++ b/assets/src/stories-editor/components/block-navigation/index.js
@@ -93,10 +93,15 @@ export default compose(
 		const { getCurrentPage, isReordering } = select( 'amp/story' );
 		const { getBlockOrder, getBlocksByClientId, getSelectedBlockClientId } = select( 'core/block-editor' );
 
-		const blocks = getCurrentPage() ? getBlocksByClientId( getBlockOrder( getCurrentPage() ) ) : [];
-
+		let blocks = getCurrentPage() ? getBlocksByClientId( getBlockOrder( getCurrentPage() ) ) : [];
+		const callToActionBlock = blocks.find( ( { name } ) => name === 'amp/amp-story-cta' );
+		blocks = blocks.filter( ( { name } ) => ALLOWED_MOVABLE_BLOCKS.includes( name ) ).reverse();
+		// If CTA block was found, let's add it to the end.
+		if ( callToActionBlock ) {
+			blocks.push( callToActionBlock );
+		}
 		return {
-			blocks: blocks.filter( ( { name } ) => ALLOWED_MOVABLE_BLOCKS.includes( name ) ).reverse(),
+			blocks,
 			selectedBlockClientId: getSelectedBlockClientId(),
 			isReordering: isReordering(),
 		};

--- a/assets/src/stories-editor/components/block-navigation/index.js
+++ b/assets/src/stories-editor/components/block-navigation/index.js
@@ -18,30 +18,44 @@ import BlockNavigationItem from './item';
 import { ALLOWED_MOVABLE_BLOCKS } from '../../constants';
 import './edit.css';
 
-function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock } ) {
+function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock, callToActionBlock } ) {
 	return (
 		/*
 		 * Disable reason: The `list` ARIA role is redundant but
 		 * Safari+VoiceOver won't announce the list otherwise.
 		 */
 		/* eslint-disable jsx-a11y/no-redundant-roles */
-		<DropZoneProvider>
-			<ul className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
-				{ blocks.map( ( block ) => {
-					const isSelected = block.clientId === selectedBlockClientId;
+		<>
+			<DropZoneProvider>
+				<ul className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
+					{ blocks.map( ( block ) => {
+						const isSelected = block.clientId === selectedBlockClientId;
 
-					return (
-						<li key={ block.clientId }>
-							<BlockNavigationItem
-								block={ block }
-								isSelected={ isSelected }
-								onClick={ () => selectBlock( block.clientId ) }
-							/>
-						</li>
-					);
-				} ) }
-			</ul>
-		</DropZoneProvider>
+						return (
+							<li key={ block.clientId }>
+								<BlockNavigationItem
+									block={ block }
+									isSelected={ isSelected }
+									onClick={ () => selectBlock( block.clientId ) }
+								/>
+							</li>
+						);
+					} ) }
+				</ul>
+			</DropZoneProvider>
+			{ /* Add CTA block as a separate item to exclude it from DropZone. */ }
+			{ callToActionBlock && (
+				<ul className="editor-block-navigation__list block-editor-block-navigation__list editor-block-navigation__list__static" role="list">
+					<li key={ callToActionBlock.clientId }>
+						<BlockNavigationItem
+							block={ callToActionBlock }
+							isSelected={ callToActionBlock.clientId === selectedBlockClientId }
+							onClick={ () => selectBlock( callToActionBlock.clientId ) }
+						/>
+					</li>
+				</ul>
+			) }
+		</>
 		/* eslint-enable jsx-a11y/no-redundant-roles */
 	);
 }
@@ -52,6 +66,9 @@ BlockNavigationList.propTypes = {
 	} ) ).isRequired,
 	selectedBlockClientId: PropTypes.string,
 	selectBlock: PropTypes.func.isRequired,
+	callToActionBlock: PropTypes.shape( {
+		clientId: PropTypes.string.isRequired,
+	} ),
 };
 
 function BlockNavigation( { callToActionBlock, blocks, selectBlock, selectedBlockClientId } ) {
@@ -68,14 +85,7 @@ function BlockNavigation( { callToActionBlock, blocks, selectBlock, selectedBloc
 					blocks={ blocks }
 					selectedBlockClientId={ selectedBlockClientId }
 					selectBlock={ selectBlock }
-				/>
-			) }
-			{ /* Add CTA block as a separate item to exclude it from DropZone. */ }
-			{ callToActionBlock && (
-				<BlockNavigationItem
-					block={ callToActionBlock }
-					isSelected={ callToActionBlock.clientId === selectedBlockClientId }
-					onClick={ () => selectBlock( callToActionBlock.clientId ) }
+					callToActionBlock={ callToActionBlock }
 				/>
 			) }
 			{ ! hasBlocks && ! callToActionBlock && (

--- a/assets/src/stories-editor/components/block-navigation/index.js
+++ b/assets/src/stories-editor/components/block-navigation/index.js
@@ -43,7 +43,7 @@ function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock, call
 					} ) }
 				</ul>
 			</DropZoneProvider>
-			{ /* Add CTA block as a separate item to exclude it from DropZone. */ }
+			{ /* Add CTA block separately to exclude it from DropZone. */ }
 			{ callToActionBlock && (
 				<ul className="editor-block-navigation__list block-editor-block-navigation__list editor-block-navigation__list__static" role="list">
 					<li key={ callToActionBlock.clientId }>

--- a/assets/src/stories-editor/components/block-navigation/index.js
+++ b/assets/src/stories-editor/components/block-navigation/index.js
@@ -26,23 +26,25 @@ function BlockNavigationList( { blocks,	selectedBlockClientId, selectBlock, call
 		 */
 		/* eslint-disable jsx-a11y/no-redundant-roles */
 		<>
-			<DropZoneProvider>
-				<ul className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
-					{ blocks.map( ( block ) => {
-						const isSelected = block.clientId === selectedBlockClientId;
+			{ blocks.length > 0 && (
+				<DropZoneProvider>
+					<ul className="editor-block-navigation__list block-editor-block-navigation__list" role="list">
+						{ blocks.map( ( block ) => {
+							const isSelected = block.clientId === selectedBlockClientId;
 
-						return (
-							<li key={ block.clientId }>
-								<BlockNavigationItem
-									block={ block }
-									isSelected={ isSelected }
-									onClick={ () => selectBlock( block.clientId ) }
-								/>
-							</li>
-						);
-					} ) }
-				</ul>
-			</DropZoneProvider>
+							return (
+								<li key={ block.clientId }>
+									<BlockNavigationItem
+										block={ block }
+										isSelected={ isSelected }
+										onClick={ () => selectBlock( block.clientId ) }
+									/>
+								</li>
+							);
+						} ) }
+					</ul>
+				</DropZoneProvider>
+			) }
 			{ /* Add CTA block separately to exclude it from DropZone. */ }
 			{ callToActionBlock && (
 				<ul className="editor-block-navigation__list block-editor-block-navigation__list editor-block-navigation__list__static" role="list">
@@ -72,7 +74,7 @@ BlockNavigationList.propTypes = {
 };
 
 function BlockNavigation( { callToActionBlock, blocks, selectBlock, selectedBlockClientId } ) {
-	const hasBlocks = blocks.length > 0;
+	const hasBlocks = blocks.length > 0 || callToActionBlock;
 
 	return (
 		<NavigableMenu
@@ -88,7 +90,7 @@ function BlockNavigation( { callToActionBlock, blocks, selectBlock, selectedBloc
 					callToActionBlock={ callToActionBlock }
 				/>
 			) }
-			{ ! hasBlocks && ! callToActionBlock && (
+			{ ! hasBlocks && (
 				<p className="block-editor-block-navigation__paragraph">
 					{ __( 'No elements added to this page yet.', 'amp' ) }
 				</p>

--- a/assets/src/stories-editor/components/block-navigation/item.js
+++ b/assets/src/stories-editor/components/block-navigation/item.js
@@ -178,8 +178,8 @@ const applyWithSelect = withSelect( ( select, { block: { clientId } } ) => {
 
 	const blockOrder = getBlockOrder( getBlockRootClientId( clientId ) );
 
-	// Need to reverse the list and exclude CTA blocks just like BlockNavigation does.
-	const blocks = getBlocksByClientId( blockOrder ).filter( ( { name } ) => ALLOWED_MOVABLE_BLOCKS.includes( name ) ).map( ( { clientId: id } ) => id ).reverse();
+	// Need to reverse the list just like BlockNavigation does.
+	const blocks = getBlocksByClientId( blockOrder ).map( ( { clientId: id } ) => id ).reverse();
 
 	return {
 		getBlockIndex: ( blockClientId ) => {

--- a/assets/src/stories-editor/components/block-navigation/item.js
+++ b/assets/src/stories-editor/components/block-navigation/item.js
@@ -17,7 +17,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BlockPreviewLabel } from '../';
-import { ALLOWED_MOVABLE_BLOCKS } from '../../constants';
 
 /**
  * Parses drag & drop events to ensure the event contains valid transfer data.

--- a/assets/src/stories-editor/components/block-navigation/item.js
+++ b/assets/src/stories-editor/components/block-navigation/item.js
@@ -84,8 +84,32 @@ class BlockNavigationItem extends Component {
 
 	render() {
 		const { block, getBlockIndex, isSelected, onClick } = this.props;
+		const isCallToActionBlock = 'amp/amp-story-cta' === block.name;
 		const { clientId } = block;
 		const blockElementId = `block-navigation-item-${ clientId }`;
+
+		if ( isCallToActionBlock ) {
+			return (
+				<div className="editor-block-navigation__item block-editor-block-navigation__item">
+					<Button
+						className={ classnames(
+							'components-button editor-block-navigation__item-button block-editor-block-navigation__item-button',
+							{
+								'is-selected': isSelected,
+							}
+						) }
+						onClick={ onClick }
+						id={ blockElementId }
+					>
+						<BlockPreviewLabel
+							block={ block }
+							accessibilityText={ isSelected && __( '(selected block)', 'amp' ) }
+						/>
+					</Button>
+				</div>
+			);
+		}
+
 		const transferData = {
 			type: 'block',
 			srcIndex: getBlockIndex( clientId ),


### PR DESCRIPTION
Fixes #2564.

- Displays CTA block in the block navigation.
- Excludes CTA block from DropZone.

Note that there is space between the CTA block and the rest of the blocks in the block navigation. This comes from the default margin of the list, however, left it like this since it could actually make sense, to separate the non-draggable CTA from others and to clearly position it as the last block. Thoughts welcome.

UI:
<img width="582" alt="Screenshot 2019-06-19 at 17 01 19" src="https://user-images.githubusercontent.com/3294597/59776898-e331be00-92b3-11e9-93a6-29cb2a233aec.png">
