### PR TITLE
Improve handling of iframes: handle same-origin URLs and convert 100% width to fixed-height

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -796,6 +796,12 @@ function amp_get_content_sanitizers( $post = null ) {
 		$post = null;
 	}
 
+	$parsed_home_url = wp_parse_url( get_home_url() );
+	$current_origin  = $parsed_home_url['scheme'] . '://' . $parsed_home_url['host'];
+	if ( isset( $parsed_home_url['port'] ) ) {
+		$current_origin .= ':' . $parsed_home_url['port'];
+	}
+
 	$sanitizers = array(
 		'AMP_Core_Theme_Sanitizer'        => array(
 			'template'   => get_template(),
@@ -815,6 +821,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		'AMP_Embed_Sanitizer'             => array(),
 		'AMP_Iframe_Sanitizer'            => array(
 			'add_placeholder' => true,
+			'current_origin'  => $current_origin,
 		),
 		'AMP_Gallery_Block_Sanitizer'     => array( // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
 			'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -278,8 +278,10 @@ abstract class AMP_Base_Sanitizer {
 			unset( $attributes['width'] );
 			$attributes['height'] = self::FALLBACK_HEIGHT;
 		}
-		if ( empty( $attributes['width'] ) ) {
+
+		if ( empty( $attributes['width'] ) || '100%' === $attributes['width'] ) {
 			$attributes['layout'] = 'fixed-height';
+			$attributes['width']  = 'auto';
 		}
 
 		return $attributes;

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -34,11 +34,20 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Default args.
 	 *
-	 * @var array
+	 * @var array {
+	 *     Default args.
+	 *
+	 *     @type bool   $add_placeholder       Whether to add a placeholder element.
+	 *     @type bool   $add_noscript_fallback Whether to add a noscript fallback.
+	 *     @type string $current_origin        The current origin serving the page. Normally this will be the $_SERVER[HTTP_HOST].
+	 *     @type string $alias_origin          An alternative origin which can be supplied which is used when encountering same-origin iframes.
+	 * }
 	 */
 	protected $DEFAULT_ARGS = array(
 		'add_placeholder'       => false,
 		'add_noscript_fallback' => true,
+		'current_origin'        => null,
+		'alias_origin'          => null,
 	);
 
 	/**
@@ -70,7 +79,18 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$this->initialize_noscript_allowed_attributes( self::$tag );
 		}
 
+		// Ensure origins are normalized.
+		$this->args['current_origin'] = $this->get_origin_from_url( $this->args['current_origin'] );
+		if ( ! empty( $this->args['alias_origin'] ) ) {
+			$this->args['alias_origin'] = $this->get_origin_from_url( $this->args['alias_origin'] );
+		}
+
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			/**
+			 * Iframe element.
+			 *
+			 * @var DOMElement $node
+			 */
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback.
@@ -86,7 +106,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			 * If the src doesn't exist, remove the node. Either it never
 			 * existed or was invalidated while filtering attributes above.
 			 *
-			 * @todo: add a filter to allow for a fallback element in this instance.
+			 * @todo: add an arg to allow for a fallback element in this instance (note that filter cannot be used inside a sanitizer).
 			 * @see: https://github.com/ampproject/amphtml/issues/2261
 			 */
 			if ( empty( $normalized_attributes['src'] ) ) {
@@ -140,10 +160,27 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	private function normalize_attributes( $attributes ) {
 		$out = array();
 
+		$remove_allow_same_origin = false;
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
 				case 'src':
-					$out[ $name ] = $this->maybe_enforce_https_src( $value, true );
+					// Make the URL absolute since relative URLs are not allowed in amp-iframe.
+					if ( '/' === substr( $value, 0, 1 ) ) {
+						$value = untrailingslashit( $this->args['current_origin'] ) . $value;
+					}
+
+					$value = $this->maybe_enforce_https_src( $value, true );
+
+					// Handle case where iframe source origin is the same as the host page's origin.
+					if ( $this->get_origin_from_url( $value ) === $this->args['current_origin'] ) {
+						if ( ! empty( $this->args['alias_origin'] ) ) {
+							$value = preg_replace( '#^\w+://[^/]+#', $this->args['alias_origin'], $value );
+						} else {
+							$remove_allow_same_origin = true;
+						}
+					}
+
+					$out[ $name ] = $value;
 					break;
 
 				case 'width':
@@ -175,7 +212,34 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$out['sandbox'] = self::SANDBOX_DEFAULTS;
 		}
 
+		// Remove allow-same-origin from sandbox if required.
+		if ( $remove_allow_same_origin ) {
+			$out['sandbox'] = trim( preg_replace( '/(^|\s)allow-same-origin(\s|$)/', ' ', $out['sandbox'] ) );
+		}
+
 		return $out;
+	}
+
+	/**
+	 * Obtain the origin part of a given URL (scheme, host, port).
+	 *
+	 * @param string $url URL.
+	 * @return string|null Origin URL or null if parse failed.
+	 */
+	private function get_origin_from_url( $url ) {
+		$parsed_url = wp_parse_url( $url );
+		if ( ! isset( $parsed_url['host'] ) ) {
+			return null;
+		}
+		if ( ! isset( $parsed_url['scheme'] ) ) {
+			$parsed_url['scheme'] = wp_parse_url( $this->args['current_origin'], PHP_URL_SCHEME );
+		}
+		$origin  = $parsed_url['scheme'] . '://';
+		$origin .= $parsed_url['host'];
+		if ( isset( $parsed_url['port'] ) ) {
+			$origin .= ':' . $parsed_url['port'];
+		}
+		return $origin;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -78,7 +78,9 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			$normalized_attributes = $this->normalize_attributes( AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node ) );
+			$normalized_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
+			$normalized_attributes = $this->set_layout( $normalized_attributes );
+			$normalized_attributes = $this->normalize_attributes( $normalized_attributes );
 
 			/**
 			 * If the src doesn't exist, remove the node. Either it never
@@ -93,7 +95,6 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			$this->did_convert_elements = true;
-			$normalized_attributes      = $this->set_layout( $normalized_attributes );
 			if ( empty( $normalized_attributes['layout'] ) && ! empty( $normalized_attributes['width'] ) && ! empty( $normalized_attributes['height'] ) ) {
 				$normalized_attributes['layout'] = 'intrinsic';
 				$this->add_or_append_attribute( $normalized_attributes, 'class', 'amp-wp-enforced-sizes' );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -165,7 +165,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			switch ( $name ) {
 				case 'src':
 					// Make the URL absolute since relative URLs are not allowed in amp-iframe.
-					if ( '/' === substr( $value, 0, 1 ) ) {
+					if ( '/' === substr( $value, 0, 1 ) && '/' !== substr( $value, 1, 1 ) ) {
 						$value = untrailingslashit( $this->args['current_origin'] ) . $value;
 					}
 

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -65,7 +65,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			'iframe_without_dimensions'                 => array(
 				'<iframe src="https://example.com/video/132886713"></iframe>',
 				'
-					<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
 						<noscript>
 							<iframe src="https://example.com/video/132886713"></iframe>
 						</noscript>
@@ -76,9 +76,20 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			'iframe_with_height_only'                   => array(
 				'<iframe src="https://example.com/video/132886713" height="400"></iframe>',
 				'
-					<amp-iframe src="https://example.com/video/132886713" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height">
+					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
 						<noscript>
 							<iframe src="https://example.com/video/132886713" height="400"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+			),
+
+			'iframe_with_100_percent_width'             => array(
+				'<iframe src="https://example.com/video/132886713" height="123" width="100%"></iframe>',
+				'
+					<amp-iframe src="https://example.com/video/132886713" height="123" width="auto" layout="fixed-height" sandbox="allow-scripts allow-same-origin">
+						<noscript>
+							<iframe src="https://example.com/video/132886713" height="123" width="100%"></iframe>
 						</noscript>
 					</amp-iframe>
 				',
@@ -87,7 +98,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			'iframe_with_width_only'                    => array(
 				'<iframe src="https://example.com/video/132886713" width="600"></iframe>',
 				'
-					<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
 						<noscript>
 							<iframe src="https://example.com/video/132886713" width="600"></iframe>
 						</noscript>
@@ -153,7 +164,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			'iframe_with_id_attribute'                  => array(
 				'<iframe src="https://example.com/iframe" id="myIframe"></iframe>',
 				'
-					<amp-iframe src="https://example.com/iframe" id="myIframe" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+					<amp-iframe src="https://example.com/iframe" id="myIframe" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
 						<noscript>
 							<iframe src="https://example.com/iframe" id="myIframe"></iframe>
 						</noscript>
@@ -164,7 +175,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 			'iframe_with_protocol_relative_url'         => array(
 				'<iframe src="//example.com/video/132886713"></iframe>',
 				'
-					<amp-iframe src="https://example.com/video/132886713" sandbox="allow-scripts allow-same-origin" height="400" layout="fixed-height">
+					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
 						<noscript>
 							<iframe src="https://example.com/video/132886713"></iframe>
 						</noscript>

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -300,6 +300,38 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					'add_placeholder'       => true,
 				),
 			),
+
+			'iframe_relative_url'                       => array(
+				'<iframe src="/same-origin/" width="50" height="100"></iframe>',
+				'<amp-iframe src="https://example.com/same-origin/" width="50" height="100" sandbox="allow-scripts" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				array(
+					'add_noscript_fallback' => false,
+					'add_placeholder'       => false,
+					'current_origin'        => 'https://example.com',
+				),
+			),
+
+			'iframe_relative_url_with_alias_origin'     => array(
+				'<iframe src="/same-origin/" width="50" height="100"></iframe>',
+				'<amp-iframe src="https://alt.example.org/same-origin/" width="50" height="100" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				array(
+					'add_noscript_fallback' => false,
+					'add_placeholder'       => false,
+					'current_origin'        => 'https://example.com',
+					'alias_origin'          => 'https://alt.example.org',
+				),
+			),
+
+			'iframe_absolute_url_with_alias_origin'     => array(
+				'<iframe src="https://example.com/same-origin/" width="50" height="100"></iframe>',
+				'<amp-iframe src="https://alt.example.org/same-origin/" width="50" height="100" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				array(
+					'add_noscript_fallback' => false,
+					'add_placeholder'       => false,
+					'current_origin'        => 'https://example.com',
+					'alias_origin'          => 'https://alt.example.org',
+				),
+			),
 		);
 	}
 

--- a/tests/test-amp-iframe-sanitizer.php
+++ b/tests/test-amp-iframe-sanitizer.php
@@ -311,6 +311,16 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				),
 			),
 
+			'iframe_scheme_relative_url'                => array(
+				'<iframe src="//example.com/same-origin/" width="50" height="100"></iframe>',
+				'<amp-iframe src="https://example.com/same-origin/" width="50" height="100" sandbox="allow-scripts" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
+				array(
+					'add_noscript_fallback' => false,
+					'add_placeholder'       => false,
+					'current_origin'        => 'https://example.com',
+				),
+			),
+
 			'iframe_relative_url_with_alias_origin'     => array(
 				'<iframe src="/same-origin/" width="50" height="100"></iframe>',
 				'<amp-iframe src="https://alt.example.org/same-origin/" width="50" height="100" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',

--- a/tests/test-amp-script-sanitizer.php
+++ b/tests/test-amp-script-sanitizer.php
@@ -104,6 +104,6 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertRegExp( '/<!-- Google Tag Manager -->\s*<!-- End Google Tag Manager -->/', $content );
 		$this->assertContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
 		$this->assertContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
-		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" sandbox="allow-scripts allow-same-origin" layout="fixed-height" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
+		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
 	}
 }

--- a/tests/test-amp-video-sanitizer.php
+++ b/tests/test-amp-video-sanitizer.php
@@ -44,7 +44,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 
 			'video_without_dimensions' => array(
 				'<video src="https://example.com/file.mp4"></video>',
-				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
+				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
 			),
 
 			'autoplay_attribute' => array(

--- a/tests/test-class-amp-base-sanitizer.php
+++ b/tests/test-class-amp-base-sanitizer.php
@@ -54,6 +54,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				array(
 					'height' => 400,
 					'layout' => 'fixed-height',
+					'width'  => 'auto',
 				),
 			),
 
@@ -65,6 +66,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				array(
 					'height' => 400,
 					'layout' => 'fixed-height',
+					'width'  => 'auto',
 				),
 			),
 
@@ -75,6 +77,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				array(
 					'height' => 100,
 					'layout' => 'fixed-height',
+					'width'  => 'auto',
 				),
 			),
 
@@ -85,6 +88,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				array(
 					'height' => 400,
 					'layout' => 'fixed-height',
+					'width'  => 'auto',
 				),
 			),
 


### PR DESCRIPTION
This PR improves a couple aspects for how iframes are converted to AMP. Spurred on by a [support topic](https://wordpress.org/support/topic/shortcodes-for-geo-mashup-not-working/#post-11659045).

# Absolutize iframe URLs

AMP [does not allow relative URLs](https://github.com/ampproject/amphtml/blob/2708f15903cfa60f8a70a2dce330bfbf18302aee/validator/validator-main.protoascii#L2290) for `iframe` elements and it [may eventually not allow relative URLs](https://github.com/ampproject/amphtml/blob/2708f15903cfa60f8a70a2dce330bfbf18302aee/extensions/amp-iframe/validator-amp-iframe.protoascii#L69) for `amp-iframe`. So this PR adds the scheme and host to a URL that only includes a path.

Input:

```html
<iframe src="/core-dev/src/readme.html" width="100%" height="123"></iframe>
```

Before:

```html
<amp-iframe src="/core-dev/src/readme.html" width="525" height="123" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
    <span placeholder="" class="amp-wp-iframe-placeholder"></span>
    <noscript>
        <iframe width="100%" height="123"></iframe>
    </noscript>
</amp-iframe>
```

After:

```html
<amp-iframe src="https://wordpressdev.lndo.site/core-dev/src/readme.html" width="auto" height="123" layout="fixed-height" sandbox="allow-scripts">
    <span placeholder="" class="amp-wp-iframe-placeholder"></span>
    <noscript>
        <iframe src="https://wordpressdev.lndo.site/core-dev/src/readme.html" width="100%" height="123"></iframe>
    </noscript>
</amp-iframe>
```

This also fixes an AMP validation error where the `src` of the fallback noscript `iframe` was getting stripped. Note that the `noscript > iframe` should be removed by the validating sanitizer once this is implemented:

https://github.com/ampproject/amp-wp/blob/61ed6bf9cb425b2fbff621a92f1a874a9a6579e5/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L23-L24

# Remove `allow-same-origin` sandbox from same-origin iframes

One very common issue with iframes in WordPress is issues due to using a same-origin source. This is not allowed in AMP when `allow-same-origin` is in the `sandbox` attribute. In this case, an error is shown:

![image](https://user-images.githubusercontent.com/134745/60402683-b0a38300-9b47-11e9-8fb7-5a1c3ce5b1a8.png)

See [same origin policy](https://github.com/ampproject/amphtml/blob/master/spec/amp-iframe-origin-policy.md).

Instead of the iframe having a hard failure due to violating the same-origin policy, an alternative is to simply remove the `allow-same-origin` from the iframe. While the iframe won't be able to interact with the parent window, at least the content can load instead of being blank. 

- [x] Still need to confirm what other side-effects will be experienced here.
- [x] Test with same-site post embeds.

For before/after, see above.

# Allow alias origin to be supplied

In a case where a site has a domain alias set up (which does not automatically redirect), the iframe sanitizer now supports converting same-origin URL to use the alias origin when encountering such an iframe. No alias is provided by default, but it can be done via a filter:

```php
add_filter(
	'amp_content_sanitizers',
	function ( $sanitizers ) {
		$sanitizers['AMP_Iframe_Sanitizer']['alias_origin'] = 'https://alias.' . wp_parse_url( get_home_url(), PHP_URL_HOST );
		return $sanitizers;
	}
);
```

Without this filter, see the example output above under absolutized iframe URLs. With the filter present, the output for a site that has an  origin of `https://wordpressdev.lndo.site`:

```html
<amp-iframe src="https://alias.wordpressdev.lndo.site/core-dev/src/readme.html" width="auto" height="123" layout="fixed-height" sandbox="allow-scripts allow-same-origin">
     <span placeholder="" class="amp-wp-iframe-placeholder"></span>
    <noscript>
        <iframe src="https://alias.wordpressdev.lndo.site/core-dev/src/readme.html" width="100%" height="123"></iframe>
    </noscript>
</amp-iframe>
```

# Convert 100% width to fixed-layout

AMP does not support the percentage unit in the `width` attribute. Instead, the `fixed-height` layout is supposed to be used when 100% width is desired.

Input:

```html
<iframe src="https://example.com/" width="100%" height="123"></iframe>
```

Before:

```html
<amp-iframe src="https://example.com/" width="525" height="123" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>
```

After:

```html
<amp-iframe src="https://example.com/" width="auto" height="123" layout="fixed-height" sandbox="allow-scripts allow-same-origin"></amp-iframe>
```

Support for the `auto` value for the `width` attribute was added in #2209.

----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3343396/amp.zip) (v1.2.1-alpha-20190630T221839Z-737f8ca5)
