### PR TITLE
Group tests with external HTTP requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,9 +73,9 @@ jobs:
         - source "$DEV_LIB_PATH/travis.script.sh"
         - npm run test:js -- --ci
 
-    - name: PHP unit tests (7.3, WordPress latest)
+    - name: PHP unit tests w/ external-http (7.3, WordPress latest)
       php: "7.3"
-      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1
+      env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1 PHPUNIT_EXTRA_GROUP=external-http
 
     - name: PHP unit tests (7.2, WordPress latest)
       php: "7.2"
@@ -101,9 +101,9 @@ jobs:
       php: "5.5"
       env: WP_VERSION=5.0    DEV_LIB_ONLY=phpunit,phpsyntax
 
-    - name: PHP unit tests (5.4, WordPress 4.9)
+    - name: PHP unit tests w/ external-http (5.4, WordPress 4.9)
       php: "5.4"
-      env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax
+      env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax                     PHPUNIT_EXTRA_GROUP=external-http
 
     - name: PHP unit tests (7.3, WordPress trunk)
       php: "7.3"
@@ -118,6 +118,7 @@ jobs:
       script:
         - npm run build:js
         - source "$DEV_LIB_PATH/travis.script.sh"
+        - if [[ ! -z "$PHPUNIT_EXTRA_GROUP" ]]; then echo "Running phpunit group $PHPUNIT_EXTRA_GROUP"; phpunit --group $PHPUNIT_EXTRA_GROUP; fi
         - bash <(curl -s https://codecov.io/bash) -cF php -f /tmp/wordpress/src/wp-content/plugins/amp/build/logs/clover.xml
         - npm run test:js -- --collectCoverage
         - bash <(curl -s https://codecov.io/bash) -cF javascript -f build/logs/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,11 @@ before_script:
 script:
   - npm run build:js
   - source "$DEV_LIB_PATH/travis.script.sh"
-  - if [[ ! -z "$PHPUNIT_EXTRA_GROUP" ]]; then echo "Running phpunit group $PHPUNIT_EXTRA_GROUP"; phpunit --group $PHPUNIT_EXTRA_GROUP; fi
+  - |
+    if [[ ! -z "$PHPUNIT_EXTRA_GROUP" ]]; then
+      echo "Running phpunit group $PHPUNIT_EXTRA_GROUP"
+      phpunit --group $PHPUNIT_EXTRA_GROUP
+    fi
 
 after_script:
   - source "$DEV_LIB_PATH/travis.after_script.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ before_script:
 script:
   - npm run build:js
   - source "$DEV_LIB_PATH/travis.script.sh"
+  - if [[ ! -z "$PHPUNIT_EXTRA_GROUP" ]]; then echo "Running phpunit group $PHPUNIT_EXTRA_GROUP"; phpunit --group $PHPUNIT_EXTRA_GROUP; fi
 
 after_script:
   - source "$DEV_LIB_PATH/travis.after_script.sh"
@@ -118,7 +119,6 @@ jobs:
       script:
         - npm run build:js
         - source "$DEV_LIB_PATH/travis.script.sh"
-        - if [[ ! -z "$PHPUNIT_EXTRA_GROUP" ]]; then echo "Running phpunit group $PHPUNIT_EXTRA_GROUP"; phpunit --group $PHPUNIT_EXTRA_GROUP; fi
         - bash <(curl -s https://codecov.io/bash) -cF php -f /tmp/wordpress/src/wp-content/plugins/amp/build/logs/clover.xml
         - npm run test:js -- --collectCoverage
         - bash <(curl -s https://codecov.io/bash) -cF javascript -f build/logs/lcov.info

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,9 +19,9 @@
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<directory suffix=".php">./</directory>
 			<exclude>
-				<directory suffix=".php">dev-lib</directory>
 				<directory suffix=".php">svn</directory>
 				<directory suffix=".php">node_modules</directory>
+				<directory suffix=".php">bin</directory>
 				<directory suffix=".php">tests</directory>
 				<directory suffix=".php">vendor</directory>
 				<directory suffix=".php">build</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,8 @@
 		<const name="WP_TEST_ACTIVATED_PLUGINS" value="jetpack/jetpack.php,gutenberg/gutenberg.php,pwa/pwa.php" />
 	</php>
 	<testsuites>
-		<testsuite name="amp-wp">
+		<!-- Default test suite to run all tests -->
+		<testsuite name="default">
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,11 @@
 			<directory prefix="test-" suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
+	<groups>
+		<exclude>
+			<group>external-http</group>
+		</exclude>
+	</groups>
 	<filter>
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<directory suffix=".php">./</directory>

--- a/tests/test-amp-image-dimension-extractor.php
+++ b/tests/test-amp-image-dimension-extractor.php
@@ -182,8 +182,10 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	/**
 	 * Test a valid image file.
 	 *
-	 * TODO: tests for transients, errors, lock
-	 * TODO: mocked tests
+	 * @todo: tests for transients, errors, lock
+	 * @todo: mocked tests
+	 *
+	 * @group external-http
 	 */
 	public function test__valid_image_file() {
 		$sources  = array(
@@ -203,6 +205,8 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test multiple valid image files.
+	 *
+	 * @group external-http
 	 */
 	public function test__multiple_valid_image_files() {
 		$sources  = array(
@@ -237,6 +241,8 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test an invalid image file.
+	 *
+	 * @group external-http
 	 */
 	public function test__invalid_image_file() {
 		$sources  = array(
@@ -253,6 +259,8 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 
 	/**
 	 * Test a mix of valid and invalid image files.
+	 *
+	 * @group external-http
 	 */
 	public function test__mix_of_valid_and_invalid_image_file() {
 		$sources  = array(


### PR DESCRIPTION
Further optimization of tests after #2713.

**Usage:**

1. Run all tests (except `external-http`): `phpunit`
2. Run `external-http` only: `phpunit --group external-http`

**Todo:**

* [x] Do this on Travis

See #2705.