### PR TITLE
Improve wrapping callbacks for validation sourcing and guard against infinite recursion when sourcing callbacks

### DIFF
--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -99,6 +99,7 @@ class AMP_Autoloader {
 		'AMP_HTML_Utils'                     => 'includes/utils/class-amp-html-utils',
 		'AMP_Image_Dimension_Extractor'      => 'includes/utils/class-amp-image-dimension-extractor',
 		'AMP_Validation_Manager'             => 'includes/validation/class-amp-validation-manager',
+		'AMP_Validation_Callback_Wrapper'    => 'includes/validation/class-amp-validation-callback-wrapper',
 		'AMP_Validated_URL_Post_Type'        => 'includes/validation/class-amp-validated-url-post-type',
 		'AMP_Validation_Error_Taxonomy'      => 'includes/validation/class-amp-validation-error-taxonomy',
 		'AMP_CLI'                            => 'includes/class-amp-cli',

--- a/includes/validation/class-amp-validation-callback-wrapper.php
+++ b/includes/validation/class-amp-validation-callback-wrapper.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Class AMP_Validation_Callback_Wrapper
+ *
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Validation_Callback_Wrapper
+ *
+ * @since 1.2.1
+ */
+class AMP_Validation_Callback_Wrapper implements ArrayAccess {
+
+	/**
+	 * Callback data.
+	 *
+	 * @var array
+	 */
+	protected $callback;
+
+	/**
+	 * AMP_Validation_Callback_Wrapper constructor.
+	 *
+	 * @param array $callback {
+	 *     The callback data.
+	 *
+	 *     @type callable $function
+	 *     @type int      $accepted_args
+	 *     @type array    $source
+	 * }
+	 */
+	public function __construct( $callback ) {
+		$this->callback = $callback;
+	}
+
+	/**
+	 * Invoke wrapped callback.
+	 *
+	 * @return mixed
+	 */
+	public function __invoke() {
+		global $wp_styles, $wp_scripts;
+
+		$function      = $this->callback['function'];
+		$accepted_args = $this->callback['accepted_args'];
+		$args          = func_get_args();
+
+		$before_styles_enqueued = array();
+		if ( isset( $wp_styles ) && isset( $wp_styles->queue ) ) {
+			$before_styles_enqueued = $wp_styles->queue;
+		}
+		$before_scripts_enqueued = array();
+		if ( isset( $wp_scripts ) && isset( $wp_scripts->queue ) ) {
+			$before_scripts_enqueued = $wp_scripts->queue;
+		}
+
+		$is_filter = isset( $callback['source']['hook'] ) && ! did_action( $this->callback['source']['hook'] );
+
+		// Wrap the markup output of (action) hooks in source comments.
+		AMP_Validation_Manager::$hook_source_stack[] = $this->callback['source'];
+		$has_buffer_started                          = false;
+		if ( ! $is_filter && AMP_Validation_Manager::can_output_buffer() ) {
+			$has_buffer_started = ob_start( array( 'AMP_Validation_Manager', 'wrap_buffer_with_source_comments' ) );
+		}
+		$result = call_user_func_array( $function, array_slice( $args, 0, intval( $accepted_args ) ) );
+		if ( $has_buffer_started ) {
+			ob_end_flush();
+		}
+		array_pop( AMP_Validation_Manager::$hook_source_stack );
+
+		// Keep track of which source enqueued the styles.
+		if ( isset( $wp_styles ) && isset( $wp_styles->queue ) ) {
+			foreach ( array_diff( $wp_styles->queue, $before_styles_enqueued ) as $handle ) {
+				AMP_Validation_Manager::$enqueued_style_sources[ $handle ][] = array_merge( $this->callback['source'], compact( 'handle' ) );
+			}
+		}
+
+		// Keep track of which source enqueued the scripts, and immediately report validity.
+		if ( isset( $wp_scripts ) && isset( $wp_scripts->queue ) ) {
+			foreach ( array_diff( $wp_scripts->queue, $before_scripts_enqueued ) as $queued_handle ) {
+				$handles = array( $queued_handle );
+
+				// Account for case where registered script is a placeholder for a set of scripts (e.g. jquery).
+				if ( isset( $wp_scripts->registered[ $queued_handle ] ) && false === $wp_scripts->registered[ $queued_handle ]->src ) {
+					$handles = array_merge( $handles, $wp_scripts->registered[ $queued_handle ]->deps );
+				}
+
+				foreach ( $handles as $handle ) {
+					AMP_Validation_Manager::$enqueued_script_sources[ $handle ][] = array_merge( $this->callback['source'], compact( 'handle' ) );
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Offset set.
+	 *
+	 * @param mixed $offset Offset.
+	 * @param mixed $value  Value.
+	 */
+	public function offsetSet( $offset, $value ) {
+		if ( ! is_array( $this->callback['function'] ) ) {
+			return;
+		}
+		if ( is_null( $offset ) ) {
+			$this->callback['function'][] = $value;
+		} else {
+			$this->callback['function'][ $offset ] = $value;
+		}
+	}
+
+	/**
+	 * Offset exists.
+	 *
+	 * @param mixed $offset Offset.
+	 * @return bool Exists.
+	 */
+	public function offsetExists( $offset ) {
+		if ( ! is_array( $this->callback['function'] ) ) {
+			return false;
+		}
+		return isset( $this->callback['function'][ $offset ] );
+	}
+
+	/**
+	 * Offset unset.
+	 *
+	 * @param mixed $offset Offset.
+	 */
+	public function offsetUnset( $offset ) {
+		if ( ! is_array( $this->callback['function'] ) ) {
+			return;
+		}
+		unset( $this->callback['function'][ $offset ] );
+	}
+
+	/**
+	 * Offset get.
+	 *
+	 * @param mixed $offset Offset.
+	 * @return mixed|null Value.
+	 */
+	public function offsetGet( $offset ) {
+		if ( is_array( $this->callback['function'] ) && isset( $this->callback['function'][ $offset ] ) ) {
+			return $this->callback['function'][ $offset ];
+		}
+		return null;
+	}
+}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -138,16 +138,34 @@ class AMP_Validation_Manager {
 	/**
 	 * Cached template directory to prevent infinite recursion.
 	 *
+	 * @see get_template_directory()
 	 * @var string
 	 */
 	protected static $template_directory;
 
 	/**
+	 * Cached template slug to prevent infinite recursion.
+	 *
+	 * @see get_template()
+	 * @var string
+	 */
+	protected static $template_slug;
+
+	/**
 	 * Cached stylesheet directory to prevent infinite recursion.
 	 *
+	 * @see get_stylesheet_directory()
 	 * @var string
 	 */
 	protected static $stylesheet_directory;
+
+	/**
+	 * Cached stylesheet slug to prevent infinite recursion.
+	 *
+	 * @see get_stylesheet()
+	 * @var string
+	 */
+	protected static $stylesheet_slug;
 
 	/**
 	 * Add the actions.
@@ -506,8 +524,10 @@ class AMP_Validation_Manager {
 			}
 		}
 
-		self::$template_directory   = get_template_directory();
-		self::$stylesheet_directory = get_stylesheet_directory();
+		self::$template_directory   = wp_normalize_path( get_template_directory() );
+		self::$template_slug        = get_template();
+		self::$stylesheet_directory = wp_normalize_path( get_stylesheet_directory() );
+		self::$stylesheet_slug      = get_stylesheet();
 
 		add_action( 'wp', array( __CLASS__, 'wrap_widget_callbacks' ) );
 
@@ -1434,15 +1454,12 @@ class AMP_Validation_Manager {
 			if ( preg_match( ':' . preg_quote( trailingslashit( wp_normalize_path( WP_PLUGIN_DIR ) ), ':' ) . $slug_pattern . ':s', $file, $matches ) ) {
 				$source['type'] = 'plugin';
 				$source['name'] = $matches[1];
-			} elseif ( preg_match( ':' . preg_quote( trailingslashit( wp_normalize_path( self::$template_directory ) ), ':' ) . ':s', $file ) ) {
+			} elseif ( preg_match( ':' . preg_quote( trailingslashit( self::$template_directory ), ':' ) . $slug_pattern . ':s', $file ) ) {
 				$source['type'] = 'theme';
-				$source['name'] = get_template();
-			} elseif ( preg_match( ':' . preg_quote( trailingslashit( wp_normalize_path( self::$stylesheet_directory ) ), ':' ) . ':s', $file ) ) {
+				$source['name'] = self::$template_slug;
+			} elseif ( preg_match( ':' . preg_quote( trailingslashit( self::$stylesheet_directory ), ':' ) . $slug_pattern . ':s', $file ) ) {
 				$source['type'] = 'theme';
-				$source['name'] = get_stylesheet();
-			} elseif ( preg_match( ':' . preg_quote( trailingslashit( wp_normalize_path( get_theme_root() ) ), ':' ) . $slug_pattern . ':s', $file, $matches ) ) {
-				$source['type'] = 'theme';
-				$source['name'] = $matches[1];
+				$source['name'] = self::$stylesheet_slug;
 			} elseif ( preg_match( ':' . preg_quote( trailingslashit( wp_normalize_path( WPMU_PLUGIN_DIR ) ), ':' ) . $slug_pattern . ':s', $file, $matches ) ) {
 				$source['type'] = 'mu-plugin';
 				$source['name'] = $matches[1];

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1531,64 +1531,10 @@ class AMP_Validation_Manager {
 	 *     @type int      $accepted_args
 	 *     @type array    $source
 	 * }
-	 * @return closure $wrapped_callback The callback, wrapped in comments.
+	 * @return AMP_Validation_Callback_Wrapper $wrapped_callback The callback, wrapped in comments.
 	 */
 	public static function wrapped_callback( $callback ) {
-		return function() use ( $callback ) {
-			global $wp_styles, $wp_scripts;
-
-			$function      = $callback['function'];
-			$accepted_args = $callback['accepted_args'];
-			$args          = func_get_args();
-
-			$before_styles_enqueued = array();
-			if ( isset( $wp_styles ) && isset( $wp_styles->queue ) ) {
-				$before_styles_enqueued = $wp_styles->queue;
-			}
-			$before_scripts_enqueued = array();
-			if ( isset( $wp_scripts ) && isset( $wp_scripts->queue ) ) {
-				$before_scripts_enqueued = $wp_scripts->queue;
-			}
-
-			$is_filter = isset( $callback['source']['hook'] ) && ! did_action( $callback['source']['hook'] );
-
-			// Wrap the markup output of (action) hooks in source comments.
-			AMP_Validation_Manager::$hook_source_stack[] = $callback['source'];
-			$has_buffer_started                          = false;
-			if ( ! $is_filter && AMP_Validation_Manager::can_output_buffer() ) {
-				$has_buffer_started = ob_start( array( __CLASS__, 'wrap_buffer_with_source_comments' ) );
-			}
-			$result = call_user_func_array( $function, array_slice( $args, 0, intval( $accepted_args ) ) );
-			if ( $has_buffer_started ) {
-				ob_end_flush();
-			}
-			array_pop( AMP_Validation_Manager::$hook_source_stack );
-
-			// Keep track of which source enqueued the styles.
-			if ( isset( $wp_styles ) && isset( $wp_styles->queue ) ) {
-				foreach ( array_diff( $wp_styles->queue, $before_styles_enqueued ) as $handle ) {
-					AMP_Validation_Manager::$enqueued_style_sources[ $handle ][] = array_merge( $callback['source'], compact( 'handle' ) );
-				}
-			}
-
-			// Keep track of which source enqueued the scripts, and immediately report validity.
-			if ( isset( $wp_scripts ) && isset( $wp_scripts->queue ) ) {
-				foreach ( array_diff( $wp_scripts->queue, $before_scripts_enqueued ) as $queued_handle ) {
-					$handles = array( $queued_handle );
-
-					// Account for case where registered script is a placeholder for a set of scripts (e.g. jquery).
-					if ( isset( $wp_scripts->registered[ $queued_handle ] ) && false === $wp_scripts->registered[ $queued_handle ]->src ) {
-						$handles = array_merge( $handles, $wp_scripts->registered[ $queued_handle ]->deps );
-					}
-
-					foreach ( $handles as $handle ) {
-						AMP_Validation_Manager::$enqueued_script_sources[ $handle ][] = array_merge( $callback['source'], compact( 'handle' ) );
-					}
-				}
-			}
-
-			return $result;
-		};
+		return new AMP_Validation_Callback_Wrapper( $callback );
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -895,9 +895,12 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( $widget_id, $wp_registered_widgets );
 		$this->assertInternalType( 'array', $wp_registered_widgets[ $widget_id ]['callback'] );
 		$this->assertInstanceOf( 'WP_Widget_Search', $wp_registered_widgets[ $widget_id ]['callback'][0] );
+		$this->assertSame( 'display_callback', $wp_registered_widgets[ $widget_id ]['callback'][1] );
 
 		AMP_Validation_Manager::wrap_widget_callbacks();
-		$this->assertInstanceOf( 'Closure', $wp_registered_widgets[ $widget_id ]['callback'] );
+		$this->assertInstanceOf( 'AMP_Validation_Callback_Wrapper', $wp_registered_widgets[ $widget_id ]['callback'] );
+		$this->assertInstanceOf( 'WP_Widget', $wp_registered_widgets[ $widget_id ]['callback'][0] );
+		$this->assertSame( 'display_callback', $wp_registered_widgets[ $widget_id ]['callback'][1] );
 
 		$sidebar_id = 'amp-sidebar';
 		register_sidebar(
@@ -1150,7 +1153,7 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		$value = 'Some Value';
 		apply_filters( 'foo', $value );
 		$wrapped_callback = AMP_Validation_Manager::wrapped_callback( $filter_callback );
-		$this->assertTrue( $wrapped_callback instanceof Closure );
+		$this->assertTrue( $wrapped_callback instanceof AMP_Validation_Callback_Wrapper );
 		AMP_Theme_Support::start_output_buffering();
 		$filtered_value = call_user_func( $wrapped_callback, $value );
 		$output = ob_get_clean();
@@ -1179,12 +1182,12 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 
 		do_action( 'bar' ); // So that output buffering will be done.
 		$wrapped_callback = AMP_Validation_Manager::wrapped_callback( $action_callback );
-		$this->assertTrue( $wrapped_callback instanceof Closure );
+		$this->assertTrue( $wrapped_callback instanceof AMP_Validation_Callback_Wrapper );
 		AMP_Theme_Support::start_output_buffering();
 		call_user_func( $wrapped_callback );
 		$output = ob_get_clean();
 
-		$this->assertEquals( 'Closure', get_class( $wrapped_callback ) );
+		$this->assertEquals( 'AMP_Validation_Callback_Wrapper', get_class( $wrapped_callback ) );
 		$this->assertContains( $test_string, $output );
 		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
 		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
@@ -1200,11 +1203,11 @@ class Test_AMP_Validation_Manager extends \WP_UnitTestCase {
 		);
 
 		$wrapped_callback = AMP_Validation_Manager::wrapped_callback( $action_callback );
-		$this->assertTrue( $wrapped_callback instanceof Closure );
+		$this->assertTrue( $wrapped_callback instanceof AMP_Validation_Callback_Wrapper );
 		AMP_Theme_Support::start_output_buffering();
 		$result = call_user_func( $wrapped_callback );
 		$output = ob_get_clean();
-		$this->assertEquals( 'Closure', get_class( $wrapped_callback ) );
+		$this->assertEquals( 'AMP_Validation_Callback_Wrapper', get_class( $wrapped_callback ) );
 		$this->assertEquals( '', $output );
 		$this->assertEquals( call_user_func( array( $this, 'get_string' ) ), $result );
 		unset( $post );


### PR DESCRIPTION
Fixes #2698.

In PHP a callable can take the form of an array, for example: `array( $widget_obj, 'display_callback' )`. During AMP validation, callbacks get wrapped in a Closure to inject markers before and after. This causes problems with widgets when a plugin is iterating over the registered widgets and is attempting to introspect them, since after wrapping has been performed there is no longer a way to obtain the widget object via `$callback[0]`. Instead, a fatal error ensues:

```
PHP Fatal error:  Uncaught Error: Cannot use object of type Closure as array in /app/public/content/plugins/widget-css-classes/includes/widget-css-classes.class.php:753
Stack trace:
#0 /app/public/content/plugins/widget-css-classes/includes/widget-css-classes.class.php(475): WCSSC::get_widget_opt(Array)
#1 /app/public/content/plugins/amp/includes/validation/class-amp-validation-manager.php(1544): WCSSC::add_widget_classes(Array)
#2 /app/public/content/plugins/amp/includes/validation/class-amp-validation-manager.php(1254): AMP_Validation_Manager::{closure}(Array)
#3 /app/public/core-dev/src/wp-includes/class-wp-hook.php(286): AMP_Validation_Manager::{closure}(Array)
#4 /app/public/core-dev/src/wp-includes/plugin.php(211): WP_Hook->apply_filters(Array, Array)
#5 /app/public/core-dev/src/wp-includes/widgets.php(743): apply_filters('dynamic_sidebar...', Array)
#6 /app/public/core-dev/src/wp-content/themes/twentyseventeen/sidebar.php(19): dynamic_sidebar('sidebar-1')
#7 /app/public/core-dev/src/wp-includes/template.php(722): requir in /app/public/content/plugins/widget-css-classes/includes/widget-css-classes.class.php on line 753
```

This PR fixes that problem by introducing an invokable class which wraps the original callback, instead of using a closure. This invokable class implements `ArrayAccess` to then be able to preserve the ability to get `$callback[0]`.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3357712/amp.zip) (v1.2.1-alpha-20190704T050327Z-a46dc757)