### PR TITLE
Increase specificity of [data-block] selector

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -94,7 +94,7 @@
 	height: 553px;
 }
 
-[data-block] {
+.editor-styles-wrapper [data-block] {
 	margin-top: 0;
 	margin-bottom: 0;
 }


### PR DESCRIPTION
Needed after upstream change in https://github.com/WordPress/gutenberg/pull/16207.

Before:

![Screenshot 2019-07-02 at 14 57 03](https://user-images.githubusercontent.com/841956/60514792-7fa78780-9cda-11e9-8966-8393308b2dc5.png)

After:

![Screenshot 2019-07-02 at 15 01 31](https://user-images.githubusercontent.com/841956/60514798-82a27800-9cda-11e9-96ca-64499e9810f3.png)
