### PR TITLE
Remove Variables that were Assigned to Themselves

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -313,9 +313,6 @@ def ParseRules(out_dir):
 
 	specfile='%s/validator.protoascii' % out_dir
 
-	validator_pb2=validator_pb2
-	text_format=text_format
-
 	# Merge specfile with message buffers.
 	rules = validator_pb2.ValidatorRules()
 	text_format.Merge(open(specfile).read(), rules)


### PR DESCRIPTION
This fixes two [errors found by lgtm](https://lgtm.com/projects/g/ampproject/amp-wp/snapshot/b16edbfd761ffa07825924b2b0405e908c0a7cce/files/bin/amphtml-update.py?sort=name&dir=ASC&mode=heatmap).