### PR TITLE
Fix lagging Template Inserter

### DIFF
--- a/assets/src/stories-editor/components/template-inserter/edit.css
+++ b/assets/src/stories-editor/components/template-inserter/edit.css
@@ -38,7 +38,7 @@
 
 .amp-stories__editor-inserter__results .components-spinner {
 	margin-right: calc(50% - 9px);
-	margin-top: 50%;
+	margin-top: 128px;
 }
 
 .amp-stories__template-inserter__popover.components-popover:not(.is-without-arrow):not(.is-mobile).is-top::before {

--- a/assets/src/stories-editor/components/template-inserter/edit.css
+++ b/assets/src/stories-editor/components/template-inserter/edit.css
@@ -36,6 +36,11 @@
 	margin-left: -15px;
 }
 
+.amp-stories__editor-inserter__results .components-spinner {
+	margin-right: calc(50% - 9px);
+	margin-top: 50%;
+}
+
 .amp-stories__template-inserter__popover.components-popover:not(.is-without-arrow):not(.is-mobile).is-top::before {
 	border-bottom: 8px solid rgb(226, 228, 231);
 }

--- a/assets/src/stories-editor/components/template-inserter/index.js
+++ b/assets/src/stories-editor/components/template-inserter/index.js
@@ -118,7 +118,7 @@ class TemplateInserter extends Component {
 											className="amp-stories__blank-page-inserter editor-block-preview__content block-editor-block-preview__content editor-styles-wrapper"
 										/>
 									</div>
-									{ this.state.storyTemplates.map( ( item ) => (
+									{ this.state.storyTemplates.map( ( item, index ) => (
 										<a // eslint-disable-line jsx-a11y/anchor-is-valid, see https://github.com/ampproject/amp-wp/issues/2165
 											key={ `template-preview-${ item.id }` }
 											role="button"
@@ -135,6 +135,7 @@ class TemplateInserter extends Component {
 										>
 											<TemplatePreview
 												item={ item }
+												isFirst={ 0 === index }
 											/>
 										</a>
 									) ) }

--- a/assets/src/stories-editor/components/template-inserter/index.js
+++ b/assets/src/stories-editor/components/template-inserter/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton, Spinner } from '@wordpress/components';
+import { Dropdown, IconButton } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -18,49 +18,11 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
-import { BlockPreview } from '../';
+import TemplatePreview from './template-preview';
 import pageIcon from '../../../../images/add-page-inserter.svg';
 import addTemplateIcon from '../../../../images/add-template.svg';
 import './edit.css';
 import { createSkeletonTemplate, maybeEnqueueFontStyle } from '../../helpers';
-
-class TemplatePreview extends Component {
-	constructor() {
-		super( ...arguments );
-
-		this.state = {
-			parentLoaded: false,
-		};
-	}
-
-	componentDidMount() {
-		if ( ! this.state.parentLoaded ) {
-			// Set timeout to cause a small latency between loading the templates, otherwise they all try to load instantly and cause a lag.
-			setTimeout( () => {
-				this.setState( { parentLoaded: true } );
-			}, 100 );
-		}
-	}
-
-	render() {
-		if ( ! this.state.parentLoaded ) {
-			return <Spinner />;
-		}
-		const { item } = this.props;
-		return (
-			<BlockPreview
-				name="core/block"
-				attributes={ { ref: item.id } }
-			/>
-		);
-	}
-}
-
-TemplatePreview.propTypes = {
-	item: PropTypes.shape( {
-		id: PropTypes.string.isRequired,
-	} ).isRequired,
-};
 
 class TemplateInserter extends Component {
 	constructor() {

--- a/assets/src/stories-editor/components/template-inserter/index.js
+++ b/assets/src/stories-editor/components/template-inserter/index.js
@@ -135,7 +135,6 @@ class TemplateInserter extends Component {
 										>
 											<TemplatePreview
 												item={ item }
-												isFirst={ 0 === index }
 											/>
 										</a>
 									) ) }

--- a/assets/src/stories-editor/components/template-inserter/index.js
+++ b/assets/src/stories-editor/components/template-inserter/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton } from '@wordpress/components';
+import { Dropdown, IconButton, Spinner } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -23,6 +23,44 @@ import pageIcon from '../../../../images/add-page-inserter.svg';
 import addTemplateIcon from '../../../../images/add-template.svg';
 import './edit.css';
 import { createSkeletonTemplate, maybeEnqueueFontStyle } from '../../helpers';
+
+class TemplatePreview extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			parentLoaded: false,
+		};
+	}
+
+	componentDidMount() {
+		if ( ! this.state.parentLoaded ) {
+			// Set timeout to cause a small latency between loading the templates, otherwise they all try to load instantly and cause a lag.
+			setTimeout( () => {
+				this.setState( { parentLoaded: true } );
+			}, 100 );
+		}
+	}
+
+	render() {
+		if ( ! this.state.parentLoaded ) {
+			return <Spinner />;
+		}
+		const { item } = this.props;
+		return (
+			<BlockPreview
+				name="core/block"
+				attributes={ { ref: item.id } }
+			/>
+		);
+	}
+}
+
+TemplatePreview.propTypes = {
+	item: PropTypes.shape( {
+		id: PropTypes.string.isRequired,
+	} ).isRequired,
+};
 
 class TemplateInserter extends Component {
 	constructor() {
@@ -133,9 +171,8 @@ class TemplateInserter extends Component {
 											} }
 											className="components-button block-editor-block-preview"
 										>
-											<BlockPreview
-												name="core/block"
-												attributes={ { ref: item.id } }
+											<TemplatePreview
+												item={ item }
 											/>
 										</a>
 									) ) }

--- a/assets/src/stories-editor/components/template-inserter/index.js
+++ b/assets/src/stories-editor/components/template-inserter/index.js
@@ -118,7 +118,7 @@ class TemplateInserter extends Component {
 											className="amp-stories__blank-page-inserter editor-block-preview__content block-editor-block-preview__content editor-styles-wrapper"
 										/>
 									</div>
-									{ this.state.storyTemplates.map( ( item, index ) => (
+									{ this.state.storyTemplates.map( ( item ) => (
 										<a // eslint-disable-line jsx-a11y/anchor-is-valid, see https://github.com/ampproject/amp-wp/issues/2165
 											key={ `template-preview-${ item.id }` }
 											role="button"

--- a/assets/src/stories-editor/components/template-inserter/template-preview.js
+++ b/assets/src/stories-editor/components/template-inserter/template-preview.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+
 /**
  * WordPress dependencies
  */
@@ -25,7 +26,7 @@ class TemplatePreview extends Component {
 
 	componentDidMount() {
 		if ( ! this.state.shouldLoad ) {
-			// @todo Look into React Concurrent mode to replace this once it get available.
+			// @todo Look into React Concurrent mode to replace this once it gets available.
 			// Set timeout to cause a small latency between loading the templates, otherwise they all try to load instantly and cause a lag.
 			this.props.setTimeout( () => {
 				this.setState( { shouldLoad: true } );

--- a/assets/src/stories-editor/components/template-inserter/template-preview.js
+++ b/assets/src/stories-editor/components/template-inserter/template-preview.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+/**
+ * WordPress dependencies
+ */
+import { withSafeTimeout } from '@wordpress/compose';
+import { Spinner } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { BlockPreview } from '../';
+
+class TemplatePreview extends Component {
+	constructor() {
+		super( ...arguments );
+
+		this.state = {
+			parentLoaded: false,
+		};
+	}
+
+	componentDidMount() {
+		if ( ! this.state.parentLoaded ) {
+			// Set timeout to cause a small latency between loading the templates, otherwise they all try to load instantly and cause a lag.
+			this.props.setTimeout( () => {
+				this.setState( { parentLoaded: true } );
+			}, 100 );
+		}
+	}
+
+	render() {
+		if ( ! this.state.parentLoaded ) {
+			return <Spinner />;
+		}
+		const { item } = this.props;
+		return (
+			<BlockPreview
+				name="core/block"
+				attributes={ { ref: item.id } }
+			/>
+		);
+	}
+}
+
+TemplatePreview.propTypes = {
+	item: PropTypes.shape( {
+		id: PropTypes.string.isRequired,
+	} ).isRequired,
+	setTimeout: PropTypes.func.isRequired,
+};
+
+export default withSafeTimeout( TemplatePreview );

--- a/assets/src/stories-editor/components/template-inserter/template-preview.js
+++ b/assets/src/stories-editor/components/template-inserter/template-preview.js
@@ -55,7 +55,6 @@ TemplatePreview.propTypes = {
 		id: PropTypes.string.isRequired,
 	} ).isRequired,
 	setTimeout: PropTypes.func.isRequired,
-	isFirst: PropTypes.bool.isRequired,
 };
 
 export default withSafeTimeout( TemplatePreview );

--- a/assets/src/stories-editor/components/template-inserter/template-preview.js
+++ b/assets/src/stories-editor/components/template-inserter/template-preview.js
@@ -34,8 +34,10 @@ class TemplatePreview extends Component {
 	}
 
 	render() {
+		const { isFirst } = this.props;
 		if ( ! this.state.shouldLoad ) {
-			return <Spinner />;
+			// Display the spinner for the first template only to avoid overloading.
+			return isFirst ? <Spinner /> : null;
 		}
 		const { item } = this.props;
 		return (
@@ -52,6 +54,7 @@ TemplatePreview.propTypes = {
 		id: PropTypes.string.isRequired,
 	} ).isRequired,
 	setTimeout: PropTypes.func.isRequired,
+	isFirst: PropTypes.bool.isRequired,
 };
 
 export default withSafeTimeout( TemplatePreview );

--- a/assets/src/stories-editor/components/template-inserter/template-preview.js
+++ b/assets/src/stories-editor/components/template-inserter/template-preview.js
@@ -19,21 +19,22 @@ class TemplatePreview extends Component {
 		super( ...arguments );
 
 		this.state = {
-			parentLoaded: false,
+			shouldLoad: false,
 		};
 	}
 
 	componentDidMount() {
-		if ( ! this.state.parentLoaded ) {
+		if ( ! this.state.shouldLoad ) {
+			// @todo Look into React Concurrent mode to replace this once it get available.
 			// Set timeout to cause a small latency between loading the templates, otherwise they all try to load instantly and cause a lag.
 			this.props.setTimeout( () => {
-				this.setState( { parentLoaded: true } );
+				this.setState( { shouldLoad: true } );
 			}, 100 );
 		}
 	}
 
 	render() {
-		if ( ! this.state.parentLoaded ) {
+		if ( ! this.state.shouldLoad ) {
 			return <Spinner />;
 		}
 		const { item } = this.props;

--- a/assets/src/stories-editor/components/template-inserter/template-preview.js
+++ b/assets/src/stories-editor/components/template-inserter/template-preview.js
@@ -35,12 +35,12 @@ class TemplatePreview extends Component {
 	}
 
 	render() {
-		const { isFirst } = this.props;
 		if ( ! this.state.shouldLoad ) {
-			// Display the spinner for the first template only to avoid overloading.
-			return isFirst ? <Spinner /> : null;
+			return <Spinner />;
 		}
+
 		const { item } = this.props;
+
 		return (
 			<BlockPreview
 				name="core/block"


### PR DESCRIPTION
Fixes #2577.

Creates `TemplatePreview` component and loads it with a small latency to not cause a lag for loading all the previews at the same time.