### PR TITLE
Add missing prop type for block name

### DIFF
--- a/assets/src/stories-editor/components/block-navigation/item.js
+++ b/assets/src/stories-editor/components/block-navigation/item.js
@@ -166,6 +166,7 @@ BlockNavigationItem.propTypes = {
 	getBlockIndex: PropTypes.func.isRequired,
 	moveBlockToPosition: PropTypes.func.isRequired,
 	block: PropTypes.shape( {
+		name: PropTypes.string.isRequired,
 		clientId: PropTypes.string.isRequired,
 	} ),
 	isSelected: PropTypes.bool,


### PR DESCRIPTION
Introduced in #2664. Not immediately caught as the PR wasn't rebased before merging.