### PR TITLE
Improve Soundcloud embed: support playlists, preserve visual/height params, include fallback content

### DIFF
--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -82,8 +82,8 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	private function parse_amp_component_from_iframe( $html, $url ) {
 		$embed = '';
 
-		if ( preg_match( '#<iframe[^>]*?src="(?P<url>[^"]+)"#s', $html, $matches ) ) {
-			$src   = html_entity_decode( $matches['url'], ENT_QUOTES );
+		if ( preg_match( '#<iframe[^>]*?src="(?P<src>[^"]+)"#s', $html, $matches ) ) {
+			$src   = html_entity_decode( $matches['src'], ENT_QUOTES );
 			$query = array();
 			parse_str( wp_parse_url( $src, PHP_URL_QUERY ), $query );
 			if ( ! empty( $query['url'] ) ) {

--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -138,7 +138,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 			$url = shortcode_new_to_old_params( $attr );
 		}
 
-		// Defer to oEmbed an oEmbeddable URL is provided.
+		// Defer to oEmbed if an oEmbeddable URL is provided.
 		if ( isset( $url ) && 'api.soundcloud.com' !== wp_parse_url( $url, PHP_URL_HOST ) ) {
 			global $wp_embed;
 			return $wp_embed->shortcode( $attr, $url );

--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -82,7 +82,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	private function parse_amp_component_from_iframe( $html, $url ) {
 		$embed = '';
 
-		if ( preg_match( '#<iframe[^>]*?src="(?P<url>.+?)"#', $html, $matches ) ) {
+		if ( preg_match( '#<iframe[^>]*?src="(?P<url>[^"]+)"#s', $html, $matches ) ) {
 			$src   = html_entity_decode( $matches['url'], ENT_QUOTES );
 			$query = array();
 			parse_str( wp_parse_url( $src, PHP_URL_QUERY ), $query );
@@ -92,7 +92,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 					$props['visual'] = $query['visual'];
 				}
 
-				if ( $url && preg_match( '#<iframe[^>]*?title="(?P<title>[^"]+)"#', $html, $matches ) ) {
+				if ( $url && preg_match( '#<iframe[^>]*?title="(?P<title>[^"]+)"#s', $html, $matches ) ) {
 					$props['fallback'] = sprintf(
 						'<a fallback href="%s">%s</a>',
 						esc_url( $url ),
@@ -100,11 +100,11 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 					);
 				}
 
-				if ( preg_match( '#<iframe[^>]*?height="(?P<height>\d+)"#', $html, $matches ) ) {
+				if ( preg_match( '#<iframe[^>]*?height="(?P<height>\d+)"#s', $html, $matches ) ) {
 					$props['height'] = (int) $matches['height'];
 				}
 
-				if ( preg_match( '#<iframe[^>]*?width="(?P<width>\d+)"#', $html, $matches ) ) {
+				if ( preg_match( '#<iframe[^>]*?width="(?P<width>\d+)"#s', $html, $matches ) ) {
 					$props['width'] = (int) $matches['width'];
 				}
 

--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -23,7 +23,10 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_shortcode( 'soundcloud', array( $this, 'shortcode' ) );
+		if ( function_exists( 'soundcloud_shortcode' ) ) {
+			// @todo Move this to Jetpack.
+			add_shortcode( 'soundcloud', array( $this, 'shortcode' ) );
+		}
 		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 2 );
 	}
 
@@ -31,7 +34,10 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_shortcode( 'soundcloud' );
+		if ( function_exists( 'soundcloud_shortcode' ) ) {
+			// @todo Move this to Jetpack.
+			remove_shortcode( 'soundcloud' );
+		}
 		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
 	}
 
@@ -42,15 +48,14 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @deprecated Core's oEmbed handler is now used instead, with embed_oembed_html filter used to convert to AMP.
 	 * @param array  $matches URL pattern matches.
-	 * @param array  $attr    Shortcode attribues.
+	 * @param array  $attr    Shortcode attributes.
 	 * @param string $url     URL.
 	 * @return string Rendered oEmbed.
 	 */
 	public function oembed( $matches, $attr, $url ) {
 		_deprecated_function( __METHOD__, '0.6' );
 		unset( $matches, $attr );
-		$track_id = $this->get_track_id_from_url( $url );
-		return $this->render( compact( 'track_id' ) );
+		return $this->render( $this->extract_params_from_iframe_src( $url ), $url );
 	}
 
 	/**
@@ -61,31 +66,49 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string Embed.
 	 */
 	public function filter_embed_oembed_html( $cache, $url ) {
-		$parsed_url = wp_parse_url( $url );
-		if ( false === strpos( $parsed_url['host'], 'soundcloud.com' ) ) {
+		if ( false === strpos( wp_parse_url( $url, PHP_URL_HOST ), 'soundcloud.com' ) ) {
 			return $cache;
 		}
-		return $this->parse_amp_component_from_iframe( $cache );
+		return $this->parse_amp_component_from_iframe( $cache, $url );
 	}
 
 	/**
 	 * Parse AMP component from iframe.
 	 *
-	 * @param string $html HTML.
+	 * @param string      $html HTML.
+	 * @param string|null $url  Embed URL, for fallback purposes.
 	 * @return string AMP component or empty if unable to determine SoundCloud ID.
 	 */
-	private function parse_amp_component_from_iframe( $html ) {
+	private function parse_amp_component_from_iframe( $html, $url ) {
 		$embed = '';
-		if ( preg_match( '#<iframe.+?src="(?P<url>.+?)".*>#', $html, $matches ) ) {
+
+		if ( preg_match( '#<iframe[^>]*?src="(?P<url>.+?)"#', $html, $matches ) ) {
 			$src   = html_entity_decode( $matches['url'], ENT_QUOTES );
 			$query = array();
 			parse_str( wp_parse_url( $src, PHP_URL_QUERY ), $query );
 			if ( ! empty( $query['url'] ) ) {
-				$embed = $this->render(
-					array(
-						'track_id' => $this->get_track_id_from_url( $query['url'] ),
-					)
-				);
+				$props = $this->extract_params_from_iframe_src( $query['url'] );
+				if ( isset( $query['visual'] ) ) {
+					$props['visual'] = $query['visual'];
+				}
+
+				if ( $url && preg_match( '#<iframe[^>]*?title="(?P<title>[^"]+)"#', $html, $matches ) ) {
+					$props['fallback'] = sprintf(
+						'<a fallback href="%s">%s</a>',
+						esc_url( $url ),
+						esc_html( $matches['title'] )
+					);
+				}
+
+				if ( preg_match( '#<iframe[^>]*?height="(?P<height>\d+)"#', $html, $matches ) ) {
+					$props['height'] = (int) $matches['height'];
+				}
+
+				if ( preg_match( '#<iframe[^>]*?width="(?P<width>\d+)"#', $html, $matches ) ) {
+					$props['width'] = (int) $matches['width'];
+				}
+
+				$embed = $this->render( $props, $url );
 			}
 		}
 		return $embed;
@@ -94,68 +117,87 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Render shortcode.
 	 *
+	 * @todo Move this to Jetpack.
+	 *
 	 * @param array  $attr    Shortcode attributes.
 	 * @param string $content Shortcode content.
 	 * @return string Rendered shortcode.
 	 */
 	public function shortcode( $attr, $content = null ) {
-		$output = '';
-		if ( function_exists( 'soundcloud_shortcode' ) ) {
-			if ( empty( $attr['url'] ) && ! empty( $attr['id'] ) ) {
-				$attr['url'] = 'https://api.soundcloud.com/tracks/' . intval( $attr['id'] );
-			}
-			$output = soundcloud_shortcode( $attr, $content );
-			$output = $this->parse_amp_component_from_iframe( $output );
-		} else {
-			$url = null;
-			if ( isset( $attr['id'] ) ) {
-				$url = 'https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F' . intval( $attr['id'] );
-			}
-
-			if ( isset( $attr['url'] ) ) {
-				$url = $attr['url'];
-			} elseif ( isset( $attr[0] ) ) {
-				$url = $attr[0];
-			} elseif ( function_exists( 'shortcode_new_to_old_params' ) ) {
-				$url = shortcode_new_to_old_params( $attr );
-			}
-
-			if ( $url ) {
-				$output = $this->render_embed_fallback( $url );
-			}
+		if ( ! function_exists( 'soundcloud_shortcode' ) ) {
+			return '';
 		}
-		return $output;
+
+		if ( isset( $attr['url'] ) ) {
+			$url = $attr['url'];
+		} elseif ( isset( $attr['id'] ) ) {
+			$url = 'https://api.soundcloud.com/tracks/' . $attr['id'];
+		} elseif ( isset( $attr[0] ) ) {
+			$url = is_numeric( $attr[0] ) ? 'https://api.soundcloud.com/tracks/' . $attr[0] : $attr[0];
+		} elseif ( function_exists( 'shortcode_new_to_old_params' ) ) {
+			$url = shortcode_new_to_old_params( $attr );
+		}
+
+		// Defer to oEmbed an oEmbeddable URL is provided.
+		if ( isset( $url ) && 'api.soundcloud.com' !== wp_parse_url( $url, PHP_URL_HOST ) ) {
+			global $wp_embed;
+			return $wp_embed->shortcode( $attr, $url );
+		}
+
+		if ( isset( $url ) && ! isset( $attr['url'] ) ) {
+			$attr['url'] = $url;
+		}
+		$output = soundcloud_shortcode( $attr, $content );
+
+		return $this->parse_amp_component_from_iframe( $output, null );
 	}
 
 	/**
 	 * Render embed.
 	 *
-	 * @param array $args Args.
+	 * @param array  $args Args.
+	 * @param string $url  Embed URL for fallback purposes. Optional.
 	 * @return string Rendered embed.
 	 * @global WP_Embed $wp_embed
 	 */
-	public function render( $args ) {
+	public function render( $args, $url ) {
 		$args = wp_parse_args(
 			$args,
 			array(
-				'track_id' => false,
-				'url'      => null,
+				'track_id'    => false,
+				'playlist_id' => false,
+				'height'      => null,
+				'width'       => null,
+				'visual'      => null,
+				'fallback'    => '',
 			)
 		);
 
-		if ( empty( $args['track_id'] ) ) {
-			return $this->render_embed_fallback( $args['url'] );
+		$this->did_convert_elements = true;
+
+		$attributes = array();
+		if ( ! empty( $args['track_id'] ) ) {
+			$attributes['data-trackid'] = $args['track_id'];
+		} elseif ( ! empty( $args['playlist_id'] ) ) {
+			$attributes['data-playlistid'] = $args['playlist_id'];
+		} elseif ( $url ) {
+			return $this->render_embed_fallback( $url );
+		} else {
+			return '';
 		}
 
-		$this->did_convert_elements = true;
+		if ( isset( $args['visual'] ) ) {
+			$attributes['data-visual'] = rest_sanitize_boolean( $args['visual'] ) ? 'true' : 'false';
+		}
+
+		// @todo Set width to $args['width'] and layout to responsive once amp-soundcloud supports it: <https://github.com/ampproject/amphtml/issues/23144>.
+		$attributes['height'] = $args['height'] ? $args['height'] : $this->args['height'];
+		$attributes['layout'] = 'fixed-height';
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-soundcloud',
-			array(
-				'data-trackid' => $args['track_id'],
-				'layout'       => 'fixed-height',
-				'height'       => $this->args['height'],
-			)
+			$attributes,
+			$args['fallback']
 		);
 	}
 
@@ -163,13 +205,13 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Render embed fallback.
 	 *
 	 * @param string $url URL.
-	 * @returns string
+	 * @return string Fallback link.
 	 */
 	private function render_embed_fallback( $url ) {
 		return AMP_HTML_Utils::build_tag(
 			'a',
 			array(
-				'href'  => esc_url( $url ),
+				'href'  => esc_url_raw( $url ),
 				'class' => 'amp-wp-embed-fallback',
 			),
 			esc_html( $url )
@@ -177,17 +219,23 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	/**
-	 * Get track_id from URL.
+	 * Get params from Soundcloud iframe src.
 	 *
 	 * @param string $url URL.
-	 *
-	 * @return string Track ID or empty string if none matched.
+	 * @return array Params extracted from URL.
 	 */
-	private function get_track_id_from_url( $url ) {
+	private function extract_params_from_iframe_src( $url ) {
 		$parsed_url = wp_parse_url( $url );
-		if ( ! preg_match( '#tracks/(?P<track_id>[^/]+)#', $parsed_url['path'], $matches ) ) {
-			return '';
+		if ( preg_match( '#tracks/(?P<track_id>\d+)#', $parsed_url['path'], $matches ) ) {
+			return array(
+				'track_id' => $matches['track_id'],
+			);
 		}
-		return $matches['track_id'];
+		if ( preg_match( '#playlists/(?P<playlist_id>\d+)#', $parsed_url['path'], $matches ) ) {
+			return array(
+				'playlist_id' => $matches['playlist_id'],
+			);
+		}
+		return array();
 	}
 }

--- a/tests/test-amp-soundcloud-embed.php
+++ b/tests/test-amp-soundcloud-embed.php
@@ -123,12 +123,12 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 
 			'track_simple'    => array(
 				$this->track_url . PHP_EOL,
-				'<p><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height"><a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart &#8211; Requiem in D minor Complete Full by Jack Villano Villano</a></amp-soundcloud></p>' . PHP_EOL,
+				'<p><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart &#8211; Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
 			),
 
 			'playlist_simple' => array(
 				$this->playlist_url . PHP_EOL,
-				'<p><amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height"><a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music &#8211; The Essential Collection by Classical Music</a></amp-soundcloud></p>' . PHP_EOL,
+				'<p><amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music &#8211; The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
 			),
 		);
 
@@ -152,17 +152,17 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 
 					'shortcode_with_track_permalink'      => array(
 						"[soundcloud url=$this->track_url]",
-						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height"><a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a></amp-soundcloud>' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
 					),
 
 					'shortcode_with_bare_track_permalink' => array(
 						"[soundcloud $this->track_url]",
-						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height"><a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a></amp-soundcloud>' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
 					),
 
 					'shortcode_with_playlist_permalink'   => array(
 						"[soundcloud url=$this->playlist_url]",
-						'<amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height"><a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music - The Essential Collection by Classical Music</a></amp-soundcloud>' . PHP_EOL,
+						'<amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music - The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
 					),
 
 					// This apparently only works on WordPress.com.

--- a/tests/test-class-amp-theme-support.php
+++ b/tests/test-class-amp-theme-support.php
@@ -1379,7 +1379,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers \amp_render_scripts()
 	 */
 	public function test_prepare_response() {
-		remove_action( 'wp_print_scripts', 'wp_print_service_workers', 9 );
+		add_theme_support( 'amp' );
 
 		add_filter(
 			'home_url',


### PR DESCRIPTION
Fixes #2715.

* Add support for Soundcloud playlists
* Preserve `visual` param to match the non-AMP version.
* Preserve `height` param so the height is largely the same as the non-AMP version. Note that there is not a 1:1 match yet because `amp-soundcloud` does not support the `responsive` layout. See https://github.com/ampproject/amphtml/issues/23144.
* Add `fallback` content with a link to the original Soundcloud link with its title; this improves accessibility and indexability.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3347837/amp.zip) (1.2.1-alpha-20190702T011358Z-e864ea9d)


# Non-AMP version

Track embed: https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor

![image](https://user-images.githubusercontent.com/134745/60471848-3a705080-9c1b-11e9-9da7-4836d91bb299.png)

Playlist embed: https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection

![image](https://user-images.githubusercontent.com/134745/60471864-4e1bb700-9c1b-11e9-8a50-f16fe3f8f1ce.png)

# Old AMP Version 

Track embed:

![image](https://user-images.githubusercontent.com/134745/60471926-920ebc00-9c1b-11e9-845f-36978172e777.png)

```html
<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud  wp-has-aspect-ratio">
	<div class="wp-block-embed__wrapper">
		<amp-soundcloud data-trackid="90097394" layout="fixed-height" height="200"></amp-soundcloud>
	</div>
</figure>
```

Playlist embed:

(Fails to render)

```html
<p><a href="" class="amp-wp-embed-fallback"></a></p>
```

# New AMP Version

Track:

![image](https://user-images.githubusercontent.com/134745/60472016-03e70580-9c1c-11e9-8346-a037400368ed.png)

```html
<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud  wp-has-aspect-ratio">
	<div class="wp-block-embed__wrapper">
		<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">
			<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart – Requiem in D minor Complete Full by Jack Villano Villano</a>
		</amp-soundcloud>
	</div>
</figure>
```

Playlist:

![image](https://user-images.githubusercontent.com/134745/60472032-15301200-9c1c-11e9-915b-e3046190bec1.png)

```html
<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud  wp-has-aspect-ratio">
	<div class="wp-block-embed__wrapper">
		<amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">
			<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music – The Essential Collection by Classical Music</a>
		</amp-soundcloud>
	</div>
</figure>
```