### PR TITLE
Fix hidden editor on zooming.

### DIFF
--- a/assets/css/amp-stories-editor.css
+++ b/assets/css/amp-stories-editor.css
@@ -89,7 +89,7 @@
  * @see https://github.com/WordPress/gutenberg/issues/7180
  */
 
-.wp-block-image .components-resizable-box__container + .__resizable_base__ { /* stylelint-disable-line selector-class-pattern */
+.wp-block .components-resizable-box__container + .__resizable_base__ { /* stylelint-disable-line selector-class-pattern */
 	left: 0 !important;
 }
 


### PR DESCRIPTION
Fixes #2662.

Applies the CSS for `__resizable_base__` for all the blocks, not just the image block since it looks like other blocks are causing the same issue.