### PR TITLE
Add support for portrait featured images in non-AMP Story posts

### DIFF
--- a/assets/src/block-editor/index.js
+++ b/assets/src/block-editor/index.js
@@ -11,7 +11,7 @@ import { select } from '@wordpress/data';
  */
 import { withCroppedFeaturedImage, withFeaturedImageNotice } from '../common/components';
 import { addAMPAttributes, addAMPExtraProps, filterBlocksEdit, filterBlocksSave } from './helpers';
-import { getMinimumFeaturedImageDimensions } from '../common/helpers';
+import { getMinimumFeaturedImageDimensions, getMinimumPortraitFeaturedImageDimensions } from '../common/helpers';
 import './store';
 
 const {
@@ -37,7 +37,7 @@ if ( isWebsiteEnabled() ) {
 	addFilter( 'editor.BlockEdit', 'ampEditorBlocks/filterEdit', filterBlocksEdit, 20 );
 	addFilter( 'blocks.getSaveContent.extraProps', 'ampEditorBlocks/addExtraAttributes', addAMPExtraProps );
 	addFilter( 'editor.PostFeaturedImage', 'ampEditorBlocks/withFeaturedImageNotice', withFeaturedImageNotice );
-	addFilter( 'editor.MediaUpload', 'ampEditorBlocks/addCroppedFeaturedImage', ( InitialMediaUpload ) => withCroppedFeaturedImage( InitialMediaUpload, getMinimumFeaturedImageDimensions() ) );
+	addFilter( 'editor.MediaUpload', 'ampEditorBlocks/addCroppedFeaturedImage', ( InitialMediaUpload ) => withCroppedFeaturedImage( InitialMediaUpload, getMinimumFeaturedImageDimensions(), getMinimumPortraitFeaturedImageDimensions() ) );
 }
 
 /*

--- a/assets/src/common/components/featured-image-select-media-frame.js
+++ b/assets/src/common/components/featured-image-select-media-frame.js
@@ -72,7 +72,7 @@ const FeaturedImageToolbarSelect = wp.media.view.Toolbar.Select.extend( {
 		const minWidth = state.collection.get( 'library' ).get( 'suggestedWidth' );
 		const minHeight = state.collection.get( 'library' ).get( 'suggestedHeight' );
 
-		if ( ! attachment || ( attachment.get( 'width' ) >= minWidth && attachment.get( 'height' ) >= minHeight ) ) {
+		if ( ! attachment || ! attachment.get( 'width' ) || ( attachment.get( 'width' ) >= minWidth && attachment.get( 'height' ) >= minHeight ) ) {
 			this.secondary.unset( 'select-error' );
 		} else {
 			this.secondary.set(

--- a/assets/src/common/components/with-cropped-featured-image.js
+++ b/assets/src/common/components/with-cropped-featured-image.js
@@ -26,7 +26,7 @@ const { wp } = window;
  * Mostly copied from customize-controls.js.
  * The optional alternateMinImageDimensions are used for the crop size when they are the same aspect ratio type as the actual image dimensions.
  * For example, if the selected image has a portrait aspect ratio, and the alternateMinImageDimensions are also portrait,
- * this will use the alternate dimensions.
+ * this will use the alternate dimensions as long as the selected image is big enough.
  * Otherwise, this will use the minImageDimensions.
  *
  * @param {Function} InitialMediaUpload          The MediaUpload component, passed from the filter.

--- a/assets/src/common/components/with-cropped-featured-image.js
+++ b/assets/src/common/components/with-cropped-featured-image.js
@@ -24,9 +24,10 @@ const { wp } = window;
  * Only applies to the MediaUpload in the Featured Image component, PostFeaturedImage.
  * Suggests cropping of the featured image if it's not 696 x 928.
  * Mostly copied from customize-controls.js.
- * The optional alternateMinImageDimensions are used when they are the same aspect ratio type as the actual image dimensions.
+ * The optional alternateMinImageDimensions are used for the crop size when they are the same aspect ratio type as the actual image dimensions.
  * For example, if the selected image has a portrait aspect ratio, and the alternateMinImageDimensions are also portrait,
  * this will use the alternate dimensions.
+ * Otherwise, this will use the minImageDimensions.
  *
  * @param {Function} InitialMediaUpload          The MediaUpload component, passed from the filter.
  * @param {Object}   minImageDimensions          Minimum required image dimensions.
@@ -115,10 +116,19 @@ export default ( InitialMediaUpload, minImageDimensions, alternateMinImageDimens
 		 */
 		calculateImageSelectOptions( attachment, controller ) {
 			const realWidth = attachment.get( 'width' ),
-				realHeight = attachment.get( 'height' ),
-				realAspectRatioType = getAspectRatioType( realWidth, realHeight ),
-				alternateAspectRatioType = getAspectRatioType( ALTERNATE_EXPECTED_WIDTH, ALTERNATE_EXPECTED_HEIGHT ),
-				shouldUseAlternateWidthAndHeight = ALTERNATE_EXPECTED_WIDTH && ( realAspectRatioType === alternateAspectRatioType );
+				realHeight = attachment.get( 'height' );
+
+			/*
+			 * Only use the alternate dimensions if the image is big enough, and if they have the same aspect ratio type.
+			 * For example, if they are portrait dimensions, the real image must also have portrait dimensions.
+			 * This allows having an alternative crop size, for example, a portrait crop in addition to a landscape crop.
+			 */
+			const shouldUseAlternateWidthAndHeight = (
+				ALTERNATE_EXPECTED_WIDTH &&
+				realWidth >= ALTERNATE_EXPECTED_WIDTH &&
+				realHeight >= ALTERNATE_EXPECTED_HEIGHT &&
+				getAspectRatioType( realWidth, realHeight ) === getAspectRatioType( ALTERNATE_EXPECTED_WIDTH, ALTERNATE_EXPECTED_HEIGHT )
+			);
 
 			let xInit = shouldUseAlternateWidthAndHeight ? parseInt( ALTERNATE_EXPECTED_WIDTH, 10 ) : parseInt( EXPECTED_WIDTH, 10 ),
 				yInit = shouldUseAlternateWidthAndHeight ? parseInt( ALTERNATE_EXPECTED_HEIGHT, 10 ) : parseInt( EXPECTED_HEIGHT, 10 );

--- a/assets/src/common/constants.js
+++ b/assets/src/common/constants.js
@@ -1,3 +1,4 @@
 // See https://github.com/ampproject/amphtml/blob/e7a1b3ff97645ec0ec482192205134bd0735943c/extensions/amp-fit-text/0.1/amp-fit-text.js#L81-L85
 export const MIN_FONT_SIZE = 6;
 export const MAX_FONT_SIZE = 72;
+export const MINIMUM_FEATURED_IMAGE_WIDTH = 1200;

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -5,6 +5,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { getColorObjectByAttributeValues, getColorObjectByColorValue } from '@wordpress/block-editor';
 
 /**
+ * Internal dependencies
+ */
+import { MINIMUM_FEATURED_IMAGE_WIDTH } from '../constants';
+
+/**
  * Determines whether whether the image has the minimum required dimensions.
  *
  * The image should have a width of at least 1200 pixels to satisfy the requirements of Google Search for Schema.org metadata.
@@ -46,9 +51,22 @@ export const hasMinimumDimensions = ( media, dimensions ) => {
  * @return {Object} Minimum dimensions including width and height.
  */
 export const getMinimumFeaturedImageDimensions = () => {
-	const width = 1200;
+	const width = MINIMUM_FEATURED_IMAGE_WIDTH;
 
 	const height = width * ( 9 / 16 );
+
+	return { width, height };
+};
+
+/**
+ * Get minimum dimensions for a portrait featured image, but not for an AMP Story.
+ *
+ * @return {Object} Minimum dimensions including width and height.
+ */
+export const getMinimumPortraitFeaturedImageDimensions = () => {
+	const width = MINIMUM_FEATURED_IMAGE_WIDTH;
+
+	const height = width * ( 16 / 9 );
 
 	return { width, height };
 };
@@ -159,4 +177,21 @@ export const getBackgroundColorWithOpacity = ( colors, backgroundColor, customBa
 	}
 
 	return undefined;
+};
+
+/**
+ * Gets The aspect ratio type, either 'landscape', 'portrait', or 'square'.
+ *
+ * @param {number} width  The image width.
+ * @param {number} height The image height.
+ * @return {string|null} The aspect ratio type: 'landscape', 'portrait', or 'square'.
+ */
+export const getAspectRatioType = ( width, height ) => {
+	if ( width > height ) {
+		return 'landscape';
+	} else if ( height > width ) {
+		return 'portrait';
+	} else if ( height === width ) {
+		return 'square';
+	}
 };

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -66,7 +66,7 @@ export const getMinimumFeaturedImageDimensions = () => {
 export const getMinimumPortraitFeaturedImageDimensions = () => {
 	const width = MINIMUM_FEATURED_IMAGE_WIDTH;
 
-	const height = width * ( 16 / 9 );
+	const height = Math.floor( width * ( 16 / 9 ) );
 
 	return { width, height };
 };

--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -187,6 +187,10 @@ export const getBackgroundColorWithOpacity = ( colors, backgroundColor, customBa
  * @return {string|null} The aspect ratio type: 'landscape', 'portrait', or 'square'.
  */
 export const getAspectRatioType = ( width, height ) => {
+	if ( ! width || ! height ) {
+		return null;
+	}
+
 	if ( width > height ) {
 		return 'landscape';
 	} else if ( height > width ) {

--- a/assets/src/common/helpers/test/getAspectRatioType.js
+++ b/assets/src/common/helpers/test/getAspectRatioType.js
@@ -1,0 +1,19 @@
+/**
+ * Internal dependencies
+ */
+import { getAspectRatioType } from '../';
+
+describe( 'getAspectRatioType', () => {
+	it( 'should return landscape when the aspect ratio is landscape', () => {
+		expect( getAspectRatioType( 1400, 1000 ) ).toEqual( 'landscape' );
+	} );
+	it( 'should return portrait when the aspect ratio is portrait', () => {
+		expect( getAspectRatioType( 1400, 1800 ) ).toEqual( 'portrait' );
+	} );
+	it( 'should return square when the aspect ratio is square', () => {
+		expect( getAspectRatioType( 1200, 1200 ) ).toEqual( 'square' );
+	} );
+	it( 'should return null when the arguments are null', () => {
+		expect( getAspectRatioType( null, null ) ).toEqual( null );
+	} );
+} );

--- a/assets/src/common/helpers/test/getMinimumFeaturedImageDimensions.js
+++ b/assets/src/common/helpers/test/getMinimumFeaturedImageDimensions.js
@@ -4,7 +4,7 @@
 import { getMinimumFeaturedImageDimensions } from '../';
 
 describe( 'getMinimumFeaturedImageDimensions', () => {
-	it( 'should return size with correct aspect ration', () => {
+	it( 'should return size with correct aspect ratio', () => {
 		expect( getMinimumFeaturedImageDimensions() ).toEqual( { width: 1200, height: 675 } );
 	} );
 } );

--- a/assets/src/common/helpers/test/getMinimumPortraitFeaturedImageDimensions.js
+++ b/assets/src/common/helpers/test/getMinimumPortraitFeaturedImageDimensions.js
@@ -5,6 +5,6 @@ import { getMinimumPortraitFeaturedImageDimensions } from '../';
 
 describe( 'getMinimumPortraitFeaturedImageDimensions', () => {
 	it( 'should return size with correct portrait aspect ratio', () => {
-		expect( getMinimumPortraitFeaturedImageDimensions() ).toEqual( { width: 1200, height: 1200 * ( 16 / 9 ) } );
+		expect( getMinimumPortraitFeaturedImageDimensions() ).toEqual( { width: 1200, height: 2133 } );
 	} );
 } );

--- a/assets/src/common/helpers/test/getMinimumPortraitFeaturedImageDimensions.js
+++ b/assets/src/common/helpers/test/getMinimumPortraitFeaturedImageDimensions.js
@@ -1,0 +1,10 @@
+/**
+ * Internal dependencies
+ */
+import { getMinimumPortraitFeaturedImageDimensions } from '../';
+
+describe( 'getMinimumPortraitFeaturedImageDimensions', () => {
+	it( 'should return size with correct portrait aspect ratio', () => {
+		expect( getMinimumPortraitFeaturedImageDimensions() ).toEqual( { width: 1200, height: 1200 * ( 16 / 9 ) } );
+	} );
+} );


### PR DESCRIPTION
* Only applies to non-AMP Story posts, like posts and pages
* If the featured image is a portrait, this suggests a crop of `1200 x 2133` if the featured image has at least those dimensions
* Before, it suggested a landscape crop, even for portrait images. For example, a `1600 x 2200` image would have a suggested crop of `1200 x 675`.

See #2684.