### PR TITLE
Fix an issue with the story background image not being downsized 

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -1527,7 +1527,7 @@ class AMP_Story_Post_Type {
 	}
 
 	/**
-	 * Adds a new max image size to the images sizes available.
+	 * Adds a new max image size to the image sizes available.
 	 *
 	 * In the AMP story editor, when selecting Background Media,
 	 * it will use this custom image size.
@@ -1544,7 +1544,7 @@ class AMP_Story_Post_Type {
 	public static function add_new_max_image_size( $image_sizes ) {
 		$full_size_name = __( 'AMP Story Max Size', 'amp' );
 
-		if ( isset( $_POST['action'] ) && 'query-attachments' === $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( isset( $_POST['action'] ) && ( 'query-attachments' === $_POST['action'] || 'upload-attachment' === $_POST['action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$image_sizes[ self::MAX_IMAGE_SIZE_SLUG ] = $full_size_name;
 		} elseif ( get_post_type() && self::POST_TYPE_SLUG === get_post_type() ) {
 			$image_sizes[ self::MAX_IMAGE_SIZE_SLUG ] = $full_size_name;


### PR DESCRIPTION
Thanks to Weston for finding this and describing the solution.

## Steps To Reproduce

1. Create a new story

2. For the 1st page, in 'Background Media,' click 'Select Media'

3. Upload a [3000 x 4000 image](https://ipsumimage.appspot.com/3000x4000), don't select an existing image from the 'Media Library' tab:

<img width="908" alt="upload-image" src="https://user-images.githubusercontent.com/4063887/60483181-0405f600-9c5a-11e9-881c-1082ed05db84.png">

4. Once the image has uploaded, click 'Select'

5. Expected: the background image should end with `1400.png`, meaning it was resized down

6. Actual: it doesn't end with `1400.png`:

<img width="1040" alt="bg-image" src="https://user-images.githubusercontent.com/4063887/60483315-91494a80-9c5a-11e9-8e73-d953ac38359a.png">
