### PR TITLE
Ensure AMP customizer gets initialized in Reader mode

### DIFF
--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -21,7 +21,7 @@ define( 'AMP_CUSTOMIZER_QUERY_VAR', 'customize_amp' );
  * And this does not need to toggle between the AMP and normal display.
  */
 function amp_init_customizer() {
-	if ( amp_is_canonical() || ! AMP_Options_Manager::is_website_experience_enabled() ) {
+	if ( ! AMP_Options_Manager::is_website_experience_enabled() || AMP_Theme_Support::READER_MODE_SLUG !== AMP_Options_Manager::get_option( 'theme_support' ) ) {
 		return;
 	}
 

--- a/includes/settings/class-amp-customizer-design-settings.php
+++ b/includes/settings/class-amp-customizer-design-settings.php
@@ -41,7 +41,7 @@ class AMP_Customizer_Design_Settings {
 	 */
 	public static function is_amp_customizer_enabled() {
 
-		if ( current_theme_supports( 'amp' ) ) {
+		if ( AMP_Theme_Support::READER_MODE_SLUG !== AMP_Options_Manager::get_option( 'theme_support' ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #2753, regression introduced in #2622.

<blockquote>

Given a theme without `amp` theme support (Twenty Seventeen), when in Reader mode it looks like this:

![image](https://user-images.githubusercontent.com/134745/60759396-a9fa8d00-9fd9-11e9-8a18-82829ee29fe4.png)

But if I add `add_theme_support('amp');` then it is being rendered as:

<img width="837" alt="Screen Shot 2019-07-06 at 10 37 47" src="https://user-images.githubusercontent.com/134745/60759417-21c8b780-9fda-11e9-8dfe-042ff1f3fb5d.png">

It appears there is a problem with the Reader mode Customizer settings not getting applied:

```diff
99,100c100,101
< 	background: ;
< 	color: ;
---
> 	background: #fff;
> 	color: #353535;
116c117
< 	color: ;
---
> 	color: #0a89c0;
122c123
< 	color: ;
---
> 	color: #353535;
128c129
< 	color: ;
---
> 	color: #353535;
130c131
< 	border-left: 2px solid ;
---
> 	border-left: 2px solid #0a89c0;
160c161
< 	color: ;
---
> 	color: #fff;
170c171
< 	color: ;
---
> 	color: #fff;
182,183c183,184
< 	background-color: ;
< 	border: 1px solid ;
---
> 	background-color: #fff;
> 	border: 1px solid #fff;
193c194
< 	color: ;
---
> 	color: #353535;
213c214
< 	color: ;
---
> 	color: #353535;
224c225
< 	color: ;
---
> 	color: #696969;
248c249
< 	border: 1px solid ;
---
> 	border: 1px solid #0a89c0;
312,313c313,314
< 	border-bottom: 1px solid ;
< 	color: ;
---
> 	border-bottom: 1px solid #c2c2c2;
> 	color: #696969;
328c329
< 	background: ;
---
> 	background: #c2c2c2;
335c336
< 	background: ;
---
> 	background: #c2c2c2;
348c349
< 	background:  url( https://wordpressdev.lndo.site/content/plugins/amp/assets/images/placeholder-icon.png ) no-repeat center 40%;
---
> 	background: #c2c2c2 url( https://wordpressdev.lndo.site/content/plugins/amp/assets/images/placeholder-icon.png ) no-repeat center 40%;
361c362
< 	color: ;
---
> 	color: #696969;
368c369
< 	color: ;
---
> 	color: #696969;
377c378
< 	border-color: ;
---
> 	border-color: #c2c2c2;
381c382
< 	color: ;
---
> 	color: #0a89c0;
399c400
< 	border-top: 1px solid ;
---
> 	border-top: 1px solid #c2c2c2;
417c418
< 	color: ;
---
> 	color: #696969;
```
</blockquote>