### PR TITLE
Use short array syntax throughout the project

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -3,12 +3,9 @@
 DEFAULT_BASE_BRANCH=develop
 ASSETS_DIR=wp-assets
 PROJECT_SLUG=amp
-SKIP_ECHO_PATHS_SCOPE=1
 README_MD_TITLE="AMP Plugin for WordPress"
 DEV_LIB_SKIP="$DEV_LIB_SKIP,jshint"
-if [[ ! -z $TRAVIS ]]; then
-	CHECK_SCOPE=all
-fi
+CHECK_SCOPE=all
 
 function after_wp_install {
 	if [[ "$WP_VERSION" != "4.9" ]]; then

--- a/back-compat/templates-v0-3/meta-author.php
+++ b/back-compat/templates-v0-3/meta-author.php
@@ -8,9 +8,9 @@
 $post_author = $this->get( 'post_author' );
 $avatar_url  = get_avatar_url(
 	$post_author->user_email,
-	array(
+	[
 		'size' => 24,
-	)
+	]
 );
 ?>
 <li class="amp-wp-byline">

--- a/back-compat/templates-v0-3/single.php
+++ b/back-compat/templates-v0-3/single.php
@@ -14,16 +14,16 @@
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>
-	<?php $this->load_parts( array( 'style' ) ); ?>
+	<?php $this->load_parts( [ 'style' ] ); ?>
 	<?php do_action( 'amp_post_template_css', $this ); ?>
 	</style>
 </head>
 <body>
-<?php $this->load_parts( array( 'header-bar' ) ); ?>
+<?php $this->load_parts( [ 'header-bar' ] ); ?>
 <div class="amp-wp-content">
 	<h1 class="amp-wp-title"><?php echo wp_kses_data( $this->get( 'post_title' ) ); ?></h1>
 	<ul class="amp-wp-meta">
-		<?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', array( 'meta-author', 'meta-time', 'meta-taxonomy' ) ) ); ?>
+		<?php $this->load_parts( apply_filters( 'amp_post_template_meta_parts', [ 'meta-author', 'meta-time', 'meta-taxonomy' ] ) ); ?>
 	</ul>
 	<?php echo $this->get( 'post_amp_content' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 </div>

--- a/bin/add-test-widgets-to-sidebar.php
+++ b/bin/add-test-widgets-to-sidebar.php
@@ -15,7 +15,7 @@ function amp_populate_sidebar() {
 	global $wp_registered_sidebars;
 	$widgets         = amp_get_widgets();
 	$sidebar         = amp_get_first_sidebar();
-	$created_widgets = array();
+	$created_widgets = [];
 	foreach ( $widgets as $widget ) {
 		if ( ! amp_widget_already_in_sidebar( $widget, $sidebar ) ) {
 			amp_create_widget( $widget );
@@ -32,89 +32,89 @@ function amp_populate_sidebar() {
  * @return array $widgets Data for the widgets.
  */
 function amp_get_widgets() {
-	return array(
-		array(
+	return [
+		[
 			'widget'   => 'media_audio',
 			'settings' => array_merge(
 				amp_media_widget( 'audio' ),
-				array(
+				[
 					'title' => 'Test Audio Widget: No Loop or Preload',
-				)
+				]
 			),
-		),
-		array(
+		],
+		[
 			'widget'   => 'media_audio',
 			'settings' => array_merge(
 				amp_media_widget( 'audio' ),
-				array(
+				[
 					'title'   => 'Test Audio Widget: With Loop, Preload',
 					'loop'    => true,
 					'preload' => 'auto',
-				)
+				]
 			),
-		),
-		array(
+		],
+		[
 			'widget'   => 'archives',
-			'settings' => array(
+			'settings' => [
 				'title' => 'Test Archives Widget: No Dropdown or Count',
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'archives',
-			'settings' => array(
+			'settings' => [
 				'title'    => 'Test Archives Widget: With Dropdown, Count',
 				'count'    => 1,
 				'dropdown' => 1,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget' => 'calendar',
-		),
-		array(
+		],
+		[
 			'widget'   => 'categories',
-			'settings' => array(
+			'settings' => [
 				'title' => 'Test Categories Widget: No Count, Dropdown, or Hierarchical',
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'categories',
-			'settings' => array(
+			'settings' => [
 				'title' => 'Test Categories Widget: With Count',
 				'count' => 1,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'categories',
-			'settings' => array(
+			'settings' => [
 				'title'        => 'Test Categories Widget: With Count, Dropdown, And Hierarchical',
 				'count'        => 1,
 				'dropdown'     => 1,
 				'hierarchical' => 1,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'custom_html',
-			'settings' => array(
+			'settings' => [
 				'title'   => 'Test Custom HTML Widget',
 				'content' => '<h2>Example Custom HTML widget</h2><article>Here is some custom HTML with a <a href="http://example.com/m">link</a></article>',
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'media_gallery',
 			'settings' => array_merge(
 				amp_gallery_widget(),
-				array(
+				[
 					'link_type'      => 'post',
 					'orderby_random' => false,
 					'size'           => 'thumbnail',
-				)
+				]
 			),
-		),
-		array(
+		],
+		[
 			'widget'   => 'media_image',
 			'settings' => array_merge(
 				amp_image_widget(),
-				array(
+				[
 					'alt'               => 'Example alt value',
 					'caption'           => 'Example caption',
 					'image_classes'     => 'foo bar',
@@ -125,97 +125,97 @@ function amp_get_widgets() {
 					'link_type'         => 'custom',
 					'link_url'          => 'http://example.com/amp-test',
 					'size'              => 'full',
-				)
+				]
 			),
-		),
-		array(
+		],
+		[
 			'widget' => 'meta',
-		),
-		array(
+		],
+		[
 			'widget'   => 'nav_menu',
-			'settings' => array(
+			'settings' => [
 				'nav_menu' => amp_menu(),
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget' => 'pages',
-		),
-		array(
+		],
+		[
 			'widget' => 'recent-comments',
-		),
-		array(
+		],
+		[
 			'widget'   => 'recent-posts',
-			'settings' => array(
+			'settings' => [
 				'show_date' => true,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'rss',
-			'settings' => array(
+			'settings' => [
 				'title'        => 'Test RSS Widget: No Content, Author, or Date',
 				'url'          => 'https://amphtml.wordpress.com/feed/',
 				'show_author'  => 0,
 				'show_date'    => 0,
 				'show_summary' => 0,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'rss',
-			'settings' => array(
+			'settings' => [
 				'title'        => 'Test RSS Widget: With Content, Author, Date',
 				'url'          => 'https://amphtml.wordpress.com/feed/',
 				'show_author'  => 1,
 				'show_date'    => 1,
 				'show_summary' => 1,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget' => 'search',
-		),
-		array(
+		],
+		[
 			'widget'   => 'tag_cloud',
-			'settings' => array(
+			'settings' => [
 				'title' => 'Test Tag Widget, No Count',
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'tag_cloud',
-			'settings' => array(
+			'settings' => [
 				'title' => 'Test Tag Widget, With Count',
 				'count' => 1,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'text',
-			'settings' => array(
+			'settings' => [
 				'filter' => true,
 				'text'   => '<strong>Example Headline</strong><ul><li>This is to test possible text</li><li>This should display as expected</li></ul>',
 				'visual' => true,
-			),
-		),
-		array(
+			],
+		],
+		[
 			'widget'   => 'media_video',
 			'settings' => array_merge(
 				amp_media_widget( 'video' ),
-				array(
+				[
 					'title'   => 'Test Video Widget: No Loop or Preload',
 					'loop'    => false,
 					'preload' => 'none',
-				)
+				]
 			),
-		),
-		array(
+		],
+		[
 			'widget'   => 'media_video',
 			'settings' => array_merge(
 				amp_media_widget( 'video' ),
-				array(
+				[
 					'title'   => 'Test Video Widget: With Loop, Preload',
 					'loop'    => true,
 					'preload' => 'metadata',
-				)
+				]
 			),
-		),
-	);
+		],
+	];
 }
 
 /**
@@ -231,10 +231,10 @@ function amp_get_widgets() {
 function amp_media_widget( $type ) {
 	$all_media = amp_media( $type, 1 );
 	$media     = reset( $all_media );
-	return array(
+	return [
 		'attachment_id' => $media->ID,
 		'url'           => $media->guid,
-	);
+	];
 }
 
 /**
@@ -244,9 +244,9 @@ function amp_media_widget( $type ) {
  */
 function amp_gallery_widget() {
 	$images = amp_media( 'image', 3 );
-	return array(
+	return [
 		'ids' => wp_list_pluck( $images, 'ID' ),
-	);
+	];
 }
 
 /**
@@ -259,12 +259,12 @@ function amp_image_widget() {
 	$image             = reset( $all_images );
 	$metadata          = wp_get_attachment_metadata( $image->ID );
 	$default_dimension = 100;
-	return array(
+	return [
 		'attachment_id' => $image->ID,
 		'height'        => isset( $metadata['height'] ) ? $metadata['height'] : $default_dimension,
 		'width'         => isset( $metadata['width'] ) ? $metadata['width'] : $default_dimension,
 		'url'           => wp_get_attachment_url( $image->ID ),
-	);
+	];
 }
 
 /**
@@ -277,12 +277,12 @@ function amp_image_widget() {
  */
 function amp_media( $type, $count = 3 ) {
 	$query = new WP_Query(
-		array(
+		[
 			'post_type'      => 'attachment',
 			'post_mime_type' => $type,
 			'post_status'    => 'inherit',
 			'posts_per_page' => $count,
-		)
+		]
 	);
 	if ( $query->post_count < $count ) {
 		throw new Exception(
@@ -335,7 +335,7 @@ function amp_widget_already_in_sidebar( $widget, $sidebar ) {
 	}
 
 	$id_base         = $widget['widget'];
-	$all_widget_data = get_option( 'widget_' . $id_base, array() );
+	$all_widget_data = get_option( 'widget_' . $id_base, [] );
 
 	foreach ( $sidebars[ $sidebar ] as $possible_widget ) {
 		if ( false !== strpos( $possible_widget, $id_base ) ) {
@@ -356,7 +356,7 @@ function amp_widget_already_in_sidebar( $widget, $sidebar ) {
 			}
 
 			// Find if all of the settings in $widget['settings'] are present in the widget that's already in the sidebar.
-			if ( array() === array_diff_assoc( array_map( 'serialize', $widget['settings'] ), array_map( 'serialize', $widget_data ) ) ) {
+			if ( [] === array_diff_assoc( array_map( 'serialize', $widget['settings'] ), array_map( 'serialize', $widget_data ) ) ) {
 				return true;
 			}
 		}
@@ -377,11 +377,11 @@ function amp_create_widget( $widget ) {
 
 	$id_base    = $widget['widget'];
 	$option_key = 'widget_' . $id_base;
-	$widgets    = get_option( $option_key, array() );
-	$settings   = isset( $widget['settings'] ) ? $widget['settings'] : array();
+	$widgets    = get_option( $option_key, [] );
+	$settings   = isset( $widget['settings'] ) ? $widget['settings'] : [];
 
 	if ( ! isset( $settings['title'] ) ) {
-		$title             = str_replace( array( '_', '-' ), ' ', $id_base );
+		$title             = str_replace( [ '_', '-' ], ' ', $id_base );
 		$settings['title'] = sprintf( 'Test %s Widget', ucwords( $title ) );
 	}
 
@@ -421,7 +421,7 @@ function amp_get_first_sidebar() {
  * @return string $widget_id The ID of the widget, like 'text-2'.
  */
 function amp_get_widget_id( $id_base ) {
-	$settings = get_option( "widget_{$id_base}", array() );
+	$settings = get_option( "widget_{$id_base}", [] );
 	if ( $settings instanceof ArrayObject || $settings instanceof ArrayIterator ) {
 		$settings = $settings->getArrayCopy();
 	}

--- a/bin/create-comments-on-test-post.php
+++ b/bin/create-comments-on-test-post.php
@@ -13,19 +13,19 @@
  * @return int Post ID.
  */
 function amp_create_comments_test_post() {
-	$q = new WP_Query( array( 'name' => 'amp-test-comments' ) );
+	$q = new WP_Query( [ 'name' => 'amp-test-comments' ] );
 	if ( $q->have_posts() ) {
 		$post    = $q->next_post();
 		$post_id = $post->ID;
 	} else {
 		$post_id = wp_insert_post(
-			array(
+			[
 				'post_name'    => 'amp-test-comments',
 				'post_title'   => 'AMP Test Comments',
 				'post_type'    => 'post',
 				'post_status'  => 'publish',
 				'post_content' => amp_get_test_random_content( 200 ),
-			)
+			]
 		);
 
 		if ( ! $post_id || is_wp_error( $post_id ) ) {
@@ -49,7 +49,7 @@ function amp_create_comments_test_post() {
  */
 function amp_add_comments( $post_id ) {
 	$data = amp_get_test_comment_entries();
-	$ids  = array();
+	$ids  = [];
 	foreach ( $data as $comment ) {
 		$comment['comment_post_ID'] = $post_id;
 		$yes_no                     = rand( 0, 1 );
@@ -71,14 +71,14 @@ function amp_add_comments( $post_id ) {
  * @return array Data entries.
  */
 function amp_get_test_comment_entries() {
-	$comments = array();
+	$comments = [];
 	$time     = strtotime( 'now' );
 	for ( $i = 0; $i < 30; $i++ ) {
 		$author = preg_replace( '/[^\w ]+/', '', amp_get_test_random_content( 2, '' ) );
 		$time   = strtotime( '+3 minutes', $time );
 
 		// Add comment.
-		$comments[] = array(
+		$comments[] = [
 			'comment_author'       => ucwords( $author ),
 			'comment_author_email' => strtolower( implode( '@', explode( ' ', $author ) ) ) . '.com',
 			'comment_author_url'   => strtolower( implode( '.', explode( ' ', $author ) ) ) . '.com',
@@ -89,7 +89,7 @@ function amp_get_test_comment_entries() {
 			'comment_agent'        => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 Safari/537.36',
 			'comment_date'         => date( 'Y-m-d H:i:s', $time ),
 			'comment_approved'     => '1',
-		);
+		];
 	}
 
 	return $comments;

--- a/bin/create-embed-test-post.php
+++ b/bin/create-embed-test-post.php
@@ -14,208 +14,208 @@
  */
 function amp_get_test_data_entries() {
 	list( $img_src ) = wp_get_attachment_image_src( amp_get_media_items_ids( 'image', 1 ) );
-	return array(
-		array(
+	return [
+		[
 			'heading' => 'Media Gallery',
 			'content' => sprintf( '[gallery ids="%s"]', amp_get_media_items_ids( 'image' ) ),
-		),
-		array(
+		],
+		[
 			'heading' => 'Media Image',
 			'content' => wp_get_attachment_image( amp_get_media_items_ids( 'image', 1 ) ),
-		),
-		array(
+		],
+		[
 			'heading' => 'Media Caption',
 			'content' => sprintf( '[caption width=150]%sExample image caption[/caption]', wp_get_attachment_image( amp_get_media_items_ids( 'image', 1 ) ) ),
-		),
-		array(
+		],
+		[
 			'heading' => 'Media Video',
 			'content' => sprintf( '[video poster="%s" src=https://videos.files.wordpress.com/DK5mLrbr/video-ca6dc0ab4a_hd.mp4]', $img_src ),
-		),
-		array(
+		],
+		[
 			'heading' => 'Media Audio',
 			'content' => '[audio src=https://wptavern.com/wp-content/uploads/2017/11/EPISODE-296-Gutenberg-Telemetry-Calypso-and-More-With-Matt-Mullenweg.mp3]',
-		),
-		array(
+		],
+		[
 			'heading' => 'Video Playlist',
 			'content' => sprintf( '[playlist type="video" ids="%s"]', amp_get_media_items_ids( 'video' ) ),
-		),
-		array(
+		],
+		[
 			'heading' => 'Audio Playlist',
 			'content' => sprintf( '[playlist ids="%s"]', amp_get_media_items_ids( 'audio' ) ),
-		),
-		array(
+		],
+		[
 			'heading' => 'WordPress Post Embed',
 			'content' => 'https://make.wordpress.org/core/2017/12/11/whats-new-in-gutenberg-11th-december/',
-		),
-		array(
+		],
+		[
 			'heading' => 'Amazon Com Smile Embed',
 			'content' => 'https://smile.amazon.com/dp/B00DPM7TIG',
-		),
-		array(
+		],
+		[
 			'heading' => 'Amazon Co Smile Embed',
 			'content' => 'https://smile.amazon.co.uk/dp/B00DPM7TIG',
-		),
-		array(
+		],
+		[
 			'heading' => 'Amazon Read CN Embed',
 			'content' => 'https://read.amazon.cn/kp/embed?asin=B00DPM7TIG',
-		),
-		array(
+		],
+		[
 			'heading' => 'Animoto Embed',
 			'content' => 'https://animoto.com/play/TDfViXkPqIwYj5EjamYjnw',
-		),
-		array(
+		],
+		[
 			'heading' => 'CloudUp Image Embed',
 			'content' => 'https://cloudup.com/iWn3EIpgjev',
-		),
-		array(
+		],
+		[
 			'heading' => 'CloudUp Video Embed',
 			'content' => 'https://cloudup.com/ioyW8a_Tjme',
-		),
-		array(
+		],
+		[
 			'heading' => 'CloudUp Gallery Embed',
 			'content' => 'https://cloudup.com/cQNdYtQLO5U',
-		),
-		array(
+		],
+		[
 			'heading' => 'CollegeHumor Embed',
 			'content' => 'http://www.collegehumor.com/video/40002823/how-to-actually-finish-something-for-once',
-		),
-		array(
+		],
+		[
 			'heading' => 'DailyMotion Embed',
 			'content' => 'http://www.dailymotion.com/video/x6bacgf',
-		),
-		array(
+		],
+		[
 			'heading' => 'Facebook Post Embed',
 			'content' => 'https://www.facebook.com/WordPress/posts/10155651799877911',
-		),
-		array(
+		],
+		[
 			'heading' => 'Facebook Video Embed',
 			'content' => 'https://www.facebook.com/WordPress/videos/10154702401472911/',
-		),
-		array(
+		],
+		[
 			'heading' => 'Flickr Image Embed',
 			'content' => 'https://www.flickr.com/photos/sylvainmessier/38089894895/in/explore-2017-12-11/',
-		),
-		array(
+		],
+		[
 			'heading' => 'Flickr Video Embed',
 			'content' => 'https://flic.kr/p/5TPDWa',
-		),
-		array(
+		],
+		[
 			'heading' => 'Funny Or Die Video Embed',
 			'content' => 'http://www.funnyordie.com/videos/2977012a20/i-still-haven-t-found-the-droids-i-m-looking-for',
-		),
-		array(
+		],
+		[
 			'heading' => 'Hulu Embed',
 			'content' => 'https://www.hulu.com/watch/807443',
-		),
-		array(
+		],
+		[
 			'heading' => 'Instagram Embed',
 			'content' => 'https://www.instagram.com/p/bNd86MSFv6/',
-		),
-		array(
+		],
+		[
 			'heading' => 'Issuu Embed',
 			'content' => 'https://issuu.com/ajcwfu/docs/seatatthetablefinal',
-		),
-		array(
+		],
+		[
 			'heading' => 'Kickstarter Embed',
 			'content' => 'https://www.kickstarter.com/projects/iananderson/save-froots-magazine',
-		),
-		array(
+		],
+		[
 			'heading' => 'Meetup Embed',
 			'content' => 'https://www.meetup.com/WordPress-Mexico',
-		),
-		array(
+		],
+		[
 			'heading' => 'Mixcloud Embed',
 			'content' => 'https://www.mixcloud.com/TheWireMagazine/adventures-in-sound-and-music-hosted-by-derek-walmsley-7-december-2017/',
-		),
-		array(
+		],
+		[
 			'heading' => 'Photobucket Embed',
 			'content' => 'http://i1259.photobucket.com/albums/ii543/iamnotpeterpan/EditPostlsaquoDennisDoesCricketmdashWordPress_zpsf72cc13d.png',
-		),
-		array(
+		],
+		[
 			'heading' => 'Crowdsingal Poll Embed',
 			'content' => 'https://poll.fm/7012505',
-		),
-		array(
+		],
+		[
 			'heading' => 'Polldaddy Survey Embed',
 			'content' => 'https://rydk.survey.fm/test-survey',
-		),
-		array(
+		],
+		[
 			'heading' => 'Reddit Embed',
 			'content' => 'https://www.reddit.com/r/Android/comments/7jbkub/google_maps_will_soon_tell_you_when_its_time_to/?ref=share&ref_source=link',
-		),
-		array(
+		],
+		[
 			'heading' => 'Reverb Nation Embed',
 			'content' => 'https://www.reverbnation.com/fernandotorresleiva/song/28755694-breve-amor-new-version',
-		),
-		array(
+		],
+		[
 			'heading' => 'Screencast Embed',
 			'content' => 'http://www.screencast.com/t/nMCYr3N3uF',
-		),
-		array(
+		],
+		[
 			'heading' => 'Scribd Embed',
 			'content' => 'http://www.scribd.com/doc/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests',
-		),
-		array(
+		],
+		[
 			'heading' => 'SlideShare Embed',
 			'content' => 'https://www.slideshare.net/slideshow/embed_code/key/u6WNbsR5worSzC',
-		),
-		array(
+		],
+		[
 			'heading' => 'SmugMug Embed',
 			'content' => 'https://stuckincustoms.smugmug.com/Portfolio/i-GnwtS8R/A',
-		),
-		array(
+		],
+		[
 			'heading' => 'Someecards Embed',
 			'content' => 'https://www.someecards.com/usercards/viewcard/mjaxmi1jmgy2y2exm2m2ngu2ntfi/?tagSlug=christmas',
-		),
-		array(
+		],
+		[
 			'heading' => 'Someecards Short URL Embed',
 			'content' => 'https://some.ly/V3RZUq/',
-		),
-		array(
+		],
+		[
 			'heading' => 'SoundCloud Embed',
 			'content' => 'https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor',
-		),
-		array(
+		],
+		[
 			'heading' => 'Speaker Deck Embed',
 			'content' => 'https://speakerdeck.com/wallat/why-backbone',
-		),
-		array(
+		],
+		[
 			'heading' => 'Spotify Embed',
 			'content' => 'https://open.spotify.com/track/2XULDEvijLgHttFgLzzpM5',
-		),
-		array(
+		],
+		[
 			'heading' => 'Ted Embed',
 			'content' => 'https://www.ted.com/talks/derek_sivers_how_to_start_a_movement',
-		),
-		array(
+		],
+		[
 			'heading' => 'Tumblr Post Embed',
 			'content' => 'http://ifpaintingscouldtext.tumblr.com/post/92003045635/grant-wood-american-gothic-1930',
-		),
-		array(
+		],
+		[
 			'heading' => 'Twitter Embed',
 			'content' => 'https://twitter.com/WordPress/status/936550699336437760',
-		),
-		array(
+		],
+		[
 			'heading' => 'VideoPress Embed',
 			'content' => 'https://videopress.com/v/kUJmAcSf',
-		),
-		array(
+		],
+		[
 			'heading' => 'Vimeo Embed',
 			'content' => 'https://vimeo.com/59172123',
-		),
-		array(
+		],
+		[
 			'heading' => 'WordPress Plugin Directory Embed',
 			'content' => 'https://wordpress.org/plugins/amp/',
-		),
-		array(
+		],
+		[
 			'heading' => 'WordPress TV Embed',
 			'content' => 'https://videopress.com/v/DK5mLrbr',
-		),
-		array(
+		],
+		[
 			'heading' => 'YouTube Embed',
 			'content' => 'https://www.youtube.com/watch?v=XOY3ZUO6P0k',
-		),
-	);
+		],
+	];
 }
 
 /**
@@ -228,13 +228,13 @@ function amp_get_test_data_entries() {
  */
 function amp_get_media_items_ids( $type, $image_count = 3 ) {
 	$query = new WP_Query(
-		array(
+		[
 			'post_type'      => 'attachment',
 			'post_mime_type' => $type,
 			'post_status'    => 'inherit',
 			'posts_per_page' => $image_count,
 			'fields'         => 'ids',
-		)
+		]
 	);
 	if ( $query->post_count < $image_count ) {
 		throw new Exception(
@@ -263,11 +263,11 @@ function amp_create_embed_test_post( $data_entries ) {
 		$page_id = $page->ID;
 	} else {
 		$page_id = wp_insert_post(
-			array(
+			[
 				'post_name'  => 'amp-test-embeds',
 				'post_title' => 'AMP Test Embeds',
 				'post_type'  => 'page',
-			)
+			]
 		);
 
 		if ( ! $page_id || is_wp_error( $page_id ) ) {
@@ -289,10 +289,10 @@ function amp_create_embed_test_post( $data_entries ) {
 
 	$update = wp_update_post(
 		wp_slash(
-			array(
+			[
 				'ID'           => $page_id,
 				'post_content' => $content,
-			)
+			]
 		)
 	);
 

--- a/bin/create-gutenberg-test-post.php
+++ b/bin/create-gutenberg-test-post.php
@@ -55,48 +55,48 @@ function get_test_block_fixtures() {
  * @return string $content The blocks as HTML.
  */
 function get_test_block_permutations() {
-	$blocks = array(
-		array(
+	$blocks = [
+		[
 			'title'   => '(Reusable) Block With Video',
 			'content' => sprintf( '<!-- wp:block {"ref":%d} /-->', create_test_reusable_block() ),
-		),
-		array(
+		],
+		[
 			'title'   => 'Categories With Dropdown',
 			'content' => '<!-- wp:core/categories {"showPostCounts":false,"displayAsDropdown":true,"showHierarchy":false} /-->',
-		),
-		array(
+		],
+		[
 			'title'   => 'Columns, With 2 Columns',
 			'content' => '<!-- wp:core/columns {"columns":2} --><div class="wp-block-columns has-2-columns"><!-- wp:core/paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph One</p><!-- /wp:core/paragraph --><!-- wp:core/paragraph {"layout":"column-1"} --><p class="layout-column-1">Column One, Paragraph Two</p><!-- /wp:core/paragraph --><!-- wp:core/paragraph {"layout":"column-2"} --><p class="layout-column-2">Column Two, Paragraph One</p><!-- /wp:core/paragraph --></div><!-- /wp:core/columns -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'Cover Image With Fixed Background',
 			'content' => '<!-- wp:core/cover-image {"url":"https://cldup.com/uuUqE_dXzy.jpg","dimRatio":40} --><section class="wp-block-cover-image has-background-dim-40 has-background-dim has-parallax" style="background-image:url(https://cldup.com/uuUqE_dXzy.jpg)"><h2>Guten Berg!</h2></section><!-- /wp:core/cover-image -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'WordPress Embed',
 			'content' => '<!-- wp:core-embed/wordpress {"url":"https://make.wordpress.org/core/2017/12/11/whats-new-in-gutenberg-11th-december/"} --><figure class="wp-block-embed-wordpress wp-block-embed">https://make.wordpress.org/core/2017/12/11/whats-new-in-gutenberg-11th-december/<figcaption>Embedded content from WordPress</figcaption></figure><!-- /wp:core-embed/wordpress -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'YouTube Embed',
 			'content' => '<!-- wp:core-embed/youtube {"url":"https://www.youtube.com/watch?v=GGS-tKTXw4Y"} --><figure class="wp-block-embed-youtube wp-block-embed">https://www.youtube.com/watch?v=GGS-tKTXw4Y<figcaption>Embedded content from youtube</figcaption></figure><!-- /wp:core-embed/youtube -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'Twitter Embed',
 			'content' => '<!-- wp:core-embed/twitter {"url":"https://twitter.com/AMPhtml/status/963443140005957632"} --><figure class="wp-block-embed-twitter wp-block-embed">https://twitter.com/AMPhtml/status/963443140005957632<figcaption>We are Automattic</figcaption></figure><!-- /wp:core-embed/twitter -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'Gallery With 3 Columns',
 			'content' => '<!-- wp:core/gallery --><ul class="wp-block-gallery alignnone columns-3 is-cropped"><li class="blocks-gallery-item"><figure><img src="https://cldup.com/uuUqE_dXzy.jpg" alt="title" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/-3VMmmrPm9.jpg" alt="title" /></figure></li><li class="blocks-gallery-item"><figure><img src="https://cldup.com/aMbxBM0zAi.jpg" alt="title" /></figure></li></ul><!-- /wp:core/gallery -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'Audio Shortcode',
 			'content' => '<!-- wp:core/shortcode -->[audio src=https://wptavern.com/wp-content/uploads/2017/11/EPISODE-296-Gutenberg-Telemetry-Calypso-and-More-With-Matt-Mullenweg.mp3]<!-- /wp:core/shortcode -->',
-		),
-		array(
+		],
+		[
 			'title'   => 'Caption Shortcode',
 			'content' => '<!-- wp:core/shortcode -->[caption width=150]This is a caption[/caption]<!-- /wp:core/shortcode -->',
-		),
-	);
+		],
+	];
 
 	$content = '';
 	foreach ( $blocks as $block ) {
@@ -117,12 +117,12 @@ function get_test_block_permutations() {
  */
 function create_test_reusable_block() {
 	return wp_insert_post(
-		array(
+		[
 			'post_type'    => 'wp_block',
 			'post_title'   => 'Test Reusable Block',
 			'post_content' => '<!-- wp:core/video --><figure class="wp-block-video"><video src="https://videos.files.wordpress.com/DK5mLrbr/video-ca6dc0ab4a_hd.mp4" controls=""></video></figure><!-- /wp:core/video -->',
 			'post_status'  => 'publish',
-		)
+		]
 	);
 }
 
@@ -142,11 +142,11 @@ function create_gutenberg_test_post( $content ) {
 		$page_id = $page->ID;
 	} else {
 		$page_id = wp_insert_post(
-			array(
+			[
 				'post_name'  => $slug,
 				'post_title' => $title,
 				'post_type'  => 'page',
-			)
+			]
 		);
 
 		if ( ! $page_id || is_wp_error( $page_id ) ) {
@@ -155,10 +155,10 @@ function create_gutenberg_test_post( $content ) {
 	}
 
 	$update = wp_update_post(
-		array(
+		[
 			'ID'           => $page_id,
 			'post_content' => $content,
-		)
+		]
 	);
 
 	if ( ! $update ) {

--- a/bin/verify-version-consistency.php
+++ b/bin/verify-version-consistency.php
@@ -12,7 +12,7 @@ if ( 'cli' !== php_sapi_name() ) {
 	exit( 1 );
 }
 
-$versions = array();
+$versions = [];
 
 $readme_txt = file_get_contents( dirname( __FILE__ ) . '/../readme.txt' );
 if ( ! preg_match( '/Stable tag:\s+(?P<version>\S+)/i', $readme_txt, $matches ) ) {

--- a/includes/admin/class-amp-admin-pointer.php
+++ b/includes/admin/class-amp-admin-pointer.php
@@ -61,10 +61,10 @@ class AMP_Admin_Pointer {
 	 * }
 	 */
 	public function __construct( $slug, array $args ) {
-		$default_position = array(
+		$default_position = [
 			'edge'  => is_rtl() ? 'right' : 'left',
 			'align' => 'bottom',
-		);
+		];
 
 		if ( isset( $args['position'] ) ) {
 			$args['position'] = wp_parse_args( (array) $args['position'], $default_position );
@@ -73,7 +73,7 @@ class AMP_Admin_Pointer {
 		$this->slug = $slug;
 		$this->args = wp_parse_args(
 			$args,
-			array(
+			[
 				'selector'        => '',
 				'description'     => '',
 				'heading'         => '',
@@ -81,7 +81,7 @@ class AMP_Admin_Pointer {
 				'position'        => $default_position,
 				'class'           => '',
 				'active_callback' => null,
-			)
+			]
 		);
 	}
 
@@ -141,7 +141,7 @@ class AMP_Admin_Pointer {
 		wp_enqueue_style(
 			'amp-validation-tooltips',
 			amp_get_asset_url( 'css/amp-validation-tooltips.css' ),
-			array( 'wp-pointer' ),
+			[ 'wp-pointer' ],
 			AMP__VERSION
 		);
 
@@ -169,11 +169,11 @@ class AMP_Admin_Pointer {
 			$content = '<h3>' . wp_kses( $this->args['heading'], 'amp_admin_pointer' ) . '</h3>' . $content;
 		}
 
-		$args = array(
+		$args = [
 			'content'      => $content,
 			'position'     => $this->args['position'],
 			'pointerClass' => 'wp-pointer wp-amp-pointer' . ( ! empty( $this->args['class'] ) ? ' ' . $this->args['class'] : '' ),
-		);
+		];
 
 		?>
 		<script type="text/javascript">

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -21,7 +21,7 @@ class AMP_Admin_Pointers {
 	public function init() {
 		add_action(
 			'admin_enqueue_scripts',
-			array( $this, 'enqueue_scripts' )
+			[ $this, 'enqueue_scripts' ]
 		);
 	}
 
@@ -57,57 +57,57 @@ class AMP_Admin_Pointers {
 	 * @return array List of AMP_Admin_Pointer instances.
 	 */
 	private function get_pointers() {
-		return array(
+		return [
 			new AMP_Admin_Pointer(
 				'amp_template_mode_pointer_10',
-				array(
+				[
 					'selector'        => '#toplevel_page_amp-options',
 					'heading'         => __( 'AMP', 'amp' ),
 					'subheading'      => __( 'New AMP Template Modes', 'amp' ),
 					'description'     => __( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Standard&#8221; modes.', 'amp' ),
-					'position'        => array(
+					'position'        => [
 						'align' => 'middle',
-					),
+					],
 					'active_callback' => static function() {
 						return version_compare( strtok( AMP__VERSION, '-' ), '1.1', '<' );
 					},
-				)
+				]
 			),
 			new AMP_Admin_Pointer(
 				'amp_stories_support_pointer_12',
-				array(
+				[
 					'selector'        => '#toplevel_page_amp-options',
 					'heading'         => __( 'AMP', 'amp' ),
 					'subheading'      => __( 'Stories', 'amp' ),
 					'description'     => __( 'You can now enable Stories, a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences.', 'amp' ),
-					'position'        => array(
+					'position'        => [
 						'align' => 'middle',
-					),
+					],
 					'active_callback' => static function( $hook_suffix ) {
 						if ( 'toplevel_page_amp-options' === $hook_suffix ) {
 							return false;
 						}
 						return ! AMP_Options_Manager::is_stories_experience_enabled();
 					},
-				)
+				]
 			),
 			new AMP_Admin_Pointer(
 				'amp_stories_menu_pointer_12',
-				array(
+				[
 					'selector'        => '#menu-posts-' . AMP_Story_Post_Type::POST_TYPE_SLUG,
 					'heading'         => __( 'AMP', 'amp' ),
 					'description'     => __( 'Head over here to create your first story.', 'amp' ),
-					'position'        => array(
+					'position'        => [
 						'align' => 'middle',
-					),
+					],
 					'active_callback' => static function( $hook_suffix ) {
 						if ( 'edit.php' === $hook_suffix && AMP_Story_Post_Type::POST_TYPE_SLUG === filter_input( INPUT_GET, 'post_type' ) ) {
 							return false;
 						}
 						return AMP_Options_Manager::is_stories_experience_enabled();
 					},
-				)
+				]
 			),
-		);
+		];
 	}
 }

--- a/includes/admin/class-amp-customizer.php
+++ b/includes/admin/class-amp-customizer.php
@@ -59,9 +59,9 @@ class AMP_Template_Customizer {
 		$self->register_settings();
 		$self->register_ui();
 
-		add_action( 'customize_controls_enqueue_scripts', array( $self, 'add_customizer_scripts' ) );
-		add_action( 'customize_controls_print_footer_scripts', array( $self, 'print_controls_templates' ) );
-		add_action( 'customize_preview_init', array( $self, 'init_preview' ) );
+		add_action( 'customize_controls_enqueue_scripts', [ $self, 'add_customizer_scripts' ] );
+		add_action( 'customize_controls_print_footer_scripts', [ $self, 'print_controls_templates' ] );
+		add_action( 'customize_preview_init', [ $self, 'init_preview' ] );
 	}
 
 	/**
@@ -72,15 +72,15 @@ class AMP_Template_Customizer {
 	 */
 	public function init_preview() {
 		add_action( 'amp_post_template_head', 'wp_no_robots' );
-		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_preview_scripts' ) );
-		add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'enqueue_preview_scripts' ) );
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_preview_scripts' ] );
+		add_action( 'amp_customizer_enqueue_preview_scripts', [ $this, 'enqueue_preview_scripts' ] );
 
 		// Output scripts and styles which will break AMP validation only when preview is opened with controls for manipulation.
 		if ( $this->wp_customize->get_messenger_channel() ) {
-			add_action( 'amp_post_template_head', array( $this->wp_customize, 'customize_preview_loading_style' ) );
-			add_action( 'amp_post_template_css', array( $this, 'add_customize_preview_styles' ) );
-			add_action( 'amp_post_template_head', array( $this->wp_customize, 'remove_frameless_preview_messenger_channel' ) );
-			add_action( 'amp_post_template_footer', array( $this, 'add_preview_scripts' ) );
+			add_action( 'amp_post_template_head', [ $this->wp_customize, 'customize_preview_loading_style' ] );
+			add_action( 'amp_post_template_css', [ $this, 'add_customize_preview_styles' ] );
+			add_action( 'amp_post_template_head', [ $this->wp_customize, 'remove_frameless_preview_messenger_channel' ] );
+			add_action( 'amp_post_template_footer', [ $this, 'add_preview_scripts' ] );
 		}
 	}
 
@@ -90,12 +90,12 @@ class AMP_Template_Customizer {
 	public function register_ui() {
 		$this->wp_customize->add_panel(
 			self::PANEL_ID,
-			array(
+			[
 				'type'        => 'amp',
 				'title'       => __( 'AMP', 'amp' ),
 				/* translators: placeholder is URL to AMP project. */
 				'description' => sprintf( __( '<a href="%s" target="_blank">The AMP Project</a> is a Google-led initiative that dramatically improves loading speeds on phones and tablets. You can use the Customizer to preview changes to your AMP template before publishing them.', 'amp' ), 'https://ampproject.org' ),
-			)
+			]
 		);
 
 		/**
@@ -137,7 +137,7 @@ class AMP_Template_Customizer {
 			wp_enqueue_script(
 				'amp-customize-controls',
 				amp_get_asset_url( 'js/amp-customize-controls.js' ),
-				array( 'jquery', 'customize-controls' ),
+				[ 'jquery', 'customize-controls' ],
 				AMP__VERSION,
 				true
 			);
@@ -147,15 +147,15 @@ class AMP_Template_Customizer {
 				sprintf(
 					'ampCustomizeControls.boot( %s );',
 					wp_json_encode(
-						array(
+						[
 							'queryVar' => amp_get_slug(),
 							'panelId'  => self::PANEL_ID,
 							'ampUrl'   => amp_admin_get_preview_permalink(),
-							'l10n'     => array(
+							'l10n'     => [
 								'unavailableMessage'  => __( 'AMP is not available for the page currently being previewed.', 'amp' ),
 								'unavailableLinkText' => __( 'Navigate to an AMP compatible page', 'amp' ),
-							),
-						)
+							],
+						]
 					)
 				)
 			);
@@ -195,7 +195,7 @@ class AMP_Template_Customizer {
 		wp_enqueue_script(
 			'amp-customize-preview',
 			amp_get_asset_url( 'js/amp-customize-preview.js' ),
-			array( 'jquery', 'customize-preview' ),
+			[ 'jquery', 'customize-preview' ],
 			AMP__VERSION,
 			true
 		);
@@ -220,10 +220,10 @@ class AMP_Template_Customizer {
 			sprintf(
 				'ampCustomizePreview.boot( %s );',
 				wp_json_encode(
-					array(
+					[
 						'available' => $available,
 						'enabled'   => is_amp_endpoint(),
-					)
+					]
 				)
 			)
 		);

--- a/includes/admin/class-amp-editor-blocks.php
+++ b/includes/admin/class-amp-editor-blocks.php
@@ -16,14 +16,14 @@ class AMP_Editor_Blocks {
 	 *
 	 * @var array
 	 */
-	public $content_required_amp_scripts = array();
+	public $content_required_amp_scripts = [];
 
 	/**
 	 * AMP components that have blocks.
 	 *
 	 * @var array
 	 */
-	public $amp_blocks = array(
+	public $amp_blocks = [
 		'amp-mathml',
 		'amp-timeago',
 		'amp-o2-player',
@@ -34,14 +34,14 @@ class AMP_Editor_Blocks {
 		'amp-brid-player',
 		'amp-ima-video',
 		'amp-fit-text',
-	);
+	];
 
 	/**
 	 * Init.
 	 */
 	public function init() {
 		if ( function_exists( 'register_block_type' ) ) {
-			add_filter( 'wp_kses_allowed_html', array( $this, 'whitelist_block_atts_in_wp_kses_allowed_html' ), 10, 2 );
+			add_filter( 'wp_kses_allowed_html', [ $this, 'whitelist_block_atts_in_wp_kses_allowed_html' ], 10, 2 );
 
 			/*
 			 * Dirty AMP is required when a site is in AMP-first mode but not all templates are being served
@@ -55,8 +55,8 @@ class AMP_Editor_Blocks {
 			 * as much as possible. For more, see <https://github.com/ampproject/amp-wp/issues/1192>.
 			 */
 			if ( amp_is_canonical() ) {
-				add_filter( 'the_content', array( $this, 'tally_content_requiring_amp_scripts' ) );
-				add_action( 'wp_print_footer_scripts', array( $this, 'print_dirty_amp_scripts' ) );
+				add_filter( 'the_content', [ $this, 'tally_content_requiring_amp_scripts' ] );
+				add_action( 'wp_print_footer_scripts', [ $this, 'print_dirty_amp_scripts' ] );
 			}
 		}
 	}
@@ -89,18 +89,18 @@ class AMP_Editor_Blocks {
 
 		foreach ( $this->amp_blocks as $amp_block ) {
 			if ( ! isset( $tags[ $amp_block ] ) ) {
-				$tags[ $amp_block ] = array();
+				$tags[ $amp_block ] = [];
 			}
 
 			// @todo The global attributes included here should be matched up with what is actually used by each block.
 			$tags[ $amp_block ] = array_merge(
 				array_fill_keys(
-					array(
+					[
 						'layout',
 						'width',
 						'height',
 						'class',
-					),
+					],
 					true
 				),
 				$tags[ $amp_block ]

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -86,20 +86,20 @@ class AMP_Post_Meta_Box {
 		register_meta(
 			'post',
 			self::STATUS_POST_META_KEY,
-			array(
-				'sanitize_callback' => array( $this, 'sanitize_status' ),
+			[
+				'sanitize_callback' => [ $this, 'sanitize_status' ],
 				'type'              => 'string',
 				'description'       => __( 'AMP status.', 'amp' ),
 				'show_in_rest'      => true,
 				'single'            => true,
-			)
+			]
 		);
 
-		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_assets' ) );
-		add_action( 'post_submitbox_misc_actions', array( $this, 'render_status' ) );
-		add_action( 'save_post', array( $this, 'save_amp_status' ) );
-		add_filter( 'preview_post_link', array( $this, 'preview_post_link' ) );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_assets' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_assets' ] );
+		add_action( 'post_submitbox_misc_actions', [ $this, 'render_status' ] );
+		add_action( 'save_post', [ $this, 'save_amp_status' ] );
+		add_filter( 'preview_post_link', [ $this, 'preview_post_link' ] );
 	}
 
 	/**
@@ -110,7 +110,7 @@ class AMP_Post_Meta_Box {
 	 */
 	public function sanitize_status( $status ) {
 		$status = strtolower( trim( $status ) );
-		if ( ! in_array( $status, array( self::ENABLED_STATUS, self::DISABLED_STATUS ), true ) ) {
+		if ( ! in_array( $status, [ self::ENABLED_STATUS, self::DISABLED_STATUS ], true ) ) {
 			/*
 			 * In lieu of actual validation being available, clear the status entirely
 			 * so that the underlying default status will be used instead.
@@ -153,7 +153,7 @@ class AMP_Post_Meta_Box {
 		$script_deps_path    = AMP__DIR__ . '/assets/js/' . self::ASSETS_HANDLE . '.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			: array();
+			: [];
 
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter
 		wp_enqueue_script(
@@ -176,16 +176,16 @@ class AMP_Post_Meta_Box {
 			sprintf(
 				'ampPostMetaBox.boot( %s );',
 				wp_json_encode(
-					array(
+					[
 						'previewLink'     => esc_url_raw( add_query_arg( amp_get_slug(), '', get_preview_post_link( $post ) ) ),
 						'canonical'       => amp_is_canonical(),
 						'enabled'         => empty( $support_errors ),
-						'canSupport'      => 0 === count( array_diff( $support_errors, array( 'post-status-disabled' ) ) ),
+						'canSupport'      => 0 === count( array_diff( $support_errors, [ 'post-status-disabled' ] ) ),
 						'statusInputName' => self::STATUS_INPUT_NAME,
-						'l10n'            => array(
+						'l10n'            => [
 							'ampPreviewBtnLabel' => __( 'Preview changes in AMP (opens in new window)', 'amp' ),
-						),
-					)
+						],
+					]
 				)
 			)
 		);
@@ -205,14 +205,14 @@ class AMP_Post_Meta_Box {
 		wp_enqueue_style(
 			self::BLOCK_ASSET_HANDLE,
 			amp_get_asset_url( 'css/' . self::BLOCK_ASSET_HANDLE . '.css' ),
-			array(),
+			[],
 			AMP__VERSION
 		);
 
 		$script_deps_path    = AMP__DIR__ . '/assets/js/' . self::BLOCK_ASSET_HANDLE . '.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			: array();
+			: [];
 
 		wp_enqueue_script(
 			self::BLOCK_ASSET_HANDLE,
@@ -226,15 +226,15 @@ class AMP_Post_Meta_Box {
 		$enabled_status    = $status_and_errors['status'];
 		$error_messages    = $this->get_error_messages( $status_and_errors['status'], $status_and_errors['errors'] );
 
-		$data = array(
-			'possibleStatuses' => array( self::ENABLED_STATUS, self::DISABLED_STATUS ),
+		$data = [
+			'possibleStatuses' => [ self::ENABLED_STATUS, self::DISABLED_STATUS ],
 			'defaultStatus'    => $enabled_status,
 			'errorMessages'    => $error_messages,
 			'isWebsiteEnabled' => AMP_Options_Manager::is_website_experience_enabled(),
 			'isStoriesEnabled' => AMP_Options_Manager::is_stories_experience_enabled(),
 			'hasThemeSupport'  => current_theme_supports( AMP_Theme_Support::SLUG ),
 			'isStandardMode'   => amp_is_canonical(),
-		);
+		];
 
 		wp_localize_script(
 			self::BLOCK_ASSET_HANDLE,
@@ -280,10 +280,10 @@ class AMP_Post_Meta_Box {
 		$errors            = $status_and_errors['errors'];
 		$error_messages    = $this->get_error_messages( $status, $errors );
 
-		$labels = array(
+		$labels = [
 			'enabled'  => __( 'Enabled', 'amp' ),
 			'disabled' => __( 'Disabled', 'amp' ),
-		);
+		];
 
 		// The preceding variables are used inside the following amp-status.php template.
 		include AMP__DIR__ . '/templates/admin/amp-status.php';
@@ -310,14 +310,14 @@ class AMP_Post_Meta_Box {
 		if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
 			$availability = AMP_Theme_Support::get_template_availability( $post );
 			$status       = $availability['supported'] ? self::ENABLED_STATUS : self::DISABLED_STATUS;
-			$errors       = array_diff( $availability['errors'], array( 'post-status-disabled' ) ); // Subtract the status which the metabox will allow to be toggled.
+			$errors       = array_diff( $availability['errors'], [ 'post-status-disabled' ] ); // Subtract the status which the metabox will allow to be toggled.
 			if ( true === $availability['immutable'] ) {
 				$errors[] = 'status_immutable';
 			}
 		} else {
 			$errors = AMP_Post_Type_Support::get_support_errors( $post );
 			$status = empty( $errors ) ? self::ENABLED_STATUS : self::DISABLED_STATUS;
-			$errors = array_diff( $errors, array( 'post-status-disabled' ) ); // Subtract the status which the metabox will allow to be toggled.
+			$errors = array_diff( $errors, [ 'post-status-disabled' ] ); // Subtract the status which the metabox will allow to be toggled.
 		}
 
 		return compact( 'status', 'errors' );
@@ -332,7 +332,7 @@ class AMP_Post_Meta_Box {
 	 * @return array $error_messages The error messages, as an array of strings.
 	 */
 	public function get_error_messages( $status, $errors ) {
-		$error_messages = array();
+		$error_messages = [];
 		if ( in_array( 'status_immutable', $errors, true ) ) {
 			if ( self::ENABLED_STATUS === $status ) {
 				$error_messages[] = __( 'Your site does not allow AMP to be disabled.', 'amp' );
@@ -360,7 +360,7 @@ class AMP_Post_Meta_Box {
 		if ( in_array( 'skip-post', $errors, true ) ) {
 			$error_messages[] = __( 'A plugin or theme has disabled AMP support.', 'amp' );
 		}
-		if ( count( array_diff( $errors, array( 'status_immutable', 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template_unsupported', 'no_matching_template' ) ) ) > 0 ) {
+		if ( count( array_diff( $errors, [ 'status_immutable', 'page-on-front', 'page-for-posts', 'password-protected', 'post-type-support', 'skip-post', 'template_unsupported', 'no_matching_template' ] ) ) > 0 ) {
 			$error_messages[] = __( 'Unavailable for an unknown reason.', 'amp' );
 		}
 

--- a/includes/admin/class-amp-story-templates.php
+++ b/includes/admin/class-amp-story-templates.php
@@ -36,12 +36,12 @@ class AMP_Story_Templates {
 			return;
 		}
 
-		add_filter( 'rest_wp_block_query', array( $this, 'filter_rest_wp_block_query' ), 10, 2 );
-		add_action( 'save_post_wp_block', array( $this, 'flag_template_as_modified' ) );
+		add_filter( 'rest_wp_block_query', [ $this, 'filter_rest_wp_block_query' ], 10, 2 );
+		add_action( 'save_post_wp_block', [ $this, 'flag_template_as_modified' ] );
 
 		// Temporary filters for disallowing the users to edit any templates until the feature has been implemented.
-		add_filter( 'user_has_cap', array( $this, 'filter_user_has_cap' ), 10, 3 );
-		add_filter( 'pre_get_posts', array( $this, 'filter_pre_get_posts' ) );
+		add_filter( 'user_has_cap', [ $this, 'filter_user_has_cap' ], 10, 3 );
+		add_filter( 'pre_get_posts', [ $this, 'filter_pre_get_posts' ] );
 
 		$this->register_taxonomy();
 		$this->maybe_import_story_templates();
@@ -83,15 +83,15 @@ class AMP_Story_Templates {
 
 		$tax_query = $query->get( 'tax_query' );
 		if ( empty( $tax_query ) ) {
-			$tax_query = array();
+			$tax_query = [];
 		}
 
-		$tax_query[] = array(
+		$tax_query[] = [
 			'taxonomy' => self::TEMPLATES_TAXONOMY,
 			'field'    => 'slug',
-			'terms'    => array( self::TEMPLATES_TERM ),
+			'terms'    => [ self::TEMPLATES_TERM ],
 			'operator' => 'NOT IN',
-		);
+		];
 
 		$query->set( 'tax_query', $tax_query );
 		return $query;
@@ -129,13 +129,13 @@ class AMP_Story_Templates {
 
 			$post_id = wp_insert_post(
 				wp_slash(
-					array(
+					[
 						'post_title'   => $template['title'],
 						'post_type'    => 'wp_block',
 						'post_status'  => 'publish',
 						'post_content' => $post_content,
 						'post_name'    => $template['name'],
-					)
+					]
 				)
 			);
 			if ( ! $post_id ) {
@@ -160,17 +160,17 @@ class AMP_Story_Templates {
 			return;
 		}
 
-		remove_action( 'save_post_wp_block', array( $this, 'flag_template_as_modified' ) );
+		remove_action( 'save_post_wp_block', [ $this, 'flag_template_as_modified' ] );
 		wp_update_post(
 			wp_slash(
-				array(
+				[
 					'ID'           => $template_id,
 					'post_content' => $content,
 					'post_title'   => $template['title'],
-				)
+				]
 			)
 		);
-		add_action( 'save_post_wp_block', array( $this, 'flag_template_as_modified' ) );
+		add_action( 'save_post_wp_block', [ $this, 'flag_template_as_modified' ] );
 	}
 
 	/**
@@ -179,48 +179,48 @@ class AMP_Story_Templates {
 	 * @return array Story templates.
 	 */
 	public static function get_story_templates() {
-		return array(
-			array(
+		return [
+			[
 				'title' => __( 'Template: Travel Tip', 'amp' ),
 				'name'  => 'travel-tip',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Quote', 'amp' ),
 				'name'  => 'quote',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Travel CTA', 'amp' ),
 				'name'  => 'travel-cta',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Title Page', 'amp' ),
 				'name'  => 'title-page',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Travel Vertical', 'amp' ),
 				'name'  => 'travel-vertical',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Fandom Title', 'amp' ),
 				'name'  => 'fandom-title',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Fandom CTA', 'amp' ),
 				'name'  => 'fandom-cta',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Fandom Fact', 'amp' ),
 				'name'  => 'fandom-fact',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Fandom Fact Text', 'amp' ),
 				'name'  => 'fandom-fact-text',
-			),
-			array(
+			],
+			[
 				'title' => __( 'Template: Fandom Intro', 'amp' ),
 				'name'  => 'fandom-intro',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -234,12 +234,12 @@ class AMP_Story_Templates {
 			return 0;
 		}
 
-		$args      = array(
+		$args      = [
 			'name'           => $slug,
 			'post_type'      => 'wp_block',
 			'post_status'    => 'publish',
 			'posts_per_page' => 1,
-		);
+		];
 		$templates = get_posts( $args );
 		if ( ! empty( $templates ) ) {
 			return $templates[0]->ID;
@@ -255,7 +255,7 @@ class AMP_Story_Templates {
 		register_taxonomy(
 			self::TEMPLATES_TAXONOMY,
 			'wp_block',
-			array(
+			[
 				'query_var'             => self::TEMPLATES_TAXONOMY,
 				'show_admin_column'     => false,
 				'show_in_rest'          => true,
@@ -268,17 +268,17 @@ class AMP_Story_Templates {
 				'hierarchical'          => false,
 				'show_in_menu'          => false,
 				'meta_box_cb'           => false,
-			)
+			]
 		);
 
 		if ( ! term_exists( self::TEMPLATES_TERM, self::TEMPLATES_TAXONOMY ) ) {
 			wp_insert_term(
 				__( 'Story Template', 'amp' ),
 				self::TEMPLATES_TAXONOMY,
-				array(
+				[
 					'description' => __( 'Story Template', 'amp' ),
 					'slug'        => self::TEMPLATES_TERM,
-				)
+				]
 			);
 		}
 	}
@@ -308,14 +308,14 @@ class AMP_Story_Templates {
 		$edited_post = get_post( absint( $params['post'] ) );
 		if ( AMP_Story_Post_Type::POST_TYPE_SLUG !== $edited_post->post_type ) {
 			if ( ! isset( $args['tax_query'] ) ) {
-				$args['tax_query'] = array();
+				$args['tax_query'] = [];
 			}
-			$args['tax_query'][] = array(
+			$args['tax_query'][] = [
 				'taxonomy' => self::TEMPLATES_TAXONOMY,
 				'field'    => 'slug',
-				'terms'    => array( self::TEMPLATES_TERM ),
+				'terms'    => [ self::TEMPLATES_TERM ],
 				'operator' => 'NOT IN',
-			);
+			];
 		}
 
 		return $args;

--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -26,10 +26,10 @@ function amp_init_customizer() {
 	}
 
 	// Fire up the AMP Customizer.
-	add_action( 'customize_register', array( 'AMP_Template_Customizer', 'init' ), 500 );
+	add_action( 'customize_register', [ 'AMP_Template_Customizer', 'init' ], 500 );
 
 	// Add some basic design settings + controls to the Customizer.
-	add_action( 'amp_init', array( 'AMP_Customizer_Design_Settings', 'init' ) );
+	add_action( 'amp_init', [ 'AMP_Customizer_Design_Settings', 'init' ] );
 
 	// Add a link to the Customizer.
 	add_action( 'admin_menu', 'amp_add_customizer_link' );
@@ -51,7 +51,7 @@ function amp_admin_get_preview_permalink() {
 	// Make sure the desired post type is actually supported, and if so, prefer it.
 	$supported_post_types = get_post_types_by_support( AMP_Post_Type_Support::SLUG );
 	if ( in_array( $post_type, $supported_post_types, true ) ) {
-		$supported_post_types = array_unique( array_merge( array( $post_type ), $supported_post_types ) );
+		$supported_post_types = array_unique( array_merge( [ $post_type ], $supported_post_types ) );
 	}
 
 	// Bail if there are no supported post types.
@@ -68,7 +68,7 @@ function amp_admin_get_preview_permalink() {
 	}
 
 	$post_ids = get_posts(
-		array(
+		[
 			'no_found_rows'    => true,
 			'suppress_filters' => false,
 			'post_status'      => 'publish',
@@ -77,7 +77,7 @@ function amp_admin_get_preview_permalink() {
 			'posts_per_page'   => 1,
 			'fields'           => 'ids',
 		// @todo This should eventually do a meta_query to make sure there are none that have AMP_Post_Meta_Box::STATUS_POST_META_KEY = DISABLED_STATUS.
-		)
+		]
 	);
 
 	if ( empty( $post_ids ) ) {
@@ -99,11 +99,11 @@ function amp_add_customizer_link() {
 	}
 
 	$menu_slug = add_query_arg(
-		array(
+		[
 			'autofocus[panel]' => AMP_Template_Customizer::PANEL_ID,
 			'url'              => rawurlencode( amp_admin_get_preview_permalink() ),
 			'return'           => rawurlencode( admin_url() ),
-		),
+		],
 		'customize.php'
 	);
 
@@ -151,7 +151,7 @@ function amp_add_options_menu() {
  * @param array $analytics Analytics.
  * @return array Analytics.
  */
-function amp_add_custom_analytics( $analytics = array() ) {
+function amp_add_custom_analytics( $analytics = [] ) {
 	$analytics = amp_get_analytics( $analytics );
 
 	/**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -194,7 +194,7 @@ function amp_add_amphtml_link() {
 
 	// Check to see if there are known unaccepted validation errors for this URL.
 	if ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-		$validation_errors = AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( $current_url, array( 'ignore_accepted' => true ) );
+		$validation_errors = AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( $current_url, [ 'ignore_accepted' => true ] );
 		$error_count       = count( $validation_errors );
 		if ( $error_count > 0 ) {
 			echo "<!--\n";
@@ -250,7 +250,7 @@ function post_supports_amp( $post ) {
 function is_amp_endpoint() {
 	global $pagenow, $wp_query;
 
-	if ( is_admin() || is_embed() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ), true ) ) {
+	if ( is_admin() || is_embed() || is_feed() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) || in_array( $pagenow, [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ], true ) ) {
 		return false;
 	}
 
@@ -400,7 +400,7 @@ function amp_register_default_scripts( $wp_scripts ) {
 	 * Polyfill dependencies that are registered in Gutenberg and WordPress 5.0.
 	 * Note that Gutenberg will override these at wp_enqueue_scripts if it is active.
 	 */
-	$handles = array( 'wp-i18n', 'wp-dom-ready' );
+	$handles = [ 'wp-i18n', 'wp-dom-ready' ];
 	foreach ( $handles as $handle ) {
 		if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {
 			$wp_scripts->add( $handle, amp_get_asset_url( sprintf( 'js/%s.js', $handle ) ) );
@@ -412,15 +412,15 @@ function amp_register_default_scripts( $wp_scripts ) {
 	$wp_scripts->add(
 		$handle,
 		'https://cdn.ampproject.org/v0.js',
-		array(),
+		[],
 		null
 	);
 	$wp_scripts->add_data(
 		$handle,
 		'amp_script_attributes',
-		array(
+		[
 			'async' => true,
-		)
+		]
 	);
 
 	// Shadow AMP API.
@@ -428,19 +428,19 @@ function amp_register_default_scripts( $wp_scripts ) {
 	$wp_scripts->add(
 		$handle,
 		'https://cdn.ampproject.org/shadow-v0.js',
-		array(),
+		[],
 		null
 	);
 	$wp_scripts->add_data(
 		$handle,
 		'amp_script_attributes',
-		array(
+		[
 			'async' => true,
-		)
+		]
 	);
 
 	// Get all AMP components as defined in the spec.
-	$extensions = array();
+	$extensions = [];
 	foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'script' ) as $script_spec ) {
 		if ( isset( $script_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec']['name'], $script_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec']['version'] ) ) {
 			$versions = $script_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec']['version'];
@@ -459,7 +459,7 @@ function amp_register_default_scripts( $wp_scripts ) {
 		$wp_scripts->add(
 			$extension,
 			$src,
-			array( 'amp-runtime' ),
+			[ 'amp-runtime' ],
 			null
 		);
 	}
@@ -533,9 +533,9 @@ function amp_filter_script_loader_tag( $tag, $handle ) {
 	 * All scripts from AMP CDN should be loaded async.
 	 * See <https://www.ampproject.org/docs/integration/pwa-amp/amp-in-pwa#include-"shadow-amp"-in-your-progressive-web-app>.
 	 */
-	$attributes = array(
+	$attributes = [
 		'async' => true,
-	);
+	];
 
 	// Add custom-template and custom-element attributes. All component scripts look like https://cdn.ampproject.org/v0/:name-:version.js.
 	if ( 'v0' === strtok( substr( $src, strlen( $prefix ) ), '/' ) ) {
@@ -622,8 +622,8 @@ function amp_filter_font_style_loader_tag_with_crossorigin_anonymous( $tag, $han
  * @param array $analytics Analytics entries.
  * @return array Analytics.
  */
-function amp_get_analytics( $analytics = array() ) {
-	$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
+function amp_get_analytics( $analytics = [] ) {
+	$analytics_entries = AMP_Options_Manager::get_option( 'analytics', [] );
 
 	/**
 	 * Add amp-analytics tags.
@@ -642,11 +642,11 @@ function amp_get_analytics( $analytics = array() ) {
 	}
 
 	foreach ( $analytics_entries as $entry_id => $entry ) {
-		$analytics[ $entry_id ] = array(
+		$analytics[ $entry_id ] = [
 			'type'        => $entry['type'],
-			'attributes'  => array(),
+			'attributes'  => [],
 			'config_data' => json_decode( $entry['config'] ),
-		);
+		];
 	}
 
 	return $analytics;
@@ -661,7 +661,7 @@ function amp_get_analytics( $analytics = array() ) {
  */
 function amp_print_analytics( $analytics ) {
 	if ( '' === $analytics ) {
-		$analytics = array();
+		$analytics = [];
 	}
 	$analytics_entries = amp_get_analytics( $analytics );
 
@@ -689,17 +689,17 @@ function amp_print_analytics( $analytics ) {
 		}
 		$script_element = AMP_HTML_Utils::build_tag(
 			'script',
-			array(
+			[
 				'type' => 'application/json',
-			),
+			],
 			wp_json_encode( $analytics_entry['config_data'] )
 		);
 
 		$amp_analytics_attr = array_merge(
-			array(
+			[
 				'id'   => $id,
 				'type' => $analytics_entry['type'],
-			),
+			],
 			$analytics_entry['attributes']
 		);
 
@@ -741,28 +741,28 @@ function amp_get_content_embed_handlers( $post = null ) {
 	 */
 	return apply_filters(
 		'amp_content_embed_handlers',
-		array(
-			'AMP_Core_Block_Handler'        => array(),
-			'AMP_Twitter_Embed_Handler'     => array(),
-			'AMP_YouTube_Embed_Handler'     => array(),
-			'AMP_Crowdsignal_Embed_Handler' => array(),
-			'AMP_DailyMotion_Embed_Handler' => array(),
-			'AMP_Vimeo_Embed_Handler'       => array(),
-			'AMP_SoundCloud_Embed_Handler'  => array(),
-			'AMP_Instagram_Embed_Handler'   => array(),
-			'AMP_Issuu_Embed_Handler'       => array(),
-			'AMP_Meetup_Embed_Handler'      => array(),
-			'AMP_Vine_Embed_Handler'        => array(),
-			'AMP_Facebook_Embed_Handler'    => array(),
-			'AMP_Pinterest_Embed_Handler'   => array(),
-			'AMP_Playlist_Embed_Handler'    => array(),
-			'AMP_Reddit_Embed_Handler'      => array(),
-			'AMP_Tumblr_Embed_Handler'      => array(),
-			'AMP_Gallery_Embed_Handler'     => array(),
-			'AMP_Gfycat_Embed_Handler'      => array(),
-			'AMP_Hulu_Embed_Handler'        => array(),
-			'AMP_Imgur_Embed_Handler'       => array(),
-		),
+		[
+			'AMP_Core_Block_Handler'        => [],
+			'AMP_Twitter_Embed_Handler'     => [],
+			'AMP_YouTube_Embed_Handler'     => [],
+			'AMP_Crowdsignal_Embed_Handler' => [],
+			'AMP_DailyMotion_Embed_Handler' => [],
+			'AMP_Vimeo_Embed_Handler'       => [],
+			'AMP_SoundCloud_Embed_Handler'  => [],
+			'AMP_Instagram_Embed_Handler'   => [],
+			'AMP_Issuu_Embed_Handler'       => [],
+			'AMP_Meetup_Embed_Handler'      => [],
+			'AMP_Vine_Embed_Handler'        => [],
+			'AMP_Facebook_Embed_Handler'    => [],
+			'AMP_Pinterest_Embed_Handler'   => [],
+			'AMP_Playlist_Embed_Handler'    => [],
+			'AMP_Reddit_Embed_Handler'      => [],
+			'AMP_Tumblr_Embed_Handler'      => [],
+			'AMP_Gallery_Embed_Handler'     => [],
+			'AMP_Gfycat_Embed_Handler'      => [],
+			'AMP_Hulu_Embed_Handler'        => [],
+			'AMP_Imgur_Embed_Handler'       => [],
+		],
 		$post
 	);
 }
@@ -799,37 +799,37 @@ function amp_get_content_sanitizers( $post = null ) {
 		$current_origin .= ':' . $parsed_home_url['port'];
 	}
 
-	$sanitizers = array(
-		'AMP_Core_Theme_Sanitizer'        => array(
+	$sanitizers = [
+		'AMP_Core_Theme_Sanitizer'        => [
 			'template'   => get_template(),
 			'stylesheet' => get_stylesheet(),
-		),
-		'AMP_Img_Sanitizer'               => array(
+		],
+		'AMP_Img_Sanitizer'               => [
 			'align_wide_support' => current_theme_supports( 'align-wide' ),
-		),
-		'AMP_Form_Sanitizer'              => array(),
-		'AMP_Comments_Sanitizer'          => array(
+		],
+		'AMP_Form_Sanitizer'              => [],
+		'AMP_Comments_Sanitizer'          => [
 			'comments_live_list' => ! empty( $theme_support_args['comments_live_list'] ),
-		),
-		'AMP_Video_Sanitizer'             => array(),
-		'AMP_O2_Player_Sanitizer'         => array(),
-		'AMP_Audio_Sanitizer'             => array(),
-		'AMP_Playbuzz_Sanitizer'          => array(),
-		'AMP_Embed_Sanitizer'             => array(),
-		'AMP_Iframe_Sanitizer'            => array(
+		],
+		'AMP_Video_Sanitizer'             => [],
+		'AMP_O2_Player_Sanitizer'         => [],
+		'AMP_Audio_Sanitizer'             => [],
+		'AMP_Playbuzz_Sanitizer'          => [],
+		'AMP_Embed_Sanitizer'             => [],
+		'AMP_Iframe_Sanitizer'            => [
 			'add_placeholder' => true,
 			'current_origin'  => $current_origin,
-		),
-		'AMP_Gallery_Block_Sanitizer'     => array( // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
+		],
+		'AMP_Gallery_Block_Sanitizer'     => [ // Note: Gallery block sanitizer must come after image sanitizers since itś logic is using the already sanitized images.
 			'carousel_required' => ! is_array( $theme_support_args ), // For back-compat.
-		),
-		'AMP_Block_Sanitizer'             => array(), // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
-		'AMP_Script_Sanitizer'            => array(),
-		'AMP_Style_Sanitizer'             => array(
+		],
+		'AMP_Block_Sanitizer'             => [], // Note: Block sanitizer must come after embed / media sanitizers since its logic is using the already sanitized content.
+		'AMP_Script_Sanitizer'            => [],
+		'AMP_Style_Sanitizer'             => [
 			'include_manifest_comment' => ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? 'always' : 'when_excessive',
-		),
-		'AMP_Tag_And_Attribute_Sanitizer' => array(), // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
-	);
+		],
+		'AMP_Tag_And_Attribute_Sanitizer' => [], // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
+	];
 
 	if ( ! empty( $theme_support_args['nav_menu_toggle'] ) ) {
 		$sanitizers['AMP_Nav_Menu_Toggle_Sanitizer'] = $theme_support_args['nav_menu_toggle'];
@@ -851,7 +851,7 @@ function amp_get_content_sanitizers( $post = null ) {
 	$sanitizers = apply_filters( 'amp_content_sanitizers', $sanitizers, $post );
 
 	// Force style sanitizer and whitelist sanitizer to be at end.
-	foreach ( array( 'AMP_Style_Sanitizer', 'AMP_Tag_And_Attribute_Sanitizer' ) as $class_name ) {
+	foreach ( [ 'AMP_Style_Sanitizer', 'AMP_Tag_And_Attribute_Sanitizer' ] as $class_name ) {
 		if ( isset( $sanitizers[ $class_name ] ) ) {
 			$sanitizer = $sanitizers[ $class_name ];
 			unset( $sanitizers[ $class_name ] );
@@ -885,7 +885,7 @@ function amp_get_post_image_metadata( $post = null ) {
 		$post_image_id = $post->ID;
 	} else {
 		$attached_image_ids = get_posts(
-			array(
+			[
 				'post_parent'      => $post->ID,
 				'post_type'        => 'attachment',
 				'post_mime_type'   => 'image',
@@ -894,7 +894,7 @@ function amp_get_post_image_metadata( $post = null ) {
 				'order'            => 'ASC',
 				'fields'           => 'ids',
 				'suppress_filters' => false,
-			)
+			]
 		);
 
 		if ( ! empty( $attached_image_ids ) ) {
@@ -909,12 +909,12 @@ function amp_get_post_image_metadata( $post = null ) {
 	$post_image_src = wp_get_attachment_image_src( $post_image_id, 'full' );
 
 	if ( is_array( $post_image_src ) ) {
-		$post_image_meta = array(
+		$post_image_meta = [
 			'@type'  => 'ImageObject',
 			'url'    => $post_image_src[0],
 			'width'  => $post_image_src[1],
 			'height' => $post_image_src[2],
-		);
+		];
 	}
 
 	return $post_image_meta;
@@ -929,13 +929,13 @@ function amp_get_post_image_metadata( $post = null ) {
  * @return array $metadata All schema.org metadata for the post.
  */
 function amp_get_schemaorg_metadata() {
-	$metadata = array(
+	$metadata = [
 		'@context'  => 'http://schema.org',
-		'publisher' => array(
+		'publisher' => [
 			'@type' => 'Organization',
 			'name'  => get_bloginfo( 'name' ),
-		),
-	);
+		],
+	];
 
 	/*
 	 * "The logo should be a rectangle, not a square. The logo should fit in a 60x600px rectangle.,
@@ -946,17 +946,17 @@ function amp_get_schemaorg_metadata() {
 	$max_logo_width  = 600;
 	$max_logo_height = 60;
 	$custom_logo_id  = get_theme_mod( 'custom_logo' );
-	$schema_img      = array();
+	$schema_img      = [];
 
 	if ( has_custom_logo() && $custom_logo_id ) {
-		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, array( $max_logo_width, $max_logo_height ), false );
+		$custom_logo_img = wp_get_attachment_image_src( $custom_logo_id, [ $max_logo_width, $max_logo_height ], false );
 		if ( $custom_logo_img ) {
 			// @todo Warning: The width/height returned may not actually be physically the $max_logo_width and $max_logo_height for the image returned.
-			$schema_img = array(
+			$schema_img = [
 				'url'    => $custom_logo_img[0],
 				'width'  => $custom_logo_img[1],
 				'height' => $custom_logo_img[2],
-			);
+			];
 		}
 	}
 
@@ -968,11 +968,11 @@ function amp_get_schemaorg_metadata() {
 		 * to add a site_icon_image_sizes filter which appends 60 to the list of sizes, but this will only help
 		 * when adding a new site icon and it would be irrelevant when a custom logo is present, per above.
 		 */
-		$schema_img = array(
+		$schema_img = [
 			'url'    => get_site_icon_url( AMP_Post_Template::SITE_ICON_SIZE ),
 			'width'  => AMP_Post_Template::SITE_ICON_SIZE,
 			'height' => AMP_Post_Template::SITE_ICON_SIZE,
-		);
+		];
 	}
 
 	/**
@@ -993,9 +993,9 @@ function amp_get_schemaorg_metadata() {
 
 	if ( ! empty( $schema_img['url'] ) ) {
 		$metadata['publisher']['logo'] = array_merge(
-			array(
+			[
 				'@type' => 'ImageObject',
-			),
+			],
 			$schema_img
 		);
 	}
@@ -1004,21 +1004,21 @@ function amp_get_schemaorg_metadata() {
 	if ( $post instanceof WP_Post ) {
 		$metadata = array_merge(
 			$metadata,
-			array(
+			[
 				'@type'            => is_page() ? 'WebPage' : 'BlogPosting',
 				'mainEntityOfPage' => get_permalink(),
 				'headline'         => get_the_title(),
 				'datePublished'    => mysql2date( 'c', $post->post_date_gmt, false ),
 				'dateModified'     => mysql2date( 'c', $post->post_modified_gmt, false ),
-			)
+			]
 		);
 
 		$post_author = get_userdata( $post->post_author );
 		if ( $post_author ) {
-			$metadata['author'] = array(
+			$metadata['author'] = [
 				'@type' => 'Person',
 				'name'  => html_entity_decode( $post_author->display_name, ENT_QUOTES, get_bloginfo( 'charset' ) ),
-			);
+			];
 		}
 
 		$image_metadata = amp_get_post_image_metadata( $post );
@@ -1081,8 +1081,8 @@ function amp_print_schemaorg_metadata() {
  * @return string HTML markup with tags allowed by amp-mustache.
  */
 function amp_wp_kses_mustache( $markup ) {
-	$amp_mustache_allowed_html_tags = array( 'strong', 'b', 'em', 'i', 'u', 's', 'small', 'mark', 'del', 'ins', 'sup', 'sub' );
-	return wp_kses( $markup, array_fill_keys( $amp_mustache_allowed_html_tags, array() ) );
+	$amp_mustache_allowed_html_tags = [ 'strong', 'b', 'em', 'i', 'u', 's', 'small', 'mark', 'del', 'ins', 'sup', 'sub' ];
+	return wp_kses( $markup, array_fill_keys( $amp_mustache_allowed_html_tags, [] ) );
 }
 
 /**
@@ -1114,7 +1114,7 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 	}
 
 	// Show nothing if there are rejected validation errors for this URL.
-	if ( ! is_amp_endpoint() && count( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( amp_get_current_url(), array( 'ignore_accepted' => true ) ) ) > 0 ) {
+	if ( ! is_amp_endpoint() && count( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( amp_get_current_url(), [ 'ignore_accepted' => true ] ) ) > 0 ) {
 		return;
 	}
 
@@ -1128,7 +1128,7 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 
 	$icon = '&#x1F517;'; // LINK SYMBOL.
 
-	$parent = array(
+	$parent = [
 		'id'    => 'amp',
 		'title' => sprintf(
 			'<span id="amp-admin-bar-item-status-icon">%s</span> %s',
@@ -1136,7 +1136,7 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 			esc_html( is_amp_endpoint() ? __( 'Non-AMP', 'amp' ) : __( 'AMP', 'amp' ) )
 		),
 		'href'  => esc_url( $href ),
-	);
+	];
 
 	$wp_admin_bar->add_menu( $parent );
 }
@@ -1155,7 +1155,7 @@ function amp_print_story_auto_ads() {
 	 * @param array   $data Story ads configuration data.
 	 * @param WP_Post $post The current story's post object.
 	 */
-	$data = apply_filters( 'amp_story_auto_ads_configuration', array(), get_post() );
+	$data = apply_filters( 'amp_story_auto_ads_configuration', [], get_post() );
 
 	if ( empty( $data ) ) {
 		return;
@@ -1163,11 +1163,11 @@ function amp_print_story_auto_ads() {
 
 	$script_element = AMP_HTML_Utils::build_tag(
 		'script',
-		array(
+		[
 			'type' => 'application/json',
-		),
+		],
 		wp_json_encode( $data )
 	);
 
-	echo AMP_HTML_Utils::build_tag( 'amp-story-auto-ads', array(), $script_element ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo AMP_HTML_Utils::build_tag( 'amp-story-auto-ads', [], $script_element ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -55,11 +55,11 @@ function amp_post_template_add_scripts( $amp_template ) {
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	echo amp_render_scripts(
 		array_merge(
-			array(
+			[
 				// Just in case the runtime has been overridden by amp_post_template_data filter.
 				'amp-runtime' => $amp_template->get( 'amp_runtime_script' ),
-			),
-			$amp_template->get( 'amp_component_scripts', array() )
+			],
+			$amp_template->get( 'amp_component_scripts', [] )
 		)
 	);
 }
@@ -70,7 +70,7 @@ function amp_post_template_add_scripts( $amp_template ) {
  * @param AMP_Post_Template $amp_template Template.
  */
 function amp_post_template_add_fonts( $amp_template ) {
-	$font_urls = $amp_template->get( 'font_urls', array() );
+	$font_urls = $amp_template->get( 'font_urls', [] );
 	foreach ( $font_urls as $slug => $url ) {
 		printf( '<link rel="stylesheet" href="%s">', esc_url( esc_url( $url ) ) ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 	}

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -28,7 +28,7 @@ class AMP_Autoloader {
 	 *
 	 * @var string[]
 	 */
-	private static $classmap = array(
+	private static $classmap = [
 		'AMP_Editor_Blocks'                  => 'includes/admin/class-amp-editor-blocks',
 		'AMP_Theme_Support'                  => 'includes/class-amp-theme-support',
 		'AMP_Story_Post_Type'                => 'includes/class-amp-story-post-type',
@@ -110,7 +110,7 @@ class AMP_Autoloader {
 		'AMP_Widget_Text'                    => 'includes/widgets/class-amp-widget-text',
 		'AMP_Test_Stub_Sanitizer'            => 'tests/php/stubs',
 		'AMP_Test_World_Sanitizer'           => 'tests/php/stubs',
-	);
+	];
 
 	/**
 	 * Is registered.
@@ -149,7 +149,7 @@ class AMP_Autoloader {
 		}
 
 		if ( ! self::$is_registered ) {
-			spl_autoload_register( array( __CLASS__, 'autoload' ) );
+			spl_autoload_register( [ __CLASS__, 'autoload' ] );
 			self::$is_registered = true;
 		}
 	}

--- a/includes/class-amp-cli.php
+++ b/includes/class-amp-cli.php
@@ -100,7 +100,7 @@ class AMP_CLI {
 	 *
 	 * @var array
 	 */
-	public static $include_conditionals = array();
+	public static $include_conditionals = [];
 
 	/**
 	 * The maximum number of URLs to validate for each type.
@@ -123,7 +123,7 @@ class AMP_CLI {
 	 *     @type int $total The total number of URLs for this type, valid or invalid.
 	 * }
 	 */
-	public static $validity_by_type = array();
+	public static $validity_by_type = [];
 
 	/**
 	 * Crawl the entire site to get AMP validation results.
@@ -152,7 +152,7 @@ class AMP_CLI {
 	 * @throws Exception If an error happens.
 	 */
 	public function validate_site( $args, $assoc_args ) {
-		self::$include_conditionals      = array();
+		self::$include_conditionals      = [];
 		self::$force_crawl_urls          = false;
 		self::$limit_type_validate_count = (int) $assoc_args[ self::LIMIT_URLS_ARGUMENT ];
 
@@ -218,13 +218,13 @@ class AMP_CLI {
 		$key_url_count     = 'URL Count';
 		$key_validity_rate = 'Validity Rate';
 
-		$table_validation_by_type = array();
+		$table_validation_by_type = [];
 		foreach ( self::$validity_by_type as $type_name => $validity ) {
-			$table_validation_by_type[] = array(
+			$table_validation_by_type[] = [
 				$key_template_type => $type_name,
 				$key_url_count     => $validity['total'],
 				$key_validity_rate => sprintf( '%d%%', 100.0 * ( $validity['valid'] / $validity['total'] ) ),
-			);
+			];
 		}
 
 		if ( empty( $table_validation_by_type ) ) {
@@ -245,7 +245,7 @@ class AMP_CLI {
 		WP_CLI\Utils\format_items(
 			'table',
 			$table_validation_by_type,
-			array( $key_template_type, $key_url_count, $key_validity_rate )
+			[ $key_template_type, $key_url_count, $key_validity_rate ]
 		);
 
 		$url_more_details = add_query_arg(
@@ -334,18 +334,18 @@ class AMP_CLI {
 		$total_count = 'posts' === get_option( 'show_on_front' ) && self::is_template_supported( 'is_home' ) ? 1 : 0;
 
 		$amp_enabled_taxonomies = array_filter(
-			get_taxonomies( array( 'public' => true ) ),
-			array( 'AMP_CLI', 'does_taxonomy_support_amp' )
+			get_taxonomies( [ 'public' => true ] ),
+			[ 'AMP_CLI', 'does_taxonomy_support_amp' ]
 		);
 
 		// Count all public taxonomy terms.
 		foreach ( $amp_enabled_taxonomies as $taxonomy ) {
 			$term_query = new WP_Term_Query(
-				array(
+				[
 					'taxonomy' => $taxonomy,
 					'fields'   => 'ids',
 					'number'   => self::$limit_type_validate_count,
-				)
+				]
 			);
 
 			// If $term_query->terms is an empty array, passing it to count() will throw an error.
@@ -353,7 +353,7 @@ class AMP_CLI {
 		}
 
 		// Count posts by type, like post, page, attachment, etc.
-		$public_post_types = get_post_types( array( 'public' => true ), 'names' );
+		$public_post_types = get_post_types( [ 'public' => true ], 'names' );
 		foreach ( $public_post_types as $post_type ) {
 			$posts        = self::get_posts_that_support_amp( self::get_posts_by_type( $post_type ) );
 			$total_count += ! empty( $posts ) ? count( $posts ) : 0;
@@ -388,7 +388,7 @@ class AMP_CLI {
 	 */
 	public static function get_posts_that_support_amp( $ids ) {
 		if ( ! self::is_template_supported( 'is_singular' ) ) {
-			return array();
+			return [];
 		}
 
 		if ( self::$force_crawl_urls ) {
@@ -456,14 +456,14 @@ class AMP_CLI {
 	 * @return int[]   $post_ids The post IDs in an array.
 	 */
 	public static function get_posts_by_type( $post_type, $offset = null, $number = null ) {
-		$args = array(
+		$args = [
 			'post_type'      => $post_type,
 			'posts_per_page' => is_int( $number ) ? $number : self::$limit_type_validate_count,
 			'post_status'    => 'publish',
 			'orderby'        => 'ID',
 			'order'          => 'DESC',
 			'fields'         => 'ids',
-		);
+		];
 		if ( is_int( $offset ) ) {
 			$args['offset'] = $offset;
 		}
@@ -492,9 +492,9 @@ class AMP_CLI {
 			get_terms(
 				array_merge(
 					compact( 'taxonomy', 'offset', 'number' ),
-					array(
+					[
 						'orderby' => 'id',
-					)
+					]
 				)
 			)
 		);
@@ -511,7 +511,7 @@ class AMP_CLI {
 	 * @return array The author page URLs, or an empty array.
 	 */
 	public static function get_author_page_urls( $offset = '', $number = '' ) {
-		$author_page_urls = array();
+		$author_page_urls = [];
 		if ( ! self::is_template_supported( 'is_author' ) ) {
 			return $author_page_urls;
 		}
@@ -567,10 +567,10 @@ class AMP_CLI {
 		}
 
 		$amp_enabled_taxonomies = array_filter(
-			get_taxonomies( array( 'public' => true ) ),
-			array( 'AMP_CLI', 'does_taxonomy_support_amp' )
+			get_taxonomies( [ 'public' => true ] ),
+			[ 'AMP_CLI', 'does_taxonomy_support_amp' ]
 		);
-		$public_post_types      = get_post_types( array( 'public' => true ), 'names' );
+		$public_post_types      = get_post_types( [ 'public' => true ], 'names' );
 
 		// Validate one URL of each template/content type, then another URL of each type on the next iteration.
 		for ( $i = 0; $i < self::$limit_type_validate_count; $i++ ) {
@@ -632,7 +632,7 @@ class AMP_CLI {
 		AMP_Validated_URL_Post_Type::store_validation_errors(
 			$validation_errors,
 			$validity['url'],
-			wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+			wp_array_slice_assoc( $validity, [ 'queried_object' ] )
 		);
 		$unaccepted_error_count = count(
 			array_filter(
@@ -658,10 +658,10 @@ class AMP_CLI {
 		self::$number_crawled++;
 
 		if ( ! isset( self::$validity_by_type[ $type ] ) ) {
-			self::$validity_by_type[ $type ] = array(
+			self::$validity_by_type[ $type ] = [
 				'valid' => 0,
 				'total' => 0,
-			);
+			];
 		}
 		self::$validity_by_type[ $type ]['total']++;
 		if ( 0 === $unaccepted_error_count ) {

--- a/includes/class-amp-comment-walker.php
+++ b/includes/class-amp-comment-walker.php
@@ -32,7 +32,7 @@ class AMP_Comment_Walker extends Walker_Comment {
 	 * @since 0.7
 	 * @var array
 	 */
-	private $comment_thread_age = array();
+	private $comment_thread_age = [];
 
 	/**
 	 * Starts the element output.
@@ -50,7 +50,7 @@ class AMP_Comment_Walker extends Walker_Comment {
 	 * @param array      $args Optional. An array of arguments. Default empty array.
 	 * @param int        $id Optional. ID of the current comment. Default 0 (unused).
 	 */
-	public function start_el( &$output, $comment, $depth = 0, $args = array(), $id = 0 ) {
+	public function start_el( &$output, $comment, $depth = 0, $args = [], $id = 0 ) {
 
 		$new_out = '';
 		parent::start_el( $new_out, $comment, $depth, $args, $id );

--- a/includes/class-amp-http.php
+++ b/includes/class-amp-http.php
@@ -28,7 +28,7 @@ class AMP_HTTP {
 	 * @see AMP_HTTP::send_header()
 	 * @var array[]
 	 */
-	public static $headers_sent = array();
+	public static $headers_sent = [];
 
 	/**
 	 * Whether Server-Timing headers are sent.
@@ -53,7 +53,7 @@ class AMP_HTTP {
 	 * @see AMP_HTTP::purge_amp_query_vars()
 	 * @var string[]
 	 */
-	public static $purged_amp_query_vars = array();
+	public static $purged_amp_query_vars = [];
 
 	/**
 	 * Send an HTTP response header.
@@ -73,12 +73,12 @@ class AMP_HTTP {
 	 * }
 	 * @return bool Whether the header was sent.
 	 */
-	public static function send_header( $name, $value, $args = array() ) {
+	public static function send_header( $name, $value, $args = [] ) {
 		$args = array_merge(
-			array(
+			[
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			$args
 		);
 
@@ -113,7 +113,7 @@ class AMP_HTTP {
 		}
 		$value = $name;
 		if ( isset( $description ) ) {
-			$value .= sprintf( ';desc="%s"', str_replace( array( '\\', '"' ), '', substr( $description, 0, 100 ) ) );
+			$value .= sprintf( ';desc="%s"', str_replace( [ '\\', '"' ], '', substr( $description, 0, 100 ) ) );
 		}
 		if ( isset( $duration ) ) {
 			if ( $duration < 0 ) {
@@ -121,7 +121,7 @@ class AMP_HTTP {
 			}
 			$value .= sprintf( ';dur=%f', $duration * 1000 );
 		}
-		return self::send_header( 'Server-Timing', $value, array( 'replace' => false ) );
+		return self::send_header( 'Server-Timing', $value, [ 'replace' => false ] );
 	}
 
 	/**
@@ -138,12 +138,12 @@ class AMP_HTTP {
 	 * @since 1.0 Moved to AMP_HTTP class.
 	 */
 	public static function purge_amp_query_vars() {
-		$query_vars = array(
+		$query_vars = [
 			'__amp_source_origin',
 			self::ACTION_XHR_CONVERTED_QUERY_VAR,
 			'amp_latest_update_time',
 			'amp_last_check_time',
-		);
+		];
 
 		// Scrub input vars.
 		foreach ( $query_vars as $query_var ) {
@@ -158,7 +158,7 @@ class AMP_HTTP {
 		if ( isset( $scrubbed ) ) {
 			$build_query = static function ( $query ) use ( $query_vars ) {
 				$pattern = '/^(' . implode( '|', $query_vars ) . ')(?==|$)/';
-				$pairs   = array();
+				$pairs   = [];
 				foreach ( explode( '&', $query ) as $pair ) {
 					if ( ! preg_match( $pattern, $pair ) ) {
 						$pairs[] = $pair;
@@ -207,17 +207,17 @@ class AMP_HTTP {
 	 * @return array AMP cache hosts.
 	 */
 	public static function get_amp_cache_hosts() {
-		$hosts = array();
+		$hosts = [];
 
 		// Google AMP Cache (legacy).
 		$hosts[] = 'cdn.ampproject.org';
 
 		// From the publisher’s own origins.
 		$domains = array_unique(
-			array(
+			[
 				wp_parse_url( site_url(), PHP_URL_HOST ),
 				wp_parse_url( home_url(), PHP_URL_HOST ),
-			)
+			]
 		);
 
 		/*
@@ -232,7 +232,7 @@ class AMP_HTTP {
 				// phpcs:ignore PHPCompatibility.Constants.RemovedConstants.intl_idna_variant_2003Deprecated
 				$domain = idn_to_utf8( $domain, IDNA_DEFAULT, defined( 'INTL_IDNA_VARIANT_UTS46' ) ? INTL_IDNA_VARIANT_UTS46 : INTL_IDNA_VARIANT_2003 );
 			}
-			$subdomain = str_replace( array( '-', '.' ), array( '--', '-' ), $domain );
+			$subdomain = str_replace( [ '-', '.' ], [ '--', '-' ], $domain );
 
 			// Google AMP Cache subdomain.
 			$hosts[] = sprintf( '%s.cdn.ampproject.org', $subdomain );
@@ -293,13 +293,13 @@ class AMP_HTTP {
 		}
 
 		if ( $origin ) {
-			self::send_header( 'Access-Control-Allow-Origin', $origin, array( 'replace' => false ) );
+			self::send_header( 'Access-Control-Allow-Origin', $origin, [ 'replace' => false ] );
 			self::send_header( 'Access-Control-Allow-Credentials', 'true' );
-			self::send_header( 'Vary', 'Origin', array( 'replace' => false ) );
+			self::send_header( 'Vary', 'Origin', [ 'replace' => false ] );
 		}
 		if ( $source_origin ) {
 			self::send_header( 'AMP-Access-Control-Allow-Source-Origin', $source_origin );
-			self::send_header( 'Access-Control-Expose-Headers', 'AMP-Access-Control-Allow-Source-Origin', array( 'replace' => false ) );
+			self::send_header( 'Access-Control-Expose-Headers', 'AMP-Access-Control-Allow-Source-Origin', [ 'replace' => false ] );
 		}
 	}
 
@@ -320,14 +320,14 @@ class AMP_HTTP {
 		}
 
 		// Intercept POST requests which redirect.
-		add_filter( 'wp_redirect', array( __CLASS__, 'intercept_post_request_redirect' ), PHP_INT_MAX );
+		add_filter( 'wp_redirect', [ __CLASS__, 'intercept_post_request_redirect' ], PHP_INT_MAX );
 
 		// Add special handling for redirecting after comment submission.
-		add_filter( 'comment_post_redirect', array( __CLASS__, 'filter_comment_post_redirect' ), PHP_INT_MAX, 2 );
+		add_filter( 'comment_post_redirect', [ __CLASS__, 'filter_comment_post_redirect' ], PHP_INT_MAX, 2 );
 
 		// Add die handler for AMP error display, most likely due to problem with comment.
 		$handle_wp_die = static function () {
-			return array( __CLASS__, 'handle_wp_die' );
+			return [ __CLASS__, 'handle_wp_die' ];
 		};
 		add_filter( 'wp_die_json_handler', $handle_wp_die );
 		add_filter( 'wp_die_handler', $handle_wp_die ); // Needed for WP<5.1.
@@ -346,11 +346,11 @@ class AMP_HTTP {
 
 		// Make sure relative redirects get made absolute.
 		$parsed_location = array_merge(
-			array(
+			[
 				'scheme' => 'https',
 				'host'   => wp_parse_url( home_url(), PHP_URL_HOST ),
 				'path'   => isset( $_SERVER['REQUEST_URI'] ) ? strtok( wp_unslash( $_SERVER['REQUEST_URI'] ), '?' ) : '/',
-			),
+			],
 			wp_parse_url( $location )
 		);
 
@@ -371,13 +371,13 @@ class AMP_HTTP {
 		}
 
 		self::send_header( 'AMP-Redirect-To', $absolute_location );
-		self::send_header( 'Access-Control-Expose-Headers', 'AMP-Redirect-To', array( 'replace' => false ) );
+		self::send_header( 'Access-Control-Expose-Headers', 'AMP-Redirect-To', [ 'replace' => false ] );
 
 		wp_send_json(
-			array(
+			[
 				'message'     => __( 'Redirecting…', 'amp' ),
 				'redirecting' => true, // Make sure that the submit-success doesn't get styled as success since redirection _could_ be to error page.
-			),
+			],
 			200
 		);
 	}
@@ -402,7 +402,7 @@ class AMP_HTTP {
 	 * }
 	 * @global string $pagenow
 	 */
-	public static function handle_wp_die( $error, $title = '', $args = array() ) {
+	public static function handle_wp_die( $error, $title = '', $args = [] ) {
 		global $pagenow;
 		if ( is_int( $title ) ) {
 			$status_code = $title;
@@ -434,9 +434,9 @@ class AMP_HTTP {
 
 		// Message will be shown in template defined by AMP_Theme_Support::amend_comment_form().
 		wp_send_json(
-			array(
+			[
 				'message' => amp_wp_kses_mustache( $error ),
-			),
+			],
 			$status_code
 		);
 	}
@@ -483,9 +483,9 @@ class AMP_HTTP {
 
 		// Message will be shown in template defined by AMP_Theme_Support::amend_comment_form().
 		wp_send_json(
-			array(
+			[
 				'message' => amp_wp_kses_mustache( $message ),
-			),
+			],
 			200
 		);
 

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -26,7 +26,7 @@ class AMP_Post_Type_Support {
 	 */
 	public static function get_builtin_supported_post_types() {
 		_deprecated_function( __METHOD__, '1.0' );
-		return array_filter( array( 'post' ), 'post_type_exists' );
+		return array_filter( [ 'post' ], 'post_type_exists' );
 	}
 
 	/**
@@ -39,15 +39,15 @@ class AMP_Post_Type_Support {
 		return array_diff(
 			array_values(
 				get_post_types(
-					array(
+					[
 						'public' => true,
-					),
+					],
 					'names'
 				)
 			),
-			array(
+			[
 				AMP_Story_Post_Type::POST_TYPE_SLUG,
-			)
+			]
 		);
 	}
 
@@ -63,7 +63,7 @@ class AMP_Post_Type_Support {
 		if ( current_theme_supports( AMP_Theme_Support::SLUG ) && AMP_Options_Manager::get_option( 'all_templates_supported' ) ) {
 			$post_types = self::get_eligible_post_types();
 		} else {
-			$post_types = AMP_Options_Manager::get_option( 'supported_post_types', array() );
+			$post_types = AMP_Options_Manager::get_option( 'supported_post_types', [] );
 		}
 		foreach ( $post_types as $post_type ) {
 			add_post_type_support( $post_type, self::SLUG );
@@ -82,7 +82,7 @@ class AMP_Post_Type_Support {
 		if ( ! ( $post instanceof WP_Post ) ) {
 			$post = get_post( $post );
 		}
-		$errors = array();
+		$errors = [];
 
 		if ( ! post_type_supports( $post->post_type, self::SLUG ) ) {
 			$errors[] = 'post-type-support';
@@ -128,10 +128,10 @@ class AMP_Post_Type_Support {
 						&&
 						in_array(
 							(int) $post->ID,
-							array(
+							[
 								(int) get_option( 'page_on_front' ),
 								(int) get_option( 'page_for_posts' ),
-							),
+							],
 							true
 						)
 					)

--- a/includes/class-amp-service-worker.php
+++ b/includes/class-amp-service-worker.php
@@ -27,9 +27,9 @@ class AMP_Service_Worker {
 		}
 
 		// Shim support for service worker installation from PWA feature plugin.
-		add_filter( 'query_vars', array( __CLASS__, 'add_query_var' ) );
-		add_action( 'parse_request', array( __CLASS__, 'handle_service_worker_iframe_install' ) );
-		add_action( 'wp', array( __CLASS__, 'add_install_hooks' ) );
+		add_filter( 'query_vars', [ __CLASS__, 'add_query_var' ] );
+		add_action( 'parse_request', [ __CLASS__, 'handle_service_worker_iframe_install' ] );
+		add_action( 'wp', [ __CLASS__, 'add_install_hooks' ] );
 
 		$theme_support = AMP_Theme_Support::get_theme_support_args();
 		if ( isset( $theme_support['service_worker'] ) && false === $theme_support['service_worker'] ) {
@@ -40,11 +40,11 @@ class AMP_Service_Worker {
 		 * The default-enabled options reflect which features are not commented-out in the AMP-by-Example service worker.
 		 * See <https://github.com/ampproject/amp-by-example/blob/e093edb401b1617859b5365e80b639d81b06f058/boilerplate-generator/templates/files/serviceworkerJs.js>.
 		 */
-		$enabled_options = array(
+		$enabled_options = [
 			'cdn_script_caching'   => true,
 			'image_caching'        => false,
 			'google_fonts_caching' => false,
-		);
+		];
 		if ( isset( $theme_support['service_worker'] ) && is_array( $theme_support['service_worker'] ) ) {
 			$enabled_options = array_merge(
 				$enabled_options,
@@ -53,13 +53,13 @@ class AMP_Service_Worker {
 		}
 
 		if ( $enabled_options['cdn_script_caching'] ) {
-			add_action( 'wp_front_service_worker', array( __CLASS__, 'add_cdn_script_caching' ) );
+			add_action( 'wp_front_service_worker', [ __CLASS__, 'add_cdn_script_caching' ] );
 		}
 		if ( $enabled_options['image_caching'] ) {
-			add_action( 'wp_front_service_worker', array( __CLASS__, 'add_image_caching' ) );
+			add_action( 'wp_front_service_worker', [ __CLASS__, 'add_image_caching' ] );
 		}
 		if ( $enabled_options['google_fonts_caching'] ) {
-			add_action( 'wp_front_service_worker', array( __CLASS__, 'add_google_fonts_caching' ) );
+			add_action( 'wp_front_service_worker', [ __CLASS__, 'add_google_fonts_caching' ] );
 		}
 	}
 
@@ -111,9 +111,9 @@ class AMP_Service_Worker {
 		// Serve the AMP Runtime from cache and check for an updated version in the background. See <https://github.com/ampproject/amp-by-example/blob/4593af61609898043302a101826ddafe7206bfd9/boilerplate-generator/templates/files/serviceworkerJs.js#L54-L58>.
 		$service_workers->caching_routes()->register(
 			'^https:\/\/cdn\.ampproject\.org\/.*',
-			array(
+			[
 				'strategy' => WP_Service_Worker_Caching_Routes::STRATEGY_STALE_WHILE_REVALIDATE,
-			)
+			]
 		);
 	}
 
@@ -132,19 +132,19 @@ class AMP_Service_Worker {
 
 		$service_workers->caching_routes()->register(
 			'^' . preg_quote( set_url_scheme( content_url( '/' ), 'https' ), '/' ) . '[^\?]+?\.(?:png|gif|jpg|jpeg|svg|webp)(\?.*)?$',
-			array(
+			[
 				'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_FIRST,
 				'cacheName' => 'images',
-				'plugins'   => array(
-					'cacheableResponse' => array(
-						'statuses' => array( 0, 200 ),
-					),
-					'expiration'        => array(
+				'plugins'   => [
+					'cacheableResponse' => [
+						'statuses' => [ 0, 200 ],
+					],
+					'expiration'        => [
 						'maxEntries'    => 60,
 						'maxAgeSeconds' => MONTH_IN_SECONDS,
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 
@@ -171,28 +171,28 @@ class AMP_Service_Worker {
 		// Cache the Google Fonts stylesheets with a stale while revalidate strategy.
 		$service_workers->caching_routes()->register(
 			'^https:\/\/fonts\.googleapis\.com',
-			array(
+			[
 				'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_STALE_WHILE_REVALIDATE,
 				'cacheName' => 'google-fonts-stylesheets',
-			)
+			]
 		);
 
 		// Cache the Google Fonts webfont files with a cache first strategy for 1 year.
 		$service_workers->caching_routes()->register(
 			'^https:\/\/fonts\.gstatic\.com',
-			array(
+			[
 				'strategy'  => WP_Service_Worker_Caching_Routes::STRATEGY_CACHE_FIRST,
 				'cacheName' => 'google-fonts-webfonts',
-				'plugins'   => array(
-					'cacheableResponse' => array(
-						'statuses' => array( 0, 200 ),
-					),
-					'expiration'        => array(
+				'plugins'   => [
+					'cacheableResponse' => [
+						'statuses' => [ 0, 200 ],
+					],
+					'expiration'        => [
 						'maxAgeSeconds' => YEAR_IN_SECONDS,
 						'maxEntries'    => 30,
-					),
-				),
-			)
+					],
+				],
+			]
 		);
 	}
 
@@ -211,12 +211,12 @@ class AMP_Service_Worker {
 	public static function get_precached_script_cdn_urls() {
 
 		// List of AMP scripts that we know will be used in WordPress always.
-		$precached_handles = array(
+		$precached_handles = [
 			'amp-runtime',
 			'amp-bind', // Used by comments.
 			'amp-form', // Used by comments.
 			'amp-install-serviceworker',
-		);
+		];
 
 		$theme_support = AMP_Theme_Support::get_theme_support_args();
 		if ( ! empty( $theme_support['comments_live_list'] ) ) {
@@ -227,7 +227,7 @@ class AMP_Service_Worker {
 			$precached_handles[] = 'amp-analytics';
 		}
 
-		$urls = array();
+		$urls = [];
 		foreach ( $precached_handles as $handle ) {
 			if ( wp_script_is( $handle, 'registered' ) ) {
 				$urls[] = wp_scripts()->registered[ $handle ]->src;
@@ -242,10 +242,10 @@ class AMP_Service_Worker {
 	 */
 	public static function add_install_hooks() {
 		if ( current_theme_supports( 'amp' ) && is_amp_endpoint() ) {
-			add_action( 'wp_footer', array( __CLASS__, 'install_service_worker' ) );
+			add_action( 'wp_footer', [ __CLASS__, 'install_service_worker' ] );
 
 			// Prevent validation error due to the script that installs the service worker on non-AMP pages.
-			foreach ( array( 'wp_print_scripts', 'wp_print_footer_scripts' ) as $action ) {
+			foreach ( [ 'wp_print_scripts', 'wp_print_footer_scripts' ] as $action ) {
 				$priority = has_action( $action, 'wp_print_service_workers' );
 				if ( false !== $priority ) {
 					remove_action( $action, 'wp_print_service_workers', $priority );
@@ -254,7 +254,7 @@ class AMP_Service_Worker {
 		}
 
 		// Reader mode integration.
-		add_action( 'amp_post_template_footer', array( __CLASS__, 'install_service_worker' ) );
+		add_action( 'amp_post_template_footer', [ __CLASS__, 'install_service_worker' ] );
 		add_filter(
 			'amp_post_template_data',
 			static function ( $data ) {
@@ -308,7 +308,7 @@ class AMP_Service_Worker {
 			wp_die(
 				esc_html__( 'No service workers registered for the requested scope.', 'amp' ),
 				esc_html__( 'Service Worker Installation', 'amp' ),
-				array( 'response' => 404 )
+				[ 'response' => 404 ]
 			);
 		}
 
@@ -327,7 +327,7 @@ class AMP_Service_Worker {
 				printf(
 					'<script>navigator.serviceWorker.register( %s, %s );</script>',
 					wp_json_encode( wp_get_service_worker_url( $scope ) ),
-					wp_json_encode( array( 'scope' => $front_scope ) )
+					wp_json_encode( [ 'scope' => $front_scope ] )
 				);
 				?>
 			</body>

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -133,8 +133,8 @@ class AMP_Story_Post_Type {
 
 		register_post_type(
 			self::POST_TYPE_SLUG,
-			array(
-				'labels'       => array(
+			[
+				'labels'       => [
 					'name'                     => _x( 'Stories', 'post type general name', 'amp' ),
 					'singular_name'            => _x( 'Story', 'post type singular name', 'amp' ),
 					'add_new'                  => _x( 'New', 'story', 'amp' ),
@@ -165,59 +165,59 @@ class AMP_Story_Post_Type {
 					'item_updated'             => __( 'Story updated.', 'amp' ),
 					'menu_name'                => _x( 'Stories', 'admin menu', 'amp' ),
 					'name_admin_bar'           => _x( 'Story', 'add new on admin bar', 'amp' ),
-				),
+				],
 				'menu_icon'    => 'dashicons-book',
-				'taxonomies'   => array(
+				'taxonomies'   => [
 					'post_tag',
 					'category',
-				),
-				'supports'     => array(
+				],
+				'supports'     => [
 					'title', // Used for amp-story[title].
 					'author', // Used for the amp/amp-story-post-author block.
 					'editor',
 					'thumbnail', // Used for poster images.
 					'amp',
 					'revisions', // Without this, the REST API will return 404 for an autosave request.
-				),
-				'rewrite'      => array(
+				],
+				'rewrite'      => [
 					'slug' => self::REWRITE_SLUG,
-				),
+				],
 				'public'       => true,
 				'show_ui'      => true,
 				'show_in_rest' => true,
-				'template'     => array(
-					array(
+				'template'     => [
+					[
 						'amp/amp-story-page',
-						array(),
-						array(
-							array(
+						[],
+						[
+							[
 								'amp/amp-story-text',
-								array(
+								[
 									'placeholder' => __( 'Write text…', 'amp' ),
-								),
-							),
-						),
-					),
-				),
-			)
+								],
+							],
+						],
+					],
+				],
+			]
 		);
 
-		add_filter( 'post_row_actions', array( __CLASS__, 'remove_classic_editor_link' ), 11, 2 );
+		add_filter( 'post_row_actions', [ __CLASS__, 'remove_classic_editor_link' ], 11, 2 );
 
-		add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'filter_kses_allowed_html' ), 10, 2 );
+		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'filter_kses_allowed_html' ], 10, 2 );
 
-		add_action( 'wp_default_styles', array( __CLASS__, 'register_story_card_styling' ) );
+		add_action( 'wp_default_styles', [ __CLASS__, 'register_story_card_styling' ] );
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_styles' ) );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_styles' ] );
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_editor_scripts' ) );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_scripts' ] );
 
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'export_latest_stories_block_editor_data' ), 100 );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'export_latest_stories_block_editor_data' ], 100 );
 
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_custom_stories_styles' ) );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'add_custom_stories_styles' ] );
 
 		// Remove unnecessary settings.
-		add_filter( 'block_editor_settings', array( __CLASS__, 'filter_block_editor_settings' ), 10, 2 );
+		add_filter( 'block_editor_settings', [ __CLASS__, 'filter_block_editor_settings' ], 10, 2 );
 
 		// Used for amp-story[publisher-logo-src]: The publisher's logo in square format (1x1 aspect ratio). This will be supplied by the custom logo or else site icon.
 		add_image_size( 'amp-publisher-logo', 100, 100, true );
@@ -235,72 +235,72 @@ class AMP_Story_Post_Type {
 		add_image_size( self::MAX_IMAGE_SIZE_SLUG, 99999, 1440 );
 
 		// In case there is no featured image for the poster-portrait-src, add a fallback image.
-		add_filter( 'wp_get_attachment_image_src', array( __CLASS__, 'poster_portrait_fallback' ), 10, 3 );
+		add_filter( 'wp_get_attachment_image_src', [ __CLASS__, 'poster_portrait_fallback' ], 10, 3 );
 
 		// If the image is for a poster-square-src or poster-landscape-src, this ensures that it's not too small.
-		add_filter( 'wp_get_attachment_image_src', array( __CLASS__, 'ensure_correct_poster_size' ), 10, 3 );
+		add_filter( 'wp_get_attachment_image_src', [ __CLASS__, 'ensure_correct_poster_size' ], 10, 3 );
 
 		// Limit the styles that are printed in a story.
-		add_filter( 'print_styles_array', array( __CLASS__, 'filter_frontend_print_styles_array' ) );
-		add_filter( 'print_styles_array', array( __CLASS__, 'filter_editor_print_styles_array' ) );
+		add_filter( 'print_styles_array', [ __CLASS__, 'filter_frontend_print_styles_array' ] );
+		add_filter( 'print_styles_array', [ __CLASS__, 'filter_editor_print_styles_array' ] );
 
 		// Select the single-amp_story.php template for AMP Stories.
-		add_filter( 'template_include', array( __CLASS__, 'filter_template_include' ) );
+		add_filter( 'template_include', [ __CLASS__, 'filter_template_include' ] );
 
 		// Get an embed template for this post type.
-		add_filter( 'embed_template', array( __CLASS__, 'get_embed_template' ), 10, 3 );
+		add_filter( 'embed_template', [ __CLASS__, 'get_embed_template' ], 10, 3 );
 
 		// Enqueue the styling for the /embed endpoint.
-		add_action( 'embed_footer', array( __CLASS__, 'enqueue_embed_styling' ) );
+		add_action( 'embed_footer', [ __CLASS__, 'enqueue_embed_styling' ] );
 
 		// In the block editor, remove the title from above the AMP Stories embed.
-		add_filter( 'embed_html', array( __CLASS__, 'remove_title_from_embed' ), 10, 2 );
+		add_filter( 'embed_html', [ __CLASS__, 'remove_title_from_embed' ], 10, 2 );
 
 		// Change some attributes for the AMP story embed.
-		add_filter( 'embed_html', array( __CLASS__, 'change_embed_iframe_attributes' ), 10, 2 );
+		add_filter( 'embed_html', [ __CLASS__, 'change_embed_iframe_attributes' ], 10, 2 );
 
 		// Override the render_callback for AMP story embeds.
-		add_filter( 'pre_render_block', array( __CLASS__, 'override_story_embed_callback' ), 10, 2 );
+		add_filter( 'pre_render_block', [ __CLASS__, 'override_story_embed_callback' ], 10, 2 );
 
 		// The AJAX handler for when an image is cropped and sent via POST.
-		add_action( 'wp_ajax_custom-header-crop', array( __CLASS__, 'crop_featured_image' ) );
+		add_action( 'wp_ajax_custom-header-crop', [ __CLASS__, 'crop_featured_image' ] );
 
 		// Register render callback for just-in-time inclusion of dependent Google Font styles.
-		add_filter( 'render_block', array( __CLASS__, 'render_block_with_google_fonts' ), 10, 2 );
+		add_filter( 'render_block', [ __CLASS__, 'render_block_with_google_fonts' ], 10, 2 );
 
-		add_filter( 'use_block_editor_for_post_type', array( __CLASS__, 'use_block_editor_for_story_post_type' ), PHP_INT_MAX, 2 );
-		add_filter( 'classic_editor_enabled_editors_for_post_type', array( __CLASS__, 'filter_enabled_editors_for_story_post_type' ), PHP_INT_MAX, 2 );
+		add_filter( 'use_block_editor_for_post_type', [ __CLASS__, 'use_block_editor_for_story_post_type' ], PHP_INT_MAX, 2 );
+		add_filter( 'classic_editor_enabled_editors_for_post_type', [ __CLASS__, 'filter_enabled_editors_for_story_post_type' ], PHP_INT_MAX, 2 );
 
-		add_filter( 'image_size_names_choose', array( __CLASS__, 'add_new_max_image_size' ) );
+		add_filter( 'image_size_names_choose', [ __CLASS__, 'add_new_max_image_size' ] );
 
 		self::register_block_latest_stories();
 
 		register_block_type(
 			'amp/amp-story-post-author',
-			array(
-				'render_callback' => array( __CLASS__, 'render_post_author_block' ),
-			)
+			[
+				'render_callback' => [ __CLASS__, 'render_post_author_block' ],
+			]
 		);
 
 		register_block_type(
 			'amp/amp-story-post-date',
-			array(
-				'render_callback' => array( __CLASS__, 'render_post_date_block' ),
-			)
+			[
+				'render_callback' => [ __CLASS__, 'render_post_date_block' ],
+			]
 		);
 
 		register_block_type(
 			'amp/amp-story-post-title',
-			array(
-				'render_callback' => array( __CLASS__, 'render_post_title_block' ),
-			)
+			[
+				'render_callback' => [ __CLASS__, 'render_post_title_block' ],
+			]
 		);
 
 		add_filter(
 			'amp_content_sanitizers',
 			static function( $sanitizers ) {
 				if ( is_singular( self::POST_TYPE_SLUG ) ) {
-					$sanitizers['AMP_Story_Sanitizer'] = array();
+					$sanitizers['AMP_Story_Sanitizer'] = [];
 
 					// Disable noscript fallbacks since not allowed in AMP Stories.
 					$sanitizers['AMP_Img_Sanitizer']['add_noscript_fallback']    = false;
@@ -323,7 +323,7 @@ class AMP_Story_Post_Type {
 			}
 		);
 
-		add_action( 'wp_head', array( __CLASS__, 'print_feed_link' ) );
+		add_action( 'wp_head', [ __CLASS__, 'print_feed_link' ] );
 	}
 
 	/**
@@ -347,11 +347,11 @@ class AMP_Story_Post_Type {
 	 * @return array Allowed tags.
 	 */
 	public static function filter_kses_allowed_html( $allowed_tags ) {
-		$story_components = array(
+		$story_components = [
 			'amp-story-page',
 			'amp-story-grid-layer',
 			'amp-story-cta-layer',
-		);
+		];
 		foreach ( $story_components as $story_component ) {
 			$attributes = array_fill_keys( array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() ), true );
 			$rule_specs = AMP_Allowed_Tags_Generated::get_allowed_tag( $story_component );
@@ -458,14 +458,14 @@ class AMP_Story_Post_Type {
 		wp_enqueue_style(
 			self::AMP_STORIES_EDITOR_STYLE_HANDLE,
 			amp_get_asset_url( 'css/amp-stories-editor.css' ),
-			array( 'wp-edit-blocks' ),
+			[ 'wp-edit-blocks' ],
 			AMP__VERSION
 		);
 
 		wp_enqueue_style(
 			self::AMP_STORIES_EDITOR_STYLE_HANDLE . '-compiled',
 			amp_get_asset_url( 'css/amp-stories-editor-compiled.css' ),
-			array( 'wp-edit-blocks', 'amp-stories' ),
+			[ 'wp-edit-blocks', 'amp-stories' ],
 			AMP__VERSION
 		);
 
@@ -482,7 +482,7 @@ class AMP_Story_Post_Type {
 		wp_enqueue_style(
 			self::AMP_STORIES_STYLE_HANDLE,
 			amp_get_asset_url( 'css/amp-stories.css' ),
-			array(),
+			[],
 			AMP__VERSION
 		);
 
@@ -560,11 +560,11 @@ class AMP_Story_Post_Type {
 	 */
 	public static function poster_portrait_fallback( $image, $attachment_id, $size ) {
 		if ( ! $image && self::STORY_CARD_IMAGE_SIZE === $size ) {
-			return array(
+			return [
 				amp_get_asset_url( 'images/story-fallback-poster.jpg' ),
 				self::STORY_LARGE_IMAGE_DIMENSION,
 				self::STORY_SMALL_IMAGE_DIMENSION,
-			);
+			];
 		}
 
 		return $image;
@@ -607,7 +607,7 @@ class AMP_Story_Post_Type {
 		$wp_styles->add(
 			self::STORY_CARD_CSS_SLUG,
 			amp_get_asset_url( '/css/' . self::STORY_CARD_CSS_SLUG . '.css' ),
-			array(),
+			[],
 			AMP__VERSION
 		);
 	}
@@ -634,9 +634,9 @@ class AMP_Story_Post_Type {
 			sprintf(
 				'var ampLatestStoriesBlockData = %s;',
 				wp_json_encode(
-					array(
+					[
 						'storyCardStyleURL' => $url,
-					)
+					]
 				)
 			),
 			'before'
@@ -654,7 +654,7 @@ class AMP_Story_Post_Type {
 		$script_deps_path    = AMP__DIR__ . '/assets/js/' . self::AMP_STORIES_SCRIPT_HANDLE . '.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			: array();
+			: [];
 
 		wp_enqueue_script(
 			self::AMP_STORIES_SCRIPT_HANDLE,
@@ -729,7 +729,7 @@ class AMP_Story_Post_Type {
 		wp_enqueue_style(
 			'amp-stories-frontend',
 			amp_get_asset_url( 'css/amp-stories-frontend.css' ),
-			array( self::AMP_STORIES_STYLE_HANDLE ),
+			[ self::AMP_STORIES_STYLE_HANDLE ],
 			AMP__VERSION,
 			false
 		);
@@ -751,187 +751,187 @@ class AMP_Story_Post_Type {
 			return $fonts;
 		}
 
-		$fonts = array(
-			array(
+		$fonts = [
+			[
 				'name'      => 'Arial',
-				'fallbacks' => array( 'Helvetica Neue', 'Helvetica', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Helvetica Neue', 'Helvetica', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Arial Black',
-				'fallbacks' => array( 'Arial Black', 'Arial Bold', 'Gadget', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Arial Black', 'Arial Bold', 'Gadget', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Arial Narrow',
-				'fallbacks' => array( 'Arial', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Arial', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Arimo',
 				'gfont'     => 'Arimo:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Baskerville',
-				'fallbacks' => array( 'Baskerville Old Face', 'Hoefler Text', 'Garamond', 'Times New Roman', 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Baskerville Old Face', 'Hoefler Text', 'Garamond', 'Times New Roman', 'serif' ],
+			],
+			[
 				'name'      => 'Brush Script MT',
-				'fallbacks' => array( 'cursive' ),
-			),
-			array(
+				'fallbacks' => [ 'cursive' ],
+			],
+			[
 				'name'      => 'Copperplate',
-				'fallbacks' => array( 'Copperplate Gothic Light', 'fantasy' ),
-			),
-			array(
+				'fallbacks' => [ 'Copperplate Gothic Light', 'fantasy' ],
+			],
+			[
 				'name'      => 'Courier New',
-				'fallbacks' => array( 'Courier', 'Lucida Sans Typewriter', 'Lucida Typewriter', 'monospace' ),
-			),
-			array(
+				'fallbacks' => [ 'Courier', 'Lucida Sans Typewriter', 'Lucida Typewriter', 'monospace' ],
+			],
+			[
 				'name'      => 'Century Gothic',
-				'fallbacks' => array( 'CenturyGothic', 'AppleGothic', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'CenturyGothic', 'AppleGothic', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Garamond',
-				'fallbacks' => array( 'Baskerville', 'Baskerville Old Face', 'Hoefler Text', 'Times New Roman', 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Baskerville', 'Baskerville Old Face', 'Hoefler Text', 'Times New Roman', 'serif' ],
+			],
+			[
 				'name'      => 'Georgia',
-				'fallbacks' => array( 'Times', 'Times New Roman', 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Times', 'Times New Roman', 'serif' ],
+			],
+			[
 				'name'      => 'Gill Sans',
-				'fallbacks' => array( 'Gill Sans MT', 'Calibri', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Gill Sans MT', 'Calibri', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Lato',
 				'gfont'     => 'Lato:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Lora',
 				'gfont'     => 'Lora:400,700',
-				'fallbacks' => array( 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'serif' ],
+			],
+			[
 				'name'      => 'Lucida Bright',
-				'fallbacks' => array( 'Georgia', 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Georgia', 'serif' ],
+			],
+			[
 				'name'      => 'Lucida Sans Typewriter',
-				'fallbacks' => array( 'Lucida Console', 'monaco', 'Bitstream Vera Sans Mono', 'monospace' ),
-			),
-			array(
+				'fallbacks' => [ 'Lucida Console', 'monaco', 'Bitstream Vera Sans Mono', 'monospace' ],
+			],
+			[
 				'name'      => 'Merriweather',
 				'gfont'     => 'Merriweather:400,700',
-				'fallbacks' => array( 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'serif' ],
+			],
+			[
 				'name'      => 'Montserrat',
 				'gfont'     => 'Montserrat:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Noto Sans',
 				'gfont'     => 'Noto Sans:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Open Sans',
 				'gfont'     => 'Open Sans:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Open Sans Condensed',
 				'gfont'     => 'Open Sans Condensed:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Oswald',
 				'gfont'     => 'Oswald:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Palatino',
-				'fallbacks' => array( 'Palatino Linotype', 'Palatino LT STD', 'Book Antiqua', 'Georgia', 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Palatino Linotype', 'Palatino LT STD', 'Book Antiqua', 'Georgia', 'serif' ],
+			],
+			[
 				'name'      => 'Papyrus',
-				'fallbacks' => array( 'fantasy' ),
-			),
-			array(
+				'fallbacks' => [ 'fantasy' ],
+			],
+			[
 				'name'      => 'Playfair Display',
 				'gfont'     => 'Playfair Display:400,700',
-				'fallbacks' => array( 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'serif' ],
+			],
+			[
 				'name'      => 'PT Sans',
 				'gfont'     => 'PT Sans:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'PT Sans Narrow',
 				'gfont'     => 'PT Sans Narrow:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'PT Serif',
 				'gfont'     => 'PT Serif:400,700',
-				'fallbacks' => array( 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'serif' ],
+			],
+			[
 				'name'      => 'Raleway',
 				'gfont'     => 'Raleway:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Roboto',
 				'gfont'     => 'Roboto:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Roboto Condensed',
 				'gfont'     => 'Roboto Condensed:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Roboto Slab',
 				'gfont'     => 'Roboto Slab:400,700',
-				'fallbacks' => array( 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'serif' ],
+			],
+			[
 				'name'      => 'Slabo 27px',
 				'gfont'     => 'Slabo 27px:400,700',
-				'fallbacks' => array( 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'serif' ],
+			],
+			[
 				'name'      => 'Source Sans Pro',
 				'gfont'     => 'Source Sans Pro:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Tahoma',
-				'fallbacks' => array( 'Verdana', 'Segoe', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Verdana', 'Segoe', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Times New Roman',
-				'fallbacks' => array( 'Times New Roman', 'Times', 'Baskerville', 'Georgia', 'serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Times New Roman', 'Times', 'Baskerville', 'Georgia', 'serif' ],
+			],
+			[
 				'name'      => 'Trebuchet MS',
-				'fallbacks' => array( 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', 'Tahoma', 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'Lucida Grande', 'Lucida Sans Unicode', 'Lucida Sans', 'Tahoma', 'sans-serif' ],
+			],
+			[
 				'name'      => 'Ubuntu',
 				'gfont'     => 'Ubuntu:400,700',
-				'fallbacks' => array( 'sans-serif' ),
-			),
-			array(
+				'fallbacks' => [ 'sans-serif' ],
+			],
+			[
 				'name'      => 'Verdana',
-				'fallbacks' => array( 'Geneva', 'sans-serif' ),
-			),
-		);
+				'fallbacks' => [ 'Geneva', 'sans-serif' ],
+			],
+		];
 
 		$fonts_url = 'https://fonts.googleapis.com/css';
-		$subsets   = array( 'latin', 'latin-ext' );
+		$subsets   = [ 'latin', 'latin-ext' ];
 
 		/*
 		 * Translators: To add an additional character subset specific to your language,
@@ -958,10 +958,10 @@ class AMP_Story_Post_Type {
 				if ( isset( $font['gfont'] ) ) {
 					$font['handle'] = sprintf( '%s-font', $font['slug'] );
 					$font['src']    = add_query_arg(
-						array(
+						[
 							'family' => rawurlencode( $font['gfont'] ),
 							'subset' => rawurlencode( implode( ',', $subsets ) ),
-						),
+						],
 						$fonts_url
 					);
 				}
@@ -1047,7 +1047,7 @@ class AMP_Story_Post_Type {
 		}
 
 		if ( ! wp_style_is( $font['handle'], 'registered' ) ) {
-			wp_register_style( $font['handle'], $font['src'], array(), null, 'all' ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			wp_register_style( $font['handle'], $font['src'], [], null, 'all' ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		}
 
 		wp_enqueue_style( $font['handle'] );
@@ -1132,11 +1132,11 @@ class AMP_Story_Post_Type {
 	public static function the_single_story_card( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'post'         => null,
 				'size'         => 'full',
 				'disable_link' => false,
-			)
+			]
 		);
 
 		$post = get_post( $args['post'] );
@@ -1157,9 +1157,9 @@ class AMP_Story_Post_Type {
 			24,
 			'',
 			'',
-			array(
+			[
 				'class' => 'latest-stories__avatar',
-			)
+			]
 		);
 		if ( ! $args['disable_link'] ) {
 			$href = sprintf(
@@ -1219,7 +1219,7 @@ class AMP_Story_Post_Type {
 	 * @return string|null $rendered_markup The rendered markup, or null to not override the existing render_callback.
 	 */
 	public static function override_story_embed_callback( $pre_render, $block ) {
-		if ( ! isset( $block['attrs']['url'], $block['blockName'] ) || ! in_array( $block['blockName'], array( 'core-embed/wordpress', 'core/embed' ), true ) ) {
+		if ( ! isset( $block['attrs']['url'], $block['blockName'] ) || ! in_array( $block['blockName'], [ 'core-embed/wordpress', 'core/embed' ], true ) ) {
 			return $pre_render;
 		}
 
@@ -1251,10 +1251,10 @@ class AMP_Story_Post_Type {
 		<div class="amp-story-embed">
 			<?php
 			self::the_single_story_card(
-				array(
+				[
 					'post' => $post,
 					'size' => self::STORY_CARD_IMAGE_SIZE,
-				)
+				]
 			);
 			?>
 		</div>
@@ -1271,30 +1271,30 @@ class AMP_Story_Post_Type {
 	public static function register_block_latest_stories() {
 		register_block_type(
 			'amp/amp-latest-stories',
-			array(
-				'attributes'      => array(
-					'className'     => array(
+			[
+				'attributes'      => [
+					'className'     => [
 						'type' => 'string',
-					),
-					'storiesToShow' => array(
+					],
+					'storiesToShow' => [
 						'type'    => 'number',
 						'default' => 5,
-					),
-					'order'         => array(
+					],
+					'order'         => [
 						'type'    => 'string',
 						'default' => 'desc',
-					),
-					'orderBy'       => array(
+					],
+					'orderBy'       => [
 						'type'    => 'string',
 						'default' => 'date',
-					),
-					'useCarousel'   => array(
+					],
+					'useCarousel'   => [
 						'type'    => 'boolean',
 						'default' => ! is_admin(),
-					),
-				),
-				'render_callback' => array( __CLASS__, 'render_block_latest_stories' ),
-			)
+					],
+				],
+				'render_callback' => [ __CLASS__, 'render_block_latest_stories' ],
+			]
 		);
 	}
 
@@ -1308,7 +1308,7 @@ class AMP_Story_Post_Type {
 	 */
 	public static function render_block_latest_stories( $attributes ) {
 		$is_amp_carousel = ! empty( $attributes['useCarousel'] );
-		$args            = array(
+		$args            = [
 			'post_type'        => self::POST_TYPE_SLUG,
 			'posts_per_page'   => $attributes['storiesToShow'],
 			'post_status'      => 'publish',
@@ -1316,7 +1316,7 @@ class AMP_Story_Post_Type {
 			'orderby'          => $attributes['orderBy'],
 			'suppress_filters' => false,
 			'meta_key'         => '_thumbnail_id',
-		);
+		];
 		$story_query     = new WP_Query( $args );
 		$class           = 'amp-block-latest-stories';
 		if ( isset( $attributes['className'] ) ) {
@@ -1338,11 +1338,11 @@ class AMP_Story_Post_Type {
 					<<?php echo $is_amp_carousel ? 'div' : 'li'; ?> class="slide latest-stories__slide">
 						<?php
 						self::the_single_story_card(
-							array(
+							[
 								'post'         => $post,
 								'size'         => $size,
 								'disable_link' => ! $is_amp_carousel,
-							)
+							]
 						);
 						?>
 					</<?php echo $is_amp_carousel ? 'div' : 'li'; ?>>
@@ -1395,10 +1395,10 @@ class AMP_Story_Post_Type {
 
 		$crop_details = $_POST['cropDetails'];
 
-		$dimensions = array(
+		$dimensions = [
 			'dst_width'  => self::STORY_SMALL_IMAGE_DIMENSION,
 			'dst_height' => self::STORY_LARGE_IMAGE_DIMENSION,
-		);
+		];
 
 		$attachment_id = absint( $_POST['id'] );
 
@@ -1413,7 +1413,7 @@ class AMP_Story_Post_Type {
 		);
 
 		if ( ! $cropped || is_wp_error( $cropped ) ) {
-			wp_send_json_error( array( 'message' => __( 'Image could not be processed. Please go back and try again.', 'default' ) ) );
+			wp_send_json_error( [ 'message' => __( 'Image could not be processed. Please go back and try again.', 'default' ) ] );
 		}
 
 		/** This filter is documented in wp-admin/custom-header.php */
@@ -1450,14 +1450,14 @@ class AMP_Story_Post_Type {
 		}
 
 		$image_type = $size ? $size['mime'] : 'image/jpeg';
-		$object     = array(
+		$object     = [
 			'ID'             => $parent_attachment_id,
 			'post_title'     => basename( $cropped ),
 			'post_mime_type' => $image_type,
 			'guid'           => $url,
 			'context'        => 'amp-story-poster',
 			'post_parent'    => $parent_attachment_id,
-		);
+		];
 
 		return $object;
 	}

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -91,21 +91,21 @@ class AMP_Theme_Support {
 	 *
 	 * @var array
 	 */
-	protected static $sanitizer_classes = array();
+	protected static $sanitizer_classes = [];
 
 	/**
 	 * Embed handlers.
 	 *
 	 * @var AMP_Base_Embed_Handler[]
 	 */
-	protected static $embed_handlers = array();
+	protected static $embed_handlers = [];
 
 	/**
 	 * Template types.
 	 *
 	 * @var array
 	 */
-	protected static $template_types = array(
+	protected static $template_types = [
 		'paged', // Deprecated.
 		'index',
 		'404',
@@ -123,7 +123,7 @@ class AMP_Theme_Support {
 		'embed',
 		'singular',
 		'attachment',
-	);
+	];
 
 	/**
 	 * Start time when init was called.
@@ -176,14 +176,14 @@ class AMP_Theme_Support {
 
 			require_once AMP__DIR__ . '/includes/amp-post-template-functions.php';
 
-			add_action( 'widgets_init', array( __CLASS__, 'register_widgets' ) );
+			add_action( 'widgets_init', [ __CLASS__, 'register_widgets' ] );
 
 			/*
 			 * Note that wp action is use instead of template_redirect because some themes/plugins output
 			 * the response at this action and then short-circuit with exit. So this is why the the preceding
 			 * action to template_redirect--the wp action--is used instead.
 			 */
-			add_action( 'wp', array( __CLASS__, 'finish_init' ), PHP_INT_MAX );
+			add_action( 'wp', [ __CLASS__, 'finish_init' ], PHP_INT_MAX );
 		} elseif ( AMP_Options_Manager::is_stories_experience_enabled() ) {
 			add_action(
 				'wp',
@@ -279,7 +279,7 @@ class AMP_Theme_Support {
 			$args = self::get_theme_support_args();
 
 			// Validate theme support usage.
-			$keys = array( 'template_dir', 'comments_live_list', self::PAIRED_FLAG, 'templates_supported', 'available_callback', 'service_worker', 'nav_menu_toggle', 'nav_menu_dropdown' );
+			$keys = [ 'template_dir', 'comments_live_list', self::PAIRED_FLAG, 'templates_supported', 'available_callback', 'service_worker', 'nav_menu_toggle', 'nav_menu_dropdown' ];
 
 			if ( count( array_diff( array_keys( $args ), $keys ) ) !== 0 ) {
 				_doing_it_wrong(
@@ -328,9 +328,9 @@ class AMP_Theme_Support {
 			$is_paired = ( self::TRANSITIONAL_MODE_SLUG === $theme_support_option );
 			add_theme_support(
 				self::SLUG,
-				array(
+				[
 					self::PAIRED_FLAG => $is_paired,
-				)
+				]
 			);
 			self::$support_added_via_option = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
 		} elseif ( AMP_Validation_Manager::is_theme_support_forced() ) {
@@ -354,12 +354,12 @@ class AMP_Theme_Support {
 		}
 		$support = get_theme_support( self::SLUG );
 		if ( true === $support ) {
-			return array(
+			return [
 				self::PAIRED_FLAG => false,
-			);
+			];
 		}
 		if ( ! isset( $support[0] ) || ! is_array( $support[0] ) ) {
-			return array();
+			return [];
 		}
 		return $support[0];
 	}
@@ -400,7 +400,7 @@ class AMP_Theme_Support {
 
 		foreach ( self::$sanitizer_classes as $sanitizer_class => $args ) {
 			if ( method_exists( $sanitizer_class, 'add_buffering_hooks' ) ) {
-				call_user_func( array( $sanitizer_class, 'add_buffering_hooks' ), $args );
+				call_user_func( [ $sanitizer_class, 'add_buffering_hooks' ], $args );
 			}
 		}
 	}
@@ -525,7 +525,7 @@ class AMP_Theme_Support {
 			// See get_query_template().
 			$template_type = preg_replace( '|[^a-z0-9-]+|', '', $template_type );
 
-			add_filter( "{$template_type}_template_hierarchy", array( __CLASS__, 'filter_amp_template_hierarchy' ) );
+			add_filter( "{$template_type}_template_hierarchy", [ __CLASS__, 'filter_amp_template_hierarchy' ] );
 		}
 	}
 
@@ -565,18 +565,18 @@ class AMP_Theme_Support {
 			$query->parse_query_vars();
 		}
 
-		$default_response = array(
-			'errors'    => array(),
+		$default_response = [
+			'errors'    => [],
 			'supported' => false,
 			'immutable' => null,
 			'template'  => null,
-		);
+		];
 
 		if ( ! ( $query instanceof WP_Query ) ) {
 			_doing_it_wrong( __METHOD__, esc_html__( 'No WP_Query available.', 'amp' ), '1.0' );
 			return array_merge(
 				$default_response,
-				array( 'errors' => array( 'no_query_available' ) )
+				[ 'errors' => [ 'no_query_available' ] ]
 			);
 		}
 
@@ -584,7 +584,7 @@ class AMP_Theme_Support {
 		if ( false === $theme_support_args ) {
 			return array_merge(
 				$default_response,
-				array( 'errors' => array( 'no_theme_support' ) )
+				[ 'errors' => [ 'no_theme_support' ] ]
 			);
 		}
 
@@ -599,20 +599,20 @@ class AMP_Theme_Support {
 			if ( ( is_singular() || $query->is_posts_page ) && ! post_supports_amp( $queried_object ) ) {
 				return array_merge(
 					$default_response,
-					array(
-						'errors'    => array( 'no-post-support' ),
+					[
+						'errors'    => [ 'no-post-support' ],
 						'supported' => false,
 						'immutable' => true,
-					)
+					]
 				);
 			}
 
 			$response = array_merge(
 				$default_response,
-				array(
+				[
 					'supported' => call_user_func( $theme_support_args['available_callback'] ),
 					'immutable' => true,
-				)
+				]
 			);
 			if ( ! $response['supported'] ) {
 				$response['errors'][] = 'available_callback';
@@ -632,7 +632,7 @@ class AMP_Theme_Support {
 		$prev_query = $wp_query;
 		$wp_query   = $query; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 
-		$matching_templates    = array();
+		$matching_templates    = [];
 		$supportable_templates = self::get_supportable_templates();
 		foreach ( $supportable_templates as $id => $supportable_template ) {
 			if ( empty( $supportable_template['callback'] ) ) {
@@ -643,7 +643,7 @@ class AMP_Theme_Support {
 
 			// If the callback is a method on the query, then call the method on the query itself.
 			if ( is_string( $callback ) && 'is_' === substr( $callback, 0, 3 ) && method_exists( $query, $callback ) ) {
-				$is_match = call_user_func( array( $query, $callback ) );
+				$is_match = call_user_func( [ $query, $callback ] );
 			} elseif ( is_callable( $callback ) ) {
 				$is_match = $callback( $query );
 			} else {
@@ -653,11 +653,11 @@ class AMP_Theme_Support {
 			}
 
 			if ( $is_match ) {
-				$matching_templates[ $id ] = array(
+				$matching_templates[ $id ] = [
 					'template'  => $id,
 					'supported' => ! empty( $supportable_template['supported'] ),
 					'immutable' => ! empty( $supportable_template['immutable'] ),
-				);
+				];
 			}
 		}
 
@@ -704,7 +704,7 @@ class AMP_Theme_Support {
 		 * See <https://github.com/WordPress/wordpress-develop/blob/5.1.0/src/wp-includes/template-loader.php#L49-L68>.
 		 */
 		if ( count( $matching_templates ) > 1 ) {
-			$template_conditional_priority_order = array(
+			$template_conditional_priority_order = [
 				'is_embed',
 				'is_404',
 				'is_search',
@@ -721,10 +721,10 @@ class AMP_Theme_Support {
 				'is_author',
 				'is_date',
 				'is_archive',
-			);
+			];
 
 			// Obtain the template conditionals for each matching template ID (e.g. 'is_post_type_archive[product]' => 'is_post_type_archive').
-			$template_conditional_id_mapping = array();
+			$template_conditional_id_mapping = [];
 			foreach ( array_keys( $matching_templates ) as $template_id ) {
 				$template_conditional_id_mapping[ strtok( $template_id, '[' ) ] = $template_id;
 			}
@@ -747,9 +747,9 @@ class AMP_Theme_Support {
 				foreach ( $template_conditional_priority_order as $template_conditional ) {
 					if ( isset( $template_conditional_id_mapping[ $template_conditional ] ) ) {
 						$template_id        = $template_conditional_id_mapping[ $template_conditional ];
-						$matching_templates = array(
+						$matching_templates = [
 							$template_id => $matching_templates[ $template_id ],
-						);
+						];
 						break;
 					}
 				}
@@ -781,15 +781,15 @@ class AMP_Theme_Support {
 			if ( $all_templates_supported ) {
 				return array_merge(
 					$default_response,
-					array(
+					[
 						'supported' => true,
-					)
+					]
 				);
 			}
 
 			return array_merge(
 				$default_response,
-				array( 'errors' => array( 'no_matching_template' ) )
+				[ 'errors' => [ 'no_matching_template' ] ]
 			);
 		}
 		$matching_template = array_merge( $default_response, $matching_template );
@@ -825,98 +825,98 @@ class AMP_Theme_Support {
 	 * @return array Supportable templates.
 	 */
 	public static function get_supportable_templates() {
-		$templates = array(
-			'is_singular' => array(
+		$templates = [
+			'is_singular' => [
 				'label'       => __( 'Singular', 'amp' ),
 				'description' => __( 'Required for the above content types.', 'amp' ),
-			),
-		);
+			],
+		];
 		if ( 'page' === get_option( 'show_on_front' ) ) {
-			$templates['is_front_page'] = array(
+			$templates['is_front_page'] = [
 				'label'  => __( 'Homepage', 'amp' ),
 				'parent' => 'is_singular',
-			);
+			];
 			if ( AMP_Post_Meta_Box::DISABLED_STATUS === get_post_meta( get_option( 'page_on_front' ), AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) ) {
 				/* translators: %s: the URL to the edit post screen. */
 				$templates['is_front_page']['description'] = sprintf( __( 'Currently disabled at the <a href="%s">page level</a>.', 'amp' ), esc_url( get_edit_post_link( get_option( 'page_on_front' ) ) ) );
 			}
 
 			// In other words, same as is_posts_page, *but* it not is_singular.
-			$templates['is_home'] = array(
+			$templates['is_home'] = [
 				'label' => __( 'Blog', 'amp' ),
-			);
+			];
 			if ( AMP_Post_Meta_Box::DISABLED_STATUS === get_post_meta( get_option( 'page_for_posts' ), AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) ) {
 				/* translators: %s: the URL to the edit post screen. */
 				$templates['is_home']['description'] = sprintf( __( 'Currently disabled at the <a href="%s">page level</a>.', 'amp' ), esc_url( get_edit_post_link( get_option( 'page_for_posts' ) ) ) );
 			}
 		} else {
-			$templates['is_home'] = array(
+			$templates['is_home'] = [
 				'label' => __( 'Homepage', 'amp' ),
-			);
+			];
 		}
 
 		$templates = array_merge(
 			$templates,
-			array(
-				'is_archive' => array(
+			[
+				'is_archive' => [
 					'label' => __( 'Archives', 'amp' ),
-				),
-				'is_author'  => array(
+				],
+				'is_author'  => [
 					'label'  => __( 'Author', 'amp' ),
 					'parent' => 'is_archive',
-				),
-				'is_date'    => array(
+				],
+				'is_date'    => [
 					'label'  => __( 'Date', 'amp' ),
 					'parent' => 'is_archive',
-				),
-				'is_search'  => array(
+				],
+				'is_search'  => [
 					'label' => __( 'Search', 'amp' ),
-				),
-				'is_404'     => array(
+				],
+				'is_404'     => [
 					'label' => __( 'Not Found (404)', 'amp' ),
-				),
-			)
+				],
+			]
 		);
 
 		if ( taxonomy_exists( 'category' ) ) {
-			$templates['is_category'] = array(
+			$templates['is_category'] = [
 				'label'  => get_taxonomy( 'category' )->labels->name,
 				'parent' => 'is_archive',
-			);
+			];
 		}
 		if ( taxonomy_exists( 'post_tag' ) ) {
-			$templates['is_tag'] = array(
+			$templates['is_tag'] = [
 				'label'  => get_taxonomy( 'post_tag' )->labels->name,
 				'parent' => 'is_archive',
-			);
+			];
 		}
 
-		$taxonomy_args = array(
+		$taxonomy_args = [
 			'_builtin'           => false,
 			'publicly_queryable' => true,
-		);
+		];
 		foreach ( get_taxonomies( $taxonomy_args, 'objects' ) as $taxonomy ) {
-			$templates[ sprintf( 'is_tax[%s]', $taxonomy->name ) ] = array(
+			$templates[ sprintf( 'is_tax[%s]', $taxonomy->name ) ] = [
 				'label'    => $taxonomy->labels->name,
 				'parent'   => 'is_archive',
 				'callback' => static function ( WP_Query $query ) use ( $taxonomy ) {
 					return $query->is_tax( $taxonomy->name );
 				},
-			);
+			];
 		}
 
-		$post_type_args = array(
+		$post_type_args = [
 			'has_archive'        => true,
 			'publicly_queryable' => true,
-		);
+		];
 		foreach ( get_post_types( $post_type_args, 'objects' ) as $post_type ) {
-			$templates[ sprintf( 'is_post_type_archive[%s]', $post_type->name ) ] = array(
+			$templates[ sprintf( 'is_post_type_archive[%s]', $post_type->name ) ] = [
 				'label'    => $post_type->labels->archives,
 				'parent'   => 'is_archive',
 				'callback' => static function ( WP_Query $query ) use ( $post_type ) {
 					return $query->is_post_type_archive( $post_type->name );
 				},
-			);
+			];
 		}
 
 		/**
@@ -939,7 +939,7 @@ class AMP_Theme_Support {
 		$templates = apply_filters( 'amp_supportable_templates', $templates );
 
 		$theme_support_args        = self::get_theme_support_args();
-		$theme_supported_templates = array();
+		$theme_supported_templates = [];
 		if ( isset( $theme_support_args['templates_supported'] ) ) {
 			$theme_supported_templates = $theme_support_args['templates_supported'];
 		}
@@ -987,7 +987,7 @@ class AMP_Theme_Support {
 		if ( has_action( 'wp_head', 'print_emoji_detection_script' ) ) {
 			remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
 			remove_action( 'wp_print_styles', 'print_emoji_styles' );
-			add_action( 'wp_print_styles', array( __CLASS__, 'print_emoji_styles' ) );
+			add_action( 'wp_print_styles', [ __CLASS__, 'print_emoji_styles' ] );
 			add_filter( 'the_title', 'wp_staticize_emoji' );
 			add_filter( 'the_excerpt', 'wp_staticize_emoji' );
 			add_filter( 'the_content', 'wp_staticize_emoji' );
@@ -1047,11 +1047,11 @@ class AMP_Theme_Support {
 			PHP_INT_MAX
 		);
 
-		add_action( 'admin_bar_init', array( __CLASS__, 'init_admin_bar' ) );
+		add_action( 'admin_bar_init', [ __CLASS__, 'init_admin_bar' ] );
 		add_action( 'wp_head', 'amp_add_generator_metadata', 20 );
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ), 0 ); // Enqueue before theme's styles.
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'dequeue_customize_preview_scripts' ), 1000 );
-		add_filter( 'customize_partial_render', array( __CLASS__, 'filter_customize_partial_render' ) );
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ], 0 ); // Enqueue before theme's styles.
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'dequeue_customize_preview_scripts' ], 1000 );
+		add_filter( 'customize_partial_render', [ __CLASS__, 'filter_customize_partial_render' ] );
 
 		add_action( 'wp_footer', 'amp_print_analytics' );
 
@@ -1060,16 +1060,16 @@ class AMP_Theme_Support {
 		 * instead of template_include.
 		 */
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-		add_action( 'template_redirect', array( __CLASS__, 'start_output_buffering' ), $priority );
+		add_action( 'template_redirect', [ __CLASS__, 'start_output_buffering' ], $priority );
 
 		// Commenting hooks.
-		add_filter( 'comment_form_defaults', array( __CLASS__, 'filter_comment_form_defaults' ) );
-		add_filter( 'comment_reply_link', array( __CLASS__, 'filter_comment_reply_link' ), 10, 4 );
-		add_filter( 'cancel_comment_reply_link', array( __CLASS__, 'filter_cancel_comment_reply_link' ), 10, 3 );
-		add_action( 'comment_form', array( __CLASS__, 'amend_comment_form' ), 100 );
+		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ] );
+		add_filter( 'comment_reply_link', [ __CLASS__, 'filter_comment_reply_link' ], 10, 4 );
+		add_filter( 'cancel_comment_reply_link', [ __CLASS__, 'filter_cancel_comment_reply_link' ], 10, 3 );
+		add_action( 'comment_form', [ __CLASS__, 'amend_comment_form' ], 100 );
 		remove_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' );
-		add_filter( 'wp_kses_allowed_html', array( __CLASS__, 'whitelist_layout_in_wp_kses_allowed_html' ), 10 );
-		add_filter( 'get_header_image_tag', array( __CLASS__, 'amend_header_image_with_video_header' ), PHP_INT_MAX );
+		add_filter( 'wp_kses_allowed_html', [ __CLASS__, 'whitelist_layout_in_wp_kses_allowed_html' ], 10 );
+		add_filter( 'get_header_image_tag', [ __CLASS__, 'amend_header_image_with_video_header' ], PHP_INT_MAX );
 		add_action(
 			'wp_print_footer_scripts',
 			static function() {
@@ -1123,7 +1123,7 @@ class AMP_Theme_Support {
 	public static function register_content_embed_handlers() {
 		global $content_width;
 
-		$embed_handlers = array();
+		$embed_handlers = [];
 		foreach ( amp_get_content_embed_handlers() as $embed_handler_class => $args ) {
 
 			/**
@@ -1133,9 +1133,9 @@ class AMP_Theme_Support {
 			 */
 			$embed_handler = new $embed_handler_class(
 				array_merge(
-					array(
+					[
 						'content_max_width' => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
-					),
+					],
 					$args
 				)
 			);
@@ -1198,7 +1198,7 @@ class AMP_Theme_Support {
 	public static function filter_amp_template_hierarchy( $templates ) {
 		$args = self::get_theme_support_args();
 		if ( isset( $args['template_dir'] ) ) {
-			$amp_templates = array();
+			$amp_templates = [];
 			foreach ( $templates as $template ) {
 				$amp_templates[] = $args['template_dir'] . '/' . $template; // Let template_dir have precedence.
 				$amp_templates[] = $template;
@@ -1314,14 +1314,14 @@ class AMP_Theme_Support {
 		}
 
 		$state_id  = self::get_comment_form_state_id( get_the_ID() );
-		$tap_state = array(
-			$state_id => array(
+		$tap_state = [
+			$state_id => [
 				'replyToName' => $comment->comment_author,
-				'values'      => array(
+				'values'      => [
 					'comment_parent' => (string) $comment->comment_ID,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		// @todo Figure out how to support add_below. Instead of moving the form, what about letting the form get a fixed position?
 		$link = sprintf(
@@ -1351,14 +1351,14 @@ class AMP_Theme_Support {
 		}
 
 		$state_id  = self::get_comment_form_state_id( get_the_ID() );
-		$tap_state = array(
-			$state_id => array(
+		$tap_state = [
+			$state_id => [
 				'replyToName' => '',
-				'values'      => array(
+				'values'      => [
 					'comment_parent' => '0',
-				),
-			),
-		);
+				],
+			],
+		];
 
 		$respond_id = 'respond'; // Hard-coded in comment_form() and default value in get_comment_reply_link().
 		return sprintf(
@@ -1417,9 +1417,9 @@ class AMP_Theme_Support {
 				return array_merge(
 					array_diff(
 						$body_classes,
-						array( 'no-customize-support' )
+						[ 'no-customize-support' ]
 					),
-					array( 'customize-support' )
+					[ 'customize-support' ]
 				);
 			}
 		);
@@ -1440,7 +1440,7 @@ class AMP_Theme_Support {
 	 * @param DOMDocument $dom            Document.
 	 * @param string[]    $script_handles AMP script handles for components identified during output buffering.
 	 */
-	public static function ensure_required_markup( DOMDocument $dom, $script_handles = array() ) {
+	public static function ensure_required_markup( DOMDocument $dom, $script_handles = [] ) {
 		/**
 		 * Elements.
 		 *
@@ -1469,7 +1469,7 @@ class AMP_Theme_Support {
 		}
 
 		// Ensure rel=canonical link.
-		$links         = array();
+		$links         = [];
 		$link_elements = $head->getElementsByTagName( 'link' );
 		$rel_canonical = null;
 		foreach ( $link_elements as $link ) {
@@ -1481,10 +1481,10 @@ class AMP_Theme_Support {
 			$rel_canonical = AMP_DOM_Utils::create_node(
 				$dom,
 				'link',
-				array(
+				[
 					'rel'  => 'canonical',
 					'href' => self::get_current_canonical_url(),
-				)
+				]
 			);
 			$head->appendChild( $rel_canonical );
 		}
@@ -1502,7 +1502,7 @@ class AMP_Theme_Support {
 		 */
 		$meta_charset  = null;
 		$meta_viewport = null;
-		$meta_elements = array();
+		$meta_elements = [];
 		foreach ( $head->getElementsByTagName( 'meta' ) as $meta ) {
 			if ( $meta->hasAttribute( 'charset' ) ) { // There will not be a meta[http-equiv] because the sanitizer removed it.
 				$meta_charset = $meta;
@@ -1517,9 +1517,9 @@ class AMP_Theme_Support {
 			$meta_charset = AMP_DOM_Utils::create_node(
 				$dom,
 				'meta',
-				array(
+				[
 					'charset' => 'utf-8',
-				)
+				]
 			);
 		} else {
 			$head->removeChild( $meta_charset ); // So we can move it.
@@ -1530,10 +1530,10 @@ class AMP_Theme_Support {
 			$meta_viewport = AMP_DOM_Utils::create_node(
 				$dom,
 				'meta',
-				array(
+				[
 					'name'    => 'viewport',
 					'content' => 'width=device-width',
-				)
+				]
 			);
 		} else {
 			$head->removeChild( $meta_viewport ); // So we can move it.
@@ -1555,16 +1555,16 @@ class AMP_Theme_Support {
 		}
 
 		// @see https://github.com/ampproject/amphtml/blob/2fd30ca984bceac05905bd5b17f9e0010629d719/src/render-delaying-services.js#L39-L43 AMPHTML Render Delaying Services SERVICES definition.
-		$render_delaying_extensions = array(
+		$render_delaying_extensions = [
 			'amp-experiment',
 			'amp-dynamic-css-classes',
 			'amp-story',
-		);
+		];
 
 		// Obtain the existing AMP scripts.
-		$amp_scripts     = array();
-		$ordered_scripts = array();
-		$head_scripts    = array();
+		$amp_scripts     = [];
+		$ordered_scripts = [];
+		$head_scripts    = [];
 		$runtime_src     = wp_scripts()->registered['amp-runtime']->src;
 		foreach ( $head->getElementsByTagName( 'script' ) as $script ) { // Note that prepare_response() already moved body scripts to head.
 			$head_scripts[] = $script;
@@ -1591,10 +1591,10 @@ class AMP_Theme_Support {
 			if ( ! wp_script_is( $missing_script_handle, 'registered' ) ) {
 				continue;
 			}
-			$attrs = array(
+			$attrs = [
 				'src'   => wp_scripts()->registered[ $missing_script_handle ]->src,
 				'async' => '',
-			);
+			];
 			if ( 'amp-mustache' === $missing_script_handle ) {
 				$attrs['custom-template'] = $missing_script_handle;
 			} else {
@@ -1611,19 +1611,19 @@ class AMP_Theme_Support {
 		 * until the AMP runtime has loaded. Preloading the AMP runtime tells the browser to download the script with a higher priority."
 		 * {@link https://docs.google.com/document/d/169XUxtSSEJb16NfkrCr9y5lqhUR7vxXEAsNxBzg07fM/edit#heading=h.2ha259c3ffos Optimize the AMP Runtime loading}
 		 */
-		$prioritized_preloads = array();
+		$prioritized_preloads = [];
 		if ( ! isset( $links['preload'] ) ) {
-			$links['preload'] = array();
+			$links['preload'] = [];
 		}
 
 		$prioritized_preloads[] = AMP_DOM_Utils::create_node(
 			$dom,
 			'link',
-			array(
+			[
 				'rel'  => 'preload',
 				'as'   => 'script',
 				'href' => $runtime_src,
-			)
+			]
 		);
 
 		$amp_script_handles = array_keys( $amp_scripts );
@@ -1634,16 +1634,16 @@ class AMP_Theme_Support {
 			$prioritized_preloads[] = AMP_DOM_Utils::create_node(
 				$dom,
 				'link',
-				array(
+				[
 					'rel'  => 'preload',
 					'as'   => 'script',
 					'href' => $amp_scripts[ $script_handle ]->getAttribute( 'src' ),
-				)
+				]
 			);
 		}
 		$links['preload'] = array_merge( $prioritized_preloads, $links['preload'] );
 
-		$link_relations = array( 'preconnect', 'dns-prefetch', 'preload', 'prerender', 'prefetch' );
+		$link_relations = [ 'preconnect', 'dns-prefetch', 'preload', 'prerender', 'prefetch' ];
 		foreach ( $link_relations as $rel ) {
 			if ( ! isset( $links[ $rel ] ) ) {
 				continue;
@@ -1734,7 +1734,7 @@ class AMP_Theme_Support {
 			newrelic_disable_autorum();
 		}
 
-		ob_start( array( __CLASS__, 'finish_output_buffering' ) );
+		ob_start( [ __CLASS__, 'finish_output_buffering' ] );
 		self::$is_output_buffering = true;
 	}
 
@@ -1778,12 +1778,12 @@ class AMP_Theme_Support {
 		global $content_width;
 		if ( is_string( $partial ) && preg_match( '/<\w/', $partial ) ) {
 			$dom  = AMP_DOM_Utils::get_dom_from_content( $partial );
-			$args = array(
+			$args = [
 				'content_max_width'    => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
 				'use_document_element' => false,
 				'allow_dirty_styles'   => true,
 				'allow_dirty_scripts'  => false,
-			);
+			];
 			AMP_Content_Sanitizer::sanitize_document( $dom, self::$sanitizer_classes, $args ); // @todo Include script assets in response?
 			$partial = AMP_DOM_Utils::get_content_from_dom( $dom );
 		}
@@ -1800,7 +1800,7 @@ class AMP_Theme_Support {
 	 * @return string AMP document response.
 	 * @global int $content_width
 	 */
-	public static function prepare_response( $response, $args = array() ) {
+	public static function prepare_response( $response, $args = [] ) {
 		global $content_width;
 		$prepare_response_start = microtime( true );
 
@@ -1833,10 +1833,10 @@ class AMP_Theme_Support {
 				$status_code = 200; // Not a web server environment.
 			}
 			return wp_json_encode(
-				array(
+				[
 					'status_code' => $status_code,
 					'status_text' => get_status_header_desc( $status_code ),
-				)
+				]
 			);
 		}
 
@@ -1882,14 +1882,14 @@ class AMP_Theme_Support {
 		}
 
 		$args = array_merge(
-			array(
+			[
 				'content_max_width'    => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH, // Back-compat.
 				'use_document_element' => true,
 				'allow_dirty_styles'   => self::is_customize_preview_iframe(), // Dirty styles only needed when editing (e.g. for edit shortcodes).
 				'allow_dirty_scripts'  => is_customize_preview(), // Scripts are always needed to inject changeset UUID.
 				'user_can_validate'    => AMP_Validation_Manager::has_cap(),
 				'stream_fragment'      => $stream_fragment,
-			),
+			],
 			$args,
 			compact( 'enable_response_caching' )
 		);
@@ -1903,13 +1903,13 @@ class AMP_Theme_Support {
 		 */
 		$response_cache_key = md5(
 			wp_json_encode(
-				array(
+				[
 					$args,
 					$response,
 					self::$sanitizer_classes,
 					self::$embed_handlers,
 					AMP__VERSION,
-				)
+				]
 			)
 		);
 
@@ -1979,7 +1979,7 @@ class AMP_Theme_Support {
 						if ( in_array( $header, AMP_HTTP::$headers_sent, true ) ) {
 							continue; // Skip sending headers that were already sent prior to post-processing.
 						}
-						AMP_HTTP::send_header( $header['name'], $header['value'], wp_array_slice_assoc( $header, array( 'replace', 'status_code' ) ) );
+						AMP_HTTP::send_header( $header['name'], $header['value'], wp_array_slice_assoc( $header, [ 'replace', 'status_code' ] ) );
 					}
 				}
 
@@ -2011,11 +2011,11 @@ class AMP_Theme_Support {
 
 				return wp_cache_set(
 					$response_cache_key,
-					array(
+					[
 						'headers'            => AMP_HTTP::$headers_sent,
 						'body'               => $body,
 						'validation_results' => $validation_results,
-					),
+					],
 					AMP_Theme_Support::RESPONSE_CACHE_GROUP,
 					MONTH_IN_SECONDS
 				);
@@ -2093,7 +2093,7 @@ class AMP_Theme_Support {
 
 		// Determine what the validation errors are.
 		$blocking_error_count = 0;
-		$validation_results   = array();
+		$validation_results   = [];
 		foreach ( AMP_Validation_Manager::$validation_results as $validation_result ) {
 			if ( ! $validation_result['sanitized'] ) {
 				$blocking_error_count++;
@@ -2172,9 +2172,9 @@ class AMP_Theme_Support {
 
 		AMP_Validation_Manager::finalize_validation(
 			$dom,
-			array(
+			[
 				'remove_source_comments' => ! isset( $_GET['amp_preserve_source_comments'] ), // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			)
+			]
 		);
 
 		// For service worker streaming, restore the script that was removed above and obtain the script that should be added to the body fragment.
@@ -2238,12 +2238,12 @@ class AMP_Theme_Support {
 	private static function check_for_cache_misses() {
 		// If the cache miss threshold is exceeded, return true.
 		if ( self::exceeded_cache_miss_threshold() ) {
-			return array( true, null );
+			return [ true, null ];
 		}
 
 		// Get the cache miss URLs.
 		$cache_miss_urls = wp_cache_get( self::POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY, self::POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP );
-		$cache_miss_urls = is_array( $cache_miss_urls ) ? $cache_miss_urls : array();
+		$cache_miss_urls = is_array( $cache_miss_urls ) ? $cache_miss_urls : [];
 
 		$exceeded_threshold = (
 			! empty( $cache_miss_urls )
@@ -2252,13 +2252,13 @@ class AMP_Theme_Support {
 		);
 
 		if ( ! $exceeded_threshold ) {
-			return array( $exceeded_threshold, $cache_miss_urls );
+			return [ $exceeded_threshold, $cache_miss_urls ];
 		}
 
 		// When the threshold is exceeded, store the URL for cache miss and turn off response caching.
 		update_option( self::CACHE_MISS_URL_OPTION, amp_get_current_url() );
 		AMP_Options_Manager::update_option( 'enable_response_caching', false );
-		return array( true, null );
+		return [ true, null ];
 	}
 
 	/**
@@ -2311,7 +2311,7 @@ class AMP_Theme_Support {
 		wp_enqueue_script( 'amp-runtime' );
 
 		// Enqueue default styles expected by sanitizer.
-		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), array(), AMP__VERSION );
+		wp_enqueue_style( 'amp-default', amp_get_asset_url( 'css/amp-default.css' ), [], AMP__VERSION );
 	}
 
 	/**
@@ -2368,15 +2368,15 @@ class AMP_Theme_Support {
 
 		$video_settings   = get_header_video_settings();
 		$parsed_url       = wp_parse_url( $video_settings['videoUrl'] );
-		$query            = isset( $parsed_url['query'] ) ? wp_parse_args( $parsed_url['query'] ) : array();
-		$video_attributes = array(
+		$query            = isset( $parsed_url['query'] ) ? wp_parse_args( $parsed_url['query'] ) : [];
+		$video_attributes = [
 			'media'    => '(min-width: ' . $video_settings['minWidth'] . 'px)',
 			'width'    => $video_settings['width'],
 			'height'   => $video_settings['height'],
 			'layout'   => 'responsive',
 			'autoplay' => '',
 			'id'       => 'wp-custom-header-video',
-		);
+		];
 
 		$youtube_id = null;
 		if ( isset( $parsed_url['host'] ) && preg_match( '/(^|\.)(youtube\.com|youtu\.be)$/', $parsed_url['host'] ) ) {
@@ -2393,12 +2393,12 @@ class AMP_Theme_Support {
 				'amp-youtube',
 				array_merge(
 					$video_attributes,
-					array(
+					[
 						'data-videoid'        => $youtube_id,
 						'data-param-rel'      => '0', // Don't show related videos.
 						'data-param-showinfo' => '0', // Don't show video title at the top.
 						'data-param-controls' => '0', // Don't show video controls.
-					)
+					]
 				)
 			);
 		} else {
@@ -2406,9 +2406,9 @@ class AMP_Theme_Support {
 				'amp-video',
 				array_merge(
 					$video_attributes,
-					array(
+					[
 						'src' => $video_settings['videoUrl'],
-					)
+					]
 				)
 			);
 		}

--- a/includes/embeds/class-amp-base-embed-handler.php
+++ b/includes/embeds/class-amp-base-embed-handler.php
@@ -30,7 +30,7 @@ abstract class AMP_Base_Embed_Handler {
 	 *
 	 * @var array
 	 */
-	protected $args = array();
+	protected $args = [];
 
 	/**
 	 * Whether or not conversion was completed.
@@ -54,13 +54,13 @@ abstract class AMP_Base_Embed_Handler {
 	 *
 	 * @param array $args Height and width for embed.
 	 */
-	public function __construct( $args = array() ) {
+	public function __construct( $args = [] ) {
 		$this->args = wp_parse_args(
 			$args,
-			array(
+			[
 				'width'  => $this->DEFAULT_WIDTH,
 				'height' => $this->DEFAULT_HEIGHT,
-			)
+			]
 		);
 	}
 
@@ -75,6 +75,6 @@ abstract class AMP_Base_Embed_Handler {
 	 * @return array Scripts.
 	 */
 	public function get_scripts() {
-		return array();
+		return [];
 	}
 }

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -17,24 +17,24 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @var array
 	 */
-	protected $block_ampify_methods = array(
+	protected $block_ampify_methods = [
 		'core/categories' => 'ampify_categories_block',
 		'core/archives'   => 'ampify_archives_block',
 		'core/video'      => 'ampify_video_block',
-	);
+	];
 
 	/**
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'render_block', array( $this, 'filter_rendered_block' ), 0, 2 );
+		add_filter( 'render_block', [ $this, 'filter_rendered_block' ], 0, 2 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'render_block', array( $this, 'filter_rendered_block' ), 0 );
+		remove_filter( 'render_block', [ $this, 'filter_rendered_block' ], 0 );
 	}
 
 	/**

--- a/includes/embeds/class-amp-crowdsignal-embed-handler.php
+++ b/includes/embeds/class-amp-crowdsignal-embed-handler.php
@@ -17,14 +17,14 @@ class AMP_Crowdsignal_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 3 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 3 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**

--- a/includes/embeds/class-amp-dailymotion-embed.php
+++ b/includes/embeds/class-amp-dailymotion-embed.php
@@ -34,7 +34,7 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @param array $args Height, width and maximum width for embed.
 	 */
-	public function __construct( $args = array() ) {
+	public function __construct( $args = [] ) {
 		parent::__construct( $args );
 
 		if ( isset( $this->args['content_max_width'] ) ) {
@@ -48,8 +48,8 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( 'amp-dailymotion', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
-		add_shortcode( 'dailymotion', array( $this, 'shortcode' ) );
+		wp_embed_register_handler( 'amp-dailymotion', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		add_shortcode( 'dailymotion', [ $this, 'shortcode' ] );
 	}
 
 	/**
@@ -82,9 +82,9 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		return $this->render(
-			array(
+			[
 				'video_id' => $video_id,
-			)
+			]
 		);
 	}
 
@@ -102,9 +102,9 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function oembed( $matches, $attr, $url, $rawattr ) {
 		$video_id = $this->get_video_id_from_url( $url );
 		return $this->render(
-			array(
+			[
 				'video_id' => $video_id,
-			)
+			]
 		);
 	}
 
@@ -117,18 +117,18 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'video_id' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['video_id'] ) ) {
 			return AMP_HTML_Utils::build_tag(
 				'a',
-				array(
+				[
 					'href'  => esc_url( $args['url'] ),
 					'class' => 'amp-wp-embed-fallback',
-				),
+				],
 				esc_html( $args['url'] )
 			);
 		}
@@ -137,12 +137,12 @@ class AMP_DailyMotion_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-dailymotion',
-			array(
+			[
 				'data-videoid' => $args['video_id'],
 				'layout'       => 'responsive',
 				'width'        => $this->args['width'],
 				'height'       => $this->args['height'],
-			)
+			]
 		);
 	}
 

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -43,7 +43,7 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( $this->amp_tag, self::URL_PATTERN, array( $this, 'oembed' ), -1 );
+		wp_embed_register_handler( $this->amp_tag, self::URL_PATTERN, [ $this, 'oembed' ], -1 );
 	}
 
 	/**
@@ -63,7 +63,7 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string HTML markup for rendered embed.
 	 */
 	public function oembed( $matches, $attr, $url, $rawattr ) {
-		return $this->render( array( 'url' => $url ) );
+		return $this->render( [ 'url' => $url ] );
 	}
 
 	/**
@@ -75,9 +75,9 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'url' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['url'] ) ) {
@@ -88,12 +88,12 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			$this->amp_tag,
-			array(
+			[
 				'data-href' => $args['url'],
 				'layout'    => 'responsive',
 				'width'     => $this->args['width'],
 				'height'    => $this->args['height'],
-			)
+			]
 		);
 	}
 
@@ -136,7 +136,7 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 		$fb_root = $dom->getElementById( 'fb-root' );
 		if ( $fb_root ) {
 			$xpath   = new DOMXPath( $dom );
-			$scripts = array();
+			$scripts = [];
 			foreach ( $xpath->query( '//script[ starts-with( @src, "https://connect.facebook.net" ) and contains( @src, "sdk.js" ) ]' ) as $script ) {
 				$scripts[] = $script;
 			}
@@ -195,11 +195,11 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	private function create_amp_facebook_and_replace_node( $dom, $node, $embed_type ) {
 
-		$attributes = array(
+		$attributes = [
 			'layout' => 'responsive',
 			'width'  => $node->hasAttribute( 'data-width' ) ? $node->getAttribute( 'data-width' ) : $this->DEFAULT_WIDTH,
 			'height' => $node->hasAttribute( 'data-height' ) ? $node->getAttribute( 'data-height' ) : $this->DEFAULT_HEIGHT,
-		);
+		];
 
 		$node->removeAttribute( 'data-width' );
 		$node->removeAttribute( 'data-height' );

--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -16,8 +16,8 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'post_gallery', array( $this, 'maybe_override_gallery' ), 10, 2 );
-		add_action( 'wp_print_styles', array( $this, 'print_styles' ) );
+		add_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10, 2 );
+		add_action( 'wp_print_styles', [ $this, 'print_styles' ] );
 	}
 
 	/**
@@ -43,15 +43,15 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		$atts = shortcode_atts(
-			array(
+			[
 				'order'   => 'ASC',
 				'orderby' => 'menu_order ID',
 				'id'      => $post ? $post->ID : 0,
 				'include' => '',
 				'exclude' => '',
-				'size'    => array( $this->args['width'], $this->args['height'] ),
+				'size'    => [ $this->args['width'], $this->args['height'] ],
 				'link'    => 'none',
-			),
+			],
 			$attr,
 			'gallery'
 		);
@@ -64,7 +64,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		if ( ! empty( $atts['include'] ) ) {
 			$attachments = get_posts(
-				array(
+				[
 					'include'        => $atts['include'],
 					'post_status'    => 'inherit',
 					'post_type'      => 'attachment',
@@ -72,11 +72,11 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 					'order'          => $atts['order'],
 					'orderby'        => $atts['orderby'],
 					'fields'         => 'ids',
-				)
+				]
 			);
 		} elseif ( ! empty( $atts['exclude'] ) ) {
 			$attachments = get_children(
-				array(
+				[
 					'post_parent'    => $id,
 					'exclude'        => $atts['exclude'],
 					'post_status'    => 'inherit',
@@ -85,11 +85,11 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 					'order'          => $atts['order'],
 					'orderby'        => $atts['orderby'],
 					'fields'         => 'ids',
-				)
+				]
 			);
 		} else {
 			$attachments = get_children(
-				array(
+				[
 					'post_parent'    => $id,
 					'post_status'    => 'inherit',
 					'post_type'      => 'attachment',
@@ -97,7 +97,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 					'order'          => $atts['order'],
 					'orderby'        => $atts['orderby'],
 					'fields'         => 'ids',
-				)
+				]
 			);
 		}
 
@@ -105,7 +105,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			return '';
 		}
 
-		$urls = array();
+		$urls = [];
 		foreach ( $attachments as $attachment_id ) {
 			list( $url, $width, $height ) = wp_get_attachment_image_src( $attachment_id, $atts['size'], true );
 
@@ -122,26 +122,26 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 				}
 			}
 
-			$urls[] = array(
+			$urls[] = [
 				'href'   => $href,
 				'url'    => $url,
 				'width'  => $width,
 				'height' => $height,
-			);
+			];
 		}
 
-		$args = array(
+		$args = [
 			'images' => $urls,
-		);
+		];
 		if ( ! empty( $atts['lightbox'] ) ) {
 			$args['lightbox'] = true;
 			$lightbox_tag     = AMP_HTML_Utils::build_tag(
 				'amp-image-lightbox',
-				array(
+				[
 					'id'                           => AMP_Base_Sanitizer::AMP_IMAGE_LIGHTBOX_ID,
 					'layout'                       => 'nodisplay',
 					'data-close-button-aria-label' => __( 'Close', 'amp' ),
-				)
+				]
 			);
 			/* We need to add lightbox tag, too. @todo Could there be a better alternative for this? */
 			return $this->render( $args ) . $lightbox_tag;
@@ -164,10 +164,10 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		$is_lightbox = isset( $attributes['amp-lightbox'] ) && true === filter_var( $attributes['amp-lightbox'], FILTER_VALIDATE_BOOLEAN );
 		if ( isset( $attributes['amp-carousel'] ) && false === filter_var( $attributes['amp-carousel'], FILTER_VALIDATE_BOOLEAN ) ) {
 			if ( true === $is_lightbox ) {
-				remove_filter( 'post_gallery', array( $this, 'maybe_override_gallery' ), 10 );
+				remove_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10 );
 				$attributes['link'] = 'none';
 				$html               = '<ul class="amp-lightbox">' . gallery_shortcode( $attributes ) . '</ul>';
-				add_filter( 'post_gallery', array( $this, 'maybe_override_gallery' ), 10, 2 );
+				add_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10, 2 );
 			}
 
 			return $html;
@@ -198,9 +198,9 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'images' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['images'] ) ) {
@@ -210,14 +210,14 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		$max_width  = 0;
 		$max_height = 0;
 
-		$images = array();
+		$images = [];
 		foreach ( $args['images'] as $props ) {
-			$image_atts = array(
+			$image_atts = [
 				'src'    => $props['url'],
 				'width'  => $props['width'],
 				'height' => $props['height'],
 				'layout' => 'responsive',
-			);
+			];
 			$max_width  = max( $max_width, $props['width'] );
 			$max_height = max( $max_height, $props['height'] );
 			if ( ! empty( $args['lightbox'] ) ) {
@@ -234,9 +234,9 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			if ( ! empty( $props['href'] ) ) {
 				$image = AMP_HTML_Utils::build_tag(
 					'a',
-					array(
+					[
 						'href' => $props['href'],
-					),
+					],
 					$image
 				);
 			}
@@ -246,12 +246,12 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-carousel',
-			array(
+			[
 				'width'  => $max_width,
 				'height' => $max_height,
 				'type'   => 'slides',
 				'layout' => 'responsive',
-			),
+			],
 			implode( PHP_EOL, $images )
 		);
 	}

--- a/includes/embeds/class-amp-gfycat-embed-handler.php
+++ b/includes/embeds/class-amp-gfycat-embed-handler.php
@@ -21,14 +21,14 @@ class AMP_Gfycat_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 3 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 3 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**
@@ -53,7 +53,7 @@ class AMP_Gfycat_Embed_Handler extends AMP_Base_Embed_Handler {
 				return $return;
 			}
 
-			$attributes = wp_array_slice_assoc( $attr, array( 'width', 'height' ) );
+			$attributes = wp_array_slice_assoc( $attr, [ 'width', 'height' ] );
 
 			if ( empty( $attr['width'] ) ) {
 				$attributes['layout'] = 'fixed-height';

--- a/includes/embeds/class-amp-hulu-embed-handler.php
+++ b/includes/embeds/class-amp-hulu-embed-handler.php
@@ -28,14 +28,14 @@ class AMP_Hulu_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 3 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 3 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**
@@ -60,7 +60,7 @@ class AMP_Hulu_Embed_Handler extends AMP_Base_Embed_Handler {
 				return $return;
 			}
 
-			$attributes = wp_array_slice_assoc( $attr, array( 'width', 'height' ) );
+			$attributes = wp_array_slice_assoc( $attr, [ 'width', 'height' ] );
 
 			if ( empty( $attr['width'] ) ) {
 				$attributes['layout'] = 'fixed-height';

--- a/includes/embeds/class-amp-imgur-embed-handler.php
+++ b/includes/embeds/class-amp-imgur-embed-handler.php
@@ -24,9 +24,9 @@ class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
 
 			// Before 4.9 the embedding Imgur is not working properly, register embed for that case.
-			wp_embed_register_handler( 'amp-imgur', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
+			wp_embed_register_handler( 'amp-imgur', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
 		} else {
-			add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 3 );
+			add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 3 );
 		}
 	}
 
@@ -37,7 +37,7 @@ class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
 			wp_embed_unregister_handler( 'amp-imgur', -1 );
 		} else {
-			remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+			remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 		}
 	}
 
@@ -51,7 +51,7 @@ class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string Embed.
 	 */
 	public function oembed( $matches, $attr, $url, $rawattr ) {
-		return $this->render( array( 'url' => $url ) );
+		return $this->render( [ 'url' => $url ] );
 	}
 
 	/**
@@ -63,9 +63,9 @@ class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'url' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['url'] ) ) {
@@ -80,11 +80,11 @@ class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 		return AMP_HTML_Utils::build_tag(
 			'amp-imgur',
-			array(
+			[
 				'width'         => $this->args['width'],
 				'height'        => $this->args['height'],
 				'data-imgur-id' => $id,
-			)
+			]
 		);
 	}
 
@@ -110,7 +110,7 @@ class AMP_Imgur_Embed_Handler extends AMP_Base_Embed_Handler {
 				return $return;
 			}
 
-			$attributes = wp_array_slice_assoc( $attr, array( 'width', 'height' ) );
+			$attributes = wp_array_slice_assoc( $attr, [ 'width', 'height' ] );
 
 			if ( empty( $attr['width'] ) ) {
 				$attributes['layout'] = 'fixed-height';

--- a/includes/embeds/class-amp-instagram-embed.php
+++ b/includes/embeds/class-amp-instagram-embed.php
@@ -46,8 +46,8 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( $this->amp_tag, self::URL_PATTERN, array( $this, 'oembed' ), -1 );
-		add_shortcode( 'instagram', array( $this, 'shortcode' ) );
+		wp_embed_register_handler( $this->amp_tag, self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		add_shortcode( 'instagram', [ $this, 'shortcode' ] );
 	}
 
 	/**
@@ -78,10 +78,10 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 		$instagram_id = $this->get_instagram_id_from_url( $url );
 
 		return $this->render(
-			array(
+			[
 				'url'          => $url,
 				'instagram_id' => $instagram_id,
-			)
+			]
 		);
 	}
 
@@ -96,10 +96,10 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function oembed( $matches, $attr, $url, $rawattr ) {
 		return $this->render(
-			array(
+			[
 				'url'          => $url,
 				'instagram_id' => end( $matches ),
-			)
+			]
 		);
 	}
 
@@ -112,19 +112,19 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'url'          => false,
 				'instagram_id' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['instagram_id'] ) ) {
 			return AMP_HTML_Utils::build_tag(
 				'a',
-				array(
+				[
 					'href'  => esc_url( $args['url'] ),
 					'class' => 'amp-wp-embed-fallback',
-				),
+				],
 				esc_html( $args['url'] )
 			);
 		}
@@ -133,13 +133,13 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			$this->amp_tag,
-			array(
+			[
 				'data-shortcode' => $args['instagram_id'],
 				'data-captioned' => '',
 				'layout'         => 'responsive',
 				'width'          => $this->args['width'],
 				'height'         => $this->args['height'],
-			)
+			]
 		);
 	}
 
@@ -198,12 +198,12 @@ class AMP_Instagram_Embed_Handler extends AMP_Base_Embed_Handler {
 	private function create_amp_instagram_and_replace_node( $dom, $node ) {
 		$instagram_id = $this->get_instagram_id_from_url( $node->getAttribute( 'data-instgrm-permalink' ) );
 
-		$node_args = array(
+		$node_args = [
 			'data-shortcode' => $instagram_id,
 			'layout'         => 'responsive',
 			'width'          => $this->DEFAULT_WIDTH,
 			'height'         => $this->DEFAULT_HEIGHT,
-		);
+		];
 
 		if ( true === $node->hasAttribute( 'data-instgrm-captioned' ) ) {
 			$node_args['data-captioned'] = '';

--- a/includes/embeds/class-amp-issuu-embed-handler.php
+++ b/includes/embeds/class-amp-issuu-embed-handler.php
@@ -21,14 +21,14 @@ class AMP_Issuu_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 3 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 3 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**
@@ -51,12 +51,12 @@ class AMP_Issuu_Embed_Handler extends AMP_Base_Embed_Handler {
 
 			$return = AMP_HTML_Utils::build_tag(
 				'amp-iframe',
-				array(
+				[
 					'width'   => $attr['width'],
 					'height'  => $attr['height'],
 					'src'     => $url,
 					'sandbox' => 'allow-scripts allow-same-origin',
-				)
+				]
 			);
 		}
 		return $return;

--- a/includes/embeds/class-amp-meetup-embed-handler.php
+++ b/includes/embeds/class-amp-meetup-embed-handler.php
@@ -15,14 +15,14 @@ class AMP_Meetup_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 2 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 2 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**

--- a/includes/embeds/class-amp-pinterest-embed.php
+++ b/includes/embeds/class-amp-pinterest-embed.php
@@ -33,7 +33,7 @@ class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 		wp_embed_register_handler(
 			'amp-pinterest',
 			self::URL_PATTERN,
-			array( $this, 'oembed' ),
+			[ $this, 'oembed' ],
 			-1
 		);
 	}
@@ -55,7 +55,7 @@ class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string HTML markup for rendered embed.
 	 */
 	public function oembed( $matches, $attr, $url, $rawattr ) {
-		return $this->render( array( 'url' => $url ) );
+		return $this->render( [ 'url' => $url ] );
 	}
 
 	/**
@@ -67,9 +67,9 @@ class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'url' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['url'] ) ) {
@@ -80,12 +80,12 @@ class AMP_Pinterest_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-pinterest',
-			array(
+			[
 				'width'    => $this->args['width'],
 				'height'   => $this->args['height'],
 				'data-do'  => 'embedPin',
 				'data-url' => $args['url'],
-			)
+			]
 		);
 	}
 }

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -85,7 +85,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( shortcode_exists( self::SHORTCODE ) ) {
 			$this->removed_shortcode_callback = $shortcode_tags[ self::SHORTCODE ];
 		}
-		add_shortcode( self::SHORTCODE, array( $this, 'shortcode' ) );
+		add_shortcode( self::SHORTCODE, [ $this, 'shortcode' ] );
 		remove_action( 'wp_playlist_scripts', 'wp_playlist_scripts' );
 	}
 
@@ -111,7 +111,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		wp_enqueue_style(
 			'amp-playlist-shortcode',
 			amp_get_asset_url( 'css/amp-playlist-shortcode.css' ),
-			array( 'wp-mediaelement' ),
+			[ 'wp-mediaelement' ],
 			AMP__VERSION
 		);
 	}
@@ -152,9 +152,9 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		self::$playlist_id++;
 		$container_id = 'wpPlaylist' . self::$playlist_id . 'Carousel';
 		$state_id     = 'wpPlaylist' . self::$playlist_id;
-		$amp_state    = array(
+		$amp_state    = [
 			'selectedIndex' => 0,
-		);
+		];
 
 		$this->enqueue_styles();
 		ob_start();
@@ -206,14 +206,14 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 		self::$playlist_id++;
 		$state_id  = 'wpPlaylist' . self::$playlist_id;
-		$amp_state = array(
+		$amp_state = [
 			'selectedIndex' => 0,
-		);
+		];
 		foreach ( $data['tracks'] as $index => $track ) {
-			$amp_state[ $index ] = array(
+			$amp_state[ $index ] = [
 				'videoUrl' => $track['src'],
 				'thumb'    => isset( $track['thumb']['src'] ) ? $track['thumb']['src'] : '',
-			);
+			];
 		}
 
 		$dimensions = isset( $data['tracks'][0]['dimensions']['resized'] ) ? $data['tracks'][0]['dimensions']['resized'] : null;
@@ -278,7 +278,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		<div class="wp-playlist-tracks">
 			<?php foreach ( $tracks as $index => $track ) : ?>
 				<?php
-				$on            = 'tap:AMP.setState(' . wp_json_encode( array( $state_id => array( 'selectedIndex' => $index ) ) ) . ')';
+				$on            = 'tap:AMP.setState(' . wp_json_encode( [ $state_id => [ 'selectedIndex' => $index ] ] ) . ')';
 				$initial_class = 0 === $index ? 'wp-playlist-item wp-playlist-playing' : 'wp-playlist-item';
 				$bound_class   = sprintf( '%d == %s.selectedIndex ? "wp-playlist-item wp-playlist-playing" : "wp-playlist-item"', $index, $state_id );
 				?>
@@ -306,7 +306,7 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 		$markup = wp_playlist_shortcode( $attr );
 		preg_match( self::PLAYLIST_REGEX, $markup, $matches );
 		if ( empty( $matches[1] ) ) {
-			return array();
+			return [];
 		}
 		return json_decode( $matches[1], true );
 	}

--- a/includes/embeds/class-amp-reddit-embed-handler.php
+++ b/includes/embeds/class-amp-reddit-embed-handler.php
@@ -21,7 +21,7 @@ class AMP_Reddit_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( 'amp-reddit', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
+		wp_embed_register_handler( 'amp-reddit', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class AMP_Reddit_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string Embed.
 	 */
 	public function oembed( $matches, $attr, $url ) {
-		return $this->render( array( 'url' => $url ) );
+		return $this->render( [ 'url' => $url ] );
 	}
 
 	/**
@@ -52,9 +52,9 @@ class AMP_Reddit_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'url' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['url'] ) ) {
@@ -63,12 +63,12 @@ class AMP_Reddit_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-embedly-card',
-			array(
+			[
 				'layout'   => 'responsive',
 				'width'    => '100',
 				'height'   => '100',
 				'data-url' => $args['url'],
-			)
+			]
 		);
 	}
 }

--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -25,9 +25,9 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function register_embed() {
 		if ( function_exists( 'soundcloud_shortcode' ) ) {
 			// @todo Move this to Jetpack.
-			add_shortcode( 'soundcloud', array( $this, 'shortcode' ) );
+			add_shortcode( 'soundcloud', [ $this, 'shortcode' ] );
 		}
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 2 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 2 );
 	}
 
 	/**
@@ -38,7 +38,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 			// @todo Move this to Jetpack.
 			remove_shortcode( 'soundcloud' );
 		}
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**
@@ -83,7 +83,7 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		if ( preg_match( '#<iframe[^>]*?src="(?P<src>[^"]+)"#s', $html, $matches ) ) {
 			$src   = html_entity_decode( $matches['src'], ENT_QUOTES );
-			$query = array();
+			$query = [];
 			parse_str( wp_parse_url( $src, PHP_URL_QUERY ), $query );
 			if ( ! empty( $query['url'] ) ) {
 				$props = $this->extract_params_from_iframe_src( $query['url'] );
@@ -162,19 +162,19 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args, $url ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'track_id'    => false,
 				'playlist_id' => false,
 				'height'      => null,
 				'width'       => null,
 				'visual'      => null,
 				'fallback'    => '',
-			)
+			]
 		);
 
 		$this->did_convert_elements = true;
 
-		$attributes = array();
+		$attributes = [];
 		if ( ! empty( $args['track_id'] ) ) {
 			$attributes['data-trackid'] = $args['track_id'];
 		} elseif ( ! empty( $args['playlist_id'] ) ) {
@@ -209,10 +209,10 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	private function render_embed_fallback( $url ) {
 		return AMP_HTML_Utils::build_tag(
 			'a',
-			array(
+			[
 				'href'  => esc_url_raw( $url ),
 				'class' => 'amp-wp-embed-fallback',
-			),
+			],
 			esc_html( $url )
 		);
 	}
@@ -226,15 +226,15 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 	private function extract_params_from_iframe_src( $url ) {
 		$parsed_url = wp_parse_url( $url );
 		if ( preg_match( '#tracks/(?P<track_id>\d+)#', $parsed_url['path'], $matches ) ) {
-			return array(
+			return [
 				'track_id' => $matches['track_id'],
-			);
+			];
 		}
 		if ( preg_match( '#playlists/(?P<playlist_id>\d+)#', $parsed_url['path'], $matches ) ) {
-			return array(
+			return [
 				'playlist_id' => $matches['playlist_id'],
-			);
+			];
 		}
-		return array();
+		return [];
 	}
 }

--- a/includes/embeds/class-amp-tumblr-embed-handler.php
+++ b/includes/embeds/class-amp-tumblr-embed-handler.php
@@ -15,14 +15,14 @@ class AMP_Tumblr_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10, 2 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 2 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', array( $this, 'filter_embed_oembed_html' ), 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
 	}
 
 	/**
@@ -42,13 +42,13 @@ class AMP_Tumblr_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( preg_match( '#data-href="(?P<href>https://embed.tumblr.com/embed/post/\w+/\w+)"#', $cache, $matches ) ) {
 			$cache = AMP_HTML_Utils::build_tag(
 				'amp-iframe',
-				array(
+				[
 					'width'   => $this->args['width'],
 					'height'  => $this->args['height'],
 					'layout'  => 'responsive',
 					'sandbox' => 'allow-scripts allow-popups', // The allow-scripts is needed to allow the iframe to render; allow-popups needed to allow clicking.
 					'src'     => $matches['href'],
-				),
+				],
 				sprintf( '<a placeholder href="%s">Tumblr</a>', $url )
 			);
 		}

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -46,9 +46,9 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers embed.
 	 */
 	public function register_embed() {
-		add_shortcode( 'tweet', array( $this, 'shortcode' ) ); // Note: This is a Jetpack shortcode.
-		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
-		wp_embed_register_handler( 'amp-twitter-timeline', self::URL_PATTERN_TIMELINE, array( $this, 'oembed_timeline' ), -1 );
+		add_shortcode( 'tweet', [ $this, 'shortcode' ] ); // Note: This is a Jetpack shortcode.
+		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		wp_embed_register_handler( 'amp-twitter-timeline', self::URL_PATTERN_TIMELINE, [ $this, 'oembed_timeline' ], -1 );
 	}
 
 	/**
@@ -71,9 +71,9 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function shortcode( $attr ) {
 		$attr = wp_parse_args(
 			$attr,
-			array(
+			[
 				'tweet' => false,
-			)
+			]
 		);
 
 		if ( empty( $attr['tweet'] ) && ! empty( $attr[0] ) ) {
@@ -98,12 +98,12 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			$this->amp_tag,
-			array(
+			[
 				'data-tweetid' => $id,
 				'layout'       => 'responsive',
 				'width'        => $this->args['width'],
 				'height'       => $this->args['height'],
-			)
+			]
 		);
 	}
 
@@ -126,7 +126,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			return '';
 		}
 
-		return $this->shortcode( array( 'tweet' => $id ) );
+		return $this->shortcode( [ 'tweet' => $id ] );
 	}
 
 	/**
@@ -142,10 +142,10 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			return '';
 		}
 
-		$attributes = array(
+		$attributes = [
 			'data-timeline-source-type' => 'profile',
 			'data-timeline-screen-name' => $matches['username'],
-		);
+		];
 
 		if ( isset( $matches['type'] ) ) {
 			switch ( $matches['type'] ) {
@@ -232,12 +232,12 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		$new_node = AMP_DOM_Utils::create_node(
 			$dom,
 			$this->amp_tag,
-			array(
+			[
 				'width'        => $this->DEFAULT_WIDTH,
 				'height'       => $this->DEFAULT_HEIGHT,
 				'layout'       => 'responsive',
 				'data-tweetid' => $tweet_id,
-			)
+			]
 		);
 
 		$this->sanitize_embed_script( $node );

--- a/includes/embeds/class-amp-vimeo-embed.php
+++ b/includes/embeds/class-amp-vimeo-embed.php
@@ -35,7 +35,7 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @param array $args Height, width and maximum width for embed.
 	 */
-	public function __construct( $args = array() ) {
+	public function __construct( $args = [] ) {
 		parent::__construct( $args );
 
 		if ( isset( $this->args['content_max_width'] ) ) {
@@ -49,9 +49,9 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( 'amp-vimeo', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
-		add_shortcode( 'vimeo', array( $this, 'shortcode' ) );
-		add_filter( 'wp_video_shortcode_override', array( $this, 'video_override' ), 10, 2 );
+		wp_embed_register_handler( 'amp-vimeo', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		add_shortcode( 'vimeo', [ $this, 'shortcode' ] );
+		add_filter( 'wp_video_shortcode_override', [ $this, 'video_override' ], 10, 2 );
 	}
 
 	/**
@@ -86,9 +86,9 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		return $this->render(
-			array(
+			[
 				'video_id' => $video_id,
-			)
+			]
 		);
 	}
 
@@ -107,10 +107,10 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 		$video_id = $this->get_video_id_from_url( $url );
 
 		return $this->render(
-			array(
+			[
 				'url'      => $url,
 				'video_id' => $video_id,
-			)
+			]
 		);
 	}
 
@@ -123,18 +123,18 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'video_id' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['video_id'] ) ) {
 			return AMP_HTML_Utils::build_tag(
 				'a',
-				array(
+				[
 					'href'  => esc_url( $args['url'] ),
 					'class' => 'amp-wp-embed-fallback',
-				),
+				],
 				esc_html( $args['url'] )
 			);
 		}
@@ -143,12 +143,12 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-vimeo',
-			array(
+			[
 				'data-videoid' => $args['video_id'],
 				'layout'       => 'responsive',
 				'width'        => $this->args['width'],
 				'height'       => $this->args['height'],
-			)
+			]
 		);
 	}
 
@@ -188,7 +188,7 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 		$src           = $attr['src'];
 		$vimeo_pattern = '#^https?://(.+\.)?vimeo\.com/.*#';
 		if ( 1 === preg_match( $vimeo_pattern, $src ) ) {
-			return $this->shortcode( array( $src ) );
+			return $this->shortcode( [ $src ] );
 		}
 		return $html;
 	}

--- a/includes/embeds/class-amp-vine-embed.php
+++ b/includes/embeds/class-amp-vine-embed.php
@@ -29,7 +29,7 @@ class AMP_Vine_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( 'amp-vine', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
+		wp_embed_register_handler( 'amp-vine', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
 	}
 
 	/**
@@ -50,10 +50,10 @@ class AMP_Vine_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function oembed( $matches, $attr, $url, $rawattr ) {
 		return $this->render(
-			array(
+			[
 				'url'     => $url,
 				'vine_id' => end( $matches ),
-			)
+			]
 		);
 	}
 
@@ -66,19 +66,19 @@ class AMP_Vine_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'url'     => false,
 				'vine_id' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['vine_id'] ) ) {
 			return AMP_HTML_Utils::build_tag(
 				'a',
-				array(
+				[
 					'href'  => esc_url( $args['url'] ),
 					'class' => 'amp-wp-embed-fallback',
-				),
+				],
 				esc_html( $args['url'] )
 			);
 		}
@@ -87,12 +87,12 @@ class AMP_Vine_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-vine',
-			array(
+			[
 				'data-vineid' => $args['vine_id'],
 				'layout'      => 'responsive',
 				'width'       => $this->args['width'],
 				'height'      => $this->args['height'],
-			)
+			]
 		);
 	}
 }

--- a/includes/embeds/class-amp-youtube-embed.php
+++ b/includes/embeds/class-amp-youtube-embed.php
@@ -35,7 +35,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @param array $args Height, width and maximum width for embed.
 	 */
-	public function __construct( $args = array() ) {
+	public function __construct( $args = [] ) {
 		parent::__construct( $args );
 
 		if ( isset( $this->args['content_max_width'] ) ) {
@@ -49,9 +49,9 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Register embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( 'amp-youtube', self::URL_PATTERN, array( $this, 'oembed' ), -1 );
-		add_shortcode( 'youtube', array( $this, 'shortcode' ) );
-		add_filter( 'wp_video_shortcode_override', array( $this, 'video_override' ), 10, 2 );
+		wp_embed_register_handler( 'amp-youtube', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		add_shortcode( 'youtube', [ $this, 'shortcode' ] );
+		add_filter( 'wp_video_shortcode_override', [ $this, 'video_override' ], 10, 2 );
 	}
 
 	/**
@@ -84,10 +84,10 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 		$video_id = $this->get_video_id_from_url( $url );
 
 		return $this->render(
-			array(
+			[
 				'url'      => $url,
 				'video_id' => $video_id,
-			)
+			]
 		);
 	}
 
@@ -103,7 +103,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string Rendered oEmbed.
 	 */
 	public function oembed( $matches, $attr, $url, $rawattr ) {
-		return $this->shortcode( array( $url ) );
+		return $this->shortcode( [ $url ] );
 	}
 
 	/**
@@ -115,18 +115,18 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	public function render( $args ) {
 		$args = wp_parse_args(
 			$args,
-			array(
+			[
 				'video_id' => false,
-			)
+			]
 		);
 
 		if ( empty( $args['video_id'] ) ) {
 			return AMP_HTML_Utils::build_tag(
 				'a',
-				array(
+				[
 					'href'  => esc_url( $args['url'] ),
 					'class' => 'amp-wp-embed-fallback',
-				),
+				],
 				esc_html( $args['url'] )
 			);
 		}
@@ -135,12 +135,12 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-youtube',
-			array(
+			[
 				'data-videoid' => $args['video_id'],
 				'layout'       => 'responsive',
 				'width'        => $this->args['width'],
 				'height'       => $this->args['height'],
-			)
+			]
 		);
 	}
 
@@ -174,7 +174,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 			/* The path looks like /(v|e|embed)/{id} */
 			$parts = explode( '/', $parsed_url['path'] );
 
-			if ( in_array( $parts[1], array( 'v', 'e', 'embed' ), true ) ) {
+			if ( in_array( $parts[1], [ 'v', 'e', 'embed' ], true ) ) {
 				$video_id = $parts[2];
 			}
 		}
@@ -214,7 +214,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 		$src             = $attr['src'];
 		$youtube_pattern = '#^https?://(?:www\.)?(?:youtube\.com/watch|youtu\.be/)#';
 		if ( 1 === preg_match( $youtube_pattern, $src ) ) {
-			return $this->shortcode( array( $src ) );
+			return $this->shortcode( [ $src ] );
 		}
 		return $html;
 	}

--- a/includes/options/class-amp-analytics-options-submenu.php
+++ b/includes/options/class-amp-analytics-options-submenu.php
@@ -50,7 +50,7 @@ class AMP_Analytics_Options_Submenu {
 
 		add_action(
 			'admin_print_styles-amp_page_' . $this->menu_slug,
-			array( $this, 'amp_options_styles' )
+			[ $this, 'amp_options_styles' ]
 		);
 	}
 
@@ -64,7 +64,7 @@ class AMP_Analytics_Options_Submenu {
 			__( 'Analytics', 'amp' ),
 			'manage_options',
 			$this->menu_slug,
-			array( $this->menu_page, 'render' )
+			[ $this->menu_page, 'render' ]
 		);
 	}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -34,18 +34,18 @@ class AMP_Options_Manager {
 	 *
 	 * @var array
 	 */
-	protected static $defaults = array(
-		'experiences'              => array( self::WEBSITE_EXPERIENCE ),
+	protected static $defaults = [
+		'experiences'              => [ self::WEBSITE_EXPERIENCE ],
 		'theme_support'            => AMP_Theme_Support::READER_MODE_SLUG,
-		'supported_post_types'     => array( 'post' ),
-		'analytics'                => array(),
+		'supported_post_types'     => [ 'post' ],
+		'analytics'                => [],
 		'auto_accept_sanitization' => true,
 		'all_templates_supported'  => true,
-		'supported_templates'      => array( 'is_singular' ),
+		'supported_templates'      => [ 'is_singular' ],
 		'enable_response_caching'  => true,
 		'version'                  => AMP__VERSION,
 		'story_templates_version'  => false,
-	);
+	];
 
 	/**
 	 * Register settings.
@@ -54,17 +54,17 @@ class AMP_Options_Manager {
 		register_setting(
 			self::OPTION_NAME,
 			self::OPTION_NAME,
-			array(
+			[
 				'type'              => 'array',
-				'sanitize_callback' => array( __CLASS__, 'validate_options' ),
-			)
+				'sanitize_callback' => [ __CLASS__, 'validate_options' ],
+			]
 		);
 
-		add_action( 'update_option_' . self::OPTION_NAME, array( __CLASS__, 'maybe_flush_rewrite_rules' ), 10, 2 );
-		add_action( 'admin_notices', array( __CLASS__, 'render_welcome_notice' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'persistent_object_caching_notice' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'render_cache_miss_notice' ) );
-		add_action( 'admin_notices', array( __CLASS__, 'render_php_css_parser_conflict_notice' ) );
+		add_action( 'update_option_' . self::OPTION_NAME, [ __CLASS__, 'maybe_flush_rewrite_rules' ], 10, 2 );
+		add_action( 'admin_notices', [ __CLASS__, 'render_welcome_notice' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'persistent_object_caching_notice' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'render_cache_miss_notice' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'render_php_css_parser_conflict_notice' ] );
 	}
 
 	/**
@@ -76,12 +76,12 @@ class AMP_Options_Manager {
 	 * @param array $new_options New options.
 	 */
 	public static function maybe_flush_rewrite_rules( $old_options, $new_options ) {
-		$old_post_types = isset( $old_options['supported_post_types'] ) ? $old_options['supported_post_types'] : array();
-		$new_post_types = isset( $new_options['supported_post_types'] ) ? $new_options['supported_post_types'] : array();
+		$old_post_types = isset( $old_options['supported_post_types'] ) ? $old_options['supported_post_types'] : [];
+		$new_post_types = isset( $new_options['supported_post_types'] ) ? $new_options['supported_post_types'] : [];
 		sort( $old_post_types );
 		sort( $new_post_types );
-		$old_experiences = isset( $old_options['experiences'] ) ? $old_options['experiences'] : array();
-		$new_experiences = isset( $new_options['experiences'] ) ? $new_options['experiences'] : array();
+		$old_experiences = isset( $old_options['experiences'] ) ? $old_options['experiences'] : [];
+		$new_experiences = isset( $new_options['experiences'] ) ? $new_options['experiences'] : [];
 		sort( $old_experiences );
 		sort( $new_experiences );
 		if ( $old_post_types !== $new_post_types || $old_experiences !== $new_experiences ) {
@@ -111,9 +111,9 @@ class AMP_Options_Manager {
 	 * @return array Options.
 	 */
 	public static function get_options() {
-		$options = get_option( self::OPTION_NAME, array() );
+		$options = get_option( self::OPTION_NAME, [] );
 		if ( empty( $options ) ) {
-			$options = array(); // Ensure empty string becomes array.
+			$options = []; // Ensure empty string becomes array.
 		}
 
 		$defaults = self::$defaults;
@@ -219,30 +219,30 @@ class AMP_Options_Manager {
 			// Validate the selected experiences.
 			$options['experiences'] = array_intersect(
 				$new_options['experiences'],
-				array(
+				[
 					self::WEBSITE_EXPERIENCE,
 					self::STORIES_EXPERIENCE,
-				)
+				]
 			);
 
 			// At least one experience must be selected.
 			if ( empty( $options['experiences'] ) ) {
-				$options['experiences'] = array( self::WEBSITE_EXPERIENCE );
+				$options['experiences'] = [ self::WEBSITE_EXPERIENCE ];
 			}
 		}
 
 		// Theme support.
-		$recognized_theme_supports = array(
+		$recognized_theme_supports = [
 			AMP_Theme_Support::READER_MODE_SLUG,
 			AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
 			AMP_Theme_Support::STANDARD_MODE_SLUG,
-		);
+		];
 		if ( isset( $new_options['theme_support'] ) && in_array( $new_options['theme_support'], $recognized_theme_supports, true ) ) {
 			$options['theme_support'] = $new_options['theme_support'];
 
 			// If this option was changed, display a notice with the new template mode.
 			if ( self::get_option( 'theme_support' ) !== $new_options['theme_support'] ) {
-				add_action( 'update_option_' . self::OPTION_NAME, array( __CLASS__, 'handle_updated_theme_support_option' ) );
+				add_action( 'update_option_' . self::OPTION_NAME, [ __CLASS__, 'handle_updated_theme_support_option' ] );
 			}
 		}
 
@@ -250,7 +250,7 @@ class AMP_Options_Manager {
 
 		// Validate post type support.
 		if ( in_array( self::WEBSITE_EXPERIENCE, $options['experiences'], true ) || isset( $new_options['supported_post_types'] ) ) {
-			$options['supported_post_types'] = array();
+			$options['supported_post_types'] = [];
 			if ( isset( $new_options['supported_post_types'] ) ) {
 				foreach ( $new_options['supported_post_types'] as $post_type ) {
 					if ( ! post_type_exists( $post_type ) ) {
@@ -269,7 +269,7 @@ class AMP_Options_Manager {
 			$options['all_templates_supported'] = ! empty( $new_options['all_templates_supported'] );
 
 			// Validate supported templates.
-			$options['supported_templates'] = array();
+			$options['supported_templates'] = [];
 			if ( isset( $new_options['supported_templates'] ) ) {
 				$options['supported_templates'] = array_intersect(
 					$new_options['supported_templates'],
@@ -315,10 +315,10 @@ class AMP_Options_Manager {
 				if ( isset( $data['delete'] ) ) {
 					unset( $options['analytics'][ $entry_id ] );
 				} else {
-					$options['analytics'][ $entry_id ] = array(
+					$options['analytics'][ $entry_id ] = [
 						'type'   => $entry_vendor_type,
 						'config' => $entry_config,
-					);
+					];
 				}
 			}
 		}
@@ -355,7 +355,7 @@ class AMP_Options_Manager {
 			return;
 		}
 
-		$supported_types = self::get_option( 'supported_post_types', array() );
+		$supported_types = self::get_option( 'supported_post_types', [] );
 		foreach ( AMP_Post_Type_Support::get_eligible_post_types() as $name ) {
 			$post_type = get_post_type_object( $name );
 			if ( empty( $post_type ) ) {
@@ -636,7 +636,7 @@ class AMP_Options_Manager {
 		if ( $has_theme_support ) {
 			$theme_support = current_theme_supports( AMP_Theme_Support::SLUG );
 			if ( ! is_array( $theme_support ) ) {
-				$theme_support = array();
+				$theme_support = [];
 			}
 			$theme_support['paired'] = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode;
 			add_theme_support( AMP_Theme_Support::SLUG, $theme_support );
@@ -647,7 +647,7 @@ class AMP_Options_Manager {
 		$url = amp_admin_get_preview_permalink();
 
 		$notice_type     = 'updated';
-		$review_messages = array();
+		$review_messages = [];
 		if ( $url && $has_theme_support ) {
 			$validation = AMP_Validation_Manager::validate_url( $url );
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -22,10 +22,10 @@ class AMP_Options_Menu {
 	 */
 	public function init() {
 		add_action( 'admin_post_amp_analytics_options', 'AMP_Options_Manager::handle_analytics_submit' );
-		add_action( 'admin_menu', array( $this, 'add_menu_items' ), 9 );
+		add_action( 'admin_menu', [ $this, 'add_menu_items' ], 9 );
 
 		$plugin_file = preg_replace( '#.+/(?=.+?/.+?)#', '', AMP__FILE__ );
-		add_filter( "plugin_action_links_{$plugin_file}", array( $this, 'add_plugin_action_links' ) );
+		add_filter( "plugin_action_links_{$plugin_file}", [ $this, 'add_plugin_action_links' ] );
 	}
 
 	/**
@@ -36,13 +36,13 @@ class AMP_Options_Menu {
 	 */
 	public function add_plugin_action_links( $links ) {
 		return array_merge(
-			array(
+			[
 				'settings' => sprintf(
 					'<a href="%1$s">%2$s</a>',
 					esc_url( add_query_arg( 'page', AMP_Options_Manager::OPTION_NAME, admin_url( 'admin.php' ) ) ),
 					__( 'Settings', 'amp' )
 				),
-			),
+			],
 			$links
 		);
 	}
@@ -57,7 +57,7 @@ class AMP_Options_Menu {
 			__( 'AMP', 'amp' ),
 			'edit_posts',
 			AMP_Options_Manager::OPTION_NAME,
-			array( $this, 'render_screen' ),
+			[ $this, 'render_screen' ],
 			self::ICON_BASE64_SVG
 		);
 
@@ -79,45 +79,45 @@ class AMP_Options_Menu {
 		add_settings_field(
 			'experiences',
 			__( 'Experiences', 'amp' ),
-			array( $this, 'render_experiences' ),
+			[ $this, 'render_experiences' ],
 			AMP_Options_Manager::OPTION_NAME,
 			'general',
-			array(
+			[
 				'class' => 'experiences',
-			)
+			]
 		);
 
 		add_settings_field(
 			'theme_support',
 			__( 'Website Mode', 'amp' ),
-			array( $this, 'render_theme_support' ),
+			[ $this, 'render_theme_support' ],
 			AMP_Options_Manager::OPTION_NAME,
 			'general',
-			array(
+			[
 				'class' => 'amp-website-mode',
-			)
+			]
 		);
 
 		add_settings_field(
 			'validation',
 			__( 'Validation Handling', 'amp' ),
-			array( $this, 'render_validation_handling' ),
+			[ $this, 'render_validation_handling' ],
 			AMP_Options_Manager::OPTION_NAME,
 			'general',
-			array(
+			[
 				'class' => 'amp-validation-field',
-			)
+			]
 		);
 
 		add_settings_field(
 			'supported_templates',
 			__( 'Supported Templates', 'amp' ),
-			array( $this, 'render_supported_templates' ),
+			[ $this, 'render_supported_templates' ],
 			AMP_Options_Manager::OPTION_NAME,
 			'general',
-			array(
+			[
 				'class' => 'amp-template-support-field',
-			)
+			]
 		);
 
 		add_action(
@@ -139,18 +139,18 @@ class AMP_Options_Menu {
 			add_settings_field(
 				'caching',
 				__( 'Caching', 'amp' ),
-				array( $this, 'render_caching' ),
+				[ $this, 'render_caching' ],
 				AMP_Options_Manager::OPTION_NAME,
 				'general',
-				array(
+				[
 					'class' => 'amp-caching-field',
-				)
+				]
 			);
 		}
 
-		$submenus = array(
+		$submenus = [
 			new AMP_Analytics_Options_Submenu( AMP_Options_Manager::OPTION_NAME ),
-		);
+		];
 
 		// Create submenu items and calls on the Submenu Page object to render the actual contents of the page.
 		foreach ( $submenus as $submenu ) {
@@ -354,10 +354,10 @@ class AMP_Options_Menu {
 											'<a href="%s">%s</a>',
 											esc_url(
 												add_query_arg(
-													array(
+													[
 														'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 														'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-													),
+													],
 													admin_url( 'edit-tags.php' )
 												)
 											),
@@ -393,9 +393,9 @@ class AMP_Options_Menu {
 		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 			<?php
 			$auto_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization(
-				array(
+				[
 					'code' => 'non_existent',
-				)
+				]
 			);
 
 			$forced_sanitization = 'with_filter' === $auto_sanitization['forced'];
@@ -426,10 +426,10 @@ class AMP_Options_Menu {
 								__( 'Existing validation errors which you have already rejected will not be modified (you may want to consider <a href="%s">bulk-accepting them</a>).', 'amp' ),
 								esc_url(
 									add_query_arg(
-										array(
+										[
 											'taxonomy'  => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 											'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-										),
+										],
 										admin_url( 'edit-tags.php' )
 									)
 								)

--- a/includes/options/views/class-amp-analytics-options-submenu-page.php
+++ b/includes/options/views/class-amp-analytics-options-submenu-page.php
@@ -186,7 +186,7 @@ class AMP_Analytics_Options_Submenu_Page {
 	public function render() {
 		$this->render_styles();
 
-		$analytics_entries = AMP_Options_Manager::get_option( 'analytics', array() );
+		$analytics_entries = AMP_Options_Manager::get_option( 'analytics', [] );
 
 		$this->render_title( ! empty( $analytics_entries ) );
 

--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -26,9 +26,9 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'add_noscript_fallback' => true,
-	);
+	];
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -36,9 +36,9 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
-		return array(
-			'audio' => array( 'amp-audio' ),
-		);
+		return [
+			'audio' => [ 'amp-audio' ],
+		];
 	}
 
 	/**
@@ -68,7 +68,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 
 			// For amp-audio, the default width and height are inferred from browser.
-			$sources        = array();
+			$sources        = [];
 			$new_attributes = $this->filter_attributes( $old_attributes );
 			if ( ! empty( $new_attributes['src'] ) ) {
 				$sources[] = $new_attributes['src'];
@@ -83,7 +83,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Gather all child nodes and supply empty video dimensions from sources.
 			$fallback    = null;
-			$child_nodes = array();
+			$child_nodes = [];
 			while ( $node->firstChild ) {
 				$child_node = $node->removeChild( $node->firstChild );
 				if ( $child_node instanceof DOMElement && 'source' === $child_node->nodeName && $child_node->hasAttribute( 'src' ) ) {
@@ -133,7 +133,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Make sure the updated src and poster are applied to the original.
-			foreach ( array( 'src', 'poster', 'artwork' ) as $attr_name ) {
+			foreach ( [ 'src', 'poster', 'artwork' ] as $attr_name ) {
 				if ( $new_node->hasAttribute( $attr_name ) ) {
 					$old_node->setAttribute( $attr_name, $new_node->getAttribute( $attr_name ) );
 				}
@@ -180,7 +180,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Returns HTML attributes; removes any not specifically declared above from input.
 	 */
 	private function filter_attributes( $attributes ) {
-		$out = array();
+		$out = [];
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -35,7 +35,7 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array();
+	protected $DEFAULT_ARGS = [];
 
 	/**
 	 * DOM.
@@ -91,7 +91,7 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	private $should_not_removed_nodes = array();
+	private $should_not_removed_nodes = [];
 
 	/**
 	 * AMP_Base_Sanitizer constructor.
@@ -110,7 +110,7 @@ abstract class AMP_Base_Sanitizer {
 	 *      @type string[] $amp_layout_allowed_attributes
 	 * }
 	 */
-	public function __construct( $dom, $args = array() ) {
+	public function __construct( $dom, $args = [] ) {
 		$this->dom  = $dom;
 		$this->args = array_merge( $this->DEFAULT_ARGS, $args );
 
@@ -135,7 +135,7 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @param array $args Args.
 	 */
-	public static function add_buffering_hooks( $args = array() ) {}
+	public static function add_buffering_hooks( $args = [] ) {}
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -143,7 +143,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -174,7 +174,7 @@ abstract class AMP_Base_Sanitizer {
 	 *                  or if it did not find any HTML elements to convert to AMP equivalents.
 	 */
 	public function get_scripts() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -186,7 +186,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @return array[][] Mapping of CSS selectors to arrays of properties.
 	 */
 	public function get_styles() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -196,7 +196,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @return array Values are the CSS stylesheets. Keys are MD5 hashes of the stylesheets.
 	 */
 	public function get_stylesheets() {
-		$stylesheets = array();
+		$stylesheets = [];
 
 		foreach ( $this->get_styles() as $selector => $properties ) {
 			$stylesheet = sprintf( '%s { %s }', $selector, implode( '; ', $properties ) . ';' );
@@ -350,7 +350,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @param array              $validation_error Validation error details.
 	 * @return bool Whether the node should have been removed, that is, that the node was sanitized for validity.
 	 */
-	public function remove_invalid_child( $node, $validation_error = array() ) {
+	public function remove_invalid_child( $node, $validation_error = [] ) {
 
 		// Prevent double-reporting nodes that are rejected for sanitization.
 		if ( isset( $this->should_not_removed_nodes[ $node->nodeName ] ) && in_array( $node, $this->should_not_removed_nodes[ $node->nodeName ], true ) ) {
@@ -379,7 +379,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @param array          $validation_error Validation error details.
 	 * @return bool Whether the node should have been removed, that is, that the node was sanitized for validity.
 	 */
-	public function remove_invalid_attribute( $element, $attribute, $validation_error = array() ) {
+	public function remove_invalid_attribute( $element, $attribute, $validation_error = [] ) {
 		if ( is_string( $attribute ) ) {
 			$node = $element->getAttributeNode( $attribute );
 		} else {
@@ -401,7 +401,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @param array $data             Data including the node.
 	 * @return bool Whether to sanitize.
 	 */
-	public function should_sanitize_validation_error( $validation_error, $data = array() ) {
+	public function should_sanitize_validation_error( $validation_error, $data = [] ) {
 		if ( empty( $this->args['validation_error_callback'] ) || ! is_callable( $this->args['validation_error_callback'] ) ) {
 			return true;
 		}
@@ -424,7 +424,7 @@ abstract class AMP_Base_Sanitizer {
 	 * }
 	 * @return array Error.
 	 */
-	public function prepare_validation_error( array $error = array(), array $data = array() ) {
+	public function prepare_validation_error( array $error = [], array $data = [] ) {
 		$node    = null;
 		$matches = null;
 
@@ -447,7 +447,7 @@ abstract class AMP_Base_Sanitizer {
 			}
 
 			if ( ! isset( $error['node_attributes'] ) ) {
-				$error['node_attributes'] = array();
+				$error['node_attributes'] = [];
 				foreach ( $node->attributes as $attribute ) {
 					$error['node_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
 				}
@@ -473,7 +473,7 @@ abstract class AMP_Base_Sanitizer {
 				$error['type'] = preg_match( '/^on\w+/', $node->nodeName ) ? AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE : AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE;
 			}
 			if ( ! isset( $error['element_attributes'] ) ) {
-				$error['element_attributes'] = array();
+				$error['element_attributes'] = [];
 				if ( $node->parentNode && $node->parentNode->hasAttributes() ) {
 					foreach ( $node->parentNode->attributes as $attribute ) {
 						$error['element_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
@@ -492,7 +492,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @return array AMP data array.
 	 */
 	public function get_data_amp_attributes( $node ) {
-		$attributes = array();
+		$attributes = [];
 
 		// Editor blocks add 'figure' as the parent node for images. If this node has data-amp-layout then we should add this as the layout attribute.
 		$parent_node = $node->parentNode;
@@ -580,11 +580,11 @@ abstract class AMP_Base_Sanitizer {
 		$amp_image_lightbox = AMP_DOM_Utils::create_node(
 			$this->dom,
 			'amp-image-lightbox',
-			array(
+			[
 				'id'                           => self::AMP_IMAGE_LIGHTBOX_ID,
 				'layout'                       => 'nodisplay',
 				'data-close-button-aria-label' => __( 'Close', 'amp' ),
-			)
+			]
 		);
 		$body_node->appendChild( $amp_image_lightbox );
 	}

--- a/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -22,11 +22,11 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
-		'add_blacklisted_protocols'  => array(),
-		'add_blacklisted_tags'       => array(),
-		'add_blacklisted_attributes' => array(),
-	);
+	protected $DEFAULT_ARGS = [
+		'add_blacklisted_protocols'  => [],
+		'add_blacklisted_tags'       => [],
+		'add_blacklisted_attributes' => [],
+	];
 
 	/**
 	 * Sanitize.
@@ -187,8 +187,8 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			$href = untrailingslashit( get_home_url() ) . $href;
 		}
 
-		$valid_protocols   = array( 'http', 'https', 'mailto', 'sms', 'tel', 'viber', 'whatsapp' );
-		$special_protocols = array( 'tel', 'sms' ); // These ones don't valid with `filter_var+FILTER_VALIDATE_URL`.
+		$valid_protocols   = [ 'http', 'https', 'mailto', 'sms', 'tel', 'viber', 'whatsapp' ];
+		$special_protocols = [ 'tel', 'sms' ]; // These ones don't valid with `filter_var+FILTER_VALIDATE_URL`.
 		$protocol          = strtok( $href, ':' );
 
 		if ( false === filter_var( $href, FILTER_VALIDATE_URL )
@@ -252,9 +252,9 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_blacklisted_protocols() {
 		return $this->merge_defaults_with_args(
 			'add_blacklisted_protocols',
-			array(
+			[
 				'javascript',
-			)
+			]
 		);
 	}
 
@@ -266,7 +266,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_blacklisted_tags() {
 		return $this->merge_defaults_with_args(
 			'add_blacklisted_tags',
-			array(
+			[
 				'script',
 				'noscript',
 				'style',
@@ -290,7 +290,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Other weird ones.
 				'comments-count',
-			)
+			]
 		);
 	}
 
@@ -302,13 +302,13 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_blacklisted_attributes() {
 		return $this->merge_defaults_with_args(
 			'add_blacklisted_attributes',
-			array(
+			[
 				'style',
 				'size',
 				'clear',
 				'align',
 				'valign',
-			)
+			]
 		);
 	}
 }

--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -19,9 +19,9 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'comment_live_list' => false,
-	);
+	];
 
 	/**
 	 * Pre-process the comment form and comment list for AMP.
@@ -74,7 +74,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 		 *
 		 * @var DOMElement[][] $form_fields
 		 */
-		$form_fields = array();
+		$form_fields = [];
 		foreach ( $comment_form->getElementsByTagName( 'input' ) as $element ) {
 			$name = $element->getAttribute( 'name' );
 			if ( $name ) {
@@ -94,11 +94,11 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 		$post_id  = (int) $form_fields['comment_post_ID'][0]->getAttribute( 'value' );
 		$state_id = AMP_Theme_Support::get_comment_form_state_id( $post_id );
 
-		$form_state = array(
-			'values'      => array(),
+		$form_state = [
+			'values'      => [],
 			'submitting'  => false,
 			'replyToName' => '',
-		);
+		];
 
 		if ( ! empty( $form_fields['comment_parent'] ) ) {
 			$comment_id = (int) $form_fields['comment_parent'][0]->getAttribute( 'value' );
@@ -115,7 +115,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $form_field as $element ) {
 
 				// @todo Radio and checkbox inputs are not supported yet.
-				if ( in_array( strtolower( $element->getAttribute( 'type' ) ), array( 'checkbox', 'radio' ), true ) ) {
+				if ( in_array( strtolower( $element->getAttribute( 'type' ) ), [ 'checkbox', 'radio' ], true ) ) {
 					continue;
 				}
 
@@ -157,7 +157,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 			$form_reset_state['values']['email'],
 			$form_reset_state['values']['url']
 		);
-		$on = array(
+		$on = [
 			// Disable the form when submitting.
 			sprintf(
 				'submit:AMP.setState( { %s: { submitting: true } } )',
@@ -174,7 +174,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 				$state_id,
 				wp_json_encode( $form_reset_state, JSON_UNESCAPED_UNICODE )
 			),
-		);
+		];
 		$comment_form->setAttribute( 'on', implode( ';', $on ) );
 	}
 
@@ -203,11 +203,11 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Ensure the top-level data-update-time reflects the max time of the comments in the thread.
 		$children = $comment_object->get_children(
-			array(
+			[
 				'format'       => 'flat',
 				'hierarchical' => 'flat',
 				'orderby'      => 'none',
-			)
+			]
 		);
 		foreach ( $children as $child_comment ) {
 			$update_time = max( strtotime( $child_comment->comment_date ), $update_time );

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -50,132 +50,132 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.0
 	 * @var array
 	 */
-	protected static $theme_features = array(
+	protected static $theme_features = [
 		// Twenty Nineteen.
-		'twentynineteen'  => array(
-			'dequeue_scripts'                    => array(
+		'twentynineteen'  => [
+			'dequeue_scripts'                    => [
 				'twentynineteen-skip-link-focus-fix', // This is part of AMP. See <https://github.com/ampproject/amphtml/issues/18671>.
 				'twentynineteen-priority-menu',
 				'twentynineteen-touch-navigation', // @todo There could be an AMP implementation of this, similar to what is implemented on ampproject.org.
-			),
-			'remove_actions'                     => array(
-				'wp_print_footer_scripts' => array(
+			],
+			'remove_actions'                     => [
+				'wp_print_footer_scripts' => [
 					'twentynineteen_skip_link_focus_fix', // See <https://github.com/WordPress/twentynineteen/pull/47>.
-				),
-			),
-			'add_twentynineteen_masthead_styles' => array(),
-			'adjust_twentynineteen_images'       => array(),
-		),
+				],
+			],
+			'add_twentynineteen_masthead_styles' => [],
+			'adjust_twentynineteen_images'       => [],
+		],
 
 		// Twenty Seventeen.
-		'twentyseventeen' => array(
+		'twentyseventeen' => [
 			// @todo Try to implement belowEntryMetaClass().
-			'dequeue_scripts'                     => array(
+			'dequeue_scripts'                     => [
 				'twentyseventeen-html5', // Only relevant for IE<9.
 				'twentyseventeen-global', // There are somethings not yet implemented in AMP. See todos below.
 				'jquery-scrollto', // Implemented via add_smooth_scrolling().
 				'twentyseventeen-navigation', // Handled by add_nav_menu_styles, add_nav_menu_toggle, add_nav_sub_menu_buttons.
 				'twentyseventeen-skip-link-focus-fix', // Unnecessary since part of the AMP runtime.
-			),
-			'remove_actions'                      => array(
-				'wp_head' => array(
+			],
+			'remove_actions'                      => [
+				'wp_head' => [
 					'twentyseventeen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
-				),
-			),
-			'force_svg_support'                   => array(),
-			'force_fixed_background_support'      => array(),
-			'add_twentyseventeen_masthead_styles' => array(),
-			'add_twentyseventeen_image_styles'    => array(),
-			'add_twentyseventeen_sticky_nav_menu' => array(),
-			'add_has_header_video_body_class'     => array(),
-			'add_nav_menu_styles'                 => array(
+				],
+			],
+			'force_svg_support'                   => [],
+			'force_fixed_background_support'      => [],
+			'add_twentyseventeen_masthead_styles' => [],
+			'add_twentyseventeen_image_styles'    => [],
+			'add_twentyseventeen_sticky_nav_menu' => [],
+			'add_has_header_video_body_class'     => [],
+			'add_nav_menu_styles'                 => [
 				'sub_menu_button_toggle_class' => 'toggled-on',
 				'no_js_submenu_visible'        => true,
-			),
-			'add_smooth_scrolling'                => array(
+			],
+			'add_smooth_scrolling'                => [
 				'//header[@id = "masthead"]//a[ contains( @class, "menu-scroll-down" ) ]',
-			),
-			'set_twentyseventeen_quotes_icon'     => array(),
-			'add_twentyseventeen_attachment_image_attributes' => array(),
-		),
+			],
+			'set_twentyseventeen_quotes_icon'     => [],
+			'add_twentyseventeen_attachment_image_attributes' => [],
+		],
 
 		// Twenty Sixteen.
-		'twentysixteen'   => array(
+		'twentysixteen'   => [
 			// @todo Figure out an AMP solution for onResizeARIA().
 			// @todo Try to implement belowEntryMetaClass().
-			'dequeue_scripts'     => array(
+			'dequeue_scripts'     => [
 				'twentysixteen-script',
 				'twentysixteen-html5', // Only relevant for IE<9.
 				'twentysixteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
 				'twentysixteen-skip-link-focus-fix', // Unnecessary since part of the AMP runtime.
-			),
-			'remove_actions'      => array(
-				'wp_head' => array(
+			],
+			'remove_actions'      => [
+				'wp_head' => [
 					'twentysixteen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
-				),
-			),
-			'add_nav_menu_styles' => array(
+				],
+			],
+			'add_nav_menu_styles' => [
 				'sub_menu_button_toggle_class' => 'toggled-on',
 				'no_js_submenu_visible'        => true,
-			),
-		),
+			],
+		],
 
 		// Twenty Fifteen.
-		'twentyfifteen'   => array(
+		'twentyfifteen'   => [
 			// @todo Figure out an AMP solution for onResizeARIA().
-			'dequeue_scripts'     => array(
+			'dequeue_scripts'     => [
 				'twentyfifteen-script',
 				'twentyfifteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
 				'twentyfifteen-skip-link-focus-fix', // Unnecessary since part of the AMP runtime.
-			),
-			'remove_actions'      => array(
-				'wp_head' => array(
+			],
+			'remove_actions'      => [
+				'wp_head' => [
 					'twentyfifteen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
-				),
-			),
-			'add_nav_menu_styles' => array(
+				],
+			],
+			'add_nav_menu_styles' => [
 				'sub_menu_button_toggle_class' => 'toggle-on',
 				'no_js_submenu_visible'        => true,
-			),
-		),
+			],
+		],
 
 		// Twenty Fourteen.
-		'twentyfourteen'  => array(
+		'twentyfourteen'  => [
 			// @todo Figure out an AMP solution for onResizeARIA().
-			'dequeue_scripts'                    => array(
+			'dequeue_scripts'                    => [
 				'twentyfourteen-script',
 				'twentyfourteen-keyboard-image-navigation', // AMP does not yet allow for listening to keydown events.
 				'jquery-masonry', // Masonry style layout is not supported in AMP.
 				'twentyfourteen-slider',
-			),
-			'add_nav_menu_styles'                => array(),
-			'add_twentyfourteen_masthead_styles' => array(),
-			'add_twentyfourteen_slider_carousel' => array(),
-			'add_twentyfourteen_search'          => array(),
-		),
+			],
+			'add_nav_menu_styles'                => [],
+			'add_twentyfourteen_masthead_styles' => [],
+			'add_twentyfourteen_slider_carousel' => [],
+			'add_twentyfourteen_search'          => [],
+		],
 
 		// Twenty Thirteen.
-		'twentythirteen'  => array(
-			'dequeue_scripts'          => array(
+		'twentythirteen'  => [
+			'dequeue_scripts'          => [
 				'jquery-masonry', // Masonry style layout is not supported in AMP.
 				'twentythirteen-script',
-			),
-			'add_nav_menu_toggle'      => array(),
-			'add_nav_sub_menu_buttons' => array(),
-			'add_nav_menu_styles'      => array(),
-		),
+			],
+			'add_nav_menu_toggle'      => [],
+			'add_nav_sub_menu_buttons' => [],
+			'add_nav_menu_styles'      => [],
+		],
 
 		// Twenty Twelve.
-		'twentytwelve'    => array(
-			'dequeue_scripts'     => array(
+		'twentytwelve'    => [
+			'dequeue_scripts'     => [
 				'twentytwelve-navigation',
-			),
-			'add_nav_menu_styles' => array(),
-		),
+			],
+			'add_nav_menu_styles' => [],
+		],
 
-		'twentyeleven'    => array(),
-		'twentyten'       => array(),
-	);
+		'twentyeleven'    => [],
+		'twentyten'       => [],
+	];
 
 	/**
 	 * Get list of supported core themes.
@@ -198,19 +198,19 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public static function get_acceptable_errors( $template ) {
 		if ( isset( self::$theme_features[ $template ] ) ) {
-			return array(
+			return [
 				'removed_unused_css_rules' => true,
-				'illegal_css_at_rule'      => array(
-					array(
+				'illegal_css_at_rule'      => [
+					[
 						'at_rule' => 'viewport',
-					),
-					array(
+					],
+					[
 						'at_rule' => '-ms-viewport',
-					),
-				),
-			);
+					],
+				],
+			];
 		}
-		return array();
+		return [];
 	}
 
 	/**
@@ -231,7 +231,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 		$support = AMP_Theme_Support::get_theme_support_args();
 		if ( ! is_array( $support ) ) {
-			$support = array();
+			$support = [];
 		}
 
 		add_theme_support( AMP_Theme_Support::SLUG, array_merge( $support, $args ) );
@@ -249,93 +249,93 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		// phpcs:disable WordPress.WP.I18n.TextDomainMismatch
 		switch ( $theme ) {
 			case 'twentytwelve':
-				return array(
-					'nav_menu_toggle' => array(
+				return [
+					'nav_menu_toggle' => [
 						'nav_container_xpath'        => '//nav[ @id = "site-navigation" ]//ul',
 						'nav_container_toggle_class' => 'toggled-on',
 						'menu_button_xpath'          => '//nav[ @id = "site-navigation" ]//button[ contains( @class, "menu-toggle" ) ]',
 						'menu_button_toggle_class'   => 'toggled-on',
-					),
-				);
+					],
+				];
 			case 'twentythirteen':
-				return array(
-					'nav_menu_toggle'   => array(
+				return [
+					'nav_menu_toggle'   => [
 						'nav_container_id'           => 'site-navigation',
 						'nav_container_toggle_class' => 'toggled-on',
 						'menu_button_xpath'          => '//nav[ @id = "site-navigation" ]//button[ contains( @class, "menu-toggle" ) ]',
-					),
-					'nav_menu_dropdown' => array(
+					],
+					'nav_menu_dropdown' => [
 						'sub_menu_button_class'        => 'dropdown-toggle',
 						'sub_menu_button_toggle_class' => 'toggle-on',
 						'expand_text'                  => __( 'expand child menu', 'amp' ),
 						'collapse_text'                => __( 'collapse child menu', 'amp' ),
-					),
-					'nav_menu_styles'   => array(),
-				);
+					],
+					'nav_menu_styles'   => [],
+				];
 			case 'twentyfourteen':
-				return array(
-					'nav_menu_toggle' => array(
+				return [
+					'nav_menu_toggle' => [
 						'nav_container_id'           => 'primary-navigation',
 						'nav_container_toggle_class' => 'toggled-on',
 						'menu_button_xpath'          => '//header[ @id = "masthead" ]//button[ contains( @class, "menu-toggle" ) ]',
 						'menu_button_toggle_class'   => '',
-					),
-				);
+					],
+				];
 
 			case 'twentyfifteen':
-				return array(
-					'nav_menu_toggle'   => array(
+				return [
+					'nav_menu_toggle'   => [
 						'nav_container_id'           => 'secondary',
 						'nav_container_toggle_class' => 'toggled-on',
 						'menu_button_xpath'          => '//header[ @id = "masthead" ]//button[ contains( @class, "secondary-toggle" ) ]',
 						'menu_button_toggle_class'   => 'toggled-on',
-					),
-					'nav_menu_dropdown' => array(
+					],
+					'nav_menu_dropdown' => [
 						'sub_menu_button_class'        => 'dropdown-toggle',
 						'sub_menu_button_toggle_class' => 'toggle-on',
 						'expand_text '                 => __( 'expand child menu', 'twentyfifteen' ),
 						'collapse_text'                => __( 'collapse child menu', 'twentyfifteen' ),
-					),
-				);
+					],
+				];
 
 			case 'twentysixteen':
-				return array(
-					'nav_menu_toggle'   => array(
+				return [
+					'nav_menu_toggle'   => [
 						'nav_container_id'           => 'site-header-menu',
 						'nav_container_toggle_class' => 'toggled-on',
 						'menu_button_xpath'          => '//header[@id = "masthead"]//button[ @id = "menu-toggle" ]',
 						'menu_button_toggle_class'   => 'toggled-on',
-					),
-					'nav_menu_dropdown' => array(
+					],
+					'nav_menu_dropdown' => [
 						'sub_menu_button_class'        => 'dropdown-toggle',
 						'sub_menu_button_toggle_class' => 'toggled-on',
 						'expand_text '                 => __( 'expand child menu', 'twentysixteen' ),
 						'collapse_text'                => __( 'collapse child menu', 'twentysixteen' ),
-					),
-				);
+					],
+				];
 
 			case 'twentyseventeen':
-				$config = array(
-					'nav_menu_toggle'   => array(
+				$config = [
+					'nav_menu_toggle'   => [
 						'nav_container_id'           => 'site-navigation',
 						'nav_container_toggle_class' => 'toggled-on',
 						'menu_button_xpath'          => '//nav[@id = "site-navigation"]//button[ contains( @class, "menu-toggle" ) ]',
 						'menu_button_toggle_class'   => 'toggled-on',
-					),
-					'nav_menu_dropdown' => array(
+					],
+					'nav_menu_dropdown' => [
 						'sub_menu_button_class'        => 'dropdown-toggle',
 						'sub_menu_button_toggle_class' => 'toggled-on',
 						'expand_text '                 => __( 'expand child menu', 'twentyseventeen' ),
 						'collapse_text'                => __( 'collapse child menu', 'twentyseventeen' ),
-					),
-				);
+					],
+				];
 
 				if ( function_exists( 'twentyseventeen_get_svg' ) ) {
 					$config['nav_menu_dropdown']['icon'] = twentyseventeen_get_svg(
-						array(
+						[
 							'icon'     => 'angle-down',
 							'fallback' => true,
-						)
+						]
 					);
 				}
 
@@ -343,7 +343,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		}
 		// phpcs:enable WordPress.WP.I18n.TextDomainMismatch
 
-		return array();
+		return [];
 	}
 
 	/**
@@ -374,8 +374,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Theme features.
 	 */
 	protected static function get_theme_features( $args, $static = false ) {
-		$theme_features   = array();
-		$theme_candidates = wp_array_slice_assoc( $args, array( 'stylesheet', 'template' ) );
+		$theme_features   = [];
+		$theme_candidates = wp_array_slice_assoc( $args, [ 'stylesheet', 'template' ] );
 		foreach ( $theme_candidates as $theme_candidate ) {
 			if ( isset( self::$theme_features[ $theme_candidate ] ) ) {
 				$theme_features = self::$theme_features[ $theme_candidate ];
@@ -388,7 +388,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			$theme_features = array_merge( $args['theme_features'], $theme_features );
 		}
 
-		$final_theme_features = array();
+		$final_theme_features = [];
 		foreach ( $theme_features as $theme_feature => $feature_args ) {
 			if ( ! method_exists( __CLASS__, $theme_feature ) ) {
 				continue;
@@ -412,11 +412,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param array $args Args.
 	 */
-	public static function add_buffering_hooks( $args = array() ) {
+	public static function add_buffering_hooks( $args = [] ) {
 		$theme_features = self::get_theme_features( $args, true );
 		foreach ( $theme_features as $theme_feature => $feature_args ) {
 			if ( method_exists( __CLASS__, $theme_feature ) ) {
-				call_user_func( array( __CLASS__, $theme_feature ), $feature_args );
+				call_user_func( [ __CLASS__, $theme_feature ], $feature_args );
 			}
 		}
 	}
@@ -436,7 +436,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Why isn't Twenty Seventeen doing this to begin with? Why is it using JS to add the quote icon?
 				if ( function_exists( 'twentyseventeen_get_svg' ) && 'quote' === get_post_format() ) {
-					$icon    = twentyseventeen_get_svg( array( 'icon' => 'quote-right' ) );
+					$icon    = twentyseventeen_get_svg( [ 'icon' => 'quote-right' ] );
 					$content = preg_replace( '#(<blockquote.*?>)#s', '$1' . $icon, $content );
 				}
 
@@ -509,7 +509,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param string[] $handles Handles, where each item value is the script handle.
 	 */
-	public static function dequeue_scripts( $handles = array() ) {
+	public static function dequeue_scripts( $handles = [] ) {
 		add_action(
 			'wp_enqueue_scripts',
 			static function() use ( $handles ) {
@@ -528,7 +528,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param array $actions Actions, with action name as key and value being callback.
 	 */
-	public static function remove_actions( $actions = array() ) {
+	public static function remove_actions( $actions = [] ) {
 		foreach ( $actions as $action => $callbacks ) {
 			foreach ( $callbacks as $callback ) {
 				$priority = has_action( $action, $callback );
@@ -603,11 +603,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param array $args Args.
 	 */
-	public static function add_has_header_video_body_class( $args = array() ) {
+	public static function add_has_header_video_body_class( $args = [] ) {
 		$args = array_merge(
-			array(
+			[
 				'class_name' => 'has-header-video',
-			),
+			],
 			$args
 		);
 
@@ -677,7 +677,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 				</style>
 				<?php
-				$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
+				$styles = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
 				wp_add_inline_style( get_template() . '-style', $styles );
 			},
 			11
@@ -783,7 +783,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 				</style>
 				<?php
-				$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
+				$styles = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
 				wp_add_inline_style( get_template() . '-style', $styles );
 			},
 			11
@@ -815,7 +815,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 				</style>
 				<?php
-				$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
+				$styles = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
 				wp_add_inline_style( get_template() . '-style', $styles );
 			},
 			11
@@ -861,58 +861,58 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			$element->setAttribute( 'id', $element->getAttribute( 'id' ) . '-fixed' );
 		}
 
-		$attributes = array(
+		$attributes = [
 			'layout'              => 'nodisplay',
 			'intersection-ratios' => 1,
 			'on'                  => implode(
 				';',
-				array(
+				[
 					'exit:navigationTopShow.start',
 					'enter:navigationTopHide.start',
-				)
+				]
 			),
-		);
+		];
 		if ( is_admin_bar_showing() ) {
 			$attributes['viewport-margins'] = '32px 0';
 		}
 		$position_observer = AMP_DOM_Utils::create_node( $this->dom, 'amp-position-observer', $attributes );
 		$navigation_top->appendChild( $position_observer );
 
-		$animations = array(
-			'navigationTopShow' => array(
+		$animations = [
+			'navigationTopShow' => [
 				'duration'   => 0,
 				'fill'       => 'both',
-				'animations' => array(
+				'animations' => [
 					'selector'  => '.navigation-top.site-navigation-fixed',
 					'media'     => '(min-width: 48em)',
-					'keyframes' => array(
+					'keyframes' => [
 						'opacity'   => 1.0,
 						'transform' => 'translateY( 0 )',
-					),
-				),
-			),
-			'navigationTopHide' => array(
+					],
+				],
+			],
+			'navigationTopHide' => [
 				'duration'   => 0,
 				'fill'       => 'both',
-				'animations' => array(
+				'animations' => [
 					'selector'  => '.navigation-top.site-navigation-fixed',
 					'media'     => '(min-width: 48em)',
-					'keyframes' => array(
+					'keyframes' => [
 						'opacity'   => 0.0,
 						'transform' => sprintf( 'translateY( -%dpx )', self::get_twentyseventeen_navigation_outer_height() ),
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 
 		foreach ( $animations as $animation_id => $animation ) {
 			$amp_animation   = AMP_DOM_Utils::create_node(
 				$this->dom,
 				'amp-animation',
-				array(
+				[
 					'id'     => $animation_id,
 					'layout' => 'nodisplay',
-				)
+				]
 			);
 			$position_script = $this->dom->createElement( 'script' );
 			$position_script->setAttribute( 'type', 'application/json' );
@@ -929,7 +929,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param array $args Args.
 	 */
-	public static function add_nav_menu_styles( $args = array() ) {
+	public static function add_nav_menu_styles( $args = [] ) {
 		add_action(
 			'wp_enqueue_scripts',
 			static function() use ( $args ) {
@@ -1208,7 +1208,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				<?php endif; ?>
 				</style>
 				<?php
-				$styles = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
+				$styles = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
 				wp_add_inline_style( get_template() . '-style', $styles );
 			},
 			11
@@ -1363,7 +1363,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					<?php endif; ?>
 				</style>
 				<?php
-				$css = str_replace( array( '<style>', '</style>' ), '', ob_get_clean() );
+				$css = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
 
 				wp_add_inline_style( 'twentyfourteen-style', $css );
 			},
@@ -1406,24 +1406,24 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		// Create the carousel slider.
 		$amp_carousel_desktop_id = 'twentyFourteenSliderDesktop';
 		$amp_carousel_mobile_id  = 'twentyFourteenSliderMobile';
-		$amp_carousel_attributes = array(
+		$amp_carousel_attributes = [
 			'layout'              => 'responsive',
 			'on'                  => "slideChange:AMP.setState( { $selected_slide_state_id: event.index } )",
 			'width'               => '100',
 			'type'                => 'slides',
 			'loop'                => '',
 			'data-amp-bind-slide' => $selected_slide_state_id,
-		);
+		];
 		$amp_carousel_desktop    = AMP_DOM_Utils::create_node(
 			$this->dom,
 			'amp-carousel',
 			array_merge(
 				$amp_carousel_attributes,
-				array(
+				[
 					'id'     => $amp_carousel_desktop_id,
 					'media'  => '(min-width: 672px)',
 					'height' => '55.49132947', // Value comes from <https://github.com/WordPress/wordpress-develop/blob/fc2a8f0e11316d066a686995b8578d82cd5546cf/src/wp-content/themes/twentyfourteen/style.css#L3024>.
-				)
+				]
 			)
 		);
 		$amp_carousel_mobile     = AMP_DOM_Utils::create_node(
@@ -1431,11 +1431,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			'amp-carousel',
 			array_merge(
 				$amp_carousel_attributes,
-				array(
+				[
 					'id'     => $amp_carousel_mobile_id,
 					'media'  => '(max-width: 672px)',
 					'height' => '73',
-				)
+				]
 			)
 		);
 

--- a/includes/sanitizers/class-amp-embed-sanitizer.php
+++ b/includes/sanitizers/class-amp-embed-sanitizer.php
@@ -17,7 +17,7 @@ class AMP_Embed_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var AMP_Base_Embed_Handler[] AMP_Base_Embed_Handler[]
 	 */
-	private $embed_handlers = array();
+	private $embed_handlers = [];
 
 	/**
 	 * AMP_Embed_Sanitizer constructor.
@@ -25,7 +25,7 @@ class AMP_Embed_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMDocument $dom  DOM.
 	 * @param array       $args Args.
 	 */
-	public function __construct( $dom, $args = array() ) {
+	public function __construct( $dom, $args = [] ) {
 		parent::__construct( $dom, $args );
 
 		if ( ! empty( $this->args['embed_handlers'] ) ) {

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -112,7 +112,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			$target = $node->getAttribute( 'target' );
 			if ( '_top' !== $target ) {
-				if ( ! $target || in_array( $target, array( '_self', '_parent' ), true ) ) {
+				if ( ! $target || in_array( $target, [ '_self', '_parent' ], true ) ) {
 					$node->setAttribute( 'target', '_top' );
 				} elseif ( '_blank' !== $target ) {
 					$node->setAttribute( 'target', '_blank' );
@@ -135,11 +135,11 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 		 *
 		 * @var DOMElement $parent
 		 */
-		$elements = array(
+		$elements = [
 			'submit-error'   => null,
 			'submit-success' => null,
 			'submitting'     => null,
-		);
+		];
 
 		$templates = $form->getElementsByTagName( 'template' );
 		for ( $i = $templates->length - 1; $i >= 0; $i-- ) {

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -63,9 +63,9 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'carousel_required' => false,
-	);
+	];
 
 	/**
 	 * Sanitize the gallery block contained by <ul> element where necessary.
@@ -107,7 +107,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			$images = array();
+			$images = [];
 
 			// If it's not AMP lightbox, look for links first.
 			if ( ! $is_amp_lightbox ) {
@@ -133,12 +133,12 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 			$amp_carousel = AMP_DOM_Utils::create_node(
 				$this->dom,
 				'amp-carousel',
-				array(
+				[
 					'width'  => $width,
 					'height' => $height,
 					'type'   => 'slides',
 					'layout' => 'responsive',
-				)
+				]
 			);
 			foreach ( $images as $image ) {
 				$amp_carousel->appendChild( $image );
@@ -166,7 +166,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 		$max_height = 0;
 		$max_width  = 0;
 		if ( 0 === $num_images ) {
-			return array( self::FALLBACK_WIDTH, self::FALLBACK_HEIGHT );
+			return [ self::FALLBACK_WIDTH, self::FALLBACK_HEIGHT ];
 		}
 		foreach ( $images as $image ) {
 			/**
@@ -184,7 +184,7 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		return array( $max_width, $max_height );
+		return [ $max_width, $max_height ];
 	}
 
 	/**
@@ -198,12 +198,12 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 		if ( 0 === $num_images ) {
 			return;
 		}
-		$attributes = array(
+		$attributes = [
 			'data-amp-lightbox' => '',
 			'on'                => 'tap:' . self::AMP_IMAGE_LIGHTBOX_ID,
 			'role'              => 'button',
 			'tabindex'          => 0,
-		);
+		];
 
 		for ( $j = $num_images - 1; $j >= 0; $j-- ) {
 			$image_node = $images->item( $j );

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -43,12 +43,12 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *     @type string $alias_origin          An alternative origin which can be supplied which is used when encountering same-origin iframes.
 	 * }
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'add_placeholder'       => false,
 		'add_noscript_fallback' => true,
 		'current_origin'        => null,
 		'alias_origin'          => null,
-	);
+	];
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -56,11 +56,11 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
-		return array(
-			'iframe' => array(
+		return [
+			'iframe' => [
 				'amp-iframe',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -158,7 +158,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Returns HTML attributes; normalizes src, dimensions, frameborder, sandox, allowtransparency and allowfullscreen
 	 */
 	private function normalize_attributes( $attributes ) {
-		$out = array();
+		$out = [];
 
 		$remove_allow_same_origin = false;
 		foreach ( $attributes as $name => $value ) {
@@ -262,10 +262,10 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 		$placeholder_node = AMP_DOM_Utils::create_node(
 			$this->dom,
 			'span',
-			array(
+			[
 				'placeholder' => '',
 				'class'       => 'amp-wp-iframe-placeholder',
-			)
+			]
 		);
 
 		return $placeholder_node;

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -45,9 +45,9 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'add_noscript_fallback' => true,
-	);
+	];
 
 	/**
 	 * Animation extension.
@@ -62,12 +62,12 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
-		return array(
-			'img' => array(
+		return [
+			'img' => [
 				'amp-img',
 				'amp-anim',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -83,7 +83,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		 * @var DOMNodeList $node
 		 */
 		$nodes           = $this->dom->getElementsByTagName( self::$tag );
-		$need_dimensions = array();
+		$need_dimensions = [];
 
 		$num_nodes = $nodes->length;
 
@@ -136,7 +136,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 				(
 					( ! $has_width || ! $has_height )
 					&&
-					in_array( $layout, array( 'fixed', 'responsive', 'intrinsic' ), true )
+					in_array( $layout, [ 'fixed', 'responsive', 'intrinsic' ], true )
 				)
 			);
 			if ( $missing_dimensions ) {
@@ -186,7 +186,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Returns HTML attributes; removes any not specifically declared above from input.
 	 */
 	private function filter_attributes( $attributes ) {
-		$out = array();
+		$out = [];
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {
@@ -336,7 +336,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		 */
 		if ( $img_node->hasAttribute( 'style' ) ) {
 			$layout = $img_node->getAttribute( 'layout' );
-			if ( in_array( $layout, array( 'fixed-height', 'responsive', 'fill', 'flex-item' ), true ) ) {
+			if ( in_array( $layout, [ 'fixed-height', 'responsive', 'fill', 'flex-item' ], true ) ) {
 				$required_display = 'block';
 			} elseif ( 'nodisplay' === $layout ) {
 				$required_display = 'none';

--- a/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-dropdown-sanitizer.php
@@ -20,14 +20,14 @@ class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.1.0
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'sub_menu_button_class'        => '',
 		'sub_menu_button_toggle_class' => '',
 		'expand_text'                  => '',
 		'collapse_text'                => '',
 		'icon'                         => null, // Optional.
 		'sub_menu_item_state_id'       => 'navMenuItemExpanded',
-	);
+	];
 
 	/**
 	 * AMP_Nav_Menu_Dropdown_Sanitizer constructor.
@@ -37,7 +37,7 @@ class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMDocument $dom  DOM.
 	 * @param array       $args Args.
 	 */
-	public function __construct( $dom, $args = array() ) {
+	public function __construct( $dom, $args = [] ) {
 		parent::__construct( $dom, $args );
 
 		$this->args = self::ensure_defaults( $this->args );
@@ -50,7 +50,7 @@ class AMP_Nav_Menu_Dropdown_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param array $args Args.
 	 */
-	public static function add_buffering_hooks( $args = array() ) {
+	public static function add_buffering_hooks( $args = [] ) {
 		if ( empty( $args['sub_menu_button_class'] ) || empty( $args['sub_menu_button_toggle_class'] ) ) {
 			return;
 		}

--- a/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
+++ b/includes/sanitizers/class-amp-nav-menu-toggle-sanitizer.php
@@ -20,7 +20,7 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.1.0
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'nav_container_id'           => '',
 		'nav_container_xpath'        => '', // Alternative for 'nav_container_id', if no ID available.
 		'menu_button_id'             => '',
@@ -28,7 +28,7 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 		'nav_container_toggle_class' => '',
 		'menu_button_toggle_class'   => '', // Optional.
 		'nav_menu_toggle_state_id'   => 'navMenuToggledOn',
-	);
+	];
 
 	/**
 	 * XPath.
@@ -46,7 +46,7 @@ class AMP_Nav_Menu_Toggle_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMDocument $dom  DOM.
 	 * @param array       $args Args.
 	 */
-	public function __construct( $dom, $args = array() ) {
+	public function __construct( $dom, $args = [] ) {
 		parent::__construct( $dom, $args );
 
 		// Ensure the state ID is always set.

--- a/includes/sanitizers/class-amp-o2-player-sanitizer.php
+++ b/includes/sanitizers/class-amp-o2-player-sanitizer.php
@@ -99,12 +99,12 @@ class AMP_O2_Player_Sanitizer extends AMP_Base_Sanitizer {
 		if ( ! empty( $o2_attributes ) ) {
 			$component_attributes = array_merge(
 				$o2_attributes,
-				array(
+				[
 					'data-macros' => 'm.playback=click',
 					'layout'      => 'responsive',
 					'width'       => self::$width,
 					'height'      => self::$height,
-				)
+				]
 			);
 
 			$amp_o2_player = AMP_DOM_Utils::create_node( $dom, self::$amp_tag, $component_attributes );
@@ -129,13 +129,13 @@ class AMP_O2_Player_Sanitizer extends AMP_Base_Sanitizer {
 	private function get_o2_player_attributes( $src ) {
 		$found = preg_match( self::URL_PATTERN, $src, $matches );
 		if ( $found ) {
-			return array(
+			return [
 				'data-pid'  => $matches['data_pid'],
 				'data-vid'  => $matches['data_vid'],
 				'data-bcid' => $matches['data_bcid'],
-			);
+			];
 		}
-		return array();
+		return [];
 	}
 
 }

--- a/includes/sanitizers/class-amp-playbuzz-sanitizer.php
+++ b/includes/sanitizers/class-amp-playbuzz-sanitizer.php
@@ -46,9 +46,9 @@ class AMP_Playbuzz_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
-		return array(
-			'div.pb_feed' => array( 'amp-playbuzz.pb_feed' ),
-		);
+		return [
+			'div.pb_feed' => [ 'amp-playbuzz.pb_feed' ],
+		];
 	}
 
 	/**
@@ -108,7 +108,7 @@ class AMP_Playbuzz_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Returns HTML attributes; removes any not specifically declared above from input.
 	 */
 	private function filter_attributes( $attributes ) {
-		$out = array();
+		$out = [];
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -60,7 +60,7 @@ abstract class AMP_Rule_Spec {
 	 * @since 1.0
 	 * @var array
 	 */
-	public static $layout_enum = array(
+	public static $layout_enum = [
 		1 => 'nodisplay',
 		2 => 'fixed',
 		3 => 'fixed-height',
@@ -70,7 +70,7 @@ abstract class AMP_Rule_Spec {
 		7 => 'flex-item',
 		8 => 'fluid',
 		9 => 'intrinsic',
-	);
+	];
 
 	/**
 	 * List of boolean attributes.
@@ -78,7 +78,7 @@ abstract class AMP_Rule_Spec {
 	 * @since 0.7
 	 * @var array
 	 */
-	public static $boolean_attributes = array(
+	public static $boolean_attributes = [
 		'allowfullscreen',
 		'async',
 		'autofocus',
@@ -123,19 +123,19 @@ abstract class AMP_Rule_Spec {
 		'truespeed',
 		'typemustmatch',
 		'visible',
-	);
+	];
 
 	/**
 	 * Additional allowed tags.
 	 *
 	 * @var array
 	 */
-	public static $additional_allowed_tags = array(
+	public static $additional_allowed_tags = [
 
 		// An experimental tag with no protoascii.
-		'amp-share-tracking' => array(
-			'attr_spec_list' => array(),
-			'tag_spec'       => array(),
-		),
-	);
+		'amp-share-tracking' => [
+			'attr_spec_list' => [],
+			'tag_spec'       => [],
+		],
+	];
 }

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -97,17 +97,17 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
-		'dynamic_element_selectors' => array(
+	protected $DEFAULT_ARGS = [
+		'dynamic_element_selectors' => [
 			'amp-list',
 			'amp-live-list',
 			'[submit-error]',
 			'[submit-success]',
-		),
+		],
 		'should_locate_sources'     => false,
 		'parsed_cache_variant'      => null,
 		'include_manifest_comment'  => 'always',
-	);
+	];
 
 	/**
 	 * List of stylesheet parts prior to selector/rule removal (tree shaking).
@@ -122,7 +122,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *     @type bool               $keyframes  Whether an amp-keyframes.
 	 * }
 	 */
-	private $pending_stylesheets = array();
+	private $pending_stylesheets = [];
 
 	/**
 	 * Spec for style[amp-custom] cdata.
@@ -190,7 +190,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.1
 	 * @var array
 	 */
-	private $used_attributes = array(
+	private $used_attributes = [
 		'autofocus' => true,
 		'checked'   => true,
 		'controls'  => true,
@@ -202,7 +202,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'readonly'  => true,
 		'required'  => true,
 		'selected'  => true,
-	);
+	];
 
 	/**
 	 * Tag names used in document.
@@ -254,7 +254,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	private $processed_imported_stylesheet_urls = array();
+	private $processed_imported_stylesheet_urls = [];
 
 	/**
 	 * List of font stylesheets that were @import'ed which should have been <link>'ed to instead.
@@ -263,14 +263,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	private $imported_font_urls = array();
+	private $imported_font_urls = [];
 
 	/**
 	 * Mapping of HTML element selectors to AMP selector elements.
 	 *
 	 * @var array
 	 */
-	private $selector_mappings = array();
+	private $selector_mappings = [];
 
 	/**
 	 * Get error codes that can be raised during parsing of CSS.
@@ -281,7 +281,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array
 	 */
 	public static function get_css_parser_validation_error_codes() {
-		return array(
+		return [
 			'css_parse_error',
 			'excessive_css',
 			self::ILLEGAL_AT_RULE_ERROR_CODE,
@@ -290,7 +290,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			'unrecognized_css',
 			'disallowed_file_extension',
 			'file_path_not_found',
-		);
+		];
 	}
 
 	/**
@@ -338,7 +338,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMDocument $dom  Represents the HTML document to sanitize.
 	 * @param array       $args Args.
 	 */
-	public function __construct( DOMDocument $dom, array $args = array() ) {
+	public function __construct( DOMDocument $dom, array $args = [] ) {
 		parent::__construct( $dom, $args );
 
 		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'style' ) as $spec_rule ) {
@@ -378,7 +378,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array[] Mapping CSS selectors to array of properties, or mapping of keys starting with 'stylesheet:' with value being the stylesheet.
 	 */
 	public function get_styles() {
-		return array();
+		return [];
 	}
 
 	/**
@@ -410,14 +410,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			return $this->used_class_names;
 		}
 
-		$dynamic_class_names = array(
+		$dynamic_class_names = [
 
 			/*
 			 * See <https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
 			 * Note that amp-referrer-* class names are handled in has_used_class_name() below.
 			 */
 			'amp-viewer',
-		);
+		];
 
 		$classes = ' ';
 		foreach ( $this->xpath->query( '//*/@class' ) as $class_attribute ) {
@@ -480,7 +480,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
 			 */
 			if ( 'amp-active' === $class_name || 'amp-hidden' === $class_name ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-live-list' ) ) && ! $this->has_used_tag_names( array( 'amp-user-notification' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) && ! $this->has_used_tag_names( [ 'amp-user-notification' ] ) ) {
 					return false;
 				}
 				continue;
@@ -488,7 +488,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-carousel, see <https://www.ampproject.org/docs/reference/components/amp-carousel#styling>.
 			if ( 'amp-carousel-' === substr( $class_name, 0, 13 ) ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-carousel' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-carousel' ] ) ) {
 					return false;
 				}
 				continue;
@@ -496,7 +496,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-date-picker, see <https://www.ampproject.org/docs/reference/components/amp-date-picker>.
 			if ( 'amp-date-picker-' === substr( $class_name, 0, 16 ) ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-date-picker' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-date-picker' ] ) ) {
 					return false;
 				}
 				continue;
@@ -504,7 +504,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
 			if ( 'amp-form-' === substr( $class_name, 0, 9 ) || 'user-valid' === $class_name || 'user-invalid' === $class_name ) {
-				if ( ! $this->has_used_tag_names( array( 'form' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
 					return false;
 				}
 				continue;
@@ -516,7 +516,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 * See <https://www.ampproject.org/docs/reference/components/amp-access-laterpay#styling>
 			 */
 			if ( 'amp-access-' === substr( $class_name, 0, 11 ) ) {
-				if ( ! $this->has_used_attributes( array( 'amp-access' ) ) ) {
+				if ( ! $this->has_used_attributes( [ 'amp-access' ] ) ) {
 					return false;
 				}
 				continue;
@@ -524,7 +524,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
 			if ( 'amp-geo-' === substr( $class_name, 0, 8 ) || 'amp-iso-country-' === substr( $class_name, 0, 16 ) ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-geo' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-geo' ] ) ) {
 					return false;
 				}
 				continue;
@@ -532,7 +532,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
 			if ( 'amp-image-lightbox-caption' === $class_name ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-image-lightbox' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
 					return false;
 				}
 				continue;
@@ -540,7 +540,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-live-list, see <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
 			if ( 'amp-live-list-' === substr( $class_name, 0, 14 ) ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-live-list' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) ) {
 					return false;
 				}
 				continue;
@@ -548,7 +548,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-sidebar, see <https://www.ampproject.org/docs/reference/components/amp-sidebar#styling-toolbar>.
 			if ( 'amp-sidebar-' === substr( $class_name, 0, 12 ) ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-sidebar' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-sidebar' ] ) ) {
 					return false;
 				}
 				continue;
@@ -556,7 +556,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-sticky-ad, see <https://www.ampproject.org/docs/reference/components/amp-sticky-ad#styling>.
 			if ( 'amp-sticky-ad-' === substr( $class_name, 0, 14 ) ) {
-				if ( ! $this->has_used_tag_names( array( 'amp-sticky-ad' ) ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-sticky-ad' ] ) ) {
 					return false;
 				}
 				continue;
@@ -564,7 +564,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Class names for amp-video-docking, see <https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md#styling>.
 			if ( 'amp-docked-' === substr( $class_name, 0, 11 ) ) {
-				if ( ! $this->has_used_attributes( array( 'dock' ) ) ) {
+				if ( ! $this->has_used_attributes( [ 'dock' ] ) ) {
 					return false;
 				}
 				continue;
@@ -586,7 +586,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function get_used_tag_names() {
 		if ( ! isset( $this->used_tag_names ) ) {
-			$this->used_tag_names = array();
+			$this->used_tag_names = [];
 			foreach ( $this->dom->getElementsByTagName( '*' ) as $el ) {
 				$this->used_tag_names[ $el->tagName ] = true;
 			}
@@ -673,7 +673,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.4
 	 */
 	public function sanitize() {
-		$elements = array();
+		$elements = [];
 
 		// Do nothing if inline styles are allowed.
 		if ( ! empty( $this->args['allow_dirty_styles'] ) ) {
@@ -695,10 +695,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$xpath = $this->xpath;
 
 		$lower_case = 'translate( %s, "ABCDEFGHIJKLMNOPQRSTUVWXYZ", "abcdefghijklmnopqrstuvwxyz" )'; // In XPath 2.0 this is lower-case().
-		$predicates = array(
+		$predicates = [
 			sprintf( '( self::style and not( @amp-boilerplate ) and ( not( @type ) or %s = "text/css" ) )', sprintf( $lower_case, '@type' ) ),
 			sprintf( '( self::link and @href and %s = "stylesheet" )', sprintf( $lower_case, '@rel' ) ),
-		);
+		];
 
 		foreach ( $xpath->query( '//*[ ' . implode( ' or ', $predicates ) . ' ]' ) as $element ) {
 			$elements[] = $element;
@@ -745,7 +745,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		$elements = array();
+		$elements = [];
 		foreach ( $xpath->query( '//*[ @style ]' ) as $element ) {
 			$elements[] = $element;
 		}
@@ -796,15 +796,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$style_handle = $matches[1];
 			}
 
-			$core_frontend_handles = array(
+			$core_frontend_handles = [
 				'wp-block-library',
 				'wp-block-library-theme',
-			);
-			$non_amp_handles       = array(
+			];
+			$non_amp_handles       = [
 				'mediaelement',
 				'wp-mediaelement',
 				'thickbox',
-			);
+			];
 
 			if ( in_array( $style_handle, $non_amp_handles, true ) ) {
 				// Styles are for non-AMP JS only so not be used in AMP at all.
@@ -939,7 +939,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string[] $allowed_extensions Allowed file extensions for local files.
 	 * @return string|WP_Error Style's absolute validated filesystem path, or WP_Error when error.
 	 */
-	public function get_validated_url_file_path( $url, $allowed_extensions = array() ) {
+	public function get_validated_url_file_path( $url, $allowed_extensions = [] ) {
 		if ( ! is_string( $url ) ) {
 			return new WP_Error( 'url_not_string' );
 		}
@@ -981,11 +981,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$admin_url    = $remove_url_scheme( get_admin_url( null, '/' ) );
 		$site_url     = $remove_url_scheme( site_url( '/' ) );
 
-		$allowed_hosts = array(
+		$allowed_hosts = [
 			wp_parse_url( $includes_url, PHP_URL_HOST ),
 			wp_parse_url( $content_url, PHP_URL_HOST ),
 			wp_parse_url( $admin_url, PHP_URL_HOST ),
-		);
+		];
 
 		// Validate file extensions.
 		if ( ! empty( $allowed_extensions ) ) {
@@ -1071,21 +1071,21 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$processed = $this->process_stylesheet(
 			$stylesheet,
-			array(
+			[
 				'allowed_at_rules'   => $cdata_spec['css_spec']['allowed_at_rules'],
 				'property_whitelist' => $cdata_spec['css_spec']['declaration'],
 				'validate_keyframes' => $cdata_spec['css_spec']['validate_keyframes'],
-			)
+			]
 		);
 
 		$this->pending_stylesheets[] = array_merge(
-			array(
+			[
 				'group'    => $is_keyframes ? 'keyframes' : 'custom',
 				'node'     => $element,
 				'sources'  => $this->current_sources,
 				'priority' => $this->get_stylesheet_priority( $element ),
-			),
-			wp_array_slice_assoc( $processed, array( 'stylesheet', 'imported_font_urls' ) )
+			],
+			wp_array_slice_assoc( $processed, [ 'stylesheet', 'imported_font_urls' ] )
 		);
 
 		if ( $element->hasAttribute( 'amp-custom' ) && ! $this->amp_custom_style_element ) {
@@ -1130,18 +1130,18 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$link = AMP_DOM_Utils::create_node(
 					$this->dom,
 					'link',
-					array(
+					[
 						'rel'         => 'preconnect',
 						'href'        => 'https://fonts.gstatic.com/',
 						'crossorigin' => '',
-					)
+					]
 				);
 				$this->head->insertBefore( $link ); // Note that \AMP_Theme_Support::ensure_required_markup() will put this in the optimal order.
 			}
 			return;
 		}
 
-		$css_file_path = $this->get_validated_url_file_path( $href, array( 'css', 'less', 'scss', 'sass' ) );
+		$css_file_path = $this->get_validated_url_file_path( $href, [ 'css', 'less', 'scss', 'sass' ] );
 		if ( ! is_wp_error( $css_file_path ) ) {
 			$stylesheet = file_get_contents( $css_file_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
 		} else {
@@ -1152,11 +1152,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			} else {
 				$this->remove_invalid_child(
 					$element,
-					array(
+					[
 						'code'    => $contents->get_error_code(),
 						'message' => $contents->get_error_message(),
 						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					)
+					]
 				);
 				return;
 			}
@@ -1165,10 +1165,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( false === $stylesheet ) {
 			$this->remove_invalid_child(
 				$element,
-				array(
+				[
 					'code' => 'stylesheet_file_missing',
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-				)
+				]
 			);
 			return;
 		}
@@ -1183,22 +1183,22 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$processed = $this->process_stylesheet(
 			$stylesheet,
-			array(
+			[
 				'allowed_at_rules'   => $this->style_custom_cdata_spec['css_spec']['allowed_at_rules'],
 				'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['declaration'],
 				'stylesheet_url'     => $href,
 				'stylesheet_path'    => $css_file_path,
-			)
+			]
 		);
 
 		$this->pending_stylesheets[] = array_merge(
-			array(
+			[
 				'group'    => 'custom',
 				'node'     => $element,
 				'sources'  => $this->current_sources, // Needed because node is removed below.
 				'priority' => $this->get_stylesheet_priority( $element ),
-			),
-			wp_array_slice_assoc( $processed, array( 'stylesheet', 'imported_font_urls' ) )
+			],
+			wp_array_slice_assoc( $processed, [ 'stylesheet', 'imported_font_urls' ] )
 		);
 
 		// Remove now that styles have been processed.
@@ -1274,7 +1274,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *    @type int   $priority           The priority of the stylesheet.
 	 * }
 	 */
-	private function process_stylesheet( $stylesheet, $options = array() ) {
+	private function process_stylesheet( $stylesheet, $options = [] ) {
 		$parsed      = null;
 		$cache_key   = null;
 		$cache_group = 'amp-parsed-stylesheet-v18'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
@@ -1282,15 +1282,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(
 				$options,
-				array( 'property_whitelist', 'property_blacklist', 'stylesheet_url', 'allowed_at_rules' )
+				[ 'property_whitelist', 'property_blacklist', 'stylesheet_url', 'allowed_at_rules' ]
 			),
 			wp_array_slice_assoc(
 				$this->args,
-				array( 'should_locate_sources', 'parsed_cache_variant' )
+				[ 'should_locate_sources', 'parsed_cache_variant' ]
 			),
-			array(
+			[
 				'language' => get_bloginfo( 'language' ), // Used to tree-shake html[lang] selectors.
-			)
+			]
 		);
 
 		$cache_key = md5( $stylesheet . wp_json_encode( $cache_impacting_options ) );
@@ -1347,13 +1347,13 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Validation results.
 	 */
 	private function parse_import_stylesheet( Import $item, CSSList $css_list, $options ) {
-		$results      = array();
+		$results      = [];
 		$at_rule_args = $item->atRuleArgs();
 		$location     = array_shift( $at_rule_args );
 		$media_query  = array_shift( $at_rule_args );
 
 		if ( isset( $options['stylesheet_url'] ) ) {
-			$this->real_path_urls( array( $location ), $options['stylesheet_url'] );
+			$this->real_path_urls( [ $location ], $options['stylesheet_url'] );
 		}
 
 		$import_stylesheet_url = $location->getURL()->getString();
@@ -1361,7 +1361,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		// Prevent importing something that has already been imported, and avoid infinite recursion.
 		if ( isset( $this->processed_imported_stylesheet_urls[ $import_stylesheet_url ] ) ) {
 			$css_list->remove( $item );
-			return array();
+			return [];
 		}
 		$this->processed_imported_stylesheet_urls[ $import_stylesheet_url ] = true;
 
@@ -1383,20 +1383,20 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				),
 				'1.0'
 			);
-			return array();
+			return [];
 		}
 
-		$css_file_path = $this->get_validated_url_file_path( $import_stylesheet_url, array( 'css', 'less', 'scss', 'sass' ) );
+		$css_file_path = $this->get_validated_url_file_path( $import_stylesheet_url, [ 'css', 'less', 'scss', 'sass' ] );
 
 		if ( is_wp_error( $css_file_path ) && ( 'disallowed_file_extension' === $css_file_path->get_error_code() || 'external_file_url' === $css_file_path->get_error_code() ) ) {
 			$contents = $this->fetch_external_stylesheet( $import_stylesheet_url );
 			if ( is_wp_error( $contents ) ) {
-				$error     = array(
+				$error     = [
 					'code'    => $contents->get_error_code(),
 					'message' => $contents->get_error_message(),
 					'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 					'url'     => $import_stylesheet_url,
-				);
+				];
 				$sanitized = $this->should_sanitize_validation_error( $error );
 				if ( $sanitized ) {
 					$css_list->remove( $item );
@@ -1407,12 +1407,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			$stylesheet = $contents;
 		} elseif ( is_wp_error( $css_file_path ) ) {
-			$error     = array(
+			$error     = [
 				'code'    => $css_file_path->get_error_code(),
 				'message' => $css_file_path->get_error_message(),
 				'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				'url'     => $import_stylesheet_url,
-			);
+			];
 			$sanitized = $this->should_sanitize_validation_error( $error );
 			if ( $sanitized ) {
 				$css_list->remove( $item );
@@ -1471,10 +1471,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * }
 	 */
 	private function parse_stylesheet( $stylesheet_string, $options ) {
-		$validation_results = array();
+		$validation_results = [];
 		$css_document       = null;
 
-		$this->imported_font_urls = array();
+		$this->imported_font_urls = [];
 		try {
 			// Remove spaces from data URLs, which cause errors and PHP-CSS-Parser can't handle them.
 			$stylesheet_string = $this->remove_spaces_from_data_urls( $stylesheet_string );
@@ -1500,11 +1500,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$this->process_css_list( $css_document, $options )
 			);
 		} catch ( Exception $exception ) {
-			$error = array(
+			$error = [
 				'code'    => 'css_parse_error',
 				'message' => $exception->getMessage(),
 				'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-			);
+			];
 
 			/*
 			 * This is not a recoverable error, so sanitized here is just used to give user control
@@ -1516,9 +1516,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 		return array_merge(
 			compact( 'validation_results', 'css_document' ),
-			array(
+			[
 				'imported_font_urls' => $this->imported_font_urls,
-			)
+			]
 		);
 	}
 
@@ -1537,22 +1537,22 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *    @type array $imported_font_urls Imported font stylesheet URLs.
 	 * }
 	 */
-	private function prepare_stylesheet( $stylesheet_string, $options = array() ) {
+	private function prepare_stylesheet( $stylesheet_string, $options = [] ) {
 		$start_time = microtime( true );
 
 		$options = array_merge(
-			array(
-				'allowed_at_rules'   => array(),
-				'property_blacklist' => array(
+			[
+				'allowed_at_rules'   => [],
+				'property_blacklist' => [
 					// See <https://www.ampproject.org/docs/design/responsive/style_pages#disallowed-styles>.
 					'behavior',
 					'-moz-binding',
-				),
-				'property_whitelist' => array(),
+				],
+				'property_whitelist' => [],
 				'validate_keyframes' => false,
 				'stylesheet_url'     => null,
 				'stylesheet_path'    => null,
-			),
+			],
 			$options
 		);
 
@@ -1565,7 +1565,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$stylesheet_string = preg_replace( '#\]\]>\s*$#', '', $stylesheet_string );
 		$stylesheet_string = preg_replace( '#-->\s*$#', '', $stylesheet_string );
 
-		$stylesheet         = array();
+		$stylesheet         = [];
 		$parsed_stylesheet  = $this->parse_stylesheet( $stylesheet_string, $options );
 		$validation_results = $parsed_stylesheet['validation_results'];
 		if ( ! empty( $parsed_stylesheet['css_document'] ) ) {
@@ -1633,9 +1633,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$declaration = $split_stylesheet[ ++$i ];
 
 					// @todo The following logic could be made much more robust if PHP-CSS-Parser did parsing of selectors. See <https://github.com/sabberworm/PHP-CSS-Parser/pull/138#issuecomment-418193262> and <https://github.com/ampproject/amp-wp/issues/2102>.
-					$selectors_parsed = array();
+					$selectors_parsed = [];
 					foreach ( $selectors as $selector ) {
-						$selectors_parsed[ $selector ] = array();
+						$selectors_parsed[ $selector ] = [];
 
 						// Remove :not() and pseudo selectors to eliminate false negatives, such as with `body:not(.title-tagline-hidden) .site-branding-text` (but not after escape character).
 						$reduced_selector = preg_replace( '/(?<!\\\\)::?[a-zA-Z0-9_-]+(\(.+?\))?/', '', $selector );
@@ -1692,10 +1692,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 						unset( $reduced_selector );
 					}
 
-					$stylesheet[] = array(
+					$stylesheet[] = [
 						$selectors_parsed,
 						$declaration,
-					);
+					];
 				} else {
 					$stylesheet[] = $split_stylesheet[ $i ];
 				}
@@ -1706,9 +1706,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		return array_merge(
 			compact( 'stylesheet', 'validation_results' ),
-			array(
+			[
 				'imported_font_urls' => $parsed_stylesheet['imported_font_urls'],
-			)
+			]
 		);
 	}
 
@@ -1721,7 +1721,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @see AMP_Style_Sanitizer::should_sanitize_validation_error()
 	 * @var array
 	 */
-	protected $previous_should_sanitize_validation_error_results = array();
+	protected $previous_should_sanitize_validation_error_results = [];
 
 	/**
 	 * Check whether or not sanitization should occur in response to validation error.
@@ -1734,7 +1734,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array $data Data including the node.
 	 * @return bool Whether to sanitize.
 	 */
-	public function should_sanitize_validation_error( $validation_error, $data = array() ) {
+	public function should_sanitize_validation_error( $validation_error, $data = [] ) {
 		if ( ! isset( $data['node'] ) ) {
 			$data['node'] = $this->current_node;
 		}
@@ -1787,7 +1787,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Validation errors.
 	 */
 	private function process_css_list( CSSList $css_list, $options ) {
-		$results = array();
+		$results = [];
 
 		foreach ( $css_list->getContents() as $css_item ) {
 			$sanitized = false;
@@ -1798,11 +1798,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				);
 			} elseif ( $css_item instanceof AtRuleBlockList ) {
 				if ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
-					$error     = array(
+					$error     = [
 						'code'    => self::ILLEGAL_AT_RULE_ERROR_CODE,
 						'at_rule' => $css_item->atRuleName(),
 						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
 				}
@@ -1819,11 +1819,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				);
 			} elseif ( $css_item instanceof AtRuleSet ) {
 				if ( ! in_array( $css_item->atRuleName(), $options['allowed_at_rules'], true ) ) {
-					$error     = array(
+					$error     = [
 						'code'    => self::ILLEGAL_AT_RULE_ERROR_CODE,
 						'at_rule' => $css_item->atRuleName(),
 						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
 				}
@@ -1836,11 +1836,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			} elseif ( $css_item instanceof KeyFrame ) {
 				if ( ! in_array( 'keyframes', $options['allowed_at_rules'], true ) ) {
-					$error     = array(
+					$error     = [
 						'code'    => self::ILLEGAL_AT_RULE_ERROR_CODE,
 						'at_rule' => $css_item->atRuleName(),
 						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
 				}
@@ -1861,20 +1861,20 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					 */
 					$sanitized = true;
 				} else {
-					$error     = array(
+					$error     = [
 						'code'    => self::ILLEGAL_AT_RULE_ERROR_CODE,
 						'at_rule' => $css_item->atRuleName(),
 						'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					$results[] = compact( 'error', 'sanitized' );
 				}
 			} else {
-				$error     = array(
+				$error     = [
 					'code' => 'unrecognized_css',
 					'item' => get_class( $css_item ),
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-				);
+				];
 				$sanitized = $this->should_sanitize_validation_error( $error );
 				$results[] = compact( 'error', 'sanitized' );
 			}
@@ -1942,7 +1942,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Validation results.
 	 */
 	private function process_css_declaration_block( RuleSet $ruleset, CSSList $css_list, $options ) {
-		$results = array();
+		$results = [];
 
 		if ( $ruleset instanceof DeclarationBlock ) {
 			$this->ampify_ruleset_selectors( $ruleset );
@@ -1958,12 +1958,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $properties as $property ) {
 				$vendorless_property_name = preg_replace( '/^-\w+-/', '', $property->getRule() );
 				if ( ! in_array( $vendorless_property_name, $options['property_whitelist'], true ) ) {
-					$error     = array(
+					$error     = [
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
 						'property_value' => $property->getValue(),
 						'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
 						$ruleset->removeRule( $property->getRule() );
@@ -1975,12 +1975,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $options['property_blacklist'] as $illegal_property_name ) {
 				$properties = $ruleset->getRules( $illegal_property_name );
 				foreach ( $properties as $property ) {
-					$error     = array(
+					$error     = [
 						'code'           => 'illegal_css_property',
 						'property_name'  => $property->getRule(),
 						'property_value' => (string) $property->getValue(),
 						'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
 						$ruleset->removeRule( $property->getRule() );
@@ -2071,23 +2071,23 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 *
 			 * Clearly the components here are not logically grouped. So the first step is to fix the order.
 			 */
-			$sources = array();
+			$sources = [];
 			foreach ( $value->getListComponents() as $component ) {
 				if ( $component instanceof RuleValueList ) {
 					$subcomponents = $component->getListComponents();
 					$subcomponent  = array_shift( $subcomponents );
 					if ( $subcomponent ) {
 						if ( empty( $sources ) ) {
-							$sources[] = array( $subcomponent );
+							$sources[] = [ $subcomponent ];
 						} else {
 							$sources[ count( $sources ) - 1 ][] = $subcomponent;
 						}
 					}
 					foreach ( $subcomponents as $subcomponent ) {
-						$sources[] = array( $subcomponent );
+						$sources[] = [ $subcomponent ];
 					}
 				} elseif ( empty( $sources ) ) {
-					$sources[] = array( $component );
+					$sources[] = [ $component ];
 				} else {
 					$sources[ count( $sources ) - 1 ][] = $component;
 				}
@@ -2099,8 +2099,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 * @var string[] $source_file_urls
 			 * @var URL[]    $source_data_url_objects
 			 */
-			$source_file_urls        = array();
-			$source_data_url_objects = array();
+			$source_file_urls        = [];
+			$source_data_url_objects = [];
 			foreach ( $sources as $i => $source ) {
 				if ( $source[0] instanceof URL ) {
 					$value = $source[0]->getURL()->getString();
@@ -2120,7 +2120,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				}
 				$extension = preg_replace( ':.+/(.+-)?:', '', $mime_type );
 
-				$guessed_urls = array();
+				$guessed_urls = [];
 
 				// Guess URLs based on any other font sources that are not using data: URLs (e.g. truetype fallback for inline woff2).
 				foreach ( $source_file_urls as $source_file_url ) {
@@ -2147,7 +2147,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Find the font file that exists, and then replace the data: URL with the external URL for the font.
 				foreach ( $guessed_urls as $guessed_url ) {
-					$path = $this->get_validated_url_file_path( $guessed_url, array( 'woff', 'woff2', 'ttf', 'otf', 'svg' ) );
+					$path = $this->get_validated_url_file_path( $guessed_url, [ 'woff', 'woff2', 'ttf', 'otf', 'svg' ] );
 					if ( ! is_wp_error( $path ) ) {
 						$data_url->getURL()->setString( $guessed_url );
 						$converted_count++;
@@ -2183,15 +2183,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Validation results.
 	 */
 	private function process_css_keyframes( KeyFrame $css_list, $options ) {
-		$results = array();
+		$results = [];
 		if ( ! empty( $options['property_whitelist'] ) ) {
 			foreach ( $css_list->getContents() as $rules ) {
 				if ( ! ( $rules instanceof DeclarationBlock ) ) {
-					$error     = array(
+					$error     = [
 						'code' => 'unrecognized_css',
 						'item' => get_class( $rules ),
 						'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
 						$css_list->remove( $rules );
@@ -2209,12 +2209,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $properties as $property ) {
 					$vendorless_property_name = preg_replace( '/^-\w+-/', '', $property->getRule() );
 					if ( ! in_array( $vendorless_property_name, $options['property_whitelist'], true ) ) {
-						$error     = array(
+						$error     = [
 							'code'           => 'illegal_css_property',
 							'property_name'  => $property->getRule(),
 							'property_value' => (string) $property->getValue(),
 							'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-						);
+						];
 						$sanitized = $this->should_sanitize_validation_error( $error );
 						if ( $sanitized ) {
 							$rules->removeRule( $property->getRule() );
@@ -2239,7 +2239,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Validation results.
 	 */
 	private function transform_important_qualifiers( RuleSet $ruleset, CSSList $css_list ) {
-		$results = array();
+		$results = [];
 
 		// An !important only makes sense for rulesets that have selectors.
 		$allow_transformation = (
@@ -2249,7 +2249,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		);
 
 		$properties = $ruleset->getRules();
-		$importants = array();
+		$importants = [];
 		foreach ( $properties as $property ) {
 			if ( $property->getIsImportant() ) {
 				if ( $allow_transformation ) {
@@ -2257,10 +2257,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$property->setIsImportant( false );
 					$ruleset->removeRule( $property->getRule() );
 				} else {
-					$error     = array(
+					$error     = [
 						'code' => 'illegal_css_important',
 						'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					);
+					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {
 						$property->setIsImportant( false );
@@ -2312,7 +2312,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$i = array_search( $ruleset, $css_list->getContents(), true );
 		if ( false !== $i && method_exists( $css_list, 'splice' ) ) {
-			$css_list->splice( $i + 1, 0, array( $important_ruleset ) );
+			$css_list->splice( $i + 1, 0, [ $important_ruleset ] );
 		} else {
 			$css_list->append( $important_ruleset );
 		}
@@ -2348,22 +2348,22 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$processed = $this->process_stylesheet(
 			$rule,
-			array(
-				'allowed_at_rules'   => array(),
+			[
+				'allowed_at_rules'   => [],
 				'property_whitelist' => $this->style_custom_cdata_spec['css_spec']['declaration'],
-			)
+			]
 		);
 
 		$element->removeAttribute( 'style' );
 
 		if ( $processed['stylesheet'] ) {
-			$this->pending_stylesheets[] = array(
+			$this->pending_stylesheets[] = [
 				'group'      => 'custom',
 				'stylesheet' => $processed['stylesheet'],
 				'node'       => $element,
 				'sources'    => $this->current_sources,
 				'priority'   => $this->get_stylesheet_priority( $style_attribute ),
-			);
+			];
 
 			if ( $element->hasAttribute( 'class' ) ) {
 				$element->setAttribute( 'class', $element->getAttribute( 'class' ) . ' ' . $class );
@@ -2385,24 +2385,24 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @see https://www.ampproject.org/docs/fundamentals/spec#keyframes-stylesheet
 	 */
 	private function finalize_styles() {
-		$stylesheet_groups = array(
-			'custom'    => array(
+		$stylesheet_groups = [
+			'custom'    => [
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-custom.css */",
 				'cdata_spec'          => $this->style_custom_cdata_spec,
-				'pending_stylesheets' => array(),
+				'pending_stylesheets' => [],
 				'included_count'      => 0,
 				'import_front_matter' => '', // Extra @import statements that are prepended when fetch fails and validation error is rejected.
-			),
-			'keyframes' => array(
+			],
+			'keyframes' => [
 				'source_map_comment'  => "\n\n/*# sourceURL=amp-keyframes.css */",
 				'cdata_spec'          => $this->style_keyframes_cdata_spec,
-				'pending_stylesheets' => array(),
+				'pending_stylesheets' => [],
 				'included_count'      => 0,
 				'import_front_matter' => '',
-			),
-		);
+			],
+		];
 
-		$imported_font_urls = array();
+		$imported_font_urls = [];
 
 		// Divide pending stylesheet between custom and keyframes, and calculate size of each (before tree shaking).
 		foreach ( $this->pending_stylesheets as $i => $pending_stylesheet ) {
@@ -2462,7 +2462,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$included_original_size = 0;
 			$excluded_size          = 0;
 			$excluded_original_size = 0;
-			$included_sources       = array();
+			$included_sources       = [];
 			foreach ( $this->pending_stylesheets as $j => $pending_stylesheet ) {
 				if ( 'custom' !== $pending_stylesheet['group'] || ! ( $pending_stylesheet['node'] instanceof DOMElement ) || ! empty( $pending_stylesheet['duplicate'] ) ) {
 					continue;
@@ -2597,10 +2597,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$body = $this->dom->getElementsByTagName( 'body' )->item( 0 );
 			if ( ! $body ) {
 				$this->should_sanitize_validation_error(
-					array(
+					[
 						'code' => 'missing_body_element',
 						'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					)
+					]
 				);
 			} else {
 				$css = $stylesheet_groups['keyframes']['import_front_matter'];
@@ -2692,7 +2692,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DeclarationBlock $ruleset Ruleset.
 	 */
 	private function ampify_ruleset_selectors( $ruleset ) {
-		$selectors = array();
+		$selectors = [];
 		$changes   = 0;
 		$language  = strtolower( get_bloginfo( 'language' ) );
 		foreach ( $ruleset->getSelectors() as $old_selector ) {
@@ -2759,7 +2759,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$before_type_selector_pattern = '(?<=^|\(|\s|>|\+|~|,|})';
 			$after_type_selector_pattern  = '(?=$|[^a-zA-Z0-9_-])';
 
-			$edited_selectors = array( $selector );
+			$edited_selectors = [ $selector ];
 			foreach ( $this->selector_mappings as $html_selector => $amp_selectors ) { // Note: The $selector_mappings array contains ~6 items.
 				$html_pattern = '/' . $before_type_selector_pattern . preg_quote( $html_selector, '/' ) . $after_type_selector_pattern . '/i';
 				foreach ( $edited_selectors as &$edited_selector ) { // Note: The $edited_selectors array contains only item in the normal case.
@@ -2804,8 +2804,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$included_count = 0;
 		$max_bytes      = $group_config['cdata_spec']['max_bytes'] - strlen( $group_config['source_map_comment'] );
 
-		$previously_seen_stylesheet_index = array();
-		$indices_by_stylesheet_element_id = array();
+		$previously_seen_stylesheet_index = [];
+		$indices_by_stylesheet_element_id = [];
 		foreach ( $this->pending_stylesheets as $pending_stylesheet_index => &$pending_stylesheet ) {
 			if ( $group !== $pending_stylesheet['group'] ) {
 				continue;
@@ -2816,7 +2816,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$indices_by_stylesheet_element_id[ $pending_stylesheet['node']->getAttribute( 'id' ) ] = $pending_stylesheet_index;
 			}
 
-			$stylesheet_parts = array();
+			$stylesheet_parts = [];
 			$original_size    = 0;
 			foreach ( $pending_stylesheet['stylesheet'] as $stylesheet_part ) {
 				if ( is_string( $stylesheet_part ) ) {
@@ -2827,7 +2827,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 				list( $selectors_parsed, $declaration_block ) = $stylesheet_part;
 
-				$selectors = array();
+				$selectors = [];
 				foreach ( $selectors_parsed as $selector => $parsed_selector ) {
 					$should_include = (
 						// If all class names are used in the doc.
@@ -2963,15 +2963,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Report validation error if size is now too big.
 			if ( $current_concatenated_size + $this->pending_stylesheets[ $i ]['size'] > $max_bytes ) {
-				$validation_error = array(
+				$validation_error = [
 					'code' => 'excessive_css',
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-				);
+				];
 				if ( isset( $this->pending_stylesheets[ $i ]['sources'] ) ) {
 					$validation_error['sources'] = $this->pending_stylesheets[ $i ]['sources'];
 				}
 
-				if ( $this->should_sanitize_validation_error( $validation_error, wp_array_slice_assoc( $this->pending_stylesheets[ $i ], array( 'node' ) ) ) ) {
+				if ( $this->should_sanitize_validation_error( $validation_error, wp_array_slice_assoc( $this->pending_stylesheets[ $i ], [ 'node' ] ) ) ) {
 					$this->pending_stylesheets[ $i ]['included'] = false;
 					continue; // Skip to the next stylesheet.
 				}
@@ -2998,7 +2998,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function exclude_all_admin_bar_css_if_excessive( $indices_by_stylesheet_element_id ) {
 		$excluded_count = 0;
 
-		$admin_bar_style_element_ids         = array( 'admin-bar-css', 'admin-bar-inline-css' );
+		$admin_bar_style_element_ids         = [ 'admin-bar-css', 'admin-bar-inline-css' ];
 		$should_exclude_admin_bar_inline_css = false;
 		foreach ( $admin_bar_style_element_ids as $admin_bar_style_element_id ) {
 			if ( ! isset( $indices_by_stylesheet_element_id[ $admin_bar_style_element_id ] ) ) {

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -29,9 +29,9 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var array
 	 */
-	protected $DEFAULT_ARGS = array(
+	protected $DEFAULT_ARGS = [
 		'add_noscript_fallback' => true,
-	);
+	];
 
 	/**
 	 * Get mapping of HTML selectors to the AMP component selectors which they may be converted into.
@@ -39,9 +39,9 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Mapping.
 	 */
 	public function get_selector_conversion_mapping() {
-		return array(
-			'video' => array( 'amp-video', 'amp-youtube' ),
-		);
+		return [
+			'video' => [ 'amp-video', 'amp-youtube' ],
+		];
 	}
 
 	/**
@@ -78,7 +78,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			$old_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );
 			$old_attributes = $this->filter_data_amp_attributes( $old_attributes, $amp_data );
 
-			$sources        = array();
+			$sources        = [];
 			$new_attributes = $this->filter_attributes( $old_attributes );
 			$layout         = isset( $amp_data['layout'] ) ? $amp_data['layout'] : false;
 			if ( isset( $new_attributes['src'] ) ) {
@@ -97,7 +97,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Gather all child nodes and supply empty video dimensions from sources.
 			$fallback    = null;
-			$child_nodes = array();
+			$child_nodes = [];
 			while ( $node->firstChild ) {
 				$child_node = $node->removeChild( $node->firstChild );
 				if ( $child_node instanceof DOMElement && 'source' === $child_node->nodeName && $child_node->hasAttribute( 'src' ) ) {
@@ -147,7 +147,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Make sure the updated src and poster are applied to the original.
-			foreach ( array( 'src', 'poster', 'artwork' ) as $attr_name ) {
+			foreach ( [ 'src', 'poster', 'artwork' ] as $attr_name ) {
 				if ( $new_node->hasAttribute( $attr_name ) ) {
 					$old_node->setAttribute( $attr_name, $new_node->getAttribute( $attr_name ) );
 				}
@@ -194,12 +194,12 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			$path = wp_parse_url( $src, PHP_URL_PATH );
 			$ext  = pathinfo( $path, PATHINFO_EXTENSION );
 			$name = sanitize_title( wp_basename( $path, ".$ext" ) );
-			$args = array(
+			$args = [
 				'name'        => $name,
 				'post_type'   => 'attachment',
 				'post_status' => 'inherit',
 				'numberposts' => 1,
-			);
+			];
 
 			$attachment = get_posts( $args );
 
@@ -239,7 +239,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Returns HTML attributes; removes any not specifically declared above from input.
 	 */
 	private function filter_attributes( $attributes ) {
-		$out = array();
+		$out = [];
 
 		foreach ( $attributes as $name => $value ) {
 			switch ( $name ) {

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -23,7 +23,7 @@ trait AMP_Noscript_Fallback {
 	 *
 	 * @var array
 	 */
-	private $noscript_fallback_allowed_attributes = array();
+	private $noscript_fallback_allowed_attributes = [];
 
 	/**
 	 * Initializes the internal allowed attributes array.

--- a/includes/settings/class-amp-customizer-design-settings.php
+++ b/includes/settings/class-amp-customizer-design-settings.php
@@ -59,10 +59,10 @@ class AMP_Customizer_Design_Settings {
 	 * Init.
 	 */
 	public static function init() {
-		add_action( 'amp_customizer_init', array( __CLASS__, 'init_customizer' ) );
+		add_action( 'amp_customizer_init', [ __CLASS__, 'init_customizer' ] );
 
 		if ( self::is_amp_customizer_enabled() ) {
-			add_filter( 'amp_customizer_get_settings', array( __CLASS__, 'append_settings' ) );
+			add_filter( 'amp_customizer_get_settings', [ __CLASS__, 'append_settings' ] );
 		}
 	}
 
@@ -71,9 +71,9 @@ class AMP_Customizer_Design_Settings {
 	 */
 	public static function init_customizer() {
 		if ( self::is_amp_customizer_enabled() ) {
-			add_action( 'amp_customizer_register_settings', array( __CLASS__, 'register_customizer_settings' ) );
-			add_action( 'amp_customizer_register_ui', array( __CLASS__, 'register_customizer_ui' ) );
-			add_action( 'amp_customizer_enqueue_preview_scripts', array( __CLASS__, 'enqueue_customizer_preview_scripts' ) );
+			add_action( 'amp_customizer_register_settings', [ __CLASS__, 'register_customizer_settings' ] );
+			add_action( 'amp_customizer_register_ui', [ __CLASS__, 'register_customizer_ui' ] );
+			add_action( 'amp_customizer_enqueue_preview_scripts', [ __CLASS__, 'enqueue_customizer_preview_scripts' ] );
 		}
 	}
 
@@ -87,45 +87,45 @@ class AMP_Customizer_Design_Settings {
 		// Header text color setting.
 		$wp_customize->add_setting(
 			'amp_customizer[header_color]',
-			array(
+			[
 				'type'              => 'option',
 				'default'           => self::DEFAULT_HEADER_COLOR,
 				'sanitize_callback' => 'sanitize_hex_color',
 				'transport'         => 'postMessage',
-			)
+			]
 		);
 
 		// Header background color.
 		$wp_customize->add_setting(
 			'amp_customizer[header_background_color]',
-			array(
+			[
 				'type'              => 'option',
 				'default'           => self::DEFAULT_HEADER_BACKGROUND_COLOR,
 				'sanitize_callback' => 'sanitize_hex_color',
 				'transport'         => 'postMessage',
-			)
+			]
 		);
 
 		// Background color scheme.
 		$wp_customize->add_setting(
 			'amp_customizer[color_scheme]',
-			array(
+			[
 				'type'              => 'option',
 				'default'           => self::DEFAULT_COLOR_SCHEME,
-				'sanitize_callback' => array( __CLASS__, 'sanitize_color_scheme' ),
+				'sanitize_callback' => [ __CLASS__, 'sanitize_color_scheme' ],
 				'transport'         => 'postMessage',
-			)
+			]
 		);
 
 		// Display exit link.
 		$wp_customize->add_setting(
 			'amp_customizer[display_exit_link]',
-			array(
+			[
 				'type'              => 'option',
 				'default'           => false,
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'transport'         => 'postMessage',
-			)
+			]
 		);
 	}
 
@@ -137,10 +137,10 @@ class AMP_Customizer_Design_Settings {
 	public static function register_customizer_ui( $wp_customize ) {
 		$wp_customize->add_section(
 			'amp_design',
-			array(
+			[
 				'title' => __( 'Design', 'amp' ),
 				'panel' => AMP_Template_Customizer::PANEL_ID,
-			)
+			]
 		);
 
 		// Header text color control.
@@ -148,12 +148,12 @@ class AMP_Customizer_Design_Settings {
 			new WP_Customize_Color_Control(
 				$wp_customize,
 				'amp_header_color',
-				array(
+				[
 					'settings' => 'amp_customizer[header_color]',
 					'label'    => __( 'Header Text Color', 'amp' ),
 					'section'  => 'amp_design',
 					'priority' => 10,
-				)
+				]
 			)
 		);
 
@@ -162,61 +162,61 @@ class AMP_Customizer_Design_Settings {
 			new WP_Customize_Color_Control(
 				$wp_customize,
 				'amp_header_background_color',
-				array(
+				[
 					'settings' => 'amp_customizer[header_background_color]',
 					'label'    => __( 'Header Background & Link Color', 'amp' ),
 					'section'  => 'amp_design',
 					'priority' => 20,
-				)
+				]
 			)
 		);
 
 		// Background color scheme.
 		$wp_customize->add_control(
 			'amp_color_scheme',
-			array(
+			[
 				'settings' => 'amp_customizer[color_scheme]',
 				'label'    => __( 'Color Scheme', 'amp' ),
 				'section'  => 'amp_design',
 				'type'     => 'radio',
 				'priority' => 30,
 				'choices'  => self::get_color_scheme_names(),
-			)
+			]
 		);
 
 		// Display exit link.
 		$wp_customize->add_control(
 			'amp_display_exit_link',
-			array(
+			[
 				'settings' => 'amp_customizer[display_exit_link]',
 				'label'    => __( 'Display link to exit reader mode?', 'amp' ),
 				'section'  => 'amp_design',
 				'type'     => 'checkbox',
 				'priority' => 40,
-			)
+			]
 		);
 
 		// Header.
 		$wp_customize->selective_refresh->add_partial(
 			'amp-wp-header',
-			array(
+			[
 				'selector'         => '.amp-wp-header',
-				'settings'         => array( 'blogname', 'amp_customizer[display_exit_link]' ), // @todo Site Icon.
-				'render_callback'  => array( __CLASS__, 'render_header_bar' ),
+				'settings'         => [ 'blogname', 'amp_customizer[display_exit_link]' ], // @todo Site Icon.
+				'render_callback'  => [ __CLASS__, 'render_header_bar' ],
 				'fallback_refresh' => false,
-			)
+			]
 		);
 
 		// Header.
 		$wp_customize->selective_refresh->add_partial(
 			'amp-wp-footer',
-			array(
+			[
 				'selector'            => '.amp-wp-footer',
-				'settings'            => array( 'blogname' ),
-				'render_callback'     => array( __CLASS__, 'render_footer' ),
+				'settings'            => [ 'blogname' ],
+				'render_callback'     => [ __CLASS__, 'render_footer' ],
 				'fallback_refresh'    => false,
 				'container_inclusive' => true,
-			)
+			]
 		);
 	}
 
@@ -226,7 +226,7 @@ class AMP_Customizer_Design_Settings {
 	public static function render_header_bar() {
 		if ( is_singular() ) {
 			$post_template = new AMP_Post_Template( get_post() );
-			$post_template->load_parts( array( 'header-bar' ) );
+			$post_template->load_parts( [ 'header-bar' ] );
 		}
 	}
 
@@ -236,7 +236,7 @@ class AMP_Customizer_Design_Settings {
 	public static function render_footer() {
 		if ( is_singular() ) {
 			$post_template = new AMP_Post_Template( get_post() );
-			$post_template->load_parts( array( 'footer' ) );
+			$post_template->load_parts( [ 'footer' ] );
 		}
 	}
 
@@ -252,16 +252,16 @@ class AMP_Customizer_Design_Settings {
 		wp_enqueue_script(
 			'amp-customizer-design-preview',
 			amp_get_asset_url( 'js/amp-customizer-design-preview.js' ),
-			array( 'amp-customize-preview' ),
+			[ 'amp-customize-preview' ],
 			false,
 			true
 		);
 		wp_localize_script(
 			'amp-customizer-design-preview',
 			'amp_customizer_design',
-			array(
+			[
 				'color_schemes' => self::get_color_schemes(),
-			)
+			]
 		);
 
 		// Prevent a theme's registered blogname partial from causing full page refreshes.
@@ -282,12 +282,12 @@ class AMP_Customizer_Design_Settings {
 	public static function append_settings( $settings ) {
 		$settings = wp_parse_args(
 			$settings,
-			array(
+			[
 				'header_color'            => self::DEFAULT_HEADER_COLOR,
 				'header_background_color' => self::DEFAULT_HEADER_BACKGROUND_COLOR,
 				'color_scheme'            => self::DEFAULT_COLOR_SCHEME,
 				'display_exit_link'       => false,
-			)
+			]
 		);
 
 		$theme_colors = self::get_colors_for_color_scheme( $settings['color_scheme'] );
@@ -295,9 +295,9 @@ class AMP_Customizer_Design_Settings {
 		return array_merge(
 			$settings,
 			$theme_colors,
-			array(
+			[
 				'link_color' => $settings['header_background_color'],
-			)
+			]
 		);
 	}
 
@@ -307,10 +307,10 @@ class AMP_Customizer_Design_Settings {
 	 * @return array Color scheme names.
 	 */
 	protected static function get_color_scheme_names() {
-		return array(
+		return [
 			'light' => __( 'Light', 'amp' ),
 			'dark'  => __( 'Dark', 'amp' ),
-		);
+		];
 	}
 
 	/**
@@ -319,22 +319,22 @@ class AMP_Customizer_Design_Settings {
 	 * @return array Color schemes.
 	 */
 	protected static function get_color_schemes() {
-		return array(
-			'light' => array(
+		return [
+			'light' => [
 				// Convert colors to greyscale for light theme color; see <http://goo.gl/2gDLsp>.
 				'theme_color'      => '#fff',
 				'text_color'       => '#353535',
 				'muted_text_color' => '#696969',
 				'border_color'     => '#c2c2c2',
-			),
-			'dark'  => array(
+			],
+			'dark'  => [
 				// Convert and invert colors to greyscale for dark theme color; see <http://goo.gl/uVB2cO>.
 				'theme_color'      => '#0a0a0a',
 				'text_color'       => '#dedede',
 				'muted_text_color' => '#b1b1b1',
 				'border_color'     => '#707070',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/includes/settings/class-amp-customizer-settings.php
+++ b/includes/settings/class-amp-customizer-settings.php
@@ -18,7 +18,7 @@ class AMP_Customizer_Settings {
 	 * @return array Associative array of $setting => $value pairs.
 	 */
 	private static function get_stored_options() {
-		return get_option( 'amp_customizer', array() );
+		return get_option( 'amp_customizer', [] );
 	}
 
 	/**

--- a/includes/templates/class-amp-content-sanitizer.php
+++ b/includes/templates/class-amp-content-sanitizer.php
@@ -24,7 +24,7 @@ class AMP_Content_Sanitizer {
 	 * @param array    $global_args       Global args.
 	 * @return array Tuple containing sanitized HTML, scripts array, and styles array (or stylesheets, if return_styles=false is passed in $global_args).
 	 */
-	public static function sanitize( $content, array $sanitizer_classes, $global_args = array() ) {
+	public static function sanitize( $content, array $sanitizer_classes, $global_args = [] ) {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $content );
 
 		// For back-compat.
@@ -33,11 +33,11 @@ class AMP_Content_Sanitizer {
 		}
 
 		$results = self::sanitize_document( $dom, $sanitizer_classes, $global_args );
-		return array(
+		return [
 			AMP_DOM_Utils::get_content_from_dom( $dom ),
 			$results['scripts'],
 			empty( $global_args['return_styles'] ) ? $results['stylesheets'] : $results['styles'],
-		);
+		];
 	}
 
 	/**
@@ -57,9 +57,9 @@ class AMP_Content_Sanitizer {
 	 * }
 	 */
 	public static function sanitize_document( &$dom, $sanitizer_classes, $args ) {
-		$scripts     = array();
-		$stylesheets = array();
-		$styles      = array();
+		$scripts     = [];
+		$stylesheets = [];
+		$styles      = [];
 
 		$return_styles = ! empty( $args['return_styles'] );
 		unset( $args['return_styles'] );
@@ -69,7 +69,7 @@ class AMP_Content_Sanitizer {
 		 *
 		 * @var AMP_Base_Sanitizer[] $sanitizers
 		 */
-		$sanitizers = array();
+		$sanitizers = [];
 
 		// Instantiate the sanitizers.
 		foreach ( $sanitizer_classes as $sanitizer_class => $sanitizer_args ) {

--- a/includes/templates/class-amp-content.php
+++ b/includes/templates/class-amp-content.php
@@ -29,7 +29,7 @@ class AMP_Content {
 	 *
 	 * @var array
 	 */
-	private $amp_scripts = array();
+	private $amp_scripts = [];
 
 	/**
 	 * AMP stylesheets.
@@ -37,7 +37,7 @@ class AMP_Content {
 	 * @since 1.0
 	 * @var array
 	 */
-	private $amp_stylesheets = array();
+	private $amp_stylesheets = [];
 
 	/**
 	 * Args.
@@ -68,7 +68,7 @@ class AMP_Content {
 	 * @param string[] $sanitizer_classes     Sanitizer class names.
 	 * @param array    $args                  Args.
 	 */
-	public function __construct( $content, $embed_handler_classes, $sanitizer_classes, $args = array() ) {
+	public function __construct( $content, $embed_handler_classes, $sanitizer_classes, $args = [] ) {
 		$this->content           = $content;
 		$this->args              = $args;
 		$this->embed_handlers    = $this->register_embed_handlers( $embed_handler_classes );
@@ -105,7 +105,7 @@ class AMP_Content {
 	 */
 	public function get_amp_styles() {
 		_deprecated_function( __METHOD__, '1.0', __CLASS__ . '::get_amp_stylesheets' );
-		return array();
+		return [];
 	}
 
 	/**
@@ -160,7 +160,7 @@ class AMP_Content {
 	 * @return array
 	 */
 	private function register_embed_handlers( $embed_handler_classes ) {
-		$embed_handlers = array();
+		$embed_handlers = [];
 
 		foreach ( $embed_handler_classes as $embed_handler_class => $args ) {
 			$embed_handler = new $embed_handler_class( array_merge( $this->args, $args ) );

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -108,7 +108,7 @@ class AMP_Post_Template {
 		}
 		$content_max_width = apply_filters( 'amp_content_max_width', $content_max_width );
 
-		$this->data = array(
+		$this->data = [
 			'content_max_width'     => $content_max_width,
 
 			'document_title'        => function_exists( 'wp_get_document_title' ) ? wp_get_document_title() : wp_title( '', false ), // Back-compat with 4.3.
@@ -116,7 +116,7 @@ class AMP_Post_Template {
 			'home_url'              => home_url( '/' ),
 			'blog_name'             => get_bloginfo( 'name' ),
 
-			'html_tag_attributes'   => array(),
+			'html_tag_attributes'   => [],
 			'body_class'            => '',
 
 			'site_icon_url'         => apply_filters( 'amp_site_icon_url', function_exists( 'get_site_icon_url' ) ? get_site_icon_url( self::SITE_ICON_SIZE ) : '' ),
@@ -127,17 +127,17 @@ class AMP_Post_Template {
 			'comments_link_text'    => false,
 
 			'amp_runtime_script'    => 'https://cdn.ampproject.org/v0.js',
-			'amp_component_scripts' => array(),
+			'amp_component_scripts' => [],
 
-			'customizer_settings'   => array(),
+			'customizer_settings'   => [],
 
-			'font_urls'             => array(),
+			'font_urls'             => [],
 
-			'post_amp_stylesheets'  => array(),
-			'post_amp_styles'       => array(), // Deprecated.
+			'post_amp_stylesheets'  => [],
+			'post_amp_styles'       => [], // Deprecated.
 
 			'amp_analytics'         => amp_add_custom_analytics(),
-		);
+		];
 
 		$this->build_post_content();
 		$this->build_post_data();
@@ -196,7 +196,7 @@ class AMP_Post_Template {
 	public function load() {
 		global $wp_query;
 		$template = is_page() || $wp_query->is_posts_page ? 'page' : 'single';
-		$this->load_parts( array( $template ) );
+		$this->load_parts( [ $template ] );
 	}
 
 	/**
@@ -265,7 +265,7 @@ class AMP_Post_Template {
 		$post_modified_timestamp = get_post_modified_time( 'U', false, $this->post );
 		$post_author             = get_userdata( $this->post->post_author );
 
-		$data = array(
+		$data = [
 			'post'                     => $this->post,
 			'post_id'                  => $this->ID,
 			'post_title'               => $post_title,
@@ -274,7 +274,7 @@ class AMP_Post_Template {
 			'post_author'              => $post_author,
 			'post_canonical_link_url'  => '',
 			'post_canonical_link_text' => '',
-		);
+		];
 
 		$customizer_settings = AMP_Customizer_Settings::get_settings();
 		if ( ! empty( $customizer_settings['display_exit_link'] ) ) {
@@ -310,10 +310,10 @@ class AMP_Post_Template {
 			: __( 'View Comments', 'amp' );
 
 		$this->add_data(
-			array(
+			[
 				'comments_link_url'  => $comments_link_url,
 				'comments_link_text' => $comments_link_text,
-			)
+			]
 		);
 	}
 
@@ -325,9 +325,9 @@ class AMP_Post_Template {
 			$this->post->post_content,
 			amp_get_content_embed_handlers( $this->post ),
 			amp_get_content_sanitizers( $this->post ),
-			array(
+			[
 				'content_max_width' => $this->get( 'content_max_width' ),
-			)
+			]
 		);
 
 		$this->add_data_by_key( 'post_amp_content', $amp_content->get_amp_content() );
@@ -364,19 +364,19 @@ class AMP_Post_Template {
 		$assets = AMP_Content_Sanitizer::sanitize_document(
 			$dom,
 			amp_get_content_sanitizers( $this->post ),
-			array(
+			[
 				'content_max_width' => $this->get( 'content_max_width' ),
-			)
+			]
 		);
 
 		$sanitized_html = AMP_DOM_Utils::get_content_from_dom( $dom );
 
 		$this->add_data_by_key(
 			'featured_image',
-			array(
+			[
 				'amp_html' => $sanitized_html,
 				'caption'  => $featured_image->post_excerpt,
-			)
+			]
 		);
 
 		if ( $assets['scripts'] ) {
@@ -415,7 +415,7 @@ class AMP_Post_Template {
 	 * Build HTML tag attributes.
 	 */
 	private function build_html_tag_attributes() {
-		$attributes = array();
+		$attributes = [];
 
 		if ( function_exists( 'is_rtl' ) && is_rtl() ) {
 			$attributes['dir'] = 'rtl';
@@ -460,7 +460,7 @@ class AMP_Post_Template {
 	 */
 	private function locate_template( $file ) {
 		$search_file = sprintf( 'amp/%s', basename( $file ) );
-		return locate_template( array( $search_file ), false );
+		return locate_template( [ $search_file ], false );
 	}
 
 	/**

--- a/includes/templates/embed-amp-story.php
+++ b/includes/templates/embed-amp-story.php
@@ -16,10 +16,10 @@ if ( have_posts() ) {
 		<div class="amp-story-embed">
 			<?php
 			AMP_Story_Post_Type::the_single_story_card(
-				array(
+				[
 					'post' => get_post(),
 					'size' => AMP_Story_Post_Type::STORY_CARD_IMAGE_SIZE,
-				)
+				]
 			);
 			?>
 		</div>

--- a/includes/templates/single-amp_story.php
+++ b/includes/templates/single-amp_story.php
@@ -15,7 +15,7 @@ the_post();
 		<title><?php echo esc_html( wp_get_document_title() ); ?></title>
 		<?php
 		wp_enqueue_scripts();
-		wp_scripts()->do_items( array( 'amp-runtime' ) ); // @todo Duplicate with AMP_Theme_Support::enqueue_assets().
+		wp_scripts()->do_items( [ 'amp-runtime' ] ); // @todo Duplicate with AMP_Theme_Support::enqueue_assets().
 		wp_styles()->do_items();
 		?>
 		<?php rel_canonical(); ?>

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -21,7 +21,7 @@ class AMP_DOM_Utils {
 	 * @link https://www.w3.org/TR/html5/syntax.html#serializing-html-fragments
 	 * @var array
 	 */
-	private static $self_closing_tags = array(
+	private static $self_closing_tags = [
 		'area',
 		'base',
 		'basefont',
@@ -40,7 +40,7 @@ class AMP_DOM_Utils {
 		'source',
 		'track',
 		'wbr',
-	);
+	];
 
 	/**
 	 * List of elements allowed in head.
@@ -49,7 +49,7 @@ class AMP_DOM_Utils {
 	 * @link https://www.w3.org/TR/html5/document-metadata.html
 	 * @var array
 	 */
-	private static $elements_allowed_in_head = array(
+	private static $elements_allowed_in_head = [
 		'title',
 		'base',
 		'link',
@@ -57,7 +57,7 @@ class AMP_DOM_Utils {
 		'style',
 		'noscript',
 		'script',
-	);
+	];
 
 	/**
 	 * Stored noscript/comment replacements for libxml<2.8.
@@ -65,7 +65,7 @@ class AMP_DOM_Utils {
 	 * @since 0.7
 	 * @var array
 	 */
-	public static $noscript_placeholder_comments = array();
+	public static $noscript_placeholder_comments = [];
 
 	/**
 	 * Return a valid DOMDocument representing HTML document passed as a parameter.
@@ -249,7 +249,7 @@ class AMP_DOM_Utils {
 			$salt = wp_rand();
 
 			// Note: The order of these tokens is important, as it determines the order of the order of the replacements.
-			$tokens       = array(
+			$tokens       = [
 				'{{{',
 				'}}}',
 				'{{#',
@@ -258,8 +258,8 @@ class AMP_DOM_Utils {
 				'{{/',
 				'{{',
 				'}}',
-			);
-			$placeholders = array();
+			];
+			$placeholders = [];
 			foreach ( $tokens as $token ) {
 				$placeholders[ $token ] = '_amp_mustache_' . md5( $salt . $token );
 			}
@@ -322,7 +322,7 @@ class AMP_DOM_Utils {
 		// Match all start tags that contain a binding attribute.
 		$pattern   = implode(
 			'',
-			array(
+			[
 				'#<',
 				'(?P<name>[a-zA-Z0-9_\-]+)',               // Tag name.
 				'(?P<attrs>\s',                            // Attributes.
@@ -330,7 +330,7 @@ class AMP_DOM_Utils {
 				'\[[a-zA-Z0-9_\-]+\]',                     // One binding attribute key.
 				'(?:[^>"\']+|"[^"]*+"|\'[^\']*+\')*+',     // Any attribute tokens, including binding ones.
 				')>#s',
-			)
+			]
 		);
 		$converted = preg_replace_callback(
 			$pattern,
@@ -596,7 +596,7 @@ class AMP_DOM_Utils {
 	 *                  empty array if it has no attributes.
 	 */
 	public static function get_node_attributes_as_assoc_array( $node ) {
-		$attributes = array();
+		$attributes = [];
 		if ( ! $node->hasAttributes() ) {
 			return $attributes;
 		}

--- a/includes/utils/class-amp-html-utils.php
+++ b/includes/utils/class-amp-html-utils.php
@@ -18,7 +18,7 @@ class AMP_HTML_Utils {
 	 * @param string $content    Inner content for the generated node.
 	 * @return string HTML markup.
 	 */
-	public static function build_tag( $tag_name, $attributes = array(), $content = '' ) {
+	public static function build_tag( $tag_name, $attributes = [], $content = '' ) {
 		$attr_string = self::build_attributes_string( $attributes );
 		return sprintf( '<%1$s %2$s>%3$s</%1$s>', sanitize_key( $tag_name ), $attr_string, $content );
 	}
@@ -30,7 +30,7 @@ class AMP_HTML_Utils {
 	 * @return string HTML attributes string.
 	 */
 	public static function build_attributes_string( $attributes ) {
-		$string = array();
+		$string = [];
 		foreach ( $attributes as $name => $value ) {
 			if ( '' === $value ) {
 				$string[] = sprintf( '%s', sanitize_key( $name ) );

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -33,17 +33,17 @@ class AMP_Image_Dimension_Extractor {
 			self::register_callbacks();
 		}
 
-		$return_dimensions = array();
+		$return_dimensions = [];
 
 		// Back-compat for users calling this method directly.
 		$is_single = is_string( $urls );
 		if ( $is_single ) {
-			$urls = array( $urls );
+			$urls = [ $urls ];
 		}
 
 		// Normalize URLs and also track a map of normalized-to-original as we'll need it to reformat things when returning the data.
-		$url_map         = array();
-		$normalized_urls = array();
+		$url_map         = [];
+		$normalized_urls = [];
 		foreach ( $urls as $original_url ) {
 			$normalized_url = self::normalize_url( $original_url );
 			if ( false !== $normalized_url ) {
@@ -130,7 +130,7 @@ class AMP_Image_Dimension_Extractor {
 	private static function register_callbacks() {
 		self::$callbacks_registered = true;
 
-		add_filter( 'amp_extract_image_dimensions_batch', array( __CLASS__, 'extract_by_downloading_images' ), 999, 1 );
+		add_filter( 'amp_extract_image_dimensions_batch', [ __CLASS__, 'extract_by_downloading_images' ], 999, 1 );
 
 		do_action( 'amp_extract_image_dimensions_batch_callbacks_registered' );
 	}
@@ -149,8 +149,8 @@ class AMP_Image_Dimension_Extractor {
 
 		$transient_expiration = 30 * DAY_IN_SECONDS;
 
-		$urls_to_fetch = array();
-		$images        = array();
+		$urls_to_fetch = [];
+		$images        = [];
 
 		self::determine_which_images_to_fetch( $dimensions, $urls_to_fetch );
 		try {
@@ -185,10 +185,10 @@ class AMP_Image_Dimension_Extractor {
 
 			// If we're able to retrieve the dimensions from a transient, set them and move on.
 			if ( is_array( $cached_dimensions ) ) {
-				$dimensions[ $url ] = array(
+				$dimensions[ $url ] = [
 					'width'  => $cached_dimensions[0],
 					'height' => $cached_dimensions[1],
-				);
+				];
 				continue;
 			}
 
@@ -207,7 +207,7 @@ class AMP_Image_Dimension_Extractor {
 			}
 
 			// Include the image as a url to fetch.
-			$urls_to_fetch[ $url ]                        = array();
+			$urls_to_fetch[ $url ]                        = [];
 			$urls_to_fetch[ $url ]['url']                 = $url;
 			$urls_to_fetch[ $url ]['transient_name']      = $transient_name;
 			$urls_to_fetch[ $url ]['transient_lock_name'] = $transient_lock_name;
@@ -256,16 +256,16 @@ class AMP_Image_Dimension_Extractor {
 				$dimensions[ $url_data['url'] ] = false;
 				set_transient( $url_data['transient_name'], self::STATUS_FAILED_LAST_ATTEMPT, $transient_expiration );
 			} else {
-				$dimensions[ $url_data['url'] ] = array(
+				$dimensions[ $url_data['url'] ] = [
 					'width'  => $image_data['size'][0],
 					'height' => $image_data['size'][1],
-				);
+				];
 				set_transient(
 					$url_data['transient_name'],
-					array(
+					[
 						$image_data['size'][0],
 						$image_data['size'][1],
-					),
+					],
 					$transient_expiration
 				);
 			}

--- a/includes/utils/class-amp-wp-utils.php
+++ b/includes/utils/class-amp-wp-utils.php
@@ -82,7 +82,7 @@ class AMP_WP_Utils {
 	 * @deprecated 0.7
 	 */
 	protected static function _wp_translate_php_url_constant_to_key( $constant ) { // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore
-		$translation = array(
+		$translation = [
 			PHP_URL_SCHEME   => 'scheme',
 			PHP_URL_HOST     => 'host',
 			PHP_URL_PORT     => 'port',
@@ -91,7 +91,7 @@ class AMP_WP_Utils {
 			PHP_URL_PATH     => 'path',
 			PHP_URL_QUERY    => 'query',
 			PHP_URL_FRAGMENT => 'fragment',
-		);
+		];
 
 		if ( isset( $translation[ $constant ] ) ) {
 			return $translation[ $constant ];

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -95,12 +95,12 @@ class AMP_Validated_URL_Post_Type {
 	 * @return void
 	 */
 	public static function register() {
-		add_action( 'amp_plugin_update', array( __CLASS__, 'handle_plugin_update' ) );
+		add_action( 'amp_plugin_update', [ __CLASS__, 'handle_plugin_update' ] );
 
 		$post_type = register_post_type(
 			self::POST_TYPE_SLUG,
-			array(
-				'labels'       => array(
+			[
+				'labels'       => [
 					'name'               => _x( 'AMP Validated URLs', 'post type general name', 'amp' ),
 					'menu_name'          => __( 'Validated URLs', 'amp' ),
 					'singular_name'      => __( 'Validated URL', 'amp' ),
@@ -108,13 +108,13 @@ class AMP_Validated_URL_Post_Type {
 					'not_found_in_trash' => __( 'No forgotten validated URLs', 'amp' ),
 					'search_items'       => __( 'Search validated URLs', 'amp' ),
 					'edit_item'          => '', // Overwritten in JS, so this prevents the page header from appearing and changing.
-				),
+				],
 				'supports'     => false,
 				'public'       => false,
 				'show_ui'      => true,
 				'show_in_menu' => ( self::should_show_in_menu() || AMP_Validation_Error_Taxonomy::should_show_in_menu() ) ? AMP_Options_Manager::OPTION_NAME : false,
 				// @todo Show in rest.
-			)
+			]
 		);
 
 		// Hide the add new post link.
@@ -136,17 +136,17 @@ class AMP_Validated_URL_Post_Type {
 		if ( '1.0-' === substr( $old_version, 0, 4 ) || version_compare( $old_version, '1.0', '<' ) ) {
 			global $wpdb;
 			$post_ids = get_posts(
-				array(
+				[
 					'post_type'      => 'amp_invalid_url',
 					'fields'         => 'ids',
 					'posts_per_page' => -1,
-				)
+				]
 			);
 			foreach ( $post_ids as $post_id ) {
 				$wpdb->update(
 					$wpdb->posts,
-					array( 'post_type' => self::POST_TYPE_SLUG ),
-					array( 'ID' => $post_id )
+					[ 'post_type' => self::POST_TYPE_SLUG ],
+					[ 'ID' => $post_id ]
 				);
 				clean_post_cache( $post_id );
 			}
@@ -170,26 +170,26 @@ class AMP_Validated_URL_Post_Type {
 	 * Add admin hooks.
 	 */
 	public static function add_admin_hooks() {
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_post_list_screen_scripts' ) );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_post_list_screen_scripts' ] );
 
 		if ( AMP_Options_Manager::is_website_experience_enabled() ) {
-			add_filter( 'dashboard_glance_items', array( __CLASS__, 'filter_dashboard_glance_items' ) );
-			add_action( 'rightnow_end', array( __CLASS__, 'print_dashboard_glance_styles' ) );
+			add_filter( 'dashboard_glance_items', [ __CLASS__, 'filter_dashboard_glance_items' ] );
+			add_action( 'rightnow_end', [ __CLASS__, 'print_dashboard_glance_styles' ] );
 		}
 
 		// Edit post screen hooks.
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_edit_post_screen_scripts' ) );
-		add_action( 'add_meta_boxes', array( __CLASS__, 'add_meta_boxes' ) );
-		add_action( 'edit_form_after_title', array( __CLASS__, 'render_single_url_list_table' ) );
-		add_filter( 'edit_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_per_page', array( __CLASS__, 'get_terms_per_page' ) );
-		add_action( 'admin_init', array( __CLASS__, 'add_taxonomy' ) );
-		add_action( 'edit_form_top', array( __CLASS__, 'print_url_as_title' ) );
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_edit_post_screen_scripts' ] );
+		add_action( 'add_meta_boxes', [ __CLASS__, 'add_meta_boxes' ] );
+		add_action( 'edit_form_after_title', [ __CLASS__, 'render_single_url_list_table' ] );
+		add_filter( 'edit_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_per_page', [ __CLASS__, 'get_terms_per_page' ] );
+		add_action( 'admin_init', [ __CLASS__, 'add_taxonomy' ] );
+		add_action( 'edit_form_top', [ __CLASS__, 'print_url_as_title' ] );
 
 		// Post list screen hooks.
 		add_filter(
 			'view_mode_post_types',
 			static function( $post_types ) {
-				return array_diff( $post_types, array( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+				return array_diff( $post_types, [ AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 			}
 		);
 		add_action(
@@ -207,23 +207,23 @@ class AMP_Validated_URL_Post_Type {
 				);
 			}
 		);
-		add_action( 'admin_notices', array( __CLASS__, 'render_link_to_error_index_screen' ) );
-		add_filter( 'the_title', array( __CLASS__, 'filter_the_title_in_post_list_table' ), 10, 2 );
-		add_action( 'restrict_manage_posts', array( __CLASS__, 'render_post_filters' ), 10, 2 );
-		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_posts_columns', array( __CLASS__, 'add_post_columns' ) );
-		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_columns', array( __CLASS__, 'add_single_post_columns' ) );
-		add_action( 'manage_posts_custom_column', array( __CLASS__, 'output_custom_column' ), 10, 2 );
-		add_filter( 'bulk_actions-edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'filter_bulk_actions' ), 10, 2 );
+		add_action( 'admin_notices', [ __CLASS__, 'render_link_to_error_index_screen' ] );
+		add_filter( 'the_title', [ __CLASS__, 'filter_the_title_in_post_list_table' ], 10, 2 );
+		add_action( 'restrict_manage_posts', [ __CLASS__, 'render_post_filters' ], 10, 2 );
+		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_posts_columns', [ __CLASS__, 'add_post_columns' ] );
+		add_filter( 'manage_' . self::POST_TYPE_SLUG . '_columns', [ __CLASS__, 'add_single_post_columns' ] );
+		add_action( 'manage_posts_custom_column', [ __CLASS__, 'output_custom_column' ], 10, 2 );
+		add_filter( 'bulk_actions-edit-' . self::POST_TYPE_SLUG, [ __CLASS__, 'filter_bulk_actions' ], 10, 2 );
 		add_filter( 'bulk_actions-' . self::POST_TYPE_SLUG, '__return_false' );
-		add_filter( 'handle_bulk_actions-edit-' . self::POST_TYPE_SLUG, array( __CLASS__, 'handle_bulk_action' ), 10, 3 );
-		add_action( 'admin_notices', array( __CLASS__, 'print_admin_notice' ) );
-		add_action( 'admin_action_' . self::VALIDATE_ACTION, array( __CLASS__, 'handle_validate_request' ) );
-		add_action( 'post_action_' . self::UPDATE_POST_TERM_STATUS_ACTION, array( __CLASS__, 'handle_validation_error_status_update' ) );
-		add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu_new_invalid_url_count' ) );
-		add_filter( 'post_row_actions', array( __CLASS__, 'filter_post_row_actions' ), 10, 2 );
-		add_filter( sprintf( 'views_edit-%s', self::POST_TYPE_SLUG ), array( __CLASS__, 'filter_table_views' ) );
-		add_filter( 'bulk_post_updated_messages', array( __CLASS__, 'filter_bulk_post_updated_messages' ), 10, 2 );
-		add_filter( 'admin_title', array( __CLASS__, 'filter_admin_title' ) );
+		add_filter( 'handle_bulk_actions-edit-' . self::POST_TYPE_SLUG, [ __CLASS__, 'handle_bulk_action' ], 10, 3 );
+		add_action( 'admin_notices', [ __CLASS__, 'print_admin_notice' ] );
+		add_action( 'admin_action_' . self::VALIDATE_ACTION, [ __CLASS__, 'handle_validate_request' ] );
+		add_action( 'post_action_' . self::UPDATE_POST_TERM_STATUS_ACTION, [ __CLASS__, 'handle_validation_error_status_update' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'add_admin_menu_new_invalid_url_count' ] );
+		add_filter( 'post_row_actions', [ __CLASS__, 'filter_post_row_actions' ], 10, 2 );
+		add_filter( sprintf( 'views_edit-%s', self::POST_TYPE_SLUG ), [ __CLASS__, 'filter_table_views' ] );
+		add_filter( 'bulk_post_updated_messages', [ __CLASS__, 'filter_bulk_post_updated_messages' ], 10, 2 );
+		add_filter( 'admin_title', [ __CLASS__, 'filter_admin_title' ] );
 
 		// Hide irrelevant "published" label in the AMP Validated URLs post list.
 		add_filter(
@@ -263,7 +263,7 @@ class AMP_Validated_URL_Post_Type {
 			$script_deps_path    = AMP__DIR__ . '/assets/js/amp-validated-urls-index.deps.json';
 			$script_dependencies = file_exists( $script_deps_path )
 				? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-				: array();
+				: [];
 
 			wp_enqueue_script(
 				'amp-validated-urls-index',
@@ -291,19 +291,19 @@ class AMP_Validated_URL_Post_Type {
 		wp_register_style(
 			'amp-validation-tooltips',
 			amp_get_asset_url( 'css/amp-validation-tooltips.css' ),
-			array( 'wp-pointer' ),
+			[ 'wp-pointer' ],
 			AMP__VERSION
 		);
 
 		$script_deps_path    = AMP__DIR__ . '/assets/js/amp-validation-tooltips.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			: array();
+			: [];
 
 		wp_register_script(
 			'amp-validation-tooltips',
 			amp_get_asset_url( 'js/amp-validation-tooltips.js' ),
-			array_merge( $script_dependencies, array( 'wp-pointer' ) ),
+			array_merge( $script_dependencies, [ 'wp-pointer' ] ),
 			AMP__VERSION,
 			true
 		);
@@ -311,14 +311,14 @@ class AMP_Validated_URL_Post_Type {
 		wp_enqueue_style(
 			'amp-validation-error-taxonomy',
 			amp_get_asset_url( 'css/amp-validation-error-taxonomy.css' ),
-			array( 'common', 'amp-validation-tooltips' ),
+			[ 'common', 'amp-validation-tooltips' ],
 			AMP__VERSION
 		);
 
 		wp_enqueue_script(
 			'amp-validation-detail-toggle',
 			amp_get_asset_url( 'js/amp-validation-detail-toggle.js' ),
-			array( 'wp-dom-ready', 'wp-i18n', 'amp-validation-tooltips' ),
+			[ 'wp-dom-ready', 'wp-i18n', 'amp-validation-tooltips' ],
 			AMP__VERSION,
 			true
 		);
@@ -368,15 +368,15 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'              => self::POST_TYPE_SLUG,
-				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => array(
+				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => [
 					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-				),
+				],
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
-			)
+			]
 		);
 
 		if ( 0 === $query->found_posts ) {
@@ -401,11 +401,11 @@ class AMP_Validated_URL_Post_Type {
 	 * }
 	 * @return array List of errors, with keys for term, data, status, and (sanitization) forced.
 	 */
-	public static function get_invalid_url_validation_errors( $url, $args = array() ) {
+	public static function get_invalid_url_validation_errors( $url, $args = [] ) {
 		$args = array_merge(
-			array(
+			[
 				'ignore_accepted' => false,
-			),
+			],
 			$args
 		);
 
@@ -416,16 +416,16 @@ class AMP_Validated_URL_Post_Type {
 			$post = get_post( $url );
 		}
 		if ( ! $post || self::POST_TYPE_SLUG !== $post->post_type ) {
-			return array();
+			return [];
 		}
 
 		// Skip when parse error.
 		$stored_validation_errors = json_decode( $post->post_content, true );
 		if ( ! is_array( $stored_validation_errors ) ) {
-			return array();
+			return [];
 		}
 
-		$errors = array();
+		$errors = [];
 		foreach ( $stored_validation_errors as $stored_validation_error ) {
 			if ( ! isset( $stored_validation_error['term_slug'] ) ) {
 				continue;
@@ -442,10 +442,10 @@ class AMP_Validated_URL_Post_Type {
 			}
 
 			$errors[] = array_merge(
-				array(
+				[
 					'term' => $term,
 					'data' => $stored_validation_error['data'],
-				),
+				],
 				$sanitization
 			);
 		}
@@ -462,17 +462,17 @@ class AMP_Validated_URL_Post_Type {
 	 *     @type bool $display_enabled_status Whether to display the status of whether AMP is enabled on the URL.
 	 * }
 	 */
-	public static function display_invalid_url_validation_error_counts_summary( $post, $args = array() ) {
+	public static function display_invalid_url_validation_error_counts_summary( $post, $args = [] ) {
 		$args              = array_merge(
-			array(
+			[
 				'display_enabled_status' => false,
-			),
+			],
 			$args
 		);
 		$validation_errors = self::get_invalid_url_validation_errors( $post );
 		$counts            = self::count_invalid_url_validation_errors( $validation_errors );
 
-		$result = array();
+		$result = [];
 		if ( $counts['new_rejected'] ) {
 			$result[] = sprintf(
 				/* translators: 1: status. 2: count. */
@@ -536,11 +536,11 @@ class AMP_Validated_URL_Post_Type {
 	 * }
 	 * @return WP_Post|null The post of the existing custom post, or null.
 	 */
-	public static function get_invalid_url_post( $url, $options = array() ) {
-		$default = array(
+	public static function get_invalid_url_post( $url, $options = [] ) {
+		$default = [
 			'normalize'       => true,
 			'include_trashed' => false,
-		);
+		];
 		$options = wp_parse_args( $options, $default );
 
 		if ( $options['normalize'] ) {
@@ -646,7 +646,7 @@ class AMP_Validated_URL_Post_Type {
 	 * @return int|WP_Error $post_id The post ID of the custom post type used, or WP_Error on failure.
 	 * @global WP $wp
 	 */
-	public static function store_validation_errors( $validation_errors, $url, $args = array() ) {
+	public static function store_validation_errors( $validation_errors, $url, $args = [] ) {
 		$url  = self::normalize_url_for_storage( $url );
 		$slug = md5( $url );
 		$post = null;
@@ -656,10 +656,10 @@ class AMP_Validated_URL_Post_Type {
 		if ( ! $post ) {
 			$post = self::get_invalid_url_post(
 				$url,
-				array(
+				[
 					'include_trashed' => true,
 					'normalize'       => false, // Since already normalized.
-				)
+				]
 			);
 		}
 
@@ -676,20 +676,20 @@ class AMP_Validated_URL_Post_Type {
 		 * The post content just contains the slugs for these terms and the sources for the given instance of
 		 * the validation error.
 		 */
-		$stored_validation_errors = array();
+		$stored_validation_errors = [];
 
 		// Prevent Kses from corrupting JSON in description.
-		$pre_term_description_filters = array(
+		$pre_term_description_filters = [
 			'wp_filter_kses'       => has_filter( 'pre_term_description', 'wp_filter_kses' ),
 			'wp_targeted_link_rel' => has_filter( 'pre_term_description', 'wp_targeted_link_rel' ),
-		);
+		];
 		foreach ( $pre_term_description_filters as $callback => $priority ) {
 			if ( false !== $priority ) {
 				remove_filter( 'pre_term_description', $callback, $priority );
 			}
 		}
 
-		$terms = array();
+		$terms = [];
 		foreach ( $validation_errors as $data ) {
 			$term_data = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( $data );
 			$term_slug = $term_data['slug'];
@@ -720,18 +720,18 @@ class AMP_Validated_URL_Post_Type {
 						wp_update_term(
 							$term_id,
 							AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-							array(
+							[
 								'term_group' => $sanitization['status'],
-							)
+							]
 						);
 					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted() || $is_story ) {
 						$term_data['term_group'] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS;
 						wp_update_term(
 							$term_id,
 							AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-							array(
+							[
 								'term_group' => $term_data['term_group'],
-							)
+							]
 						);
 					}
 
@@ -772,14 +772,14 @@ class AMP_Validated_URL_Post_Type {
 		// Create a new invalid AMP URL post, or update the existing one.
 		$r = wp_insert_post(
 			wp_slash(
-				array(
+				[
 					'ID'           => $post ? $post->ID : null,
 					'post_type'    => self::POST_TYPE_SLUG,
 					'post_title'   => $url,
 					'post_name'    => $slug,
 					'post_content' => $placeholder, // Content is provided via wp_insert_post_data filter above to guard against Kses-corruption.
 					'post_status'  => 'publish',
-				)
+				]
 			),
 			true
 		);
@@ -804,10 +804,10 @@ class AMP_Validated_URL_Post_Type {
 	 * @return array Environment.
 	 */
 	public static function get_validated_environment() {
-		return array(
+		return [
 			'theme'   => get_stylesheet(),
-			'plugins' => get_option( 'active_plugins', array() ),
-		);
+			'plugins' => get_option( 'active_plugins', [] ),
+		];
 	}
 
 	/**
@@ -825,13 +825,13 @@ class AMP_Validated_URL_Post_Type {
 	public static function get_post_staleness( $post ) {
 		$post = get_post( $post );
 		if ( empty( $post ) || self::POST_TYPE_SLUG !== $post->post_type ) {
-			return array();
+			return [];
 		}
 
 		$old_validated_environment = get_post_meta( $post->ID, '_amp_validated_environment', true );
 		$new_validated_environment = self::get_validated_environment();
 
-		$staleness = array();
+		$staleness = [];
 		if ( isset( $old_validated_environment['theme'] ) && $new_validated_environment['theme'] !== $old_validated_environment['theme'] ) {
 			$staleness['theme'] = $old_validated_environment['theme'];
 		}
@@ -859,7 +859,7 @@ class AMP_Validated_URL_Post_Type {
 	public static function add_post_columns( $columns ) {
 		$columns = array_merge(
 			$columns,
-			array(
+			[
 				AMP_Validation_Error_Taxonomy::ERROR_STATUS => sprintf(
 					'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',
 					esc_html__( 'Status', 'amp' ),
@@ -873,7 +873,7 @@ class AMP_Validated_URL_Post_Type {
 				),
 				AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => esc_html__( 'Invalid', 'amp' ),
 				AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => esc_html__( 'Sources', 'amp' ),
-			)
+			]
 		);
 
 		if ( isset( $columns['title'] ) ) {
@@ -902,7 +902,7 @@ class AMP_Validated_URL_Post_Type {
 	 * @return array The filtered post columns.
 	 */
 	public static function add_single_post_columns() {
-		return array(
+		return [
 			'cb'                          => '<input type="checkbox" />',
 			'error'                       => __( 'Error', 'amp' ),
 			'status'                      => sprintf(
@@ -929,7 +929,7 @@ class AMP_Validated_URL_Post_Type {
 			),
 			'sources_with_invalid_output' => __( 'Sources', 'amp' ),
 			'error_type'                  => __( 'Type', 'amp' ),
-		);
+		];
 	}
 
 	/**
@@ -957,7 +957,7 @@ class AMP_Validated_URL_Post_Type {
 				self::display_invalid_url_validation_error_counts_summary( $post_id );
 				break;
 			case AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES:
-				$items = array();
+				$items = [];
 				if ( ! empty( $error_summary[ AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS ] ) ) {
 					foreach ( $error_summary[ AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS ] as $name => $count ) {
 						if ( 1 === (int) $count ) {
@@ -1013,10 +1013,10 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		$sources = $error_summary[ AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT ];
-		$output  = array();
+		$output  = [];
 		$plugins = get_plugins();
-		foreach ( wp_array_slice_assoc( $sources, array( 'plugin', 'mu-plugin' ) ) as $type => $slugs ) {
-			$plugin_names = array();
+		foreach ( wp_array_slice_assoc( $sources, [ 'plugin', 'mu-plugin' ] ) as $type => $slugs ) {
+			$plugin_names = [];
 			$plugin_slugs = array_unique( $slugs );
 			foreach ( $plugin_slugs as $plugin_slug ) {
 				if ( 'mu-plugin' === $type ) {
@@ -1135,9 +1135,9 @@ class AMP_Validated_URL_Post_Type {
 		if ( self::BULK_VALIDATE_ACTION !== $action ) {
 			return $redirect;
 		}
-		$remaining_invalid_urls = array();
+		$remaining_invalid_urls = [];
 
-		$errors = array();
+		$errors = [];
 
 		foreach ( $items as $item ) {
 			$post = get_post( $item );
@@ -1160,7 +1160,7 @@ class AMP_Validated_URL_Post_Type {
 			self::store_validation_errors(
 				$validation_errors,
 				$validity['url'],
-				wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+				wp_array_slice_assoc( $validity, [ 'queried_object' ] )
 			);
 			$unaccepted_error_count = count(
 				array_filter(
@@ -1176,9 +1176,9 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		// Get the URLs that still have errors after rechecking.
-		$args = array(
+		$args = [
 			self::URLS_TESTED => count( $items ),
-		);
+		];
 		if ( ! empty( $errors ) ) {
 			$args['amp_validate_error'] = $errors;
 		} else {
@@ -1307,19 +1307,19 @@ class AMP_Validated_URL_Post_Type {
 			$validation_error = json_decode( $error->description, true );
 			$accept_all_url   = wp_nonce_url(
 				add_query_arg(
-					array(
+					[
 						'action'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION,
 						'term_id' => $error->term_id,
-					)
+					]
 				),
 				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION
 			);
 			$reject_all_url   = wp_nonce_url(
 				add_query_arg(
-					array(
+					[
 						'action'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION,
 						'term_id' => $error->term_id,
-					)
+					]
 				),
 				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION
 			);
@@ -1446,10 +1446,10 @@ class AMP_Validated_URL_Post_Type {
 				$errors,
 				$validity['url'],
 				array_merge(
-					array(
+					[
 						'invalid_url_post' => $post,
-					),
-					wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+					],
+					wp_array_slice_assoc( $validity, [ 'queried_object' ] )
 				)
 			);
 			if ( is_wp_error( $stored ) ) {
@@ -1477,7 +1477,7 @@ class AMP_Validated_URL_Post_Type {
 			} else {
 				$redirect = admin_url(
 					add_query_arg(
-						array( 'post_type' => self::POST_TYPE_SLUG ),
+						[ 'post_type' => self::POST_TYPE_SLUG ],
 						'edit.php'
 					)
 				);
@@ -1513,15 +1513,15 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		$validation_errors  = wp_list_pluck( $validity['results'], 'error' );
-		$validation_results = array();
+		$validation_results = [];
 		self::store_validation_errors(
 			$validation_errors,
 			$validity['url'],
 			array_merge(
-				array(
+				[
 					'invalid_url_post' => $post,
-				),
-				wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+				],
+				wp_array_slice_assoc( $validity, [ 'queried_object' ] )
 			)
 		);
 		foreach ( $validation_errors  as $error ) {
@@ -1580,9 +1580,9 @@ class AMP_Validated_URL_Post_Type {
 			add_filter( 'pre_term_description', 'wp_filter_kses', $has_pre_term_description_filter );
 		}
 
-		$args = array(
+		$args = [
 			'amp_taxonomy_terms_updated' => $updated_count,
-		);
+		];
 
 		/*
 		 * Re-check the post after the validation status change. This is particularly important for validation errors like
@@ -1629,7 +1629,7 @@ class AMP_Validated_URL_Post_Type {
 		$script_deps_path    = AMP__DIR__ . '/assets/js/' . self::EDIT_POST_SCRIPT_HANDLE . '.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			: array();
+			: [];
 
 		wp_enqueue_script(
 			self::EDIT_POST_SCRIPT_HANDLE,
@@ -1642,10 +1642,10 @@ class AMP_Validated_URL_Post_Type {
 		$current_screen = get_current_screen();
 		if ( $current_screen && 'post' === $current_screen->base && self::POST_TYPE_SLUG === $current_screen->post_type ) {
 			$post = get_post();
-			$data = array(
+			$data = [
 				'page_heading' => self::get_single_url_page_heading(),
 				'amp_enabled'  => self::is_amp_enabled_on_post( $post ),
-			);
+			];
 
 			wp_localize_script(
 				self::EDIT_POST_SCRIPT_HANDLE,
@@ -1679,11 +1679,11 @@ class AMP_Validated_URL_Post_Type {
 		add_meta_box(
 			self::STATUS_META_BOX,
 			__( 'Status', 'amp' ),
-			array( __CLASS__, 'print_status_meta_box' ),
+			[ __CLASS__, 'print_status_meta_box' ],
 			self::POST_TYPE_SLUG,
 			'side',
 			'default',
-			array( '__back_compat_meta_box' => true )
+			[ '__back_compat_meta_box' => true ]
 		);
 	}
 
@@ -1758,7 +1758,7 @@ class AMP_Validated_URL_Post_Type {
 							echo '</p></div>';
 						}
 						?>
-						<?php self::display_invalid_url_validation_error_counts_summary( $post, array( 'display_enabled_status' => true ) ); ?>
+						<?php self::display_invalid_url_validation_error_counts_summary( $post, [ 'display_enabled_status' => true ] ); ?>
 					</div>
 
 					<div class="misc-pub-section">
@@ -1862,10 +1862,10 @@ class AMP_Validated_URL_Post_Type {
 
 		$wp_list_table = _get_list_table( 'WP_Terms_List_Table' );
 		get_current_screen()->set_screen_reader_content(
-			array(
+			[
 				'heading_pagination' => $taxonomy_object->labels->items_list_navigation,
 				'heading_list'       => $taxonomy_object->labels->items_list,
-			)
+			]
 		);
 
 		$wp_list_table->prepare_items();
@@ -1998,9 +1998,9 @@ class AMP_Validated_URL_Post_Type {
 	 * @return string The URL to recheck the post.
 	 */
 	public static function get_recheck_url( $url_or_post ) {
-		$args = array(
+		$args = [
 			'action' => self::VALIDATE_ACTION,
-		);
+		];
 		if ( is_string( $url_or_post ) ) {
 			$args['url'] = $url_or_post;
 		} elseif ( $url_or_post instanceof WP_Post && self::POST_TYPE_SLUG === $url_or_post->post_type ) {
@@ -2022,15 +2022,15 @@ class AMP_Validated_URL_Post_Type {
 	public static function filter_dashboard_glance_items( $items ) {
 
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'              => self::POST_TYPE_SLUG,
-				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => array(
+				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => [
 					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 					AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-				),
+				],
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
-			)
+			]
 		);
 
 		if ( 0 !== $query->found_posts ) {
@@ -2039,13 +2039,13 @@ class AMP_Validated_URL_Post_Type {
 				esc_url(
 					admin_url(
 						add_query_arg(
-							array(
+							[
 								'post_type' => self::POST_TYPE_SLUG,
-								AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => array(
+								AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => [
 									AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 									AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-								),
-							),
+								],
+							],
 							'edit.php'
 						)
 					)
@@ -2235,7 +2235,7 @@ class AMP_Validated_URL_Post_Type {
 		if ( get_current_screen()->id === sprintf( 'edit-%s', self::POST_TYPE_SLUG ) ) {
 			$messages['post'] = array_merge(
 				$messages['post'],
-				array(
+				[
 					/* translators: %s is the number of posts forgotten */
 					'deleted'   => _n(
 						'%s validated URL forgotten.',
@@ -2257,7 +2257,7 @@ class AMP_Validated_URL_Post_Type {
 						$bulk_counts['untrashed'],
 						'amp'
 					),
-				)
+				]
 			);
 		}
 
@@ -2291,7 +2291,7 @@ class AMP_Validated_URL_Post_Type {
 	 */
 	protected static function count_invalid_url_validation_errors( $validation_errors ) {
 		$counts = array_fill_keys(
-			array( 'new_accepted', 'ack_accepted', 'new_rejected', 'ack_rejected' ),
+			[ 'new_accepted', 'ack_accepted', 'new_rejected', 'ack_rejected' ],
 			0
 		);
 		foreach ( $validation_errors as $error ) {

--- a/includes/validation/class-amp-validation-callback-wrapper.php
+++ b/includes/validation/class-amp-validation-callback-wrapper.php
@@ -46,11 +46,11 @@ class AMP_Validation_Callback_Wrapper implements ArrayAccess {
 		$accepted_args = $this->callback['accepted_args'];
 		$args          = func_get_args();
 
-		$before_styles_enqueued = array();
+		$before_styles_enqueued = [];
 		if ( isset( $wp_styles, $wp_styles->queue ) ) {
 			$before_styles_enqueued = $wp_styles->queue;
 		}
-		$before_scripts_enqueued = array();
+		$before_scripts_enqueued = [];
 		if ( isset( $wp_scripts, $wp_scripts->queue ) ) {
 			$before_scripts_enqueued = $wp_scripts->queue;
 		}
@@ -61,7 +61,7 @@ class AMP_Validation_Callback_Wrapper implements ArrayAccess {
 		AMP_Validation_Manager::$hook_source_stack[] = $this->callback['source'];
 		$has_buffer_started                          = false;
 		if ( ! $is_filter && AMP_Validation_Manager::can_output_buffer() ) {
-			$has_buffer_started = ob_start( array( 'AMP_Validation_Manager', 'wrap_buffer_with_source_comments' ) );
+			$has_buffer_started = ob_start( [ 'AMP_Validation_Manager', 'wrap_buffer_with_source_comments' ] );
 		}
 		$result = call_user_func_array( $function, array_slice( $args, 0, (int) $accepted_args ) );
 		if ( $has_buffer_started ) {
@@ -79,7 +79,7 @@ class AMP_Validation_Callback_Wrapper implements ArrayAccess {
 		// Keep track of which source enqueued the scripts, and immediately report validity.
 		if ( isset( $wp_scripts, $wp_scripts->queue ) ) {
 			foreach ( array_diff( $wp_scripts->queue, $before_scripts_enqueued ) as $queued_handle ) {
-				$handles = array( $queued_handle );
+				$handles = [ $queued_handle ];
 
 				// Account for case where registered script is a placeholder for a set of scripts (e.g. jquery).
 				if ( isset( $wp_scripts->registered[ $queued_handle ] ) && false === $wp_scripts->registered[ $queued_handle ]->src ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -233,8 +233,8 @@ class AMP_Validation_Error_Taxonomy {
 		register_taxonomy(
 			self::TAXONOMY_SLUG,
 			AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-			array(
-				'labels'             => array(
+			[
+				'labels'             => [
 					'name'                  => _x( 'AMP Validation Error Index', 'taxonomy general name', 'amp' ),
 					'singular_name'         => _x( 'AMP Validation Error', 'taxonomy singular name', 'amp' ),
 					'search_items'          => __( 'Search AMP Validation Errors', 'amp' ),
@@ -253,7 +253,7 @@ class AMP_Validation_Error_Taxonomy {
 					'items_list'            => __( 'Validation errors list', 'amp' ),
 					/* translators: Tab heading when selecting from the most used terms */
 					'most_used'             => __( 'Most Used Validation Errors', 'amp' ),
-				),
+				],
 				'public'             => false,
 				'show_ui'            => true, // @todo False because we need a custom UI.
 				'show_tagcloud'      => false,
@@ -261,12 +261,12 @@ class AMP_Validation_Error_Taxonomy {
 				'hierarchical'       => false, // Or true? Code could be the parent term?
 				'show_in_menu'       => self::should_show_in_menu() || AMP_Validated_URL_Post_Type::should_show_in_menu(),
 				'meta_box_cb'        => false,
-				'capabilities'       => array(
+				'capabilities'       => [
 					// Note that delete_terms is needed so the checkbox (cb) table column will work.
 					'assign_terms' => 'do_not_allow',
 					'edit_terms'   => 'do_not_allow',
-				),
-			)
+				],
+			]
 		);
 
 		if ( is_admin() ) {
@@ -361,12 +361,12 @@ class AMP_Validation_Error_Taxonomy {
 	 * }
 	 * @return int|int[]|null Returns an integer unless the multiple option is passed. Null if invalid.
 	 */
-	public static function sanitize_term_status( $status, $options = array() ) {
+	public static function sanitize_term_status( $status, $options = [] ) {
 		$multiple = ! empty( $options['multiple'] );
 
 		// Catch case where an empty string is supplied. Prevent casting to 0.
 		if ( ! is_numeric( $status ) && empty( $status ) ) {
-			return $multiple ? array() : null;
+			return $multiple ? [] : null;
 		}
 
 		if ( is_string( $status ) ) {
@@ -376,12 +376,12 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		$statuses = array_intersect(
-			array(
+			[
 				self::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 				self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 				self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 				self::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-			),
+			],
 			$statuses
 		);
 		$statuses = array_values( array_unique( $statuses ) );
@@ -418,11 +418,11 @@ class AMP_Validation_Error_Taxonomy {
 		ksort( $error );
 		$description = wp_json_encode( $error );
 		$term_slug   = md5( $description );
-		return array(
+		return [
 			'slug'        => $term_slug,
 			'name'        => $term_slug,
 			'description' => $description,
-		);
+		];
 	}
 
 	/**
@@ -457,12 +457,12 @@ class AMP_Validation_Error_Taxonomy {
 	public static function get_validation_error_sanitization( $error ) {
 		$term_data = self::prepare_validation_error_taxonomy_term( $error );
 		$term      = self::get_term( $term_data['slug'] );
-		$statuses  = array(
+		$statuses  = [
 			self::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 			self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 			self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 			self::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-		);
+		];
 		if ( ! empty( $term ) && in_array( $term->term_group, $statuses, true ) ) {
 			$term_status = $term->term_group;
 		} else {
@@ -576,17 +576,17 @@ class AMP_Validation_Error_Taxonomy {
 	 * }
 	 * @return int Term count.
 	 */
-	public static function get_validation_error_count( $args = array() ) {
+	public static function get_validation_error_count( $args = [] ) {
 		$args = array_merge(
-			array(
+			[
 				'group' => null,
-			),
+			],
 			$args
 		);
 
 		$groups = null;
 		if ( isset( $args['group'] ) ) {
-			$groups = self::sanitize_term_status( $args['group'], array( 'multiple' => true ) );
+			$groups = self::sanitize_term_status( $args['group'], [ 'multiple' => true ] );
 		}
 
 		$filter = static function( $clauses ) use ( $groups ) {
@@ -625,9 +625,9 @@ class AMP_Validation_Error_Taxonomy {
 			return $where;
 		}
 
-		$error_statuses = array();
+		$error_statuses = [];
 		if ( false !== $query->get( self::VALIDATION_ERROR_STATUS_QUERY_VAR, false ) ) {
-			$error_statuses = self::sanitize_term_status( $query->get( self::VALIDATION_ERROR_STATUS_QUERY_VAR ), array( 'multiple' => true ) );
+			$error_statuses = self::sanitize_term_status( $query->get( self::VALIDATION_ERROR_STATUS_QUERY_VAR ), [ 'multiple' => true ] );
 		}
 		$error_type = sanitize_key( $query->get( self::VALIDATION_ERROR_TYPE_QUERY_VAR ) );
 
@@ -683,10 +683,10 @@ class AMP_Validation_Error_Taxonomy {
 	 * @return array The AMP validity of the markup.
 	 */
 	public static function summarize_validation_errors( $validation_errors ) {
-		$results            = array();
-		$removed_elements   = array();
-		$removed_attributes = array();
-		$invalid_sources    = array();
+		$results            = [];
+		$removed_elements   = [];
+		$removed_attributes = [];
+		$invalid_sources    = [];
 		foreach ( $validation_errors as $validation_error ) {
 			$code = isset( $validation_error['code'] ) ? $validation_error['code'] : null;
 
@@ -723,9 +723,9 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		$results = array_merge(
-			array(
+			[
 				self::SOURCES_INVALID_OUTPUT => $invalid_sources,
-			),
+			],
 			compact(
 				'removed_elements',
 				'removed_attributes'
@@ -740,36 +740,36 @@ class AMP_Validation_Error_Taxonomy {
 	 * Add admin hooks.
 	 */
 	public static function add_admin_hooks() {
-		add_filter( 'redirect_term_location', array( __CLASS__, 'add_term_filter_query_var' ), 10, 2 );
-		add_action( 'load-edit-tags.php', array( __CLASS__, 'add_group_terms_clauses_filter' ) );
-		add_action( 'load-edit-tags.php', array( __CLASS__, 'add_error_type_clauses_filter' ) );
-		add_action( 'load-post.php', array( __CLASS__, 'add_error_type_clauses_filter' ) );
-		add_action( 'load-edit-tags.php', array( __CLASS__, 'add_order_clauses_from_description_json' ) );
-		add_action( 'load-post.php', array( __CLASS__, 'add_order_clauses_from_description_json' ) );
-		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), array( __CLASS__, 'render_taxonomy_filters' ) );
-		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), array( __CLASS__, 'render_link_to_invalid_urls_screen' ) );
+		add_filter( 'redirect_term_location', [ __CLASS__, 'add_term_filter_query_var' ], 10, 2 );
+		add_action( 'load-edit-tags.php', [ __CLASS__, 'add_group_terms_clauses_filter' ] );
+		add_action( 'load-edit-tags.php', [ __CLASS__, 'add_error_type_clauses_filter' ] );
+		add_action( 'load-post.php', [ __CLASS__, 'add_error_type_clauses_filter' ] );
+		add_action( 'load-edit-tags.php', [ __CLASS__, 'add_order_clauses_from_description_json' ] );
+		add_action( 'load-post.php', [ __CLASS__, 'add_order_clauses_from_description_json' ] );
+		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), [ __CLASS__, 'render_taxonomy_filters' ] );
+		add_action( sprintf( 'after-%s-table', self::TAXONOMY_SLUG ), [ __CLASS__, 'render_link_to_invalid_urls_screen' ] );
 		add_action(
 			'load-edit-tags.php',
 			static function() {
-				add_filter( 'user_has_cap', array( __CLASS__, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ), 10, 3 );
+				add_filter( 'user_has_cap', [ __CLASS__, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ], 10, 3 );
 			}
 		);
-		add_filter( 'terms_clauses', array( __CLASS__, 'filter_terms_clauses_for_description_search' ), 10, 3 );
-		add_action( 'admin_notices', array( __CLASS__, 'add_admin_notices' ) );
-		add_filter( 'tag_row_actions', array( __CLASS__, 'filter_tag_row_actions' ), 10, 2 );
+		add_filter( 'terms_clauses', [ __CLASS__, 'filter_terms_clauses_for_description_search' ], 10, 3 );
+		add_action( 'admin_notices', [ __CLASS__, 'add_admin_notices' ] );
+		add_filter( 'tag_row_actions', [ __CLASS__, 'filter_tag_row_actions' ], 10, 2 );
 		if ( get_taxonomy( self::TAXONOMY_SLUG )->show_in_menu ) {
-			add_action( 'admin_menu', array( __CLASS__, 'add_admin_menu_validation_error_item' ) );
+			add_action( 'admin_menu', [ __CLASS__, 'add_admin_menu_validation_error_item' ] );
 		}
-		add_action( 'parse_term_query', array( __CLASS__, 'parse_post_php_term_query' ) );
-		add_filter( 'manage_' . self::TAXONOMY_SLUG . '_custom_column', array( __CLASS__, 'filter_manage_custom_columns' ), 10, 3 );
-		add_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_sortable_columns', array( __CLASS__, 'add_single_post_sortable_columns' ) );
-		add_filter( 'posts_where', array( __CLASS__, 'filter_posts_where_for_validation_error_status' ), 10, 2 );
-		add_filter( 'post_action_' . self::VALIDATION_ERROR_REJECT_ACTION, array( __CLASS__, 'handle_single_url_page_bulk_and_inline_actions' ) );
-		add_filter( 'post_action_' . self::VALIDATION_ERROR_ACCEPT_ACTION, array( __CLASS__, 'handle_single_url_page_bulk_and_inline_actions' ) );
-		add_filter( 'handle_bulk_actions-edit-' . self::TAXONOMY_SLUG, array( __CLASS__, 'handle_validation_error_update' ), 10, 3 );
-		add_action( 'load-edit-tags.php', array( __CLASS__, 'handle_inline_edit_request' ) );
-		add_action( 'load-edit-tags.php', array( __CLASS__, 'handle_clear_empty_terms_request' ) );
-		add_action( 'load-edit.php', array( __CLASS__, 'handle_inline_edit_request' ) );
+		add_action( 'parse_term_query', [ __CLASS__, 'parse_post_php_term_query' ] );
+		add_filter( 'manage_' . self::TAXONOMY_SLUG . '_custom_column', [ __CLASS__, 'filter_manage_custom_columns' ], 10, 3 );
+		add_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_sortable_columns', [ __CLASS__, 'add_single_post_sortable_columns' ] );
+		add_filter( 'posts_where', [ __CLASS__, 'filter_posts_where_for_validation_error_status' ], 10, 2 );
+		add_filter( 'post_action_' . self::VALIDATION_ERROR_REJECT_ACTION, [ __CLASS__, 'handle_single_url_page_bulk_and_inline_actions' ] );
+		add_filter( 'post_action_' . self::VALIDATION_ERROR_ACCEPT_ACTION, [ __CLASS__, 'handle_single_url_page_bulk_and_inline_actions' ] );
+		add_filter( 'handle_bulk_actions-edit-' . self::TAXONOMY_SLUG, [ __CLASS__, 'handle_validation_error_update' ], 10, 3 );
+		add_action( 'load-edit-tags.php', [ __CLASS__, 'handle_inline_edit_request' ] );
+		add_action( 'load-edit-tags.php', [ __CLASS__, 'handle_clear_empty_terms_request' ] );
+		add_action( 'load-edit.php', [ __CLASS__, 'handle_inline_edit_request' ] );
 
 		// Prevent query vars from persisting after redirect.
 		add_filter(
@@ -797,7 +797,7 @@ class AMP_Validation_Error_Taxonomy {
 		add_filter(
 			'get_terms_defaults',
 			static function( $args, $taxonomies ) {
-				if ( array( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ) === $taxonomies ) {
+				if ( [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] === $taxonomies ) {
 					$args['orderby'] = 'term_id';
 					$args['order']   = 'DESC';
 				}
@@ -823,7 +823,7 @@ class AMP_Validation_Error_Taxonomy {
 			'manage_edit-' . self::TAXONOMY_SLUG . '_columns',
 			static function( $old_columns ) {
 
-				return array(
+				return [
 					'cb'               => $old_columns['cb'],
 					'error'            => esc_html__( 'Error', 'amp' ),
 					'status'           => sprintf(
@@ -851,7 +851,7 @@ class AMP_Validation_Error_Taxonomy {
 					'error_type'       => esc_html__( 'Type', 'amp' ),
 					'created_date_gmt' => esc_html__( 'Last Seen', 'amp' ),
 					'posts'            => esc_html__( 'Found URLs', 'amp' ),
-				);
+				];
 			}
 		);
 
@@ -892,19 +892,19 @@ class AMP_Validation_Error_Taxonomy {
 					wp_register_style(
 						'amp-validation-tooltips',
 						amp_get_asset_url( 'css/amp-validation-tooltips.css' ),
-						array( 'wp-pointer' ),
+						[ 'wp-pointer' ],
 						AMP__VERSION
 					);
 
 					$script_deps_path    = AMP__DIR__ . '/assets/js/amp-validation-tooltips.deps.json';
 					$script_dependencies = file_exists( $script_deps_path )
 						? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-						: array();
+						: [];
 
 					wp_register_script(
 						'amp-validation-tooltips',
 						amp_get_asset_url( 'js/amp-validation-tooltips.js' ),
-						array_merge( $script_dependencies, array( 'wp-pointer' ) ),
+						array_merge( $script_dependencies, [ 'wp-pointer' ] ),
 						AMP__VERSION,
 						true
 					);
@@ -912,14 +912,14 @@ class AMP_Validation_Error_Taxonomy {
 					wp_enqueue_style(
 						'amp-validation-error-taxonomy',
 						amp_get_asset_url( 'css/amp-validation-error-taxonomy.css' ),
-						array( 'common', 'amp-validation-tooltips' ),
+						[ 'common', 'amp-validation-tooltips' ],
 						AMP__VERSION
 					);
 
 					wp_enqueue_script(
 						'amp-validation-detail-toggle',
 						amp_get_asset_url( 'js/amp-validation-detail-toggle.js' ),
-						array( 'wp-dom-ready', 'wp-i18n', 'amp-validation-tooltips' ),
+						[ 'wp-dom-ready', 'wp-i18n', 'amp-validation-tooltips' ],
 						AMP__VERSION,
 						true
 					);
@@ -929,14 +929,14 @@ class AMP_Validation_Error_Taxonomy {
 					wp_enqueue_style(
 						'amp-validation-single-error-url',
 						amp_get_asset_url( 'css/amp-validation-single-error-url.css' ),
-						array( 'common' ),
+						[ 'common' ],
 						AMP__VERSION
 					);
 
 					$script_deps_path    = AMP__DIR__ . '/assets/js/amp-validation-single-error-url-details.deps.json';
 					$script_dependencies = file_exists( $script_deps_path )
 						? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-						: array();
+						: [];
 
 					wp_enqueue_script(
 						'amp-validation-single-error-url-details',
@@ -1007,7 +1007,7 @@ class AMP_Validation_Error_Taxonomy {
 			&&
 			in_array(
 				$_POST[ self::VALIDATION_ERROR_TYPE_QUERY_VAR ], // phpcs:ignore WordPress.Security.NonceVerification.Missing
-				array_merge( self::get_error_types(), array( (string) self::NO_FILTER_VALUE ) ),
+				array_merge( self::get_error_types(), [ (string) self::NO_FILTER_VALUE ] ),
 				true
 			)
 		) {
@@ -1019,13 +1019,13 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		// If the error status query var is valid, pass it along in the redirect $url.
-		$groups = array();
+		$groups = [];
 		if ( isset( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
-			$groups = self::sanitize_term_status( wp_unslash( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), array( 'multiple' => true ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			$groups = self::sanitize_term_status( wp_unslash( $_POST[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), [ 'multiple' => true ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}
 		if ( ! empty( $groups ) ) {
 			$url = add_query_arg(
-				array( self::VALIDATION_ERROR_STATUS_QUERY_VAR => $groups ),
+				[ self::VALIDATION_ERROR_STATUS_QUERY_VAR => $groups ],
 				$url
 			);
 		} else {
@@ -1043,7 +1043,7 @@ class AMP_Validation_Error_Taxonomy {
 			return;
 		}
 		self::$should_filter_terms_clauses_for_error_validation_status = true;
-		$groups = self::sanitize_term_status( wp_unslash( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), array( 'multiple' => true ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$groups = self::sanitize_term_status( wp_unslash( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ), [ 'multiple' => true ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( empty( $groups ) ) {
 			return;
 		}
@@ -1103,10 +1103,10 @@ class AMP_Validation_Error_Taxonomy {
 			return;
 		}
 
-		$sortable_column_vars = array(
+		$sortable_column_vars = [
 			self::VALIDATION_ERROR_TYPE_QUERY_VAR,
 			self::VALIDATION_DETAILS_ERROR_CODE_QUERY_VAR,
-		);
+		];
 
 		if ( ! isset( $_GET['orderby'] ) || ! in_array( $_GET['orderby'], $sortable_column_vars, true ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
@@ -1167,7 +1167,7 @@ class AMP_Validation_Error_Taxonomy {
 			<?php
 			self::render_error_status_filter();
 			self::render_error_type_filter();
-			submit_button( __( 'Apply Filter', 'amp' ), '', 'filter_action', false, array( 'id' => 'doaction' ) );
+			submit_button( __( 'Apply Filter', 'amp' ), '', 'filter_action', false, [ 'id' => 'doaction' ] );
 			self::render_clear_empty_button();
 			?>
 		</div>
@@ -1241,16 +1241,16 @@ class AMP_Validation_Error_Taxonomy {
 
 		if ( 'edit-tags' === $screen_base ) {
 			$total_term_count        = self::get_validation_error_count();
-			$ack_rejected_term_count = self::get_validation_error_count( array( 'group' => array( self::VALIDATION_ERROR_ACK_REJECTED_STATUS ) ) );
-			$ack_accepted_term_count = self::get_validation_error_count( array( 'group' => array( self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS ) ) );
+			$ack_rejected_term_count = self::get_validation_error_count( [ 'group' => [ self::VALIDATION_ERROR_ACK_REJECTED_STATUS ] ] );
+			$ack_accepted_term_count = self::get_validation_error_count( [ 'group' => [ self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS ] ] );
 			$new_term_count          = $total_term_count - $ack_rejected_term_count - $ack_accepted_term_count;
 
 		} elseif ( 'edit' === $screen_base ) {
-			$args = array(
+			$args = [
 				'post_type'              => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
 				'update_post_meta_cache' => false,
 				'update_post_term_cache' => false,
-			);
+			];
 
 			$error_type = sanitize_key( $wp_query->get( self::VALIDATION_ERROR_TYPE_QUERY_VAR ) );
 			if ( $error_type && in_array( $error_type, self::get_error_types(), true ) ) {
@@ -1260,12 +1260,12 @@ class AMP_Validation_Error_Taxonomy {
 			$with_new_query = new WP_Query(
 				array_merge(
 					$args,
-					array(
-						self::VALIDATION_ERROR_STATUS_QUERY_VAR => array(
+					[
+						self::VALIDATION_ERROR_STATUS_QUERY_VAR => [
 							self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 							self::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-						),
-					)
+						],
+					]
 				)
 			);
 			$new_term_count = $with_new_query->found_posts;
@@ -1273,7 +1273,7 @@ class AMP_Validation_Error_Taxonomy {
 			$with_rejected_query     = new WP_Query(
 				array_merge(
 					$args,
-					array( self::VALIDATION_ERROR_STATUS_QUERY_VAR => self::VALIDATION_ERROR_ACK_REJECTED_STATUS )
+					[ self::VALIDATION_ERROR_STATUS_QUERY_VAR => self::VALIDATION_ERROR_ACK_REJECTED_STATUS ]
 				)
 			);
 			$ack_rejected_term_count = $with_rejected_query->found_posts;
@@ -1281,7 +1281,7 @@ class AMP_Validation_Error_Taxonomy {
 			$with_accepted_query     = new WP_Query(
 				array_merge(
 					$args,
-					array( self::VALIDATION_ERROR_STATUS_QUERY_VAR => self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS )
+					[ self::VALIDATION_ERROR_STATUS_QUERY_VAR => self::VALIDATION_ERROR_ACK_ACCEPTED_STATUS ]
 				)
 			);
 			$ack_accepted_term_count = $with_accepted_query->found_posts;
@@ -1289,9 +1289,9 @@ class AMP_Validation_Error_Taxonomy {
 			return;
 		}
 
-		$selected_groups = array();
+		$selected_groups = [];
 		if ( isset( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$selected_groups = self::sanitize_term_status( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ], array( 'multiple' => true ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$selected_groups = self::sanitize_term_status( $_GET[ self::VALIDATION_ERROR_STATUS_QUERY_VAR ], [ 'multiple' => true ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 		if ( ! empty( $selected_groups ) ) {
 			sort( $selected_groups );
@@ -1401,7 +1401,7 @@ class AMP_Validation_Error_Taxonomy {
 	 * @return array Error types.
 	 */
 	public static function get_error_types() {
-		return array( self::HTML_ELEMENT_ERROR_TYPE, self::HTML_ATTRIBUTE_ERROR_TYPE, self::JS_ERROR_TYPE, self::CSS_ERROR_TYPE );
+		return [ self::HTML_ELEMENT_ERROR_TYPE, self::HTML_ATTRIBUTE_ERROR_TYPE, self::JS_ERROR_TYPE, self::CSS_ERROR_TYPE ];
 	}
 
 	/**
@@ -1608,10 +1608,10 @@ class AMP_Validation_Error_Taxonomy {
 					'<a href="%s">%s</a>',
 					admin_url(
 						add_query_arg(
-							array(
+							[
 								self::TAXONOMY_SLUG => $term->name,
 								'post_type'         => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-							),
+							],
 							'edit.php'
 						)
 					),
@@ -1626,7 +1626,7 @@ class AMP_Validation_Error_Taxonomy {
 				$actions[ self::VALIDATION_ERROR_REJECT_ACTION ] = sprintf(
 					'<a href="%s">%s</a>',
 					wp_nonce_url(
-						add_query_arg( array_merge( array( 'action' => self::VALIDATION_ERROR_REJECT_ACTION ), compact( 'term_id' ) ) ),
+						add_query_arg( array_merge( [ 'action' => self::VALIDATION_ERROR_REJECT_ACTION ], compact( 'term_id' ) ) ),
 						self::VALIDATION_ERROR_REJECT_ACTION
 					),
 					esc_html__( 'Reject', 'amp' )
@@ -1636,7 +1636,7 @@ class AMP_Validation_Error_Taxonomy {
 				$actions[ self::VALIDATION_ERROR_ACCEPT_ACTION ] = sprintf(
 					'<a href="%s">%s</a>',
 					wp_nonce_url(
-						add_query_arg( array_merge( array( 'action' => self::VALIDATION_ERROR_ACCEPT_ACTION ), compact( 'term_id' ) ) ),
+						add_query_arg( array_merge( [ 'action' => self::VALIDATION_ERROR_ACCEPT_ACTION ], compact( 'term_id' ) ) ),
 						self::VALIDATION_ERROR_ACCEPT_ACTION
 					),
 					esc_html__( 'Accept', 'amp' )
@@ -1652,9 +1652,9 @@ class AMP_Validation_Error_Taxonomy {
 	public static function add_admin_menu_validation_error_item() {
 		$menu_item_label = esc_html__( 'Error Index', 'amp' );
 		$new_error_count = self::get_validation_error_count(
-			array(
-				'group' => array( self::VALIDATION_ERROR_NEW_REJECTED_STATUS, self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS ),
-			)
+			[
+				'group' => [ self::VALIDATION_ERROR_NEW_REJECTED_STATUS, self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS ],
+			]
 		);
 		if ( $new_error_count ) {
 			$menu_item_label .= ' <span class="awaiting-mod"><span class="pending-count">' . esc_html( number_format_i18n( $new_error_count ) ) . '</span></span>';
@@ -1768,10 +1768,10 @@ class AMP_Validation_Error_Taxonomy {
 						'<a href="%s" class="error-code">%s</a>',
 						admin_url(
 							add_query_arg(
-								array(
+								[
 									self::TAXONOMY_SLUG => $term->name,
 									'post_type'         => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-								),
+								],
 								'edit.php'
 							)
 						),
@@ -1906,7 +1906,7 @@ class AMP_Validation_Error_Taxonomy {
 
 					unset( $validation_error['error_type'], $validation_error['parent_name'] );
 
-					$attributes         = array();
+					$attributes         = [];
 					$attributes_heading = '';
 					if ( ! empty( $validation_error['node_attributes'] ) ) {
 						$attributes_heading = sprintf( '<div class="details-attributes__title"><code>%s</code></div>', esc_html__( 'Element attributes:', 'amp' ) );
@@ -1986,10 +1986,10 @@ class AMP_Validation_Error_Taxonomy {
 	public static function add_single_post_sortable_columns( $sortable_columns ) {
 		return array_merge(
 			$sortable_columns,
-			array(
+			[
 				'error'      => self::VALIDATION_DETAILS_ERROR_CODE_QUERY_VAR,
 				'error_type' => self::VALIDATION_ERROR_TYPE_QUERY_VAR,
-			)
+			]
 		);
 	}
 
@@ -2099,12 +2099,12 @@ class AMP_Validation_Error_Taxonomy {
 			return null;
 		}
 
-		$translated_names = array(
+		$translated_names = [
 			self::HTML_ELEMENT_ERROR_TYPE   => __( 'HTML Element', 'amp' ),
 			self::HTML_ATTRIBUTE_ERROR_TYPE => __( 'HTML Attribute', 'amp' ),
 			self::JS_ERROR_TYPE             => __( 'JavaScript', 'amp' ),
 			self::CSS_ERROR_TYPE            => __( 'CSS', 'amp' ),
-		);
+		];
 
 		if ( isset( $translated_names[ $validation_error['type'] ] ) ) {
 			return $translated_names[ $validation_error['type'] ];
@@ -2140,7 +2140,7 @@ class AMP_Validation_Error_Taxonomy {
 
 		$referer  = wp_get_referer();
 		$term_id  = (int) $_GET['term_id']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$redirect = self::handle_validation_error_update( $referer, $action, array( $term_id ) );
+		$redirect = self::handle_validation_error_update( $referer, $action, [ $term_id ] );
 
 		if ( $redirect !== $referer ) {
 			wp_safe_redirect( $redirect );
@@ -2165,10 +2165,10 @@ class AMP_Validation_Error_Taxonomy {
 		$action              = sanitize_key( $_REQUEST['action'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$term_ids            = isset( $_POST['delete_tags'] ) ? array_map( 'sanitize_key', $_POST['delete_tags'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$single_term_id      = isset( $_GET['term_id'] ) ? sanitize_key( $_GET['term_id'] ) : null; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$redirect_query_args = array(
+		$redirect_query_args = [
 			'action'       => 'edit',
 			'amp_actioned' => $action,
-		);
+		];
 
 		if ( $term_ids ) {
 			// If this is a bulk action.
@@ -2176,7 +2176,7 @@ class AMP_Validation_Error_Taxonomy {
 			$redirect_query_args['amp_actioned_count'] = count( $term_ids );
 		} elseif ( $single_term_id ) {
 			// If this is an inline action, like 'Reject' or 'Accept'.
-			self::handle_validation_error_update( null, $action, array( $single_term_id ) );
+			self::handle_validation_error_update( null, $action, [ $single_term_id ] );
 			$redirect_query_args['amp_actioned_count'] = 1;
 		}
 
@@ -2219,10 +2219,10 @@ class AMP_Validation_Error_Taxonomy {
 				add_filter( 'pre_term_description', 'wp_filter_kses', $has_pre_term_description_filter );
 			}
 			$redirect_to = add_query_arg(
-				array(
+				[
 					'amp_actioned'       => $action,
 					'amp_actioned_count' => count( $term_ids ),
-				),
+				],
 				$redirect_to
 			);
 		}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -63,21 +63,21 @@ class AMP_Validation_Manager {
 	 *     @type string $slug      Hash of the error.
 	 * }
 	 */
-	public static $validation_results = array();
+	public static $validation_results = [];
 
 	/**
 	 * Sources that enqueue each script.
 	 *
 	 * @var array
 	 */
-	public static $enqueued_script_sources = array();
+	public static $enqueued_script_sources = [];
 
 	/**
 	 * Sources that enqueue each style.
 	 *
 	 * @var array
 	 */
-	public static $enqueued_style_sources = array();
+	public static $enqueued_style_sources = [];
 
 	/**
 	 * Post IDs for posts that have been updated which need to be re-validated.
@@ -86,7 +86,7 @@ class AMP_Validation_Manager {
 	 *
 	 * @var bool[]
 	 */
-	public static $posts_pending_frontend_validation = array();
+	public static $posts_pending_frontend_validation = [];
 
 	/**
 	 * Current sources gathered for a given hook currently being run.
@@ -95,7 +95,7 @@ class AMP_Validation_Manager {
 	 * @see AMP_Validation_Manager::decorate_filter_source()
 	 * @var array[]
 	 */
-	protected static $current_hook_source_stack = array();
+	protected static $current_hook_source_stack = [];
 
 	/**
 	 * Index for where block appears in a post's content.
@@ -112,7 +112,7 @@ class AMP_Validation_Manager {
 	 * @since 0.7
 	 * @var array[]
 	 */
-	public static $hook_source_stack = array();
+	public static $hook_source_stack = [];
 
 	/**
 	 * Whether validation error sources should be located.
@@ -126,7 +126,7 @@ class AMP_Validation_Manager {
 	 *
 	 * @var array
 	 */
-	public static $validation_error_status_overrides = array();
+	public static $validation_error_status_overrides = [];
 
 	/**
 	 * Whether the admin bar item was added for AMP.
@@ -177,11 +177,11 @@ class AMP_Validation_Manager {
 	 * }
 	 * @return void
 	 */
-	public static function init( $args = array() ) {
+	public static function init( $args = [] ) {
 		$args = array_merge(
-			array(
+			[
 				'should_locate_sources' => self::should_validate_response(),
-			),
+			],
 			$args
 		);
 
@@ -195,10 +195,10 @@ class AMP_Validation_Manager {
 			return;
 		}
 
-		add_action( 'save_post', array( __CLASS__, 'handle_save_post_prompting_validation' ) );
-		add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_block_validation' ) );
-		add_action( 'edit_form_top', array( __CLASS__, 'print_edit_form_validation_status' ), 10, 2 );
-		add_action( 'rest_api_init', array( __CLASS__, 'add_rest_api_fields' ) );
+		add_action( 'save_post', [ __CLASS__, 'handle_save_post_prompting_validation' ] );
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_validation' ] );
+		add_action( 'edit_form_top', [ __CLASS__, 'print_edit_form_validation_status' ], 10, 2 );
+		add_action( 'rest_api_init', [ __CLASS__, 'add_rest_api_fields' ] );
 
 		// Add actions for checking theme support is present to determine plugin compatibility and show validation links in the admin bar.
 		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) ) {
@@ -206,8 +206,8 @@ class AMP_Validation_Manager {
 			add_action(
 				'activate_plugin',
 				function() {
-					if ( ! has_action( 'shutdown', array( __CLASS__, 'validate_after_plugin_activation' ) ) ) {
-						add_action( 'shutdown', array( __CLASS__, 'validate_after_plugin_activation' ) ); // Shutdown so all plugins will have been activated.
+					if ( ! has_action( 'shutdown', [ __CLASS__, 'validate_after_plugin_activation' ] ) ) {
+						add_action( 'shutdown', [ __CLASS__, 'validate_after_plugin_activation' ] ); // Shutdown so all plugins will have been activated.
 					}
 				}
 			);
@@ -221,9 +221,9 @@ class AMP_Validation_Manager {
 				}
 			);
 
-			add_action( 'all_admin_notices', array( __CLASS__, 'print_plugin_notice' ) );
+			add_action( 'all_admin_notices', [ __CLASS__, 'print_plugin_notice' ] );
 
-			add_action( 'admin_bar_menu', array( __CLASS__, 'add_admin_bar_menu_items' ), 101 );
+			add_action( 'admin_bar_menu', [ __CLASS__, 'add_admin_bar_menu_items' ], 101 );
 		}
 
 		if ( self::$should_locate_sources ) {
@@ -350,10 +350,10 @@ class AMP_Validation_Manager {
 		$amp_url = remove_query_arg(
 			array_merge(
 				wp_removable_query_args(),
-				array(
+				[
 					self::VALIDATE_QUERY_VAR,
 					'amp_preserve_source_comments',
-				)
+				]
 			),
 			$current_url
 		);
@@ -405,7 +405,7 @@ class AMP_Validation_Manager {
 			$icon = '&#x1F517;'; // LINK SYMBOL.
 			$href = $amp_url;
 		}
-		$parent = array(
+		$parent = [
 			'id'    => 'amp',
 			'title' => sprintf(
 				'<span id="amp-admin-bar-item-status-icon">%s</span> %s',
@@ -413,14 +413,14 @@ class AMP_Validation_Manager {
 				esc_html__( 'AMP', 'amp' )
 			),
 			'href'  => esc_url( $href ),
-		);
+		];
 
 		// Construct admin bar item for validation.
-		$validate_item = array(
+		$validate_item = [
 			'parent' => 'amp',
 			'id'     => 'amp-validity',
 			'href'   => esc_url( $validate_url ),
-		);
+		];
 		if ( $error_count <= 0 ) {
 			$validate_item['title'] = esc_html__( 'Re-validate', 'amp' );
 		} else {
@@ -439,12 +439,12 @@ class AMP_Validation_Manager {
 		}
 
 		// Construct admin bar item to link to AMP version or non-AMP version.
-		$link_item = array(
+		$link_item = [
 			'parent' => 'amp',
 			'id'     => 'amp-view',
 			'title'  => esc_html( is_amp_endpoint() ? __( 'View non-AMP version', 'amp' ) : __( 'View AMP version', 'amp' ) ),
 			'href'   => esc_url( is_amp_endpoint() ? $non_amp_url : $amp_url ),
-		);
+		];
 
 		// Add admin bar item to switch between AMP and non-AMP if parent node is also an AMP link.
 		$is_single_version_available = (
@@ -529,16 +529,16 @@ class AMP_Validation_Manager {
 		self::$stylesheet_directory = wp_normalize_path( get_stylesheet_directory() );
 		self::$stylesheet_slug      = get_stylesheet();
 
-		add_action( 'wp', array( __CLASS__, 'wrap_widget_callbacks' ) );
+		add_action( 'wp', [ __CLASS__, 'wrap_widget_callbacks' ] );
 
-		add_action( 'all', array( __CLASS__, 'wrap_hook_callbacks' ) );
-		$wrapped_filters = array( 'the_content', 'the_excerpt' );
+		add_action( 'all', [ __CLASS__, 'wrap_hook_callbacks' ] );
+		$wrapped_filters = [ 'the_content', 'the_excerpt' ];
 		foreach ( $wrapped_filters as $wrapped_filter ) {
-			add_filter( $wrapped_filter, array( __CLASS__, 'decorate_filter_source' ), PHP_INT_MAX );
+			add_filter( $wrapped_filter, [ __CLASS__, 'decorate_filter_source' ], PHP_INT_MAX );
 		}
 
-		add_filter( 'do_shortcode_tag', array( __CLASS__, 'decorate_shortcode_source' ), PHP_INT_MAX, 2 );
-		add_filter( 'embed_oembed_html', array( __CLASS__, 'decorate_embed_source' ), PHP_INT_MAX, 3 );
+		add_filter( 'do_shortcode_tag', [ __CLASS__, 'decorate_shortcode_source' ], PHP_INT_MAX, 2 );
+		add_filter( 'embed_oembed_html', [ __CLASS__, 'decorate_embed_source' ], PHP_INT_MAX, 3 );
 
 		$do_blocks_priority  = has_filter( 'the_content', 'do_blocks' );
 		$is_gutenberg_active = (
@@ -547,7 +547,7 @@ class AMP_Validation_Manager {
 			class_exists( 'WP_Block_Type_Registry' )
 		);
 		if ( $is_gutenberg_active ) {
-			add_filter( 'the_content', array( __CLASS__, 'add_block_source_comments' ), $do_blocks_priority - 1 );
+			add_filter( 'the_content', [ __CLASS__, 'add_block_source_comments' ], $do_blocks_priority - 1 );
 		}
 	}
 
@@ -588,8 +588,8 @@ class AMP_Validation_Manager {
 			self::$posts_pending_frontend_validation[ $post_id ] = true;
 
 			// The reason for shutdown is to ensure that all postmeta changes have been saved, including whether AMP is enabled.
-			if ( ! has_action( 'shutdown', array( __CLASS__, 'validate_queued_posts_on_frontend' ) ) ) {
-				add_action( 'shutdown', array( __CLASS__, 'validate_queued_posts_on_frontend' ) );
+			if ( ! has_action( 'shutdown', [ __CLASS__, 'validate_queued_posts_on_frontend' ] ) ) {
+				add_action( 'shutdown', [ __CLASS__, 'validate_queued_posts_on_frontend' ] );
 			}
 		}
 	}
@@ -609,7 +609,7 @@ class AMP_Validation_Manager {
 			}
 		);
 
-		$validation_posts = array();
+		$validation_posts = [];
 
 		/*
 		 * It is unlikely that there will be more than one post in the array.
@@ -635,10 +635,10 @@ class AMP_Validation_Manager {
 					wp_list_pluck( $validity['results'], 'error' ),
 					$validity['url'],
 					array_merge(
-						array(
+						[
 							'invalid_url_post' => $invalid_url_post_id,
-						),
-						wp_array_slice_assoc( $validity, array( 'queried_object' ) )
+						],
+						wp_array_slice_assoc( $validity, [ 'queried_object' ] )
 					)
 				);
 
@@ -659,16 +659,16 @@ class AMP_Validation_Manager {
 	 */
 	public static function add_rest_api_fields() {
 		if ( ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-			$object_types = array( AMP_Story_Post_Type::POST_TYPE_SLUG ); // Eventually validation should be done in Reader mode as well, but for now, limit to stories.
+			$object_types = [ AMP_Story_Post_Type::POST_TYPE_SLUG ]; // Eventually validation should be done in Reader mode as well, but for now, limit to stories.
 		} elseif ( amp_is_canonical() ) {
 			$object_types = get_post_types_by_support( 'editor' ); // @todo Shouldn't this actually only be those with 'amp' support, or if if all_templates_supported?
 		} else {
 			$object_types = array_intersect(
 				get_post_types_by_support( 'amp' ),
 				get_post_types(
-					array(
+					[
 						'show_in_rest' => true,
-					)
+					]
 				)
 			);
 		}
@@ -676,13 +676,13 @@ class AMP_Validation_Manager {
 		register_rest_field(
 			$object_types,
 			self::VALIDITY_REST_FIELD_NAME,
-			array(
-				'get_callback' => array( __CLASS__, 'get_amp_validity_rest_field' ),
-				'schema'       => array(
+			[
+				'get_callback' => [ __CLASS__, 'get_amp_validity_rest_field' ],
+				'schema'       => [
 					'description' => __( 'AMP validity status', 'amp' ),
 					'type'        => 'object',
-				),
-			)
+				],
+			]
 		);
 	}
 
@@ -704,7 +704,7 @@ class AMP_Validation_Manager {
 		$post = get_post( $post_data['id'] );
 
 		$validation_status_post = null;
-		if ( in_array( $request->get_method(), array( 'PUT', 'POST' ), true ) ) {
+		if ( in_array( $request->get_method(), [ 'PUT', 'POST' ], true ) ) {
 			if ( ! isset( self::$posts_pending_frontend_validation[ $post->ID ] ) ) {
 				self::$posts_pending_frontend_validation[ $post->ID ] = true;
 			}
@@ -718,21 +718,21 @@ class AMP_Validation_Manager {
 			$validation_status_post = AMP_Validated_URL_Post_Type::get_invalid_url_post( amp_get_permalink( $post->ID ) );
 		}
 
-		$field = array(
-			'results'     => array(),
+		$field = [
+			'results'     => [],
 			'review_link' => null,
-		);
+		];
 
 		if ( $validation_status_post ) {
 			$field['review_link'] = get_edit_post_link( $validation_status_post->ID, 'raw' );
 			foreach ( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( $validation_status_post ) as $result ) {
-				$field['results'][] = array(
+				$field['results'][] = [
 					'sanitized'   => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS === $result['status'],
 					'error'       => $result['data'],
 					'status'      => $result['status'],
 					'term_status' => $result['term_status'],
 					'forced'      => $result['forced'],
-				);
+				];
 			}
 		}
 
@@ -758,7 +758,7 @@ class AMP_Validation_Manager {
 	 *
 	 * @return bool Whether the validation error should result in sanitization.
 	 */
-	public static function add_validation_error( array $error, array $data = array() ) {
+	public static function add_validation_error( array $error, array $data = [] ) {
 		$node    = null;
 		$matches = null;
 		$sources = null;
@@ -838,9 +838,9 @@ class AMP_Validation_Manager {
 	 * @return void
 	 */
 	public static function reset_validation_results() {
-		self::$validation_results      = array();
-		self::$enqueued_style_sources  = array();
-		self::$enqueued_script_sources = array();
+		self::$validation_results      = [];
+		self::$enqueued_style_sources  = [];
+		self::$enqueued_script_sources = [];
 	}
 
 	/**
@@ -864,7 +864,7 @@ class AMP_Validation_Manager {
 		}
 
 		// Show all validation errors which have not been explicitly acknowledged as accepted.
-		$validation_errors  = array();
+		$validation_errors  = [];
 		$has_rejected_error = false;
 		foreach ( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( $invalid_url_post ) as $error ) {
 			$needs_moderation = (
@@ -921,23 +921,23 @@ class AMP_Validation_Manager {
 		echo '</p>';
 
 		$results      = AMP_Validation_Error_Taxonomy::summarize_validation_errors( array_unique( $validation_errors, SORT_REGULAR ) );
-		$removed_sets = array();
+		$removed_sets = [];
 		if ( ! empty( $results[ AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS ] ) && is_array( $results[ AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS ] ) ) {
-			$removed_sets[] = array(
+			$removed_sets[] = [
 				'label' => __( 'Invalid elements:', 'amp' ),
 				'names' => array_map( 'sanitize_key', $results[ AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS ] ),
-			);
+			];
 		}
 		if ( ! empty( $results[ AMP_Validation_Error_Taxonomy::REMOVED_ATTRIBUTES ] ) && is_array( $results[ AMP_Validation_Error_Taxonomy::REMOVED_ATTRIBUTES ] ) ) {
-			$removed_sets[] = array(
+			$removed_sets[] = [
 				'label' => __( 'Invalid attributes:', 'amp' ),
 				'names' => array_map( 'sanitize_key', $results[ AMP_Validation_Error_Taxonomy::REMOVED_ATTRIBUTES ] ),
-			);
+			];
 		}
 		// @todo There are other kinds of errors other than REMOVED_ELEMENTS and REMOVED_ATTRIBUTES.
 		foreach ( $removed_sets as $removed_set ) {
 			printf( '<p>%s ', esc_html( $removed_set['label'] ) );
-			$items = array();
+			$items = [];
 			foreach ( $removed_set['names'] as $name => $count ) {
 				if ( 1 === (int) $count ) {
 					$items[] = sprintf( '<code>%s</code>', esc_html( $name ) );
@@ -1001,8 +1001,8 @@ class AMP_Validation_Manager {
 	public static function locate_sources( DOMNode $node ) {
 		$xpath    = new DOMXPath( $node->ownerDocument );
 		$comments = $xpath->query( 'preceding::comment()[ starts-with( ., "amp-source-stack" ) or starts-with( ., "/amp-source-stack" ) ]', $node );
-		$sources  = array();
-		$matches  = array();
+		$sources  = [];
+		$matches  = [];
 
 		foreach ( $comments as $comment ) {
 			$parsed_comment = self::parse_source_comment( $comment );
@@ -1102,7 +1102,7 @@ class AMP_Validation_Manager {
 	 */
 	public static function remove_source_comments( $dom ) {
 		$xpath    = new DOMXPath( $dom );
-		$comments = array();
+		$comments = [];
 		foreach ( $xpath->query( '//comment()[ starts-with( ., "amp-source-stack" ) or starts-with( ., "/amp-source-stack" ) ]' ) as $comment ) {
 			if ( self::parse_source_comment( $comment ) ) {
 				$comments[] = $comment;
@@ -1124,19 +1124,19 @@ class AMP_Validation_Manager {
 
 		$start_block_pattern = implode(
 			'',
-			array(
+			[
 				'#<!--\s+',
 				'(?P<closing>/)?',
 				'wp:(?P<name>\S+)',
 				'(?:\s+(?P<attributes>\{.*?\}))?',
 				'\s+(?P<self_closing>\/)?',
 				'-->#s',
-			)
+			]
 		);
 
 		return preg_replace_callback(
 			$start_block_pattern,
-			array( __CLASS__, 'handle_block_source_comment_replacement' ),
+			[ __CLASS__, 'handle_block_source_comment_replacement' ],
 			$content
 		);
 	}
@@ -1154,10 +1154,10 @@ class AMP_Validation_Manager {
 		$replaced = $matches[0];
 
 		// Obtain source information for block.
-		$source = array(
+		$source = [
 			'block_name' => $matches['name'],
 			'post_id'    => get_the_ID(),
-		);
+		];
 
 		if ( empty( $matches['closing'] ) ) {
 			$source['block_content_index'] = self::$block_content_index;
@@ -1235,7 +1235,7 @@ class AMP_Validation_Manager {
 			return;
 		}
 
-		self::$current_hook_source_stack[ $hook ] = array();
+		self::$current_hook_source_stack[ $hook ] = [];
 		foreach ( $wp_filter[ $hook ]->callbacks as $priority => &$callbacks ) {
 			foreach ( $callbacks as &$callback ) {
 				$source = self::get_source( $callback['function'] );
@@ -1315,11 +1315,11 @@ class AMP_Validation_Manager {
 
 		$output = implode(
 			'',
-			array(
+			[
 				self::get_source_comment( $source, true ),
 				$output,
 				self::get_source_comment( $source, false ),
-			)
+			]
 		);
 		return $output;
 	}
@@ -1335,17 +1335,17 @@ class AMP_Validation_Manager {
 	 * @return string Output.
 	 */
 	public static function decorate_embed_source( $output, $url, $attr ) {
-		$source = array(
+		$source = [
 			'embed' => $url,
 			'attr'  => $attr,
-		);
+		];
 		return implode(
 			'',
-			array(
+			[
 				self::get_source_comment( $source, true ),
 				trim( $output ),
 				self::get_source_comment( $source, false ),
-			)
+			]
 		);
 	}
 
@@ -1364,10 +1364,10 @@ class AMP_Validation_Manager {
 		}
 
 		$post   = get_post();
-		$source = array(
+		$source = [
 			'hook'   => current_filter(),
 			'filter' => true,
-		);
+		];
 		if ( $post ) {
 			$source['post_id']   = $post->ID;
 			$source['post_type'] = $post->post_type;
@@ -1379,11 +1379,11 @@ class AMP_Validation_Manager {
 		}
 		return implode(
 			'',
-			array(
+			[
 				self::get_source_comment( $source, true ),
 				$value,
 				self::get_source_comment( $source, false ),
-			)
+			]
 		);
 	}
 
@@ -1497,7 +1497,7 @@ class AMP_Validation_Manager {
 		}
 
 		// Check if any functions in call stack are output buffering display handlers.
-		$called_functions = array();
+		$called_functions = [];
 		if ( defined( 'DEBUG_BACKTRACE_IGNORE_ARGS' ) ) {
 			$arg = DEBUG_BACKTRACE_IGNORE_ARGS; // phpcs:ignore PHPCompatibility.Constants.NewConstants.debug_backtrace_ignore_argsFound
 		} else {
@@ -1559,11 +1559,11 @@ class AMP_Validation_Manager {
 		if ( ! empty( $output ) && preg_match( '/<.+?>/s', $output ) ) {
 			$output = implode(
 				'',
-				array(
+				[
 					self::get_source_comment( $source, true ),
 					$output,
 					self::get_source_comment( $source, false ),
-				)
+				]
 			);
 		}
 		return $output;
@@ -1609,12 +1609,12 @@ class AMP_Validation_Manager {
 	 *     @type bool $append_validation_status_comment Whether the validation errors should be appended as an HTML comment. Defaults to true.
 	 * }
 	 */
-	public static function finalize_validation( DOMDocument $dom, $args = array() ) {
+	public static function finalize_validation( DOMDocument $dom, $args = [] ) {
 		$args = array_merge(
-			array(
+			[
 				'remove_source_comments'           => true,
 				'append_validation_status_comment' => true,
-			),
+			],
 			$args
 		);
 
@@ -1667,11 +1667,11 @@ class AMP_Validation_Manager {
 			}
 
 			if ( $args['append_validation_status_comment'] ) {
-				$data = array(
+				$data = [
 					'results' => self::$validation_results,
-				);
+				];
 				if ( get_queried_object() ) {
-					$data['queried_object'] = array();
+					$data['queried_object'] = [];
 					if ( get_queried_object_id() ) {
 						$data['queried_object']['id'] = get_queried_object_id();
 					}
@@ -1708,7 +1708,7 @@ class AMP_Validation_Manager {
 		if ( isset( $sanitizers['AMP_Style_Sanitizer'] ) ) {
 			$sanitizers['AMP_Style_Sanitizer']['should_locate_sources'] = self::$should_locate_sources;
 
-			$css_validation_errors = array();
+			$css_validation_errors = [];
 			foreach ( self::$validation_error_status_overrides as $slug => $status ) {
 				$term = AMP_Validation_Error_Taxonomy::get_term( $slug );
 				if ( ! $term ) {
@@ -1754,7 +1754,7 @@ class AMP_Validation_Manager {
 			AMP_Validated_URL_Post_Type::store_validation_errors(
 				$validation_errors,
 				$validity['url'],
-				wp_array_slice_assoc( $validity, array( 'queried_object_id', 'queried_object_type' ) )
+				wp_array_slice_assoc( $validity, [ 'queried_object_id', 'queried_object_type' ] )
 			);
 			set_transient( self::PLUGIN_ACTIVATION_VALIDATION_ERRORS_TRANSIENT_KEY, $validation_errors, 60 );
 		} else {
@@ -1781,10 +1781,10 @@ class AMP_Validation_Manager {
 	 */
 	public static function validate_url( $url ) {
 
-		$added_query_vars = array(
+		$added_query_vars = [
 			self::VALIDATE_QUERY_VAR   => self::get_amp_validate_nonce(),
 			self::CACHE_BUST_QUERY_VAR => wp_rand(),
-		);
+		];
 		$validation_url   = add_query_arg( $added_query_vars, $url );
 
 		$r = null;
@@ -1794,15 +1794,15 @@ class AMP_Validation_Manager {
 		for ( $redirect_count = 0; $redirect_count < $allowed_redirects; $redirect_count++ ) {
 			$r = wp_remote_get(
 				$validation_url,
-				array(
+				[
 					'cookies'     => wp_unslash( $_COOKIE ), // Pass along cookies so private pages and drafts can be accessed.
 					'timeout'     => 15, // Increase from default of 5 to give extra time for the plugin to identify the sources for any given validation errors; also, response caching is disabled when validating.
 					'sslverify'   => false,
 					'redirection' => 0, // Because we're in a loop for redirection.
-					'headers'     => array(
+					'headers'     => [
 						'Cache-Control' => 'no-cache',
-					),
-				)
+					],
+				]
 			);
 
 			// If the response is not a redirect, then break since $r is all we need.
@@ -1919,7 +1919,7 @@ class AMP_Validation_Manager {
 			$errors          = AMP_Validation_Error_Taxonomy::summarize_validation_errors( $validation_errors );
 			$invalid_plugins = isset( $errors[ AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT ]['plugin'] ) ? array_unique( $errors[ AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT ]['plugin'] ) : null;
 			if ( isset( $invalid_plugins ) ) {
-				$reported_plugins = array();
+				$reported_plugins = [];
 				foreach ( $invalid_plugins as $plugin ) {
 					$reported_plugins[] = sprintf( '<code>%s</code>', esc_html( $plugin ) );
 				}
@@ -1977,7 +1977,7 @@ class AMP_Validation_Manager {
 		$script_deps_path    = AMP__DIR__ . '/assets/js/' . $slug . '.deps.json';
 		$script_dependencies = file_exists( $script_deps_path )
 			? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			: array();
+			: [];
 
 		wp_enqueue_script(
 			$slug,
@@ -1990,11 +1990,11 @@ class AMP_Validation_Manager {
 		$status_and_errors = AMP_Post_Meta_Box::get_status_and_errors( get_post() );
 		$enabled_status    = $status_and_errors['status'];
 
-		$data = array(
+		$data = [
 			'isSanitizationAutoAccepted' => self::is_sanitization_auto_accepted() || AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type(),
-			'possibleStatuses'           => array( AMP_Post_Meta_Box::ENABLED_STATUS, AMP_Post_Meta_Box::DISABLED_STATUS ),
+			'possibleStatuses'           => [ AMP_Post_Meta_Box::ENABLED_STATUS, AMP_Post_Meta_Box::DISABLED_STATUS ],
 			'defaultStatus'              => $enabled_status,
-		);
+		];
 
 		wp_localize_script(
 			$slug,

--- a/includes/widgets/class-amp-widget-archives.php
+++ b/includes/widgets/class-amp-widget-archives.php
@@ -58,11 +58,11 @@ class AMP_Widget_Archives extends WP_Widget_Archives {
 					/** This filter is documented in wp-includes/widgets/class-wp-widget-archives.php */
 					$dropdown_args = apply_filters(
 						'widget_archives_dropdown_args',
-						array(
+						[
 							'type'            => 'monthly',
 							'format'          => 'option',
 							'show_post_count' => $c,
-						)
+						]
 					);
 
 					switch ( $dropdown_args['type'] ) {
@@ -95,10 +95,10 @@ class AMP_Widget_Archives extends WP_Widget_Archives {
 				wp_get_archives(
 					apply_filters(
 						'widget_archives_args',
-						array(
+						[
 							'type'            => 'monthly',
 							'show_post_count' => $c,
-						)
+						]
 					)
 				);
 				?>

--- a/includes/widgets/class-amp-widget-categories.php
+++ b/includes/widgets/class-amp-widget-categories.php
@@ -46,11 +46,11 @@ class AMP_Widget_Categories extends WP_Widget_Categories {
 		if ( $title ) {
 			echo wp_kses_post( $args['before_title'] . $title . $args['after_title'] );
 		}
-		$cat_args = array(
+		$cat_args = [
 			'orderby'      => 'name',
 			'show_count'   => $c,
 			'hierarchical' => $h,
-		);
+		];
 		if ( $d ) :
 			$form_id = sprintf( 'widget-categories-dropdown-%d', $this->number );
 			printf( '<form action="%s" method="get" target="_top" id="%s">', esc_url( home_url() ), esc_attr( $form_id ) );
@@ -64,7 +64,7 @@ class AMP_Widget_Categories extends WP_Widget_Categories {
 				array_merge(
 					/** This filter is documented in wp-includes/widgets/class-wp-widget-categories.php */
 					apply_filters( 'widget_categories_dropdown_args', $cat_args, $instance ),
-					array( 'echo' => false )
+					[ 'echo' => false ]
 				)
 			);
 			$dropdown = preg_replace(

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -79,6 +79,10 @@
 		<exclude-pattern>bin/*</exclude-pattern>
 	</rule>
 
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found">
+		<exclude-pattern>amp.php</exclude-pattern>
+	</rule>
+
 	<arg value="s"/>
 	<arg name="extensions" value="php"/>
 	<file>.</file>

--- a/templates/header.php
+++ b/templates/header.php
@@ -11,4 +11,4 @@
  * @var AMP_Post_Template $this
  */
 
-$this->load_parts( array( 'header-bar' ) );
+$this->load_parts( [ 'header-bar' ] );

--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -25,7 +25,7 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 	<style amp-custom>
-		<?php $this->load_parts( array( 'style' ) ); ?>
+		<?php $this->load_parts( [ 'style' ] ); ?>
 		<?php do_action( 'amp_post_template_css', $this ); ?>
 	</style>
 </head>

--- a/templates/meta-author.php
+++ b/templates/meta-author.php
@@ -17,7 +17,7 @@ $post_author = $this->get( 'post_author' );
 <?php if ( $post_author ) : ?>
 	<div class="amp-wp-meta amp-wp-byline">
 		<?php if ( function_exists( 'get_avatar_url' ) ) : ?>
-			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, array( 'size' => 24 ) ) ); ?>" alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"></amp-img>
+			<amp-img src="<?php echo esc_url( get_avatar_url( $post_author->user_email, [ 'size' => 24 ] ) ); ?>" alt="<?php echo esc_attr( $post_author->display_name ); ?>" width="24" height="24" layout="fixed"></amp-img>
 		<?php endif; ?>
 		<span class="amp-wp-author author vcard"><?php echo esc_html( $post_author->display_name ); ?></span>
 	</div>

--- a/templates/page.php
+++ b/templates/page.php
@@ -18,24 +18,24 @@
  * @var AMP_Post_Template $this
  */
 
-$this->load_parts( array( 'html-start' ) );
+$this->load_parts( [ 'html-start' ] );
 ?>
 
-<?php $this->load_parts( array( 'header' ) ); ?>
+<?php $this->load_parts( [ 'header' ] ); ?>
 
 <article class="amp-wp-article">
 	<header class="amp-wp-article-header">
 		<h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
 	</header>
 
-	<?php $this->load_parts( array( 'featured-image' ) ); ?>
+	<?php $this->load_parts( [ 'featured-image' ] ); ?>
 
 	<div class="amp-wp-article-content">
 		<?php echo $this->get( 'post_amp_content' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</div>
 </article>
 
-<?php $this->load_parts( array( 'footer' ) ); ?>
+<?php $this->load_parts( [ 'footer' ] ); ?>
 
 <?php
-$this->load_parts( array( 'html-end' ) );
+$this->load_parts( [ 'html-end' ] );

--- a/templates/single.php
+++ b/templates/single.php
@@ -18,29 +18,29 @@
  * @var AMP_Post_Template $this
  */
 
-$this->load_parts( array( 'html-start' ) );
+$this->load_parts( [ 'html-start' ] );
 ?>
 
-<?php $this->load_parts( array( 'header' ) ); ?>
+<?php $this->load_parts( [ 'header' ] ); ?>
 
 <article class="amp-wp-article">
 	<header class="amp-wp-article-header">
 		<h1 class="amp-wp-title"><?php echo esc_html( $this->get( 'post_title' ) ); ?></h1>
-		<?php $this->load_parts( apply_filters( 'amp_post_article_header_meta', array( 'meta-author', 'meta-time' ) ) ); ?>
+		<?php $this->load_parts( apply_filters( 'amp_post_article_header_meta', [ 'meta-author', 'meta-time' ] ) ); ?>
 	</header>
 
-	<?php $this->load_parts( array( 'featured-image' ) ); ?>
+	<?php $this->load_parts( [ 'featured-image' ] ); ?>
 
 	<div class="amp-wp-article-content">
 		<?php echo $this->get( 'post_amp_content' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	</div>
 
 	<footer class="amp-wp-article-footer">
-		<?php $this->load_parts( apply_filters( 'amp_post_article_footer_meta', array( 'meta-taxonomy', 'meta-comments-link' ) ) ); ?>
+		<?php $this->load_parts( apply_filters( 'amp_post_article_footer_meta', [ 'meta-taxonomy', 'meta-comments-link' ] ) ); ?>
 	</footer>
 </article>
 
-<?php $this->load_parts( array( 'footer' ) ); ?>
+<?php $this->load_parts( [ 'footer' ] ); ?>
 
 <?php
-$this->load_parts( array( 'html-end' ) );
+$this->load_parts( [ 'html-end' ] );

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -17,10 +17,10 @@ class AMP_Test_World_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	public function get_scripts() {
-		return array( 'scripts' );
+		return [ 'scripts' ];
 	}
 
 	public function get_styles() {
-		return array( 'styles' );
+		return [ 'styles' ];
 	}
 }

--- a/tests/php/test-amp-analytics-options.php
+++ b/tests/php/test-amp-analytics-options.php
@@ -8,7 +8,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 		AMP_Options_Manager::register_settings();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 	}
 
 	private $vendor = 'googleanalytics';
@@ -51,18 +51,18 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 	}';
 
 	private function get_options() {
-		return AMP_Options_Manager::get_option( 'analytics', array() );
+		return AMP_Options_Manager::get_option( 'analytics', [] );
 	}
 
 	private function render_post() {
 		$user_id = self::factory()->user->create();
 		$post_id = self::factory()->post->create(
-			array(
+			[
 				'post_author' => $user_id,
-			)
+			]
 		);
 
-		return get_echo( 'amp_render_post', array( $post_id ) );
+		return get_echo( 'amp_render_post', [ $post_id ] );
 	}
 
 	/**
@@ -74,9 +74,9 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 	private function insert_one_option( $type, $config ) {
 		AMP_Options_Manager::update_option(
 			'analytics',
-			array(
+			[
 				'__new__' => compact( 'type', 'config' ),
-			)
+			]
 		);
 	}
 
@@ -261,7 +261,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 
 		$analytics = amp_get_analytics();
 
-		$output = get_echo( 'amp_print_analytics', array( $analytics ) );
+		$output = get_echo( 'amp_print_analytics', [ $analytics ] );
 
 		$this->assertStringStartsWith( '<amp-analytics', $output );
 		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
@@ -277,14 +277,14 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 	 * @covers ::amp_print_analytics()
 	 */
 	public function test_amp_print_analytics_when_empty() {
-		$output = get_echo( 'amp_print_analytics', array( '' ) );
+		$output = get_echo( 'amp_print_analytics', [ '' ] );
 		$this->assertEmpty( $output );
 
 		$this->insert_one_option(
 			$this->vendor,
 			$this->config_one
 		);
-		$output = get_echo( 'amp_print_analytics', array( '' ) );
+		$output = get_echo( 'amp_print_analytics', [ '' ] );
 		$this->assertStringStartsWith( '<amp-analytics', $output );
 		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
 	}

--- a/tests/php/test-amp-audio-converter.php
+++ b/tests/php/test-amp-audio-converter.php
@@ -20,64 +20,64 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'no_audios' => array(
+		return [
+			'no_audios' => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				'<p>Lorem Ipsum Demet Delorit.</p>',
-			),
+			],
 
-			'simple_audio' => array(
+			'simple_audio' => [
 				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
-				array(
+				[
 					'add_noscript_fallback' => true,
-				),
-			),
+				],
+			],
 
-			'simple_audio_without_noscript' => array(
+			'simple_audio_without_noscript' => [
 				'<audio src="https://example.com/audio/file.ogg" data-foo="bar"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a></amp-audio>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'autoplay_attribute' => array(
+			'autoplay_attribute' => [
 				'<audio src="https://example.com/audio/file.ogg" autoplay></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" autoplay="" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" autoplay></audio></noscript></amp-audio>',
-			),
+			],
 
-			'autoplay_attribute__false' => array(
+			'autoplay_attribute__false' => [
 				'<audio src="https://example.com/audio/file.ogg" autoplay="false"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" autoplay="false"></audio></noscript></amp-audio>',
-			),
+			],
 
-			'audio_with_whitelisted_attributes__enabled' => array(
+			'audio_with_whitelisted_attributes__enabled' => [
 				'<audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" class="test" loop="" muted="" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="loop" muted></audio></noscript></amp-audio>',
-			),
+			],
 
-			'audio_with_whitelisted_attributes__disabled' => array(
+			'audio_with_whitelisted_attributes__disabled' => [
 				'<audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" class="test" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg" class="test" loop="false" muted="false"></audio></noscript></amp-audio>',
-			),
+			],
 
-			'audio_with_children' => array(
+			'audio_with_children' => [
 				'<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>',
 				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
-			),
+			],
 
-			'audio_with_http_children' => array(
+			'audio_with_http_children' => [
 				'<audio><source src="http://example.com/foo.wav" type="audio/wav"></audio>',
 				'<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>',
-			),
+			],
 
-			'audio_with_layout_from_editor_fixed_height' => array(
+			'audio_with_layout_from_editor_fixed_height' => [
 				'<figure><audio src="https://example.com/audio/file.ogg" width="100" height="100"></audio><figcaption>Caption</figcaption></figure>',
 				'<figure><amp-audio src="https://example.com/audio/file.ogg" width="auto" height="100"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio><figcaption>Caption</figcaption></figure>',
-			),
+			],
 
-			'multiple_same_audio' => array(
+			'multiple_same_audio' => [
 				'
 					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
 					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
@@ -88,9 +88,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
 					<amp-audio width="auto"><source src="https://example.com/foo.wav" type="audio/wav"><a href="https://example.com/foo.wav" fallback="">https://example.com/foo.wav</a><noscript><audio><source src="https://example.com/foo.wav" type="audio/wav"></audio></noscript></amp-audio>
 				',
-			),
+			],
 
-			'multiple_different_audio' => array(
+			'multiple_different_audio' => [
 				'
 					<audio><source src="https://example.com/foo.wav" type="audio/wav"></audio>
 					<audio src="https://example.com/audio/file.ogg"></audio>
@@ -101,9 +101,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 					<amp-audio src="https://example.com/audio/file.ogg" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>
 					<amp-audio width="auto"><source src="https://example.com/foo2.wav" type="audio/wav"><a href="https://example.com/foo2.wav" fallback="">https://example.com/foo2.wav</a><noscript><audio><source src="https://example.com/foo2.wav" type="audio/wav"></audio></noscript></amp-audio>
 				',
-			),
+			],
 
-			'audio_with_track_no_source_element' => array(
+			'audio_with_track_no_source_element' => [
 				'
 					<audio src="https://example.com/audio/file.ogg">
 						<track kind="chapters" srclang="en" src="https://example.com/media/examples/friday.vtt">
@@ -120,9 +120,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-audio>
 				',
-			),
+			],
 
-			'audio_with_track_and_source_element' => array(
+			'audio_with_track_and_source_element' => [
 				'
 					<audio>
 						<source src="https://example.com/audio/file.ogg" type="audio/mp3">
@@ -142,9 +142,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-audio>
 				',
-			),
+			],
 
-			'audio_block_and_shortcode_output' => array(
+			'audio_block_and_shortcode_output' => [
 				'
 					<figure class="wp-block-audio">
 						<audio controls src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3"></audio>
@@ -179,14 +179,14 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-audio>
 				',
-			),
+			],
 
-			'amp_audio_with_existing_noscript_fallback' => array(
+			'amp_audio_with_existing_noscript_fallback' => [
 				'<amp-audio src="https://example.com/audio/file.ogg"><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
 				null,
-			),
+			],
 
-			'audio_with_existing_noscript_fallback'     => array(
+			'audio_with_existing_noscript_fallback'     => [
 				'<div id="player"><noscript><audio src="https://example.com/audio/file.mp3"></audio></noscript></div>',
 				'
 					<div id="player">
@@ -200,16 +200,16 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 						<!--/noscript-->
 					</div>
 				',
-			),
+			],
 
-			'audio_with_extra_attributes' => array(
+			'audio_with_extra_attributes' => [
 				'<audio src="https://example.com/audio/file.ogg" onclick="foo()" data-foo="bar"></audio>',
 				'<amp-audio src="https://example.com/audio/file.ogg" data-foo="bar" width="auto"><a href="https://example.com/audio/file.ogg" fallback="">https://example.com/audio/file.ogg</a><noscript><audio src="https://example.com/audio/file.ogg"></audio></noscript></amp-audio>',
-				array(
+				[
 					'add_noscript_fallback' => true,
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -221,7 +221,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 	 * @param string $expected Expected.
 	 * @param array  $args     Args for sanitizer.
 	 */
-	public function test_converter( $source, $expected = null, $args = array() ) {
+	public function test_converter( $source, $expected = null, $args = [] ) {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
@@ -252,9 +252,9 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer(
 			$dom,
-			array(
+			[
 				'require_https_src' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
 
@@ -267,7 +267,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__didnt_convert() {
 		$source   = '<p>Hello World</p>';
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );
@@ -288,7 +288,7 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<audio src="https://example.com/audio/file.ogg"></audio>';
-		$expected = array( 'amp-audio' => true );
+		$expected = [ 'amp-audio' => true ];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Audio_Sanitizer( $dom );

--- a/tests/php/test-amp-crowdsignal-embed-handler.php
+++ b/tests/php/test-amp-crowdsignal-embed-handler.php
@@ -18,52 +18,52 @@ class AMP_Crowdsignal_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_conversion_data() {
-		$poll_response   = array(
+		$poll_response   = [
 			'type'          => 'rich',
 			'version'       => '1.0',
 			'provider_name' => 'Crowdsignal',
 			'provider_url'  => 'https://crowdsignal.com',
 			'title'         => 'Which design do you prefer?',
 			'html' => '<script type="text/javascript" charset="utf-8" src="https://secure.polldaddy.com/p/7012505.js"></script><noscript><a href="https://poll.fm/7012505">Which design do you prefer?</a></noscript>', // phpcs:ignore
-		);
-		$survey_response = array(
+		];
+		$survey_response = [
 			'type'          => 'rich',
 			'version'       => '1.0',
 			'provider_name' => 'Crowdsignal',
 			'provider_url'  => 'https://crowdsignal.com',
 			'html'          => '<div class="pd-embed" data-settings="{&quot;type&quot;:&quot;iframe&quot;,&quot;auto&quot;:true,&quot;domain&quot;:&quot;rydk.survey.fm&quot;,&quot;id&quot;:&quot;test-survey&quot;}"></div><script type="text/javascript">(function(d,c,j){if(!document.getElementById(j)){var pd=d.createElement(c),s;pd.id=j;pd.src=(\'https:\'==document.location.protocol)?\'https://polldaddy.com/survey.js\':\'http://i0.poll.fm/survey.js\';s=document.getElementsByTagName(c)[0];s.parentNode.insertBefore(pd,s);}}(document,\'script\',\'pd-embed\'));</script>',
-		);
+		];
 
-		$data = array(
-			'poll.fm'          => array(
+		$data = [
+			'poll.fm'          => [
 				'https://poll.fm/7012505',
 				'<p><a href="https://poll.fm/7012505">Which design do you prefer?</a></p>',
 				$poll_response,
-			),
+			],
 
-			'polldaddy_poll'   => array(
+			'polldaddy_poll'   => [
 				'https://polldaddy.com/poll/7012505/',
 				'<p><a href="https://poll.fm/7012505">Which design do you prefer?</a></p>',
 				$poll_response,
-			),
+			],
 
-			'polldaddy_survey' => array(
+			'polldaddy_survey' => [
 				'https://rydk.polldaddy.com/s/test-survey',
 				'<p><a href="https://rydk.polldaddy.com/s/test-survey" target="_blank">View Survey</a></p>',
 				$survey_response,
-			),
-		);
+			],
+		];
 
 		/*
 		 * There is a bug with WordPress's oEmbed handling for Crowdsignal surveys.
 		 * See <https://core.trac.wordpress.org/ticket/46467>.
 		 */
 		if ( version_compare( get_bloginfo( 'version' ), '5.2.0', '>=' ) ) {
-			$data['survey.fm'] = array(
+			$data['survey.fm'] = [
 				'https://rydk.survey.fm/test-survey',
 				'<p><a href="https://rydk.survey.fm/test-survey" target="_blank">View Survey</a></p>',
 				$survey_response,
-			);
+			];
 		}
 
 		return $data;
@@ -86,13 +86,13 @@ class AMP_Crowdsignal_Embed_Test extends WP_UnitTestCase {
 					return $pre;
 				}
 
-				return array(
+				return [
 					'body'     => wp_json_encode( $oembed_response ),
-					'response' => array(
+					'response' => [
 						'code'    => 200,
 						'message' => 'OK',
-					),
-				);
+					],
+				];
 			},
 			10,
 			3

--- a/tests/php/test-amp-dailymotion-embed.php
+++ b/tests/php/test-amp-dailymotion-embed.php
@@ -2,33 +2,33 @@
 
 class AMP_DailyMotion_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'                     => array(
+		return [
+			'no_embed'                     => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'url_simple'                   => array(
+			'url_simple'                   => [
 				'https://www.dailymotion.com/video/x5awwth' . PHP_EOL,
 				'<p><amp-dailymotion data-videoid="x5awwth" layout="responsive" width="600" height="338"></amp-dailymotion></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_title'               => array(
+			'url_with_title'               => [
 				'http://www.dailymotion.com/video/x5awwth_snatched-official-trailer-2-hd_shortfilms' . PHP_EOL,
 				'<p><amp-dailymotion data-videoid="x5awwth" layout="responsive" width="600" height="338"></amp-dailymotion></p>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_unnamed_attr_as_id' => array(
+			'shortcode_unnamed_attr_as_id' => [
 				'[dailymotion x5awwth]' . PHP_EOL,
 				'<amp-dailymotion data-videoid="x5awwth" layout="responsive" width="600" height="338"></amp-dailymotion>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_named_attr_as_id'   => array(
+			'shortcode_named_attr_as_id'   => [
 				'[dailymotion id=x5awwth]' . PHP_EOL,
 				'<amp-dailymotion data-videoid="x5awwth" layout="responsive" width="600" height="338"></amp-dailymotion>' . PHP_EOL,
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -43,16 +43,16 @@ class AMP_DailyMotion_Embed_Test extends WP_UnitTestCase {
 	}
 
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.dailymotion.com/video/x5awwth' . PHP_EOL,
-				array( 'amp-dailymotion' => true ),
-			),
-		);
+				[ 'amp-dailymotion' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -18,37 +18,37 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_conversion_data() {
-		return array(
-			'no_embed'         => array(
+		return [
+			'no_embed'         => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
-			'simple_url_https' => array(
+			],
+			'simple_url_https' => [
 				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
 				'<p><amp-facebook data-href="https://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			),
-			'simple_url_http'  => array(
+			],
+			'simple_url_http'  => [
 				'http://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
 				'<p><amp-facebook data-href="http://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			),
-			'no_dubdubdub'     => array(
+			],
+			'no_dubdubdub'     => [
 				'https://facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
 				'<p><amp-facebook data-href="https://facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			),
-			'notes_url'        => array(
+			],
+			'notes_url'        => [
 				'https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/' . PHP_EOL,
 				'<p><amp-facebook data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			),
-			'photo_url'        => array(
+			],
+			'photo_url'        => [
 				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
 				'<p><amp-facebook data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			),
-			'notes_url2'       => array(
+			],
+			'notes_url2'       => [
 				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
 				'<p><amp-facebook data-href="https://www.facebook.com/zuck/videos/10102509264909801/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -72,16 +72,16 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	 * @return array Scripts.
 	 */
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				array( 'amp-facebook' => true ),
-			),
-		);
+				[ 'amp-facebook' => true ],
+			],
+		];
 	}
 
 	/**
@@ -113,22 +113,22 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_raw_embed_dataset() {
-		return array(
-			'no_embed_blockquote'   => array(
+		return [
+			'no_embed_blockquote'   => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>',
-			),
-			'div_without_instagram' => array(
+			],
+			'div_without_instagram' => [
 				'<div>lorem ipsum</div>',
 				'<div>lorem ipsum</div>',
-			),
+			],
 
-			'post_embed'            => array(
+			'post_embed'            => [
 				'<div class="fb-post" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"></div>',
 				'<amp-facebook layout="responsive" width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post"></amp-facebook>',
-			),
+			],
 
-			'post_with_fallbacks'   => array(
+			'post_with_fallbacks'   => [
 				'
 					<div class="fb-post" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/" data-width="500" data-show-text="true">
 						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore">
@@ -143,14 +143,14 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 						</blockquote>
 					</amp-facebook>
 				',
-			),
+			],
 
-			'video_embed'           => array(
+			'video_embed'           => [
 				'<div class="fb-video" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false"></div>',
 				'<amp-facebook layout="responsive" width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video"></amp-facebook>',
-			),
+			],
 
-			'page_embed'            => array(
+			'page_embed'            => [
 				'
 					<div class="fb-page" data-href="https://www.facebook.com/xwp.co/" data-width="340" data-height="432" data-hide-cover="true" data-show-facepile="true" data-show-posts="false">
 						<div class="fb-xfbml-parse-ignore">
@@ -165,9 +165,9 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 						</div>
 					</amp-facebook-page>
 				',
-			),
+			],
 
-			'like'                  => array(
+			'like'                  => [
 				'
 					<div class="fb-like" data-href="https://developers.facebook.com/docs/plugins/" data-width="400" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true"></div>
 				',
@@ -175,27 +175,27 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 					<amp-facebook-like layout="responsive" width="400" height="400" data-href="https://developers.facebook.com/docs/plugins/" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true">
 					</amp-facebook-like>
 				',
-			),
+			],
 
-			'comments'              => array(
+			'comments'              => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments layout="responsive" width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
-			),
+			],
 
-			'comment_embed'         => array(
+			'comment_embed'         => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
 				',
 				'<amp-facebook layout="responsive" width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment"></amp-facebook>',
-			),
+			],
 
-			'remove_fb_root'        => array(
+			'remove_fb_root'        => [
 				'<div id="fb-root"></div><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 				'',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-form-sanitizer.php
+++ b/tests/php/test-amp-form-sanitizer.php
@@ -35,56 +35,56 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 			preg_quote( '<div class="amp-wp-default-form-message" submitting=""><template type="amp-mustache">', '#' ) . '.+?</template></div>'
 		);
 
-		return array(
-			'no_form' => array(
+		return [
+			'no_form' => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				null, // Same.
-			),
-			'form_with_get_method_http_action_and_no_target' => array(
+			],
+			'form_with_get_method_http_action_and_no_target' => [
 				'<form method="get" action="http://example.org/example-page/"></form>',
 				'<form method="get" action="//example.org/example-page/" target="_top"></form>',
-			),
-			'form_with_implicit_method_http_action_and_no_action_or_target' => array(
+			],
+			'form_with_implicit_method_http_action_and_no_action_or_target' => [
 				'<form></form>',
 				sprintf( '<form method="get" action="%s" target="_top"></form>', preg_replace( '#^https?:#', '', home_url( '/current-page/' ) ) ),
-			),
-			'form_with_empty_method_http_action_and_no_action_or_target' => array(
+			],
+			'form_with_empty_method_http_action_and_no_action_or_target' => [
 				'<form method="" action="https://example.com/" target="_top"></form>',
 				'<form method="get" action="https://example.com/" target="_top"></form>',
-			),
-			'form_with_post_method_http_action_and_no_target' => array(
+			],
+			'form_with_post_method_http_action_and_no_target' => [
 				'<form method="post" action="http://example.org/example-page/"></form>',
 				'#' . preg_quote( '<form method="post" action-xhr="//example.org/example-page/?_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
-			),
-			'form_with_post_method_http_action_and_blank_target' => array(
+			],
+			'form_with_post_method_http_action_and_blank_target' => [
 				'<form method="post" action-xhr="http://example.org/example-page/" target="_blank"></form>',
 				'<form method="post" action-xhr="//example.org/example-page/" target="_blank"></form>',
-			),
-			'form_with_post_method_http_action_and_self_target' => array(
+			],
+			'form_with_post_method_http_action_and_self_target' => [
 				'<form method="get" action="https://example.org/" target="_self"></form>',
 				'<form method="get" action="https://example.org/" target="_top"></form>',
-			),
-			'form_with_post_method_https_action_and_custom_target' => array(
+			],
+			'form_with_post_method_https_action_and_custom_target' => [
 				'<form method="post" action="https://example.org/" target="some_other_target"></form>',
 				'#' . preg_quote( '<form method="post" target="_blank" action-xhr="https://example.org/?_wp_amp_action_xhr_converted=1">', '#' ) . $form_template_pattern . '</form>#s',
-			),
-			'jetpack_contact_form' => array(
+			],
+			'jetpack_contact_form' => [
 				'<form action="https://src.wordpress-develop.test/contact/#contact-form-9" method="post" class="contact-form commentsblock"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p></form>',
 				'#' . preg_quote( '<form method="post" class="contact-form commentsblock" action-xhr="https://src.wordpress-develop.test/contact/?_wp_amp_action_xhr_converted=1#contact-form-9" target="_top"><div class="element-has-attributes">hello</div><div><label for="g9-favoritenumber" class="grunion-field-label text">Favorite number</label><input type="text" name="g9-favoritenumber" id="g9-favoritenumber" value="" class="text"></div><p class="contact-submit"><input type="submit" value="Submit" class="pushbutton-wide"><input type="hidden" id="_wpnonce" name="_wpnonce" value="640996fb1e"><input type="hidden" name="_wp_http_referer" value="/contact/"><input type="hidden" name="contact-form-id" value="9"><input type="hidden" name="action" value="grunion-contact-form"><input type="hidden" name="contact-form-hash" value="df9f9136763f5eb819f433e4fe4af3447534e8cc"></p>', '#' ) . $form_template_pattern . '</form>#s',
-			),
-			'form_with_upload' => array(
+			],
+			'form_with_upload' => [
 				'<form action="https://src.wordpress-develop.test/upload/" method="post"><input type="file" name="upload"><button type="submit">Submit</button></form>',
 				'#' . preg_quote( '<form method="post" action-xhr="https://src.wordpress-develop.test/upload/?_wp_amp_action_xhr_converted=1" target="_top"><input type="file" name="upload"><button type="submit">Submit</button>', '#' ) . $form_template_pattern . '</form>#s',
-			),
-			'form_with_password' => array(
+			],
+			'form_with_password' => [
 				'<form action="https://src.wordpress-develop.test/login/" method="post"><input type="password" name="password"><button type="submit">Submit</button></form>',
 				'#' . preg_quote( '<form method="post" action-xhr="https://src.wordpress-develop.test/login/?_wp_amp_action_xhr_converted=1" target="_top"><input type="password" name="password"><button type="submit">Submit</button>', '#' ) . $form_template_pattern . '</form>#s',
-			),
-			'form_with_relative_action_url' => array(
+			],
+			'form_with_relative_action_url' => [
 				'<form method="post" action="/login/"></form>',
 				'#' . preg_quote( '<form method="post" action-xhr="//example.org/login/?_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -120,7 +120,7 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_scripts() {
 		$source   = '<form method="post" action-xhr="//example.org/example-page/" target="_top"></form>';
-		$expected = array( 'amp-form' => true );
+		$expected = [ 'amp-form' => true ];
 
 		$dom                 = AMP_DOM_Utils::get_dom_from_content( $source );
 		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -55,11 +55,11 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @covers ::amp_get_current_url()
 	 */
 	public function test_amp_get_current_url() {
-		$request_uris = array(
+		$request_uris = [
 			'/foo',
 			'/bar?baz',
 			null,
-		);
+		];
 
 		foreach ( $request_uris as $request_uri ) {
 			if ( $request_uri ) {
@@ -86,50 +86,50 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		flush_rewrite_rules();
 
 		$drafted_post   = self::factory()->post->create(
-			array(
+			[
 				'post_name'   => 'draft',
 				'post_status' => 'draft',
 				'post_type'   => 'post',
-			)
+			]
 		);
 		$published_post = self::factory()->post->create(
-			array(
+			[
 				'post_name'   => 'publish',
 				'post_status' => 'publish',
 				'post_type'   => 'post',
-			)
+			]
 		);
 		$published_page = self::factory()->post->create(
-			array(
+			[
 				'post_name'   => 'publish',
 				'post_status' => 'publish',
 				'post_type'   => 'page',
-			)
+			]
 		);
 
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_page ) );
 
-		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
-		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
+		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
+		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$url = amp_get_permalink( $published_post );
 		$this->assertContains( 'current_filter=amp_pre_get_permalink', $url );
 		$this->assertContains( 'url=0', $url );
 
-		remove_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10 );
+		remove_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10 );
 		$url = amp_get_permalink( $published_post );
 		$this->assertContains( 'current_filter=amp_get_permalink', $url );
-		remove_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ) );
+		remove_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ] );
 
 		// Now check with theme support added (in transitional mode).
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'template_dir' => './' ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ 'template_dir' => './' ] );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_page ) );
-		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
+		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$this->assertNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
-		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
+		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$this->assertNotContains( 'current_filter=amp_pre_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 	}
 
@@ -150,23 +150,23 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		};
 
 		$drafted_post   = self::factory()->post->create(
-			array(
+			[
 				'post_name'   => 'draft',
 				'post_status' => 'draft',
-			)
+			]
 		);
 		$published_post = self::factory()->post->create(
-			array(
+			[
 				'post_name'   => 'publish',
 				'post_status' => 'publish',
-			)
+			]
 		);
 		$published_page = self::factory()->post->create(
-			array(
+			[
 				'post_name'   => 'publish',
 				'post_status' => 'publish',
 				'post_type'   => 'page',
-			)
+			]
 		);
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '/amp/', amp_get_permalink( $published_post ) );
@@ -176,25 +176,25 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertStringEndsWith( '/amp/#anchor', amp_get_permalink( $published_post ) );
 		remove_filter( 'post_link', $add_anchor_fragment );
 
-		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
-		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
+		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
+		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$url = amp_get_permalink( $published_post );
 		$this->assertContains( 'current_filter=amp_pre_get_permalink', $url );
 		$this->assertContains( 'url=0', $url );
 
-		remove_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10 );
+		remove_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10 );
 		$url = amp_get_permalink( $published_post );
 		$this->assertContains( 'current_filter=amp_get_permalink', $url );
-		remove_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10 );
+		remove_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10 );
 
 		// Now check with theme support added (in transitional mode).
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'template_dir' => './' ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ 'template_dir' => './' ] );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_post ) );
 		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_page ) );
-		add_filter( 'amp_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
+		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$this->assertNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
-		add_filter( 'amp_pre_get_permalink', array( $this, 'return_example_url' ), 10, 2 );
+		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$this->assertNotContains( 'current_filter=amp_pre_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 
 		// Make sure that if permalink has anchor that it is persists.
@@ -221,9 +221,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => 'amp',
-			)
+			]
 		);
 	}
 
@@ -258,20 +258,20 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function get_amphtml_urls() {
 		$post_id = self::factory()->post->create();
-		return array(
-			'home' => array(
+		return [
+			'home' => [
 				home_url( '/' ),
 				add_query_arg( amp_get_slug(), '', home_url( '/' ) ),
-			),
-			'404'  => array(
+			],
+			'404'  => [
 				home_url( '/no-existe/' ),
 				add_query_arg( amp_get_slug(), '', home_url( '/no-existe/' ) ),
-			),
-			'post' => array(
+			],
+			'post' => [
 				get_permalink( $post_id ),
 				amp_get_permalink( $post_id ),
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -308,17 +308,17 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		// Make sure that the link is not provided when there are validation errors associated with the URL.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => './',
-			)
+			]
 		);
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Theme_Support::init();
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			$canonical_url
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
@@ -345,7 +345,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertFalse( is_amp_endpoint() );
 
 		// Transitional theme support.
-		add_theme_support( AMP_Theme_Support::SLUG, array( 'template_dir' => './' ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ 'template_dir' => './' ] );
 		$_GET['amp'] = '';
 		$this->assertTrue( is_amp_endpoint() );
 		unset( $_GET['amp'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -357,7 +357,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertTrue( is_amp_endpoint() );
 
 		// Special core pages.
-		$pages = array( 'wp-login.php', 'wp-signup.php', 'wp-activate.php' );
+		$pages = [ 'wp-login.php', 'wp-signup.php', 'wp-activate.php' ];
 		foreach ( $pages as $page ) {
 			$GLOBALS['pagenow'] = $page;
 			$this->assertFalse( is_amp_endpoint() );
@@ -369,7 +369,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		 * The user has chosen not to show them as AMP, so most URLs should not be AMP endpoints.
 		 */
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		AMP_Options_Manager::update_option( 'supported_templates', array( 'is_author' ) );
+		AMP_Options_Manager::update_option( 'supported_templates', [ 'is_author' ] );
 
 		// A post shouldn't be an AMP endpoint, as it was unchecked in the UI via the options above.
 		$this->go_to( self::factory()->post->create() );
@@ -464,10 +464,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 * @return mixed Value.
 	 */
 	public function capture_filter_call( $value ) {
-		$this->last_filter_call = array(
+		$this->last_filter_call = [
 			'current_filter' => current_filter(),
 			'args'           => func_get_args(),
-		);
+		];
 		return $value;
 	}
 
@@ -488,22 +488,22 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertContains( 'v' . AMP__VERSION, $output );
 		$this->assertContains( 'experiences=website', $output );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		$output = $get_generator_tag();
 		$this->assertContains( 'mode=transitional', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => false ] );
 		$output = $get_generator_tag();
 		$this->assertContains( 'mode=standard', $output );
 		$this->assertContains( 'v' . AMP__VERSION, $output );
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		$output = $get_generator_tag();
 		$this->assertContains( 'mode=none', $output );
 		$this->assertContains( 'experiences=stories', $output );
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		$output = $get_generator_tag();
 		$this->assertContains( 'mode=standard', $output );
 		$this->assertContains( 'experiences=website,stories', $output );
@@ -544,19 +544,19 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		// Try rendering via amp_render_scripts() instead of amp_render_scripts(), which is how component scripts get added normally.
 		$output = amp_render_scripts(
-			array(
+			[
 				'amp-mathml'    => true, // But already printed above.
 				'amp-carousel'  => 'https://cdn.ampproject.org/v0/amp-mustache-2.0.js',
 				'amp-accordion' => true,
-			)
+			]
 		);
 		$this->assertNotContains( 'amp-mathml', $output, 'The amp-mathml component was already printed above.' );
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mustache-2.0.js\' async custom-element="amp-carousel"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-accordion-0.1.js\' async custom-element="amp-accordion"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		// Try some experimental component to ensure expected script attributes are added.
-		wp_register_script( 'amp-foo', 'https://cdn.ampproject.org/v0/amp-foo-0.1.js', array( 'amp-runtime' ), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter, WordPress.WP.EnqueuedResourceParameters.MissingVersion
-		$output = get_echo( 'wp_print_scripts', array( 'amp-foo' ) );
+		wp_register_script( 'amp-foo', 'https://cdn.ampproject.org/v0/amp-foo-0.1.js', [ 'amp-runtime' ], null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter, WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		$output = get_echo( 'wp_print_scripts', [ 'amp-foo' ] );
 		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-foo-0.1.js\' async custom-element="amp-foo"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
 
@@ -567,7 +567,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_get_content_embed_handlers() {
 		$post = self::factory()->post->create_and_get();
-		add_filter( 'amp_content_embed_handlers', array( $this, 'capture_filter_call' ), 10, 2 );
+		add_filter( 'amp_content_embed_handlers', [ $this, 'capture_filter_call' ], 10, 2 );
 
 		$this->last_filter_call = null;
 		add_theme_support( AMP_Theme_Support::SLUG );
@@ -605,7 +605,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_get_content_sanitizers() {
 		$post = self::factory()->post->create_and_get();
-		add_filter( 'amp_content_sanitizers', array( $this, 'capture_filter_call' ), 10, 2 );
+		add_filter( 'amp_content_sanitizers', [ $this, 'capture_filter_call' ], 10, 2 );
 
 		$this->last_filter_call = null;
 		add_theme_support( AMP_Theme_Support::SLUG );
@@ -629,7 +629,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		add_filter(
 			'amp_content_sanitizers',
 			static function( $classes ) {
-				$classes['Even_After_Whitelist_Sanitizer'] = array();
+				$classes['Even_After_Whitelist_Sanitizer'] = [];
 				return $classes;
 			}
 		);
@@ -661,7 +661,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		// Test disabled by default for page for posts and show on front.
 		update_option( 'show_on_front', 'page' );
-		$post = self::factory()->post->create_and_get( array( 'post_type' => 'page' ) );
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'page' ] );
 		$this->assertTrue( post_supports_amp( $post ) );
 		update_option( 'show_on_front', 'page' );
 		$this->assertTrue( post_supports_amp( $post ) );
@@ -693,12 +693,12 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$first_test_image = '/tmp/test-image.jpg';
 		copy( DIR_TESTDATA . '/images/test-image.jpg', $first_test_image );
 		$attachment_id = self::factory()->attachment->create_object(
-			array(
+			[
 				'file'           => $first_test_image,
 				'post_parent'    => 0,
 				'post_mime_type' => 'image/jpeg',
 				'post_title'     => 'Test Image',
-			)
+			]
 		);
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $first_test_image ) );
 
@@ -712,10 +712,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		delete_post_thumbnail( $post_id );
 		$this->assertFalse( amp_get_post_image_metadata( $post_id ) );
 		wp_update_post(
-			array(
+			[
 				'ID'          => $attachment_id,
 				'post_parent' => $post_id,
-			)
+			]
 		);
 		$metadata = amp_get_post_image_metadata( $post_id );
 		$this->assertStringEndsWith( 'test-image.jpg', $metadata['url'] );
@@ -725,40 +725,40 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$attachment_height       = 45;
 		$attachment_width        = 600;
 		$attachment_id           = self::factory()->attachment->create_object(
-			array(
+			[
 				'file'           => $attachment_src,
 				'post_mime_type' => 'image/jpeg',
-			)
+			]
 		);
 		$expected_attachment_img = wp_get_attachment_image_src( $attachment_id, 'full', false );
 
 		update_post_meta(
 			$attachment_id,
 			'_wp_attachment_metadata',
-			array(
+			[
 				'height' => $attachment_height,
 				'width'  => $attachment_width,
-			)
+			]
 		);
 		$this->go_to( get_permalink( $attachment_id ) );
 
 		$this->assertEquals(
-			array(
+			[
 				'@type'  => 'ImageObject',
 				'height' => $attachment_height,
 				'url'    => $expected_attachment_img[0],
 				'width'  => $attachment_width,
-			),
+			],
 			amp_get_post_image_metadata( $attachment_id )
 		);
 
 		// Test a video as an 'attachment' post type, which shouldn't have a schema.org image.
 		$attachment_src = 'example/test-video.mpeg';
 		$attachment_id  = self::factory()->attachment->create_object(
-			array(
+			[
 				'file'           => $attachment_src,
 				'post_mime_type' => 'video/mpeg',
-			)
+			]
 		);
 		$this->go_to( get_permalink( $attachment_id ) );
 		$this->assertFalse( amp_get_post_image_metadata( $attachment_id ) );
@@ -773,30 +773,30 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		update_option( 'blogname', 'Foo' );
 		$publisher_type     = 'Organization';
 		$logo_type          = 'ImageObject';
-		$expected_publisher = array(
+		$expected_publisher = [
 			'@type' => $publisher_type,
 			'name'  => 'Foo',
-		);
+		];
 
 		$user_id = self::factory()->user->create(
-			array(
+			[
 				'first_name' => 'John',
 				'last_name'  => 'Smith',
-			)
+			]
 		);
 		$page_id = self::factory()->post->create(
-			array(
+			[
 				'post_type'   => 'page',
 				'post_title'  => 'Example Page',
 				'post_author' => $user_id,
-			)
+			]
 		);
 		$post_id = self::factory()->post->create(
-			array(
+			[
 				'post_type'   => 'post',
 				'post_title'  => 'Example Post',
 				'post_author' => $user_id,
-			)
+			]
 		);
 
 		// Test non-singular, with no publisher logo.
@@ -812,30 +812,30 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$custom_logo_height = 45;
 		$custom_logo_width  = 600;
 		$custom_logo_id     = self::factory()->attachment->create_object(
-			array(
+			[
 				'file'           => $custom_logo_src,
 				'post_mime_type' => 'image/jpeg',
-			)
+			]
 		);
 		$expected_logo_img  = wp_get_attachment_image_src( $custom_logo_id, 'full', false );
 
 		update_post_meta(
 			$custom_logo_id,
 			'_wp_attachment_metadata',
-			array(
+			[
 				'width'  => $custom_logo_width,
 				'height' => $custom_logo_height,
-			)
+			]
 		);
 		set_theme_mod( 'custom_logo', $custom_logo_id );
 		$metadata = amp_get_schemaorg_metadata();
 		$this->assertEquals(
-			array(
+			[
 				'@type'  => $logo_type,
 				'height' => $custom_logo_height,
 				'url'    => $expected_logo_img[0],
 				'width'  => $custom_logo_width,
-			),
+			],
 			$metadata['publisher']['logo']
 		);
 		set_theme_mod( 'custom_logo', null );
@@ -843,20 +843,20 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		// Test the site icon as the publisher logo.
 		$site_icon_src          = 'foo/site-icon.jpeg';
 		$site_icon_id           = self::factory()->attachment->create_object(
-			array(
+			[
 				'file'           => $site_icon_src,
 				'post_mime_type' => 'image/jpeg',
-			)
+			]
 		);
 		$expected_site_icon_img = wp_get_attachment_image_src( $site_icon_id, 'full', false );
 
 		update_option( 'site_icon', $site_icon_id );
-		$expected_schema_site_icon = array(
+		$expected_schema_site_icon = [
 			'@type'  => $logo_type,
 			'height' => 32,
 			'url'    => $expected_site_icon_img[0],
 			'width'  => 32,
-		);
+		];
 		$metadata                  = amp_get_schemaorg_metadata();
 		$this->assertEquals( $expected_schema_site_icon, $metadata['publisher']['logo'] );
 		update_option( 'site_icon', null );
@@ -872,22 +872,22 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		update_post_meta(
 			$custom_logo_id,
 			'_wp_attachment_metadata',
-			array(
+			[
 				'width'  => $custom_logo_width,
 				'height' => $custom_logo_excessive_height,
-			)
+			]
 		);
 		set_theme_mod( 'custom_logo', $custom_logo_id );
 		update_option( 'site_icon', $site_icon_id );
 		$metadata   = amp_get_schemaorg_metadata();
 		$max_height = 60;
 		$this->assertEquals(
-			array(
+			[
 				'@type'  => $logo_type,
 				'height' => $max_height,
 				'url'    => $expected_logo_img[0],
 				'width'  => $custom_logo_width * $max_height / $custom_logo_excessive_height, // Proportional to downsized height.
-			),
+			],
 			$metadata['publisher']['logo']
 		);
 		set_theme_mod( 'custom_logo', null );
@@ -902,16 +902,16 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		update_post_meta(
 			$custom_logo_id,
 			'_wp_attachment_metadata',
-			array(
+			[
 				'width'  => $custom_logo_width,
 				'height' => $custom_logo_height,
-			)
+			]
 		);
 		set_theme_mod( 'custom_logo', $custom_logo_id );
-		add_filter( 'amp_site_icon_url', array( __CLASS__, 'mock_site_icon' ) );
+		add_filter( 'amp_site_icon_url', [ __CLASS__, 'mock_site_icon' ] );
 		$metadata = amp_get_schemaorg_metadata();
 		$this->assertEquals( self::MOCK_SITE_ICON, $metadata['publisher']['logo']['url'] );
-		remove_filter( 'amp_site_icon_url', array( __CLASS__, 'mock_site_icon' ) );
+		remove_filter( 'amp_site_icon_url', [ __CLASS__, 'mock_site_icon' ] );
 		set_theme_mod( 'custom_logo', null );
 
 		// Test page.
@@ -937,10 +937,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'datePublished', $metadata );
 		$this->assertArrayHasKey( 'dateModified', $metadata );
 		$this->assertEquals(
-			array(
+			[
 				'@type' => 'Person',
 				'name'  => 'John Smith',
-			),
+			],
 			$metadata['author']
 		);
 
@@ -994,7 +994,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertNull( $admin_bar->get_node( 'amp' ) );
 
 		// Check that paired mode does add link.
-		add_theme_support( 'amp', array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( 'amp', [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		$admin_bar = new WP_Admin_Bar();
 		amp_add_admin_bar_view_link( $admin_bar );
 		$item = $admin_bar->get_node( 'amp' );

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -20,13 +20,13 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_data() {
-		return array(
-			'no_iframes'                                => array(
+		return [
+			'no_iframes'                                => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				'<p>Lorem Ipsum Demet Delorit.</p>',
-			),
+			],
 
-			'simple_iframe'                             => array(
+			'simple_iframe'                             => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
@@ -36,22 +36,22 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-				array(
+				[
 					'add_noscript_fallback' => true,
 					'add_placeholder'       => true,
-				),
-			),
+				],
+			],
 
-			'simple_iframe_without_noscript_or_placeholder' => array(
+			'simple_iframe_without_noscript_or_placeholder' => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
 				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"></amp-iframe>',
-				array(
+				[
 					'add_noscript_fallback' => false,
 					'add_placeholder'       => false,
-				),
-			),
+				],
+			],
 
-			'force_https'                               => array(
+			'force_https'                               => [
 				'<iframe src="http://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
@@ -60,9 +60,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_without_dimensions'                 => array(
+			'iframe_without_dimensions'                 => [
 				'<iframe src="https://example.com/video/132886713"></iframe>',
 				'
 					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
@@ -71,9 +71,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_height_only'                   => array(
+			'iframe_with_height_only'                   => [
 				'<iframe src="https://example.com/video/132886713" height="400"></iframe>',
 				'
 					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
@@ -82,9 +82,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_100_percent_width'             => array(
+			'iframe_with_100_percent_width'             => [
 				'<iframe src="https://example.com/video/132886713" height="123" width="100%"></iframe>',
 				'
 					<amp-iframe src="https://example.com/video/132886713" height="123" width="auto" layout="fixed-height" sandbox="allow-scripts allow-same-origin">
@@ -93,9 +93,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_width_only'                    => array(
+			'iframe_with_width_only'                    => [
 				'<iframe src="https://example.com/video/132886713" width="600"></iframe>',
 				'
 					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
@@ -104,9 +104,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_invalid_frameborder'           => array(
+			'iframe_with_invalid_frameborder'           => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="no"></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -115,9 +115,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>					
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_1_frameborder'                 => array(
+			'iframe_with_1_frameborder'                 => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder=1></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -126,9 +126,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'simple_iframe_with_sandbox'                => array(
+			'simple_iframe_with_sandbox'                => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-same-origin"></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" sandbox="allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -137,9 +137,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_blacklisted_attribute'         => array(
+			'iframe_with_blacklisted_attribute'         => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto"></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" scrolling="auto" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -148,9 +148,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_sizes_attribute_is_overridden' => array(
+			'iframe_with_sizes_attribute_is_overridden' => [
 				'<iframe src="https://example.com/iframe" width="500" height="281"></iframe>',
 				'
 					<amp-iframe src="https://example.com/iframe" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -159,9 +159,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_id_attribute'                  => array(
+			'iframe_with_id_attribute'                  => [
 				'<iframe src="https://example.com/iframe" id="myIframe"></iframe>',
 				'
 					<amp-iframe src="https://example.com/iframe" id="myIframe" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
@@ -170,9 +170,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'iframe_with_protocol_relative_url'         => array(
+			'iframe_with_protocol_relative_url'         => [
 				'<iframe src="//example.com/video/132886713"></iframe>',
 				'
 					<amp-iframe src="https://example.com/video/132886713" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin">
@@ -181,9 +181,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'multiple_same_iframe'                      => array(
+			'multiple_same_iframe'                      => [
 				'
 					<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
 					<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
@@ -199,9 +199,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					',
 					3
 				),
-			),
+			],
 
-			'multiple_different_iframes'                => array(
+			'multiple_different_iframes'                => [
 				'
 					<iframe src="https://example.com/embed/12345" width="500" height="281"></iframe>
 					<iframe src="https://example.com/embed/67890" width="280" height="501"></iframe>
@@ -224,8 +224,8 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
-			'iframe_in_p_tag'                           => array(
+			],
+			'iframe_in_p_tag'                           => [
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe></p>',
 				'
 					<p>
@@ -236,8 +236,8 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</amp-iframe>
 					</p>
 				',
-			),
-			'multiple_iframes_in_p_tag'                 => array(
+			],
+			'multiple_iframes_in_p_tag'                 => [
 				'<p><iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
 				'
 					<p><amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -252,8 +252,8 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</amp-iframe>
 					</p>
 				',
-			),
-			'multiple_iframes_and_contents_in_p_tag'    => array(
+			],
+			'multiple_iframes_and_contents_in_p_tag'    => [
 				'<p>contents<iframe src="https://example.com/video/132886713" width="500" height="281"></iframe><iframe src="https://example.com/video/132886714" width="500" height="281"></iframe></p>',
 				'
 					<p>contents<amp-iframe src="https://example.com/video/132886713" width="500" height="281" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -268,8 +268,8 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</amp-iframe>
 					</p>
 				',
-			),
-			'iframe_src_with_commas_and_colons'         => array(
+			],
+			'iframe_src_with_commas_and_colons'         => [
 				'<iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&z=15&l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen=""></iframe>',
 				'
 					<amp-iframe src="https://www.geoportail.gouv.fr/embed/visu.html?c=3.9735668054865076,43.90558192721261&amp;z=15&amp;l0=GEOLOGY.GEOLOGY::EXTERNAL:OGC:EXTERNALWMS(1)&amp;permalink=yes" width="100" height="200" sandbox="allow-forms allow-scripts allow-same-origin" allowfullscreen="" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -278,14 +278,14 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-			),
+			],
 
-			'amp_iframe_with_fallback'                  => array(
+			'amp_iframe_with_fallback'                  => [
 				'<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic"><noscript><iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe></noscript></amp-iframe>',
 				null,
-			),
+			],
 
-			'attributes_removed_from_noscript_iframe'   => array(
+			'attributes_removed_from_noscript_iframe'   => [
 				'<iframe src="https://example.com/embed/132886713" width="500" height="281" onclick="foo()" data-foo="bar"></iframe>',
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" data-foo="bar" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
@@ -295,54 +295,54 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>
 				',
-				array(
+				[
 					'add_noscript_fallback' => true,
 					'add_placeholder'       => true,
-				),
-			),
+				],
+			],
 
-			'iframe_relative_url'                       => array(
+			'iframe_relative_url'                       => [
 				'<iframe src="/same-origin/" width="50" height="100"></iframe>',
 				'<amp-iframe src="https://example.com/same-origin/" width="50" height="100" sandbox="allow-scripts" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
-				array(
+				[
 					'add_noscript_fallback' => false,
 					'add_placeholder'       => false,
 					'current_origin'        => 'https://example.com',
-				),
-			),
+				],
+			],
 
-			'iframe_scheme_relative_url'                => array(
+			'iframe_scheme_relative_url'                => [
 				'<iframe src="//example.com/same-origin/" width="50" height="100"></iframe>',
 				'<amp-iframe src="https://example.com/same-origin/" width="50" height="100" sandbox="allow-scripts" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
-				array(
+				[
 					'add_noscript_fallback' => false,
 					'add_placeholder'       => false,
 					'current_origin'        => 'https://example.com',
-				),
-			),
+				],
+			],
 
-			'iframe_relative_url_with_alias_origin'     => array(
+			'iframe_relative_url_with_alias_origin'     => [
 				'<iframe src="/same-origin/" width="50" height="100"></iframe>',
 				'<amp-iframe src="https://alt.example.org/same-origin/" width="50" height="100" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
-				array(
+				[
 					'add_noscript_fallback' => false,
 					'add_placeholder'       => false,
 					'current_origin'        => 'https://example.com',
 					'alias_origin'          => 'https://alt.example.org',
-				),
-			),
+				],
+			],
 
-			'iframe_absolute_url_with_alias_origin'     => array(
+			'iframe_absolute_url_with_alias_origin'     => [
 				'<iframe src="https://example.com/same-origin/" width="50" height="100"></iframe>',
 				'<amp-iframe src="https://alt.example.org/same-origin/" width="50" height="100" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes"></amp-iframe>',
-				array(
+				[
 					'add_noscript_fallback' => false,
 					'add_placeholder'       => false,
 					'current_origin'        => 'https://example.com',
 					'alias_origin'          => 'https://alt.example.org',
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -354,7 +354,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	 * @param string $expected Expected.
 	 * @param array  $args     Sanitizer args.
 	 */
-	public function test_converter( $source, $expected = null, $args = array() ) {
+	public function test_converter( $source, $expected = null, $args = [] ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
@@ -379,10 +379,10 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer(
 			$dom,
-			array(
+			[
 				'add_placeholder'   => true,
 				'require_https_src' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
 
@@ -395,7 +395,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__didnt_convert() {
 		$source   = '<p>Hello World</p>';
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
@@ -416,7 +416,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>';
-		$expected = array( 'amp-iframe' => true );
+		$expected = [ 'amp-iframe' => true ];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom );
@@ -442,9 +442,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Iframe_Sanitizer(
 			$dom,
-			array(
+			[
 				'add_placeholder' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/tests/php/test-amp-image-dimension-extractor.php
+++ b/tests/php/test-amp-image-dimension-extractor.php
@@ -26,7 +26,7 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		// We don't want to actually download the images; just testing the extract method.
-		add_action( 'amp_extract_image_dimensions_batch_callbacks_registered', array( $this, 'disable_downloads' ) );
+		add_action( 'amp_extract_image_dimensions_batch_callbacks_registered', [ $this, 'disable_downloads' ] );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	public function test__single_url() {
 		$source_url = 'https://example.com/image.png';
 		$cdn_url    = 'https://cdn.example.com/image.png';
-		$expected   = array( 100, 101 );
+		$expected   = [ 100, 101 ];
 
 		add_action(
 			'amp_extract_image_dimensions_batch_callbacks_registered',
@@ -52,12 +52,12 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 				add_filter(
 					'amp_extract_image_dimensions_batch',
 					static function() use ( $cdn_url ) {
-						return array(
-							$cdn_url => array(
+						return [
+							$cdn_url => [
 								100,
 								101,
-							),
-						);
+							],
+						];
 					}
 				);
 			},
@@ -87,16 +87,16 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * Test should return both urls
 	 */
 	public function test__should_return_both_urls() {
-		$source_urls = array(
+		$source_urls = [
 			home_url( '/wp-content/uploads/2018/06/IMG_0183-300x300.jpg' ),
 			site_url( '/wp-content/uploads/2018/06/IMG_0183-300x300.jpg' ),
 			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg',
-		);
-		$expected    = array(
+		];
+		$expected    = [
 			home_url( '/wp-content/uploads/2018/06/IMG_0183-300x300.jpg' ) => false,
 			site_url( '/wp-content/uploads/2018/06/IMG_0183-300x300.jpg' ) => false,
 			'/wp-content/uploads/2018/06/IMG_0183-300x300.jpg'             => false,
-		);
+		];
 
 		$actual = AMP_Image_Dimension_Extractor::extract( $source_urls );
 
@@ -107,18 +107,18 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * Test where processed URLs should match originals.
 	 */
 	public function test__should_return_original_urls() {
-		$source_urls = array(
+		$source_urls = [
 			'https://example.com',
 			'//example.com/no-protocol',
 			'/absolute-url/no-host',
 			'data:image/gif;base64,R0lGODl...', // can't normalize.
-		);
-		$expected    = array(
+		];
+		$expected    = [
 			'https://example.com'              => false,
 			'//example.com/no-protocol'        => false,
 			'/absolute-url/no-host'            => false,
 			'data:image/gif;base64,R0lGODl...' => false,
-		);
+		];
 
 		$actual = AMP_Image_Dimension_Extractor::extract( $source_urls );
 
@@ -133,36 +133,36 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	public function get_data() {
 		$home_url = home_url();
 
-		return array(
-			'empty_url'         => array(
+		return [
+			'empty_url'         => [
 				'',
 				false,
-			),
-			'data_url'          => array(
+			],
+			'data_url'          => [
 				'data:image/gif;base64,R0lGODl...',
 				false,
-			),
-			'protocol-less_url' => array(
+			],
+			'protocol-less_url' => [
 				'//example.com/file.jpg',
 				'http://example.com/file.jpg',
-			),
-			'path_only'         => array(
+			],
+			'path_only'         => [
 				'/path/to/file.png',
 				$home_url . '/path/to/file.png',
-			),
-			'query_only'        => array(
+			],
+			'query_only'        => [
 				'?file=file.png',
 				$home_url . '?file=file.png',
-			),
-			'path_and_query'    => array(
+			],
+			'path_and_query'    => [
 				'/path/file.jpg?query=1',
 				$home_url . '/path/file.jpg?query=1',
-			),
-			'normal_url'        => array(
+			],
+			'normal_url'        => [
 				'https://example.com/path/to/file.jpg',
 				'https://example.com/path/to/file.jpg',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -188,15 +188,15 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test__valid_image_file() {
-		$sources  = array(
+		$sources  = [
 			IMG_350 => false,
-		);
-		$expected = array(
-			IMG_350 => array(
+		];
+		$expected = [
+			IMG_350 => [
 				'width'  => 350,
 				'height' => 150,
-			),
-		);
+			],
+		];
 
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 
@@ -209,30 +209,30 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test__multiple_valid_image_files() {
-		$sources  = array(
+		$sources  = [
 			IMG_350          => false,
 			IMG_1024         => false,
 			IMG_SVG          => false,
 			IMG_SVG_VIEWPORT => false,
-		);
-		$expected = array(
-			IMG_350          => array(
+		];
+		$expected = [
+			IMG_350          => [
 				'width'  => 350,
 				'height' => 150,
-			),
-			IMG_1024         => array(
+			],
+			IMG_1024         => [
 				'width'  => 1024,
 				'height' => 768,
-			),
-			IMG_SVG          => array(
+			],
+			IMG_SVG          => [
 				'width'  => 175,
 				'height' => 60,
-			),
-			IMG_SVG_VIEWPORT => array(
+			],
+			IMG_SVG_VIEWPORT => [
 				'width'  => 251,
 				'height' => 80,
-			),
-		);
+			],
+		];
 
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 
@@ -245,12 +245,12 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test__invalid_image_file() {
-		$sources  = array(
+		$sources  = [
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
-		);
-		$expected = array(
+		];
+		$expected = [
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
-		);
+		];
 
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 
@@ -263,22 +263,22 @@ class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
 	 * @group external-http
 	 */
 	public function test__mix_of_valid_and_invalid_image_file() {
-		$sources  = array(
+		$sources  = [
 			IMG_350                             => false,
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
 			IMG_1024                            => false,
-		);
-		$expected = array(
-			IMG_350                             => array(
+		];
+		$expected = [
+			IMG_350                             => [
 				'width'  => 350,
 				'height' => 150,
-			),
+			],
 			AMP_IMG_DIMENSION_TEST_INVALID_FILE => false,
-			IMG_1024                            => array(
+			IMG_1024                            => [
 				'width'  => 1024,
 				'height' => 768,
-			),
-		);
+			],
+		];
 
 		$dimensions = AMP_Image_Dimension_Extractor::extract_by_downloading_images( $sources );
 

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -20,10 +20,10 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 		add_filter(
 			'amp_extract_image_dimensions_batch',
 			static function( $urls ) {
-				$dimensions = array();
+				$dimensions = [];
 				foreach ( array_keys( $urls ) as $url ) {
 					if ( preg_match( '#/(?P<width>\d+)x(?P<height>\d+)$#', $url, $matches ) ) {
-						$dimensions[ $url ] = array_map( 'intval', wp_array_slice_assoc( $matches, array( 'width', 'height' ) ) );
+						$dimensions[ $url ] = array_map( 'intval', wp_array_slice_assoc( $matches, [ 'width', 'height' ] ) );
 					} else {
 						$dimensions[ $url ] = false;
 					}
@@ -39,284 +39,284 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'no_images'                                => array(
+		return [
+			'no_images'                                => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				'<p>Lorem Ipsum Demet Delorit.</p>',
-			),
+			],
 
-			'simple_image'                             => array(
+			'simple_image'                             => [
 				'<p><img src="https://placehold.it/300x300" width="300" height="300" /></p>',
 				'<p><amp-img src="https://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/300x300" width="300" height="300"></noscript></amp-img></p>',
-				array(
+				[
 					'add_noscript_fallback' => true,
-				),
-			),
+				],
+			],
 
-			'simple_image_without_noscript'            => array(
+			'simple_image_without_noscript'            => [
 				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
 				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'image_without_src'                        => array(
+			'image_without_src'                        => [
 				'<p><img width="300" height="300" /></p>',
 				'<p></p>',
-				array(),
-				array( 'invalid_element' ),
-			),
+				[],
+				[ 'invalid_element' ],
+			],
 
-			'image_with_empty_src'                     => array(
+			'image_with_empty_src'                     => [
 				'<p><img src="" width="300" height="300" /></p>',
 				'<p></p>',
-				array(),
-				array( 'invalid_element' ),
-			),
+				[],
+				[ 'invalid_element' ],
+			],
 
-			'image_with_layout'                        => array(
+			'image_with_layout'                        => [
 				'<img src="https://placehold.it/100x100" data-amp-layout="fill" width="100" height="100" />',
 				'<amp-img src="https://placehold.it/100x100" layout="fill" width="100" height="100" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
-			),
+			],
 
-			'image_with_noloading'                     => array(
+			'image_with_noloading'                     => [
 				'<img src="https://placehold.it/100x100" data-amp-noloading="" width="100" height="100">',
 				'<amp-img src="https://placehold.it/100x100" noloading="" width="100" height="100" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
-			),
+			],
 
-			'image_with_layout_from_editor'            => array(
+			'image_with_layout_from_editor'            => [
 				'<figure data-amp-layout="fill"><img src="https://placehold.it/300x300" height="300" width="300" /></figure>',
 				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 300px;"><amp-img src="https://placehold.it/300x300" layout="fill" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'image_with_noloading_from_editor'         => array(
+			'image_with_noloading_from_editor'         => [
 				'<figure data-amp-noloading="true"><img src="https://placehold.it/300x300" height="300" width="300" /></figure>',
 				'<figure data-amp-noloading="true"><amp-img src="https://placehold.it/300x300" height="300" width="300" noloading="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/300x300" height="300" width="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'image_with_spaces_only_src'               => array(
+			'image_with_spaces_only_src'               => [
 				'<p><img src="    " width="300" height="300" /></p>',
 				'<p></p>',
-				array(),
-				array( 'invalid_element' ),
-			),
+				[],
+				[ 'invalid_element' ],
+			],
 
-			'image_with_empty_width_and_height'        => array(
+			'image_with_empty_width_and_height'        => [
 				'<p><img src="https://placehold.it/200x300" width="" height="" /></p>',
 				'<p><amp-img src="https://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_undefined_width_and_height'    => array(
+			'image_with_undefined_width_and_height'    => [
 				'<p><img src="https://placehold.it/200x300" /></p>',
 				'<p><amp-img src="https://placehold.it/200x300" width="200" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/200x300" width="200" height="300" class=""></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_empty_width'                   => array(
+			'image_with_empty_width'                   => [
 				'<p><img src="https://placehold.it/500x1000" width="" height="300" /></p>',
 				'<p><amp-img src="https://placehold.it/500x1000" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/500x1000" width="150" height="300" class=""></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_empty_height'                  => array(
+			'image_with_empty_height'                  => [
 				'<p><img src="https://placehold.it/500x1000" width="300" height="" /></p>',
 				'<p><amp-img src="https://placehold.it/500x1000" width="300" height="600" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/500x1000" width="300" height="600" class=""></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_zero_width'                    => array(
+			'image_with_zero_width'                    => [
 				'<p><img src="https://placehold.it/300x300" width="0" height="300" /></p>',
 				'<p><amp-img src="https://placehold.it/300x300" width="0" height="300" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/300x300" width="0" height="300"></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_zero_width_and_height'         => array(
+			'image_with_zero_width_and_height'         => [
 				'<p><img src="https://placehold.it/300x300" width="0" height="0" /></p>',
 				'<p><amp-img src="https://placehold.it/300x300" width="0" height="0" class="amp-wp-enforced-sizes"><noscript><img src="https://placehold.it/300x300" width="0" height="0"></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_decimal_width'                 => array(
+			'image_with_decimal_width'                 => [
 				'<p><img src="https://placehold.it/300x300" width="299.5" height="300" /></p>',
 				'<p><amp-img src="https://placehold.it/300x300" width="299.5" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/300x300" width="299.5" height="300"></noscript></amp-img></p>',
-			),
+			],
 
-			'image_with_self_closing_tag'              => array(
+			'image_with_self_closing_tag'              => [
 				'<img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" />',
 				'<amp-img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
-			),
+			],
 
-			'image_with_no_end_tag'                    => array(
+			'image_with_no_end_tag'                    => [
 				'<img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!">',
 				'<amp-img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
-			),
+			],
 
-			'image_with_end_tag'                       => array(
+			'image_with_end_tag'                       => [
 				'<img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></img>',
 				'<amp-img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" alt="Placeholder!"></noscript></amp-img>',
-			),
+			],
 
-			'image_with_extra_attributes'              => array(
+			'image_with_extra_attributes'              => [
 				'<img src="https://placehold.it/350x150" on="tap:my-lightbox" onclick="showLightbox()" media="(min-width: 650px)" role="button" itemscope="image" tabindex="0" width="350" height="150" alt="ALT!" />',
 				'<amp-img src="https://placehold.it/350x150" on="tap:my-lightbox" media="(min-width: 650px)" role="button" itemscope="image" tabindex="0" width="350" height="150" alt="ALT!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" on="tap:my-lightbox" role="button" itemscope="image" tabindex="0" width="350" height="150" alt="ALT!"></noscript></amp-img>',
-				array(),
-				array(
+				[],
+				[
 					'invalid_attribute', // The onclick attribute.
-				),
-			),
+				],
+			],
 
-			'image_with_no_dimensions_is_forced'       => array(
+			'image_with_no_dimensions_is_forced'       => [
 				'<img src="https://placehold.it/350x150" />',
 				'<amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150" class=""></noscript></amp-img>',
-			),
+			],
 
-			'image_with_bad_src_url_get_fallback_dims' => array(
+			'image_with_bad_src_url_get_fallback_dims' => [
 				'<img src="https://example.com/404.png" />',
 				'<amp-img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height"></noscript></amp-img>',
-			),
+			],
 
-			'gif_image_conversion'                     => array(
+			'gif_image_conversion'                     => [
 				'<img src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />',
 				'<amp-anim src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
-			),
+			],
 
-			'gif_image_url_with_querystring'           => array(
+			'gif_image_url_with_querystring'           => [
 				'<img src="https://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" />',
 				'<amp-anim src="https://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150.gif?foo=bar" width="350" height="150" alt="Placeholder!"></noscript></amp-anim>',
-			),
+			],
 
-			'multiple_same_image'                      => array(
+			'multiple_same_image'                      => [
 				'<img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/350x150" width="350" height="150" />',
 				'<amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
-			),
+			],
 
-			'multiple_different_images'                => array(
+			'multiple_different_images'                => [
 				'<img src="https://placehold.it/350x150" width="350" height="150" /><img src="https://placehold.it/360x160" width="360" height="160" /><img src="https://placehold.it/370x170" width="370" height="170" /><img src="https://placehold.it/380x180" width="380" height="180" />',
 				'<amp-img src="https://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img><amp-img src="https://placehold.it/360x160" width="360" height="160" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/360x160" width="360" height="160"></noscript></amp-img><amp-img src="https://placehold.it/370x170" width="370" height="170" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/370x170" width="370" height="170"></noscript></amp-img><amp-img src="https://placehold.it/380x180" width="380" height="180" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/380x180" width="380" height="180"></noscript></amp-img>',
-			),
+			],
 
-			'image_center_aligned'                     => array(
+			'image_center_aligned'                     => [
 				'<img class="aligncenter" src="https://placehold.it/350x150" width="350" height="150" />',
 				'<amp-img class="aligncenter amp-wp-enforced-sizes" src="https://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="aligncenter" src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
-			),
+			],
 
-			'image_left_aligned'                       => array(
+			'image_left_aligned'                       => [
 				'<img class="alignleft" src="https://placehold.it/350x150" width="350" height="150" />',
 				'<amp-img class="alignleft amp-wp-enforced-sizes" src="https://placehold.it/350x150" width="350" height="150" layout="intrinsic"><noscript><img class="alignleft" src="https://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
-			),
+			],
 
-			'image_with_caption'                       => array(
+			'image_with_caption'                       => [
 				'<figure class="wp-caption aligncenter"><img src="https://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
 				'<figure class="wp-caption aligncenter"><amp-img src="https://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312 amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/350x150" alt="" width="350" height="150" class="size-medium wp-image-312"></noscript></amp-img><figcaption class="wp-caption-text">This is an example caption.</figcaption></figure>',
-			),
+			],
 
-			'image_with_custom_lightbox_attrs'         => array(
+			'image_with_custom_lightbox_attrs'         => [
 				'<figure data-amp-lightbox="true"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
 				'<figure data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
-			),
+			],
 
-			'wide_image'                               => array(
+			'wide_image'                               => [
 				'<figure class="wp-block-image"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
 				'<figure class="wp-block-image"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'wide_image_center_aligned'                => array(
+			'wide_image_center_aligned'                => [
 				'<figure class="wp-block-image aligncenter"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
 				'<figure class="wp-block-image aligncenter"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'wide_image_left_aligned_custom_style'     => array(
+			'wide_image_left_aligned_custom_style'     => [
 				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
 				'<figure class="wp-block-image alignleft" style="border:solid 1px red;"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'wide_image_right_aligned'                 => array(
+			'wide_image_right_aligned'                 => [
 				'<figure class="wp-block-image alignright"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
 				'<figure class="wp-block-image alignright"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'wide_image_is_resized'                    => array(
+			'wide_image_is_resized'                    => [
 				'<figure class="wp-block-image is-resized"><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" /></figure>',
 				'<figure class="wp-block-image is-resized"><amp-img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967 amp-wp-enforced-sizes" width="580" height="300" layout="intrinsic"><noscript><img src="https://placehold.it/580x300" alt="Image Alignment 580x300" class="wp-image-967" width="580" height="300"></noscript></amp-img></figure>',
-			),
+			],
 
-			'amp_img_with_noscript_fallback'           => array(
+			'amp_img_with_noscript_fallback'           => [
 				'<amp-img src="https://placehold.it/100x100" layout="fixed" width="100" height="100"><noscript><img src="https://placehold.it/100x100" width="100" height="100"></noscript></amp-img>',
 				null,
-			),
+			],
 
-			'img_with_sizes_attribute_removed'         => array(
+			'img_with_sizes_attribute_removed'         => [
 				'<img width="825" height="510" src="https://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw">',
 				'<amp-img width="825" height="510" src="https://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image amp-wp-enforced-sizes" alt="" layout="intrinsic"><noscript><img width="825" height="510" src="https://placehold.it/825x510" class="attachment-post-thumbnail size-post-thumbnail wp-post-image" alt="" sizes="(max-width: 34.9rem) calc(100vw - 2rem), (max-width: 53rem) calc(8 * (100vw / 12)), (min-width: 53rem) calc(6 * (100vw / 12)), 100vw"></noscript></amp-img>',
-			),
+			],
 
-			'amp_img_with_sizes_attribute_retained'    => array(
+			'amp_img_with_sizes_attribute_retained'    => [
 				'<amp-img width="825" height="510" src="https://placehold.it/825x510" alt="" layout="intrinsic"></amp-img>',
 				null,
-			),
+			],
 
-			'img_with_http_protocol_src'               => array(
+			'img_with_http_protocol_src'               => [
 				'<img src="http://placehold.it/350x150" width="350" height="150">',
 				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
-			),
+			],
 
-			'img_with_http_protocol_srcset'            => array(
+			'img_with_http_protocol_srcset'            => [
 				'<img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150">',
 				'<amp-img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
-			),
+			],
 
-			'img_with_fill_layout_inline_style'        => array(
+			'img_with_fill_layout_inline_style'        => [
 				'<img src="https://placehold.it/20x20" data-amp-layout="fill" style="display: inline">',
 				'<amp-img src="https://placehold.it/20x20" layout="fill" style="display:block" class="amp-wp-enforced-sizes"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'img_with_intrinsic_layout_inline_style'   => array(
+			'img_with_intrinsic_layout_inline_style'   => [
 				'<img src="https://placehold.it/20x20" width="20" height="20" style="display: inline">',
 				'<amp-img src="https://placehold.it/20x20" width="20" height="20" style="display:inline-block" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'img_with_responsive_layout_inline_style'  => array(
+			'img_with_responsive_layout_inline_style'  => [
 				'<img src="https://placehold.it/20x20" width="20" height="20" style="display: inline" data-amp-layout="responsive">',
 				'<amp-img src="https://placehold.it/20x20" width="20" height="20" style="display:block" layout="responsive" class="amp-wp-enforced-sizes"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'img_with_fixed_height_inline_style'       => array(
+			'img_with_fixed_height_inline_style'       => [
 				'<img src="https://placehold.it/20x200" height="20" width="auto" data-amp-layout="fixed-height" style="display: inline-block">',
 				'<amp-img src="https://placehold.it/20x200" height="20" width="auto" layout="fixed-height" style="display:block" class="amp-wp-enforced-sizes"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'img_with_flex_item_inline_style'          => array(
+			'img_with_flex_item_inline_style'          => [
 				'<img src="https://placehold.it/20x200" data-amp-layout="flex-item" style="display: inline-block">',
 				'<amp-img src="https://placehold.it/20x200" layout="flex-item" style="display:block" class="amp-wp-enforced-sizes"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'img_with_nodisplay_layout_inline_style'   => array(
+			'img_with_nodisplay_layout_inline_style'   => [
 				'<img src="https://placehold.it/20x20" data-amp-layout="nodisplay" style="display: inline">',
 				'<amp-img src="https://placehold.it/20x20" layout="nodisplay" style="display:none" class="amp-wp-enforced-sizes"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'img_static_emoji'                         => array(
+			'img_static_emoji'                         => [
 				'<img src="https://s.w.org/images/core/emoji/12.0.0-1/72x72/1f468-1f3fb-200d-1f4bb.png" alt="👨🏻‍💻" class="wp-smiley" style="height: 1em; max-height: 1em;">',
 				'<amp-img src="https://s.w.org/images/core/emoji/12.0.0-1/72x72/1f468-1f3fb-200d-1f4bb.png" alt="👨🏻‍💻" class="wp-smiley amp-wp-enforced-sizes" style="height: 1em; max-height: 1em;" width="72" height="72" noloading="" layout="intrinsic"></amp-img>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -328,20 +328,20 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param string[] $expected_error_codes Expected error codes.
 	 * @dataProvider get_data
 	 */
-	public function test_converter( $source, $expected = null, $args = array(), $expected_error_codes = array() ) {
+	public function test_converter( $source, $expected = null, $args = [], $expected_error_codes = [] ) {
 		if ( ! $expected ) {
 			$expected = $source;
 		}
 
-		$error_codes = array();
+		$error_codes = [];
 
 		$args = array_merge(
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
-			),
+			],
 			$args
 		);
 
@@ -368,7 +368,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_no_gif_no_image_scripts() {
 		$source   = '<img src="https://placehold.it/350x150.png" width="350" height="150" alt="Placeholder!" />';
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
@@ -389,7 +389,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_no_gif_image_scripts() {
 		$source   = '<img src="https://placehold.it/350x150.gif" width="350" height="150" alt="Placeholder!" />';
-		$expected = array( 'amp-anim' => true );
+		$expected = [ 'amp-anim' => true ];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );

--- a/tests/php/test-amp-instagram-embed.php
+++ b/tests/php/test-amp-instagram-embed.php
@@ -2,36 +2,36 @@
 
 class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'                 => array(
+		return [
+			'no_embed'                 => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
-			'simple_url'               => array(
+			],
+			'simple_url'               => [
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
-			),
+			],
 
-			'short_url'                => array(
+			'short_url'                => [
 				'https://instagr.am/p/7-l0z_p4A4' . PHP_EOL,
 				'<p><amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram></p>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_simple'         => array(
+			'shortcode_simple'         => [
 				'[instagram url=https://www.instagram.com/p/BIyO4vXjE6b]' . PHP_EOL,
 				'<amp-instagram data-shortcode="BIyO4vXjE6b" data-captioned layout="responsive" width="600" height="600"></amp-instagram>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_url_with_query' => array(
+			'shortcode_url_with_query' => [
 				'[instagram url=https://www.instagram.com/p/BIyO4vXjE6b/?taken-by=natgeo]' . PHP_EOL,
 				'<amp-instagram data-shortcode="BIyO4vXjE6b" data-captioned layout="responsive" width="600" height="600"></amp-instagram>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_with_short_url' => array(
+			'shortcode_with_short_url' => [
 				'[instagram url=https://instagr.am/p/7-l0z_p4A4]' . PHP_EOL,
 				'<amp-instagram data-shortcode="7-l0z_p4A4" data-captioned layout="responsive" width="600" height="600"></amp-instagram>' . PHP_EOL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -55,16 +55,16 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://instagram.com/p/7-l0z_p4A4/' . PHP_EOL,
-				array( 'amp-instagram' => true ),
-			),
-		);
+				[ 'amp-instagram' => true ],
+			],
+		];
 	}
 
 	/**
@@ -96,36 +96,36 @@ class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_raw_embed_dataset() {
-		return array(
-			'no_embed'                               => array(
+		return [
+			'no_embed'                               => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>',
-			),
-			'embed_blockquote_without_instagram'     => array(
+			],
+			'embed_blockquote_without_instagram'     => [
 				'<blockquote><p>lorem ipsum</p></blockquote>',
 				'<blockquote><p>lorem ipsum</p></blockquote>',
-			),
+			],
 
-			'blockquote_embed'                       => array(
+			'blockquote_embed'                       => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram>' . "\n\n",
-			),
+			],
 
-			'blockquote_embed_notautop'              => array(
+			'blockquote_embed_notautop'              => [
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/"><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600"></amp-instagram> ',
-			),
+			],
 
-			'blockquote_embed_with_caption'          => array(
+			'blockquote_embed_with_caption'          => [
 				wpautop( '<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/" data-instgrm-captioned><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned=""></amp-instagram>' . "\n\n",
-			),
+			],
 
-			'blockquote_embed_with_caption_notautop' => array(
+			'blockquote_embed_with_caption_notautop' => [
 				'<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/BhsgU3jh6xE/" data-instgrm-captioned><div style="padding: 8px;">Lorem ipsum</div></blockquote> <script async defer src="//www.instagram.com/embed.js"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-instagram data-shortcode="BhsgU3jh6xE" layout="responsive" width="600" height="600" data-captioned=""></amp-instagram> ',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-o2-player-sanitizer.php
+++ b/tests/php/test-amp-o2-player-sanitizer.php
@@ -18,27 +18,27 @@ class AMP_O2_Player_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_data() {
-		return array(
-			'no_o2_player_item'                      => array(
+		return [
+			'no_o2_player_item'                      => [
 				'<h1>Im Not A O2 Player</h1>',
 				'<h1>Im Not A O2 Player</h1>',
-			),
-			'o2_player_item_without_script'          => array(
+			],
+			'o2_player_item_without_script'          => [
 				'<div class="vdb_player"></div>',
 				'<div class="vdb_player"></div>',
-			),
+			],
 
-			'o2_player_item'                         => array(
+			'o2_player_item'                         => [
 				'<div class="vdb_player"><script type="text/javascript" src="//delivery.vidible.tv/jsonp/pid=59521379f3bdc970c5c9d75e/vid=5b11a50d0239e257abfdf16a/59521191e9399f3a7d7de88f.js?m.embeded=cms_video_plugin_chromeExtension"></script></div>',// phpcs:ignore
 				'<amp-o2-player data-pid="59521379f3bdc970c5c9d75e" data-vid="5b11a50d0239e257abfdf16a" data-bcid="59521191e9399f3a7d7de88f" data-macros="m.playback=click" layout="responsive" width="480" height="270"></amp-o2-player>',
-			),
+			],
 
-			'o2_player_item_without_required_fields' => array(
+			'o2_player_item_without_required_fields' => [
 				'<div class="vdb_player"><script type="text/javascript" src="//delivery.vidible.tv/jsonp/vid=5b11a50d0239e257abfdf16a/59521191e9399f3a7d7de88f.js?m.embeded=cms_video_plugin_chromeExtension"></script></div>',// phpcs:ignore
 				'<div class="vdb_player"><script type="text/javascript" src="//delivery.vidible.tv/jsonp/vid=5b11a50d0239e257abfdf16a/59521191e9399f3a7d7de88f.js?m.embeded=cms_video_plugin_chromeExtension"></script></div>',// phpcs:ignore
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -68,7 +68,7 @@ class AMP_O2_Player_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_script__pid__vid__required() {
 		$source   = '<div class="vdb_player"><script type="text/javascript" src="//delivery.vidible.tv/jsonp/pid=59521379f3bdc970c5c9d75e?m.embeded=cms_video_plugin_chromeExtension"></script></div>';// phpcs:ignore
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_O2_Player_Sanitizer( $dom );
@@ -89,7 +89,7 @@ class AMP_O2_Player_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<div class="vdb_player"><script type="text/javascript" src="//delivery.vidible.tv/jsonp/pid=59521379f3bdc970c5c9d75e/vid=5b11a50d0239e257abfdf16a/59521191e9399f3a7d7de88f.js?m.embeded=cms_video_plugin_chromeExtension"></script></div>';// phpcs:ignore
-		$expected = array( 'amp-o2-player' => true );
+		$expected = [ 'amp-o2-player' => true ];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_O2_Player_Sanitizer( $dom );

--- a/tests/php/test-amp-pinterest-embed.php
+++ b/tests/php/test-amp-pinterest-embed.php
@@ -2,20 +2,20 @@
 
 class AMP_Pinterest_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'         => array(
+		return [
+			'no_embed'         => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
-			'simple_url_https' => array(
+			],
+			'simple_url_https' => [
 				'https://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="https://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
-			),
-			'simple_url_http'  => array(
+			],
+			'simple_url_http'  => [
 				'http://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
 				'<p><amp-pinterest width="450" height="750" data-do="embedPin" data-url="http://www.pinterest.com/pin/606156431067611861/"></amp-pinterest></p>' . PHP_EOL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -30,16 +30,16 @@ class AMP_Pinterest_Embed_Test extends WP_UnitTestCase {
 	}
 
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.pinterest.com/pin/606156431067611861/' . PHP_EOL,
-				array( 'amp-pinterest' => true ),
-			),
-		);
+				[ 'amp-pinterest' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-playbuzz-sanitizer.php
+++ b/tests/php/test-amp-playbuzz-sanitizer.php
@@ -9,47 +9,47 @@ class AMP_Playbuzz_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_data() {
-		return array(
-			'no_playbuzz_item'                           => array(
+		return [
+			'no_playbuzz_item'                           => [
 				'<h1>Im Not A Playbuzz Embed</h1>',
 				'<h1>Im Not A Playbuzz Embed</h1>',
-			),
+			],
 
-			'playbuzz_item_without_sorce'                => array(
+			'playbuzz_item_without_sorce'                => [
 				'<div class="pb_feed"></div>',
 				'<div class="pb_feed"></div>',
-			),
+			],
 
-			'playbuzz_item_with_data_item'               => array(
+			'playbuzz_item_with_data_item'               => [
 				'<div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
 				'<amp-playbuzz class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121" height="500"></amp-playbuzz>',
-			),
+			],
 
-			'playbuzz_item_with_data_game'               => array(
+			'playbuzz_item_with_data_game'               => [
 				'<div class="pb_feed" data-game="https://www.playbuzz.com/jessiemills10/donald-trump-hits-out-at-rachel-maddow-and-accuses-nbc-of-being-fake-news-is-he-right"></div>',
 				'<amp-playbuzz class="pb_feed" src="https://www.playbuzz.com/jessiemills10/donald-trump-hits-out-at-rachel-maddow-and-accuses-nbc-of-being-fake-news-is-he-right" height="500"></amp-playbuzz>',
-			),
+			],
 
-			'playbuzz_item_with_data_game_and_data_item' => array(
+			'playbuzz_item_with_data_game_and_data_item' => [
 				'<div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121" data-game="https://www.playbuzz.com/jessiemills10/donald-trump-hits-out-at-rachel-maddow-and-accuses-nbc-of-being-fake-news-is-he-right"></div>',
 				'<amp-playbuzz class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121" src="https://www.playbuzz.com/jessiemills10/donald-trump-hits-out-at-rachel-maddow-and-accuses-nbc-of-being-fake-news-is-he-right" height="500"></amp-playbuzz>',
-			),
+			],
 
-			'playbuzz_item_with_data_game_info'          => array(
+			'playbuzz_item_with_data_game_info'          => [
 				'<div class="pb_feed" data-game-info="true" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
 				'<amp-playbuzz class="pb_feed" data-game-info="true" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121" height="500"></amp-playbuzz>',
-			),
+			],
 
-			'playbuzz_item_with_data_shares_info'        => array(
+			'playbuzz_item_with_data_shares_info'        => [
 				'<div class="pb_feed" data-shares="true" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
 				'<amp-playbuzz class="pb_feed" data-share-buttons="true" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121" height="500"></amp-playbuzz>',
-			),
+			],
 
-			'playbuzz_item_with_data_comments'           => array(
+			'playbuzz_item_with_data_comments'           => [
 				'<div class="pb_feed" data-comments="true" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
 				'<amp-playbuzz class="pb_feed" data-comments="true" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121" height="500"></amp-playbuzz>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -66,7 +66,7 @@ class AMP_Playbuzz_Sanitizer_Test extends WP_UnitTestCase {
 
 	public function test_get_scripts__data_item_or_data_game_required() {
 		$source   = '<div class="pb_feed"></div>';
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Playbuzz_Sanitizer( $dom );
@@ -84,7 +84,7 @@ class AMP_Playbuzz_Sanitizer_Test extends WP_UnitTestCase {
 
 	public function test_get_scripts__didnt_convert() {
 		$source   = '<h1>Im A Not Playbuzz Embed</h1>';
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Playbuzz_Sanitizer( $dom );
@@ -105,7 +105,7 @@ class AMP_Playbuzz_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>';
-		$expected = array( 'amp-playbuzz' => true );
+		$expected = [ 'amp-playbuzz' => true ];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Playbuzz_Sanitizer( $dom );

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -11,9 +11,9 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 
 	public function test__valid_post() {
 		$user_id = self::factory()->user->create();
-		$post_id = self::factory()->post->create( array( 'post_author' => $user_id ) );
+		$post_id = self::factory()->post->create( [ 'post_author' => $user_id ] );
 
-		$output = get_echo( 'amp_render_post', array( $post_id ) );
+		$output = get_echo( 'amp_render_post', [ $post_id ] );
 
 		$this->assertContains( '<html amp', $output, 'Response does not include html tag with amp attribute.' );
 		$this->assertEquals( 1, did_action( 'pre_amp_render_post', 'pre_amp_render_post action fire either did not fire or fired too many times.' ) );
@@ -34,17 +34,17 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 	public function test__is_amp_endpoint() {
 		$user_id = self::factory()->user->create();
 		$post_id = self::factory()->post->create(
-			array(
+			[
 				'post_author' => $user_id,
-			)
+			]
 		);
 
 		$before_is_amp_endpoint = is_amp_endpoint();
 
-		add_action( 'pre_amp_render_post', array( $this, 'check_is_amp_endpoint' ) );
+		add_action( 'pre_amp_render_post', [ $this, 'check_is_amp_endpoint' ] );
 		$this->was_amp_endpoint = false;
 
-		$output = get_echo( 'amp_render_post', array( $post_id ) );
+		$output = get_echo( 'amp_render_post', [ $post_id ] );
 		$this->assertContains( '<html amp', $output );
 
 		$after_is_amp_endpoint = is_amp_endpoint();

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -18,24 +18,24 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_noscript_data() {
-		return array(
-			'document_write'      => array(
+		return [
+			'document_write'      => [
 				'<html><head></head><body>Has script? <script>document.write("Yep!")</script><noscript>Nope!</noscript></body></html>',
 				'<html><head></head><body>Has script? <!--noscript-->Nope!<!--/noscript--></body></html>',
-			),
-			'nested_elements'     => array(
+			],
+			'nested_elements'     => [
 				'<html><head></head><body><noscript>before <em><strong>middle</strong> end</em></noscript></body></html>',
 				'<html><head></head><body><!--noscript-->before <em><strong>middle</strong> end</em><!--/noscript--></body></html>',
-			),
-			'head_noscript_style' => array(
+			],
+			'head_noscript_style' => [
 				'<html><head><noscript><style>body{color:red}</style></noscript></head><body></body></html>',
 				'<html><head><!--noscript--><style>body{color:red}</style><!--/noscript--></head><body></body></html>',
-			),
-			'head_noscript_span'  => array(
+			],
+			'head_noscript_span'  => [
 				'<html><head><noscript><span>No script</span></noscript></head><body></body></html>',
 				'<html><head></head><body><!--noscript--><span>No script</span><!--/noscript--></body></html>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -92,9 +92,9 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 		</html>
 		<?php
 		$html = ob_get_clean();
-		$args = array(
+		$args = [
 			'use_document_element' => true,
-		);
+		];
 
 		$dom = AMP_DOM_Utils::get_dom( $html );
 		AMP_Content_Sanitizer::sanitize_document( $dom, amp_get_content_sanitizers(), $args );

--- a/tests/php/test-amp-soundcloud-embed.php
+++ b/tests/php/test-amp-soundcloud-embed.php
@@ -66,14 +66,14 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 			add_shortcode( 'soundcloud', 'soundcloud_shortcode' );
 		}
 
-		add_filter( 'pre_http_request', array( $this, 'mock_http_request' ), 10, 3 );
+		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
 	}
 
 	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
 	 */
 	public function tearDown() {
-		remove_filter( 'pre_http_request', array( $this, 'mock_http_request' ) );
+		remove_filter( 'pre_http_request', [ $this, 'mock_http_request' ] );
 		parent::tearDown();
 	}
 
@@ -97,16 +97,16 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 			$body = $this->track_oembed_response;
 		}
 
-		return array(
+		return [
 			'body'          => $body,
-			'headers'       => array(),
-			'response'      => array(
+			'headers'       => [],
+			'response'      => [
 				'code'    => 200,
 				'message' => 'ok',
-			),
-			'cookies'       => array(),
+			],
+			'cookies'       => [],
 			'http_response' => null,
-		);
+		];
 	}
 
 	/**
@@ -115,22 +115,22 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_conversion_data() {
-		$data = array(
-			'no_embed'        => array(
+		$data = [
+			'no_embed'        => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'track_simple'    => array(
+			'track_simple'    => [
 				$this->track_url . PHP_EOL,
 				'<p><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart &#8211; Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
-			),
+			],
 
-			'playlist_simple' => array(
+			'playlist_simple' => [
 				$this->playlist_url . PHP_EOL,
 				'<p><amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music &#8211; The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
-			),
-		);
+			],
+		];
 
 		// @todo All the following should be moved to Jetpack.
 		if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
@@ -139,38 +139,38 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 		if ( function_exists( 'soundcloud_shortcode' ) ) {
 			$data = array_merge(
 				$data,
-				array(
-					'shortcode_with_bare_track_api_url'   => array(
+				[
+					'shortcode_with_bare_track_api_url'   => [
 						'[soundcloud https://api.soundcloud.com/tracks/89299804]' . PHP_EOL,
 						'<amp-soundcloud data-trackid="89299804" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
-					),
+					],
 
-					'shortcode_with_track_api_url'        => array(
+					'shortcode_with_track_api_url'        => [
 						'[soundcloud url=https://api.soundcloud.com/tracks/89299804]' . PHP_EOL,
 						'<amp-soundcloud data-trackid="89299804" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
-					),
+					],
 
-					'shortcode_with_track_permalink'      => array(
+					'shortcode_with_track_permalink'      => [
 						"[soundcloud url=$this->track_url]",
 						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
-					),
+					],
 
-					'shortcode_with_bare_track_permalink' => array(
+					'shortcode_with_bare_track_permalink' => [
 						"[soundcloud $this->track_url]",
 						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
-					),
+					],
 
-					'shortcode_with_playlist_permalink'   => array(
+					'shortcode_with_playlist_permalink'   => [
 						"[soundcloud url=$this->playlist_url]",
 						'<amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music - The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
-					),
+					],
 
 					// This apparently only works on WordPress.com.
-					'shortcode_with_id'                   => array(
+					'shortcode_with_id'                   => [
 						'[soundcloud id=89299804]' . PHP_EOL,
 						'<amp-soundcloud data-trackid="89299804" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
-					),
-				)
+					],
+				]
 			);
 		}
 
@@ -202,20 +202,20 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 	 * @return array Scripts data.
 	 */
 	public function get_scripts_data() {
-		return array(
-			'not_converted'      => array(
+		return [
+			'not_converted'      => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted_track'    => array(
+				[],
+			],
+			'converted_track'    => [
 				$this->track_url . PHP_EOL,
-				array( 'amp-soundcloud' => true ),
-			),
-			'converted_playlist' => array(
+				[ 'amp-soundcloud' => true ],
+			],
+			'converted_playlist' => [
 				$this->playlist_url . PHP_EOL,
-				array( 'amp-soundcloud' => true ),
-			),
-		);
+				[ 'amp-soundcloud' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-story-sanitizer.php
+++ b/tests/php/test-amp-story-sanitizer.php
@@ -29,24 +29,24 @@ class AMP_Story_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'story_without_cta' => array(
+		return [
+			'story_without_cta' => [
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page>',
 				null, // Same.
-			),
-			'story_with_cta_on_first_page' => array(
+			],
+			'story_with_cta_on_first_page' => [
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer></amp-story-page>',
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page>',
-			),
-			'story_with_cta_on_second_page' => array(
+			],
+			'story_with_cta_on_second_page' => [
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page><amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer></amp-story-page>',
 				null, // Same.
-			),
-			'story_with_multiple_cta_on_second_page' => array(
+			],
+			'story_with_multiple_cta_on_second_page' => [
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page><amp-story-page><amp-story-grid-layer></amp-story-grid-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer></amp-story-page>',
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page><amp-story-page><amp-story-grid-layer></amp-story-grid-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer></amp-story-page>',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -39,203 +39,203 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_body_style_attribute_data() {
-		return array(
-			'empty' => array(
+		return [
+			'empty' => [
 				'',
 				'',
-				array(),
-			),
+				[],
+			],
 
-			'span_one_style' => array(
+			'span_one_style' => [
 				'<span style="color: #00ff00;">This is green.</span>',
 				'<span class="amp-wp-bb01159">This is green.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0}',
-				),
-			),
+				],
+			],
 
-			'span_one_style_bad_format' => array(
+			'span_one_style_bad_format' => [
 				'<span style="color  :   #00ff00">This is green.</span>',
 				'<span class="amp-wp-0837823">This is green.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-0837823{color:#0f0}',
-				),
-			),
+				],
+			],
 
-			'span_two_styles_reversed' => array(
+			'span_two_styles_reversed' => [
 				'<span style="color: #00ff00; background-color: #000; ">This is green.</span>',
 				'<span class="amp-wp-c71affe">This is green.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c71affe{color:#0f0;background-color:#000}',
-				),
-			),
+				],
+			],
 
-			'span_display_none' => array(
+			'span_display_none' => [
 				'<span style="display: none;">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				'<span class="amp-wp-224b51a">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none}',
-				),
-			),
+				],
+			],
 
-			'!important_is_ok' => array(
+			'!important_is_ok' => [
 				'<span style="padding:1px; margin: 2px !important; outline: 3px;">!important is converted.</span>',
 				'<span class="amp-wp-6a75598">!important is converted.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{padding:1px;outline:3px}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{margin:2px}',
-				),
-			),
+				],
+			],
 
-			'!important_with_spaces_also_converted' => array(
+			'!important_with_spaces_also_converted' => [
 				'<span style="color: red  !  important;">!important is converted.</span>',
 				'<span class="amp-wp-952600b">!important is converted.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-952600b{color:red}',
-				),
-			),
+				],
+			],
 
-			'!important_multiple_is_converted' => array(
+			'!important_multiple_is_converted' => [
 				'<span style="color: red !important; background: blue!important;">!important is converted.</span>',
 				'<span class="amp-wp-1e2bfaa">!important is converted.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-1e2bfaa{color:red;background:blue}',
-				),
-			),
+				],
+			],
 
-			'!important_takes_precedence_over_inline' => array(
+			'!important_takes_precedence_over_inline' => [
 				'<header id="header" style="display: none;"><h1>This is the header.</h1></header><style>#header { display: block !important;width: 100%;background: #fff; }',
 				'<header id="header" class="amp-wp-224b51a"><h1>This is the header.</h1></header>',
-				array(
+				[
 					'#header{width:100%;background:#fff}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #header{display:block}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none}',
-				),
-			),
+				],
+			],
 
-			'two_nodes' => array(
+			'two_nodes' => [
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
 				'<span class="amp-wp-bb01159"><span class="amp-wp-cc68ddc">This is red.</span></span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cc68ddc{color:#f00}',
-				),
-			),
+				],
+			],
 
-			'existing_class_attribute' => array(
+			'existing_class_attribute' => [
 				'<figure class="alignleft" style="background: #000"></figure>',
 				'<figure class="alignleft amp-wp-2864855"></figure>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-2864855{background:#000}',
-				),
-			),
+				],
+			],
 
-			'inline_style_element_with_multiple_rules_containing_selectors_is_removed' => array(
+			'inline_style_element_with_multiple_rules_containing_selectors_is_removed' => [
 				'<style>div > span { font-weight:bold !important; font-style: italic; } @media screen and ( max-width: 640px ) { div > span { font-weight:normal !important; font-style: normal; } }</style><div><span>bold!</span></div>',
 				'<div><span>bold!</span></div>',
-				array(
+				[
 					'div > span{font-style:italic}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) div > span{font-weight:bold}@media screen and ( max-width: 640px ){div > span{font-style:normal}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) div > span{font-weight:normal}}',
-				),
-			),
+				],
+			],
 
-			'illegal_unsafe_properties' => array(
+			'illegal_unsafe_properties' => [
 				'<style>button { behavior: url(hilite.htc) /* IE only */; font-weight:bold; -moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox); /*XBL*/ }</style><style> @media screen { button { behavior: url(hilite.htc) /* IE only */; font-weight:bold; -moz-binding: url(http://www.example.org/xbl/htmlBindings.xml#checkbox); /*XBL*/ } }</style><button>Click</button>',
 				'<button>Click</button>',
-				array(
+				[
 					'button{font-weight:bold}',
 					'@media screen{button{font-weight:bold}}',
-				),
-				array( 'illegal_css_property', 'illegal_css_property', 'illegal_css_property', 'illegal_css_property' ),
-			),
+				],
+				[ 'illegal_css_property', 'illegal_css_property', 'illegal_css_property', 'illegal_css_property' ],
+			],
 
-			'illegal_at_rule_in_style_attribute' => array(
+			'illegal_at_rule_in_style_attribute' => [
 				'<span style="color:brown; @media screen { color:green }">invalid @-rule omitted.</span>',
 				'<span class="amp-wp-481af57">invalid @-rule omitted.</span>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-481af57{color:brown}',
-				),
-				array(),
-			),
+				],
+				[],
+			],
 
-			'illegal_at_rules_removed' => array(
+			'illegal_at_rules_removed' => [
 				'<style>@charset "utf-8"; @namespace svg url(http://www.w3.org/2000/svg); @page { margin: 1cm; } @viewport { width: device-width; } @counter-style thumbs { system: cyclic; symbols: "\1F44D"; suffix: " "; } body { color: black; }</style>',
 				'',
-				array(
+				[
 					'@page{margin:1cm}body{color:black}',
-				),
-				array( 'illegal_css_at_rule', 'illegal_css_at_rule', 'illegal_css_at_rule' ),
-			),
+				],
+				[ 'illegal_css_at_rule', 'illegal_css_at_rule', 'illegal_css_at_rule' ],
+			],
 
-			'allowed_at_rules_retained' => array(
+			'allowed_at_rules_retained' => [
 				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
 				'<div></div>',
-				array(
+				[
 					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',
-				),
-			),
+				],
+			],
 
-			'selector_specificity' => array(
+			'selector_specificity' => [
 				'<style>#child {color:red !important} #parent #child {color:pink !important} .foo { color:blue !important; } #me .foo { color: green !important; }</style><div id="parent"><span id="child" class="foo bar baz">one</span><span style="color: yellow;">two</span><span style="color: purple !important;">three</span></div><div id="me"><span class="foo"></span></div>',
 				'<div id="parent"><span id="child" class="foo bar baz">one</span><span class="amp-wp-64b4fd4">two</span><span class="amp-wp-ab79d9e">three</span></div><div id="me"><span class="foo"></span></div>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #child{color:red}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #parent #child{color:pink}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .foo{color:blue}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #me .foo{color:green}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-64b4fd4{color:yellow}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-ab79d9e{color:purple}',
-				),
-			),
+				],
+			],
 
-			'grid_lines'                                  => array(
+			'grid_lines'                                  => [
 				'<style>.wrapper {display: grid;grid-template-columns: [main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end];grid-template-rows: [main-start] 100px [content-start] 100px [content-end] 100px [main-end];}</style><div class="wrapper"></div>',
 				'<div class="wrapper"></div>',
-				array(
+				[
 					'.wrapper{display:grid;grid-template-columns:[main-start] 1fr [content-start] 1fr [content-end] 1fr [main-end];grid-template-rows:[main-start] 100px [content-start] 100px [content-end] 100px [main-end]}',
-				),
-			),
+				],
+			],
 
-			'col_with_width_attribute' => array(
+			'col_with_width_attribute' => [
 				'<table><colgroup><col width="253"/></colgroup></table>',
 				'<table><colgroup><col class="amp-wp-cbcb5c2"></colgroup></table>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cbcb5c2{width:253px}',
-				),
-			),
+				],
+			],
 
-			'col_with_percent_width_attribute' => array(
+			'col_with_percent_width_attribute' => [
 				'<table><colgroup><col width="50%"/></colgroup></table>',
 				'<table><colgroup><col class="amp-wp-cd7753e"></colgroup></table>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cd7753e{width:50%}',
-				),
-			),
+				],
+			],
 
-			'col_with_star_width_attribute' => array(
+			'col_with_star_width_attribute' => [
 				'<table><colgroup><col width="0*"/></colgroup></table>',
 				'<table><colgroup><col width="0*"></colgroup></table>',
-				array(),
-			),
+				[],
+			],
 
-			'col_with_width_attribute_and_existing_style' => array(
+			'col_with_width_attribute_and_existing_style' => [
 				'<table><colgroup><col width="50" style="background-color: red; width: 60px"/></colgroup></table>',
 				'<table><colgroup><col class="amp-wp-c8aa9e9"></colgroup></table>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c8aa9e9{width:50px;width:60px;background-color:red}',
-				),
-			),
+				],
+			],
 
-			'multi_selector_in_not_pseudo_class'         => array(
+			'multi_selector_in_not_pseudo_class'         => [
 				'<style>.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul { color:red; }</style><div class="widget"><ul></ul></div>',
 				'<div class="widget"><ul></ul></div>',
-				array(
+				[
 					'.widget:not(.widget_text,.jetpack_widget_social_icons[title="a,b"]) ul{color:red}',
-				),
-			),
+				],
+			],
 
-			'selector_with_escaped_char_class_name'      => array(
+			'selector_with_escaped_char_class_name'      => [
 				'<style>.lg\:w-full { width: 100%; }</style><div class="bg-black w-16 lg:w-full hover:bg-blue"></div>',
 				'<div class="bg-black w-16 lg:w-full hover:bg-blue"></div>',
-				array(
+				[
 					'.lg\:w-full{width:100%}',
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -247,15 +247,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param string $expected_stylesheets Expected stylesheets.
 	 * @param array  $expected_errors      Expected error codes.
 	 */
-	public function test_body_style_attribute_sanitizer( $source, $expected_content, $expected_stylesheets, $expected_errors = array() ) {
+	public function test_body_style_attribute_sanitizer( $source, $expected_content, $expected_stylesheets, $expected_errors = [] ) {
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 
-		$error_codes = array();
-		$args        = array(
+		$error_codes = [];
+		$args        = [
 			'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 				$error_codes[] = $error['code'];
 			},
-		);
+		];
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
@@ -277,63 +277,63 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_link_and_style_test_data() {
-		return array(
-			'multiple_amp_custom_and_other_styles' => array(
+		return [
+			'multiple_amp_custom_and_other_styles' => [
 				'<html amp><head><meta charset="utf-8"><style amp-custom>b {color:red !important}</style><style amp-custom>i {color:blue}</style><style type="text/css">u {color:green; text-decoration: underline !important}</style></head><body><style>s {color:yellow} /* So !important! */</style><b>1</b><i>i</i><u>u</u><s>s</s></body></html>',
-				array(
+				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) b{color:red}',
 					'i{color:blue}',
 					'u{color:green}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) u{text-decoration:underline}',
 					's{color:yellow}',
-				),
-				array(),
-			),
-			'style_elements_with_link_elements' => array(
+				],
+				[],
+			],
+			'style_elements_with_link_elements' => [
 				sprintf(
 					'<html amp><head><meta charset="utf-8"><style type="text/css">strong.before-dashicon {color:green}</style><link rel="stylesheet" href="%s"><style type="text/css">strong.after-dashicon {color:green}</style></head><body><style>s {color:yellow !important}</style><s class="before-dashicon"></s><strong class="dashicons-dashboard"></strong><strong class="after-dashicon"></strong></body></html>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 					includes_url( 'css/dashicons.css' )
 				),
-				array(
+				[
 					'strong.before-dashicon',
 					'.dashicons-dashboard:before',
 					'strong.after-dashicon',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) s{color:yellow}',
-				),
-				array(),
-			),
-			'style_with_no_head' => array(
+				],
+				[],
+			],
+			'style_with_no_head' => [
 				'<html amp><body>Not good!<style>body{color:red}</style></body></html>',
-				array(
+				[
 					'body{color:red}',
-				),
-				array(),
-			),
-			'style_with_not_selectors' => array(
+				],
+				[],
+			],
+			'style_with_not_selectors' => [
 				'<html amp><head><meta charset="utf-8"><style amp-custom>body.bar > p:not(.baz) { color:red; } body.foo:not(.bar) > p { color:blue; } body.foo:not(.bar) p:not(.baz) { color:green; } body.foo p { color:yellow; }</style></head><body class="foo"><p>Hello</p></body></html>',
-				array(
+				[
 					'body.foo:not(.bar) > p{color:blue}body.foo:not(.bar) p:not(.baz){color:green}body.foo p{color:yellow}',
-				),
-				array(),
-			),
-			'style_with_attribute_selectors' => array(
+				],
+				[],
+			],
+			'style_with_attribute_selectors' => [
 				'<html amp><head><meta charset="utf-8"><style amp-custom>.social-navigation a[href*="example.com"] { color:red; } .social-navigation a.examplecom { color:blue; }</style></head><body class="foo"><nav class="social-navigation"><a href="https://example.com/">Example</a></nav></body></html>',
-				array(
+				[
 					'.social-navigation a[href*="example.com"]{color:red}',
-				),
-				array(),
-			),
-			'style_on_root_element' => array(
+				],
+				[],
+			],
+			'style_on_root_element' => [
 				'<html amp style="color:red;"><head><meta charset="utf-8"><style amp-custom>html { background-color: blue !important; }</style></head><body>Hi</body></html>',
-				array(
+				[
 					'html:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_){background-color:blue}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-10b06ba{color:red}',
-				),
-				array(),
-			),
-			'styles_with_dynamic_elements' => array(
+				],
+				[],
+			],
+			'styles_with_dynamic_elements' => [
 				implode(
 					'',
-					array(
+					[
 						'<html amp><head><meta charset="utf-8">',
 						'<style amp-custom>b.foo, form [submit-success] b, div[submit-failure] b, form.unused b { color: green }</style>',
 						'<style amp-custom>.dead-list li .highlighted, amp-live-list li .highlighted { background: yellow }</style>',
@@ -344,56 +344,56 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'<amp-live-list id="my-live-list" data-poll-interval="15000" data-max-items-per-page="20"><button update on="tap:my-live-list.update">You have updates!</button><ul items><li id="live-list-2-item-2" data-sort-time="1464281932879">Hello</li></ul></amp-live-list>',
 						'<amp-list width="auto" height="100" layout="fixed-height" src="https://ampproject-b5f4c.firebaseapp.com/examples/data/amp-list-urls.json"> <template type="amp-mustache"> <div class="url-entry"> <a href="{{url}}" class="{{class}}">{{title}}</a> </div> </template> </amp-list>',
 						'</body></html>',
-					)
+					]
 				),
-				array(
+				[
 					'form [submit-success] b{color:green}', // The [submit-failure] selector is removed because there is no div[submit-failure].
 					'amp-live-list li .highlighted{background:yellow}',
 					'',
 					'body amp-list .portland{color:blue}',
-				),
-				array(),
-			),
-			'styles_with_calc_functions' => array(
+				],
+				[],
+			],
+			'styles_with_calc_functions' => [
 				implode(
 					'',
-					array(
+					[
 						'<html amp><head>',
 						'<style amp-custom>body { color: red; width: calc( 1px + calc( 2vh / 3 ) - 2px * 5 ); outline: solid 1px blue; }</style>',
 						'<style amp-custom>.alignwide{ max-width: -webkit-calc(50% + 22.5rem); border: solid 1px red; }</style>',
 						'<style amp-custom>.alignwide{ height: calc(10% + ( 1px ); color: red; content: ")"}</style>', // Test unbalanced parentheses.
 						'</head><body><div class="alignwide"></div></body></html>',
-					)
+					]
 				),
-				array(
+				[
 					'body{color:red;width:calc(1px + calc(2vh / 3) - 2px * 5);outline:solid 1px blue}',
 					'.alignwide{max-width:-webkit-calc(50% + 22.5rem);border:solid 1px red}',
 					'.alignwide{color:red;content:")"}',
-				),
-				array(),
-			),
-			'style_with_media_element' => array(
+				],
+				[],
+			],
+			'style_with_media_element' => [
 				'<html amp><head><meta charset="utf-8"><style media="print">.print { display:none; }</style></head><body><button class="print" on="tap:AMP.print()"></button></body></html>',
-				array(
+				[
 					'@media print{.print{display:none}}',
-				),
-				array(),
-			),
-			'selectors_with_ie_hacks_removed' => array(
+				],
+				[],
+			],
+			'selectors_with_ie_hacks_removed' => [
 				'<html amp><head><meta charset="utf-8"><style>* html span { color:red; background: blue !important; } span { text-decoration:underline; } *+html span { border: solid green; }</style></head><body><span>Test</span></body></html>',
-				array(
+				[
 					'span{text-decoration:underline}',
-				),
-				array(),
-			),
-			'unamerican_lang_attribute_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
+				],
+				[],
+			],
+			'unamerican_lang_attribute_selectors_removed' => [ // USA is used for convenience here. No political statement intended.
 				'<html lang="en-US" amp><head><meta charset="utf-8"><style>html[lang=en-US] {color:red} html[lang="en-US"] {color:white} html[lang^=en] {color:blue} html[lang="en-CA"] {color:red}  html[lang^=ar] { color:green; } html[lang="es-MX"] { color:green; }</style></head><body><span>Test</span></body></html>',
-				array(
+				[
 					'html[lang=en-US]{color:red}html[lang="en-US"]{color:white}html[lang^=en]{color:blue}',
-				),
-				array(),
-			),
-			'unamerican_lang_selector_selectors_removed' => array( // USA is used for convenience here. No political statement intended.
+				],
+				[],
+			],
+			'unamerican_lang_selector_selectors_removed' => [ // USA is used for convenience here. No political statement intended.
 				'
 					<html amp><head><meta charset="utf-8">
 					<style>
@@ -409,26 +409,26 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						</style>
 					</head><body><span class="test">Test</span></body></html>
 				',
-				array(
+				[
 					'html:lang(en-US){color:red}body span:lang(en-US){color:red}html:lang(en){color:white}.test:lang(en-us, en-CA){color:white}html span.test:lang(en-US){color:blue}html:lang("en-US") span.test{color:blue}',
-				),
-				array(),
-			),
-			'external_link_without_css_file_extension' => array(
+				],
+				[],
+			],
+			'external_link_without_css_file_extension' => [
 				'<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="https://example.com/_static/??-eJx9kN1SAyEMhV9Iip3aOl44Pgs"></head><body><span>externally-styled</span></body></html>', // phpcs:ignore
-				array(
+				[
 					'span:before{content:"Returned from: https://example.com/_static/??-eJx9kN1SAyEMhV9Iip3aOl44Pgs"}',
-				),
-				array(),
-			),
-			'charset_ruleset_removed_without_warning'  => array(
+				],
+				[],
+			],
+			'charset_ruleset_removed_without_warning'  => [
 				'<html amp><body><style>@charset "utf-8"; body { color:limegreen; }</style></body></html>',
-				array(
+				[
 					'body{color:limegreen}',
-				),
-				array(),
-			),
-			'dynamic_classes_preserved_always' => array(
+				],
+				[],
+			],
+			'dynamic_classes_preserved_always' => [
 				'
 					<html amp><head>
 					<style> .amp-viewer { color: blue; } </style>
@@ -450,14 +450,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .non-existent { color: black; } </style>
 					</head><body><p>Hello!</p></body></html>
 				',
-				array(
+				[
 					'.amp-viewer{color:blue}',
 					'.amp-referrer-www-google-com{color:red}',
 					'', // Because there is no <form>, <amp-carousel>, and no non-existent.
-				),
-				array(),
-			),
-			'dynamic_classes_preserved_conditionally' => array(
+				],
+				[],
+			],
+			'dynamic_classes_preserved_conditionally' => [
 				'
 					<html amp><head>
 					<style> .amp-viewer { color: blue; } </style>
@@ -493,7 +493,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					</body>
 					</html>
 				',
-				array(
+				[
 					'.amp-viewer{color:blue}',
 					'.amp-referrer-www-google-com{color:red}',
 					'.amp-active{color:green}',
@@ -511,10 +511,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.amp-geo-group-foo{color:peru}',
 					'.amp-iso-country-us{color:oldlace}',
 					'', // Because no non-existent.
-				),
-				array(),
-			),
-		);
+				],
+				[],
+			],
+		];
 	}
 
 	/**
@@ -525,7 +525,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param array  $expected_stylesheets Expected stylesheets.
 	 * @param array  $expected_errors      Expected error codes.
 	 */
-	public function test_link_and_style_elements( $source, $expected_stylesheets, $expected_errors = array() ) {
+	public function test_link_and_style_elements( $source, $expected_stylesheets, $expected_errors = [] ) {
 		add_filter(
 			'locale',
 			static function() {
@@ -535,15 +535,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			static function( $preempt, $request, $url ) {
-				$preempt = array(
-					'response' => array(
+				$preempt = [
+					'response' => [
 						'code' => 200,
-					),
-					'headers'  => array(
+					],
+					'headers'  => [
 						'content-type' => 'text/css',
-					),
+					],
 					'body'     => sprintf( 'span:before { content: "Returned from: %s"; }', $url ),
-				);
+				];
 				return $preempt;
 			},
 			10,
@@ -551,13 +551,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		);
 		$dom = AMP_DOM_Utils::get_dom( $source );
 
-		$error_codes = array();
-		$args        = array(
+		$error_codes = [];
+		$args        = [
 			'use_document_element'      => true,
 			'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 				$error_codes[] = $error['code'];
 			},
-		);
+		];
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
@@ -592,83 +592,83 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_amp_selector_data() {
-		return array(
-			'img' => array(
+		return [
+			'img' => [
 				sprintf( '<div><img class="logo" src="%s" width="200" height="100"></div>', admin_url( 'images/wordpress-logo.png' ) ),
 				'div img.logo{border:solid 1px red}',
 				'div amp-img.logo{border:solid 1px red}', // Note amp-anim is still tree-shaken because it doesn't occur in the DOM.
-			),
-			'img-missing-class' => array(
+			],
+			'img-missing-class' => [
 				sprintf( '<div><img class="logo" src="%s" width="200" height="100"></div>', admin_url( 'images/wordpress-logo.png' ) ),
 				'div img.missing{border:solid 1px red}',
 				'', // Tree-shaken because missing class doesn't occur in the DOM.
-			),
-			'img-and-anim' => array(
+			],
+			'img-and-anim' => [
 				sprintf( '<div><img class="logo" src="%s" width="200" height="100"><img class="spinner" src="%s" width="200" height="100"></div>', admin_url( 'images/wordpress-logo.png' ), admin_url( 'images/spinner-2x.gif' ) ),
 				'div img{border:solid 1px red}',
 				'div amp-img,div amp-anim{border:solid 1px red}',
-			),
-			'img_with_amp_img' => array(
+			],
+			'img_with_amp_img' => [
 				'<amp-img></amp-img>',
 				'amp-img img{background-color:red}',
 				'amp-img img{background-color:red}',
-			),
-			'img-cover' => array(
+			],
+			'img-cover' => [
 				sprintf( '<div><amp-img class="logo" src="%s" width="200" height="100"></amp-img></div>', admin_url( 'images/wordpress-logo.png' ) ),
 				'div amp-img.logo img{object-fit:cover}',
 				'div amp-img.logo img{object-fit:cover}',
-			),
-			'img-tree-shaking' => array(
+			],
+			'img-tree-shaking' => [
 				sprintf( '<article><img class="logo" src="%s" width="200" height="100"></article>', admin_url( 'images/wordpress-logo.png' ) ),
 				'div img.logo{border:solid 1px red}',
 				'', // The selector is removed because there is no div element.
-			),
-			'attribute_selectors' => array(
+			],
+			'attribute_selectors' => [
 				'<div id="content" tabindex="-1"></div><button type=button>Hello</button><a href="#">Top</a><span></span>',
 				'[type="button"], [type="reset"], [type^="submit"] {color:red} a[href^=http]:after, a[href^="#"]:after { color:blue } span[hidden] {display:none}#content[tabindex="-1"]:focus{ outline: solid 1px red; }',
 				'[type="button"],[type="reset"],[type^="submit"]{color:red}a[href^=http]:after,a[href^="#"]:after{color:blue}span[hidden]{display:none}#content[tabindex="-1"]:focus{outline:solid 1px red}', // Any selector mentioning [type] or [href] will persist since value is not used for tree shaking.
-			),
-			'playbuzz' => array(
+			],
+			'playbuzz' => [
 				'<p>hello</p><div class="pb_feed" data-item="226dd4c0-ef13-4fee-850b-7be32bf6d121"></div>',
 				'p + div.pb_feed{border:solid 1px blue}',
 				'p + amp-playbuzz.pb_feed{border:solid 1px blue}',
-			),
-			'video' => array(
+			],
+			'video' => [
 				'<article><video src="http://example.com" height="100" width="200"></video></article>',
 				'article>video{border:solid 1px green}',
 				'article>amp-video{border:solid 1px green}',
-			),
-			'form' => array(
+			],
+			'form' => [
 				sprintf( '<div id="search"><form method="get" action="https://example.com"><label id="s">Search</label><input type="search" name="s" id="s"></form></div>' ),
 				'#search form label{display:block}',
 				'#search form label{display:block}',
-			),
-			'video_with_amp_video' => array(
+			],
+			'video_with_amp_video' => [
 				'<amp-video class="video"></amp-video>',
 				'amp-video.video video{border:solid 1px green}',
 				'amp-video.video video{border:solid 1px green}',
-			),
-			'iframe' => array(
+			],
+			'iframe' => [
 				'<p><b>purple</b><iframe src="http://example.com" height="100" width="200"></iframe></p>',
 				'p>*:not(iframe){color:purple}',
 				'p>*:not(amp-iframe){color:purple}',
-			),
-			'audio' => array(
+			],
+			'audio' => [
 				'<audio src="http://example.com/foo.mp3" height="100" width="200"></audio>',
 				'audio{border:solid 1px yellow}',
 				'amp-audio{border:solid 1px yellow}',
-			),
-			'keyframes' => array(
+			],
+			'keyframes' => [
 				'<div>test</div>',
 				'span {color:red;} @keyframes foo { from: { opacity:0; } 50% {opacity:0.5} 75%,80% { opacity:0.6 } to { opacity:1 }  }',
 				'@keyframes foo{from:{opacity:0}50%{opacity:.5}75%,80%{opacity:.6}to{opacity:1}}',
-			),
-			'type_class_names' => array(
+			],
+			'type_class_names' => [
 				'<audio src="https://example.org/foo.mp3" width="100" height="100" class="audio iframe video img form">',
 				'.video{color:blue;} audio.audio{color:purple;} .iframe{color:black;} .img{color:purple;} .form:not(form){color:green;}',
 				'.video{color:blue}amp-audio.audio{color:purple}.iframe{color:black}.img{color:purple}.form:not(form){color:green}',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -687,9 +687,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitized         = AMP_Content_Sanitizer::sanitize_document(
 			$dom,
 			$sanitizer_classes,
-			array(
+			[
 				'use_document_element' => true,
-			)
+			]
 		);
 
 		$stylesheets = array_values( $sanitized['stylesheets'] );
@@ -702,47 +702,47 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_attribute_selector_data() {
-		return array(
-			'type_attribute' => array(
+		return [
+			'type_attribute' => [
 				'<input type="color">',
 				// All selectors remain because only the existence of the attribute is examined.
-				array(
+				[
 					'[type="button"]' => true,
 					'[type*="reset"]' => true,
 					'[type^="submit"]' => true,
 					'[type$="button"]' => true,
-				),
-			),
-			'tabindex_attribute' => array(
+				],
+			],
+			'tabindex_attribute' => [
 				'<span tabindex="-1"></span>',
 				// The div[tabindex] is removed because there is no div. The span[tabindex^=2] remains because value is not considered.
-				array(
+				[
 					'div[tabindex]' => false,
 					'span[tabindex]' => true,
 					'span[tabindex=-1]' => true,
 					'span[tabindex^=2]' => true,
-				),
-			),
-			'href_attribute' => array(
+				],
+			],
+			'href_attribute' => [
 				'<a href="foo">Foo</a>',
-				array(
+				[
 					'a[href^=http]:after' => true,
 					'a[href^="#"]:after' => true,
-				),
-			),
-			'hidden_attribute' => array(
+				],
+			],
+			'hidden_attribute' => [
 				'<span>not hidden</span>',
 				// Only div[hidden] should be removed because there is no div element; the other [hidden] selectors remain because it can be dynamically added.
-				array(
+				[
 					'span[hidden]' => true,
 					'[hidden]' => true,
 					'div[hidden]' => false,
 					'span:not([hidden])' => true,
-				),
-			),
-			'selected_readonly_disabled_multiple_autofocus_required' => array(
+				],
+			],
+			'selected_readonly_disabled_multiple_autofocus_required' => [
 				'<input><select><option></option></select>',
-				array(
+				[
 					'[autofocus]' => true,
 					'[checked]'   => true,
 					'[disabled]'  => true,
@@ -750,26 +750,26 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'[readonly]'  => true,
 					'[required]'  => true,
 					'[selected]'  => true,
-				),
-			),
-			'open_attribute' => array(
+				],
+			],
+			'open_attribute' => [
 				'<details><summary>More</summary>Details</details>',
-				array(
+				[
 					'[open]'             => true,
 					'amp-lightbox[open]' => false,
 					'details[open]'      => true,
-				),
-			),
-			'media_attributes' => array(
+				],
+			],
+			'media_attributes' => [
 				'<amp-video width="720" height="305" layout="responsive" src="https://yourhost.com/videos/myvideo.mp4" poster="https://yourhost.com/posters/poster.png" artwork="https://yourhost.com/artworks/artwork.png" title="Awesome video" artist="Awesome artist" album="Amazing album"></amp-video>',
-				array(
+				[
 					'[loop]'     => true,
 					'[controls]' => true,
-				),
-			),
-			'escaped_char_class_name' => array(
+				],
+			],
+			'escaped_char_class_name' => [
 				'<div class="bg-black w-16 lg:w-full hover:bg-blue @@@"></div>',
-				array(
+				[
 					'.lg'               => false,
 					'.hover'            => false,
 					'.hover\:bg-blue'   => true,
@@ -778,12 +778,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.lg\:w-medium'     => false,
 					'.\@\@\@'           => true,
 					'.\@\@\@\@'         => false,
-				),
-			),
-			'toggle_class' => array(
+				],
+			],
+			'toggle_class' => [
 				implode(
 					'',
-					array(
+					[
 						'<div id=\"foo\"></div>',
 						'<button on="tap:foo . toggleClass ( class = \'expanded\' )">Yes</button>',
 						'<button on="tap:foo.toggleClass(class=\'clicked\')">Yes</button>',
@@ -791,9 +791,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'<button on="tap:foo.toggleClass(class=pressed);tap:foo.toggleClass(class = im-pressed)">Yes</button>',
 						'<button on="tap:foo.toggleClass(class = \'touch:ed\' )">Yes</button>',
 						'<button on="tap:AMP.setState({toggleClass:\'stateful\'})">No</button>',
-					)
+					]
 				),
-				array(
+				[
 					'.expanded'   => true,
 					'.clicked'    => true,
 					'.tapped'     => true,
@@ -802,9 +802,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.touch\:ed'  => true,
 					'.exploded'   => false,
 					'.stateful'   => false,
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -834,9 +834,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$sanitized = AMP_Content_Sanitizer::sanitize_document(
 			$dom,
 			$sanitizer_classes,
-			array(
+			[
 				'use_document_element' => true,
-			)
+			]
 		);
 
 		$stylesheets = array_values( $sanitized['stylesheets'] );
@@ -852,164 +852,164 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_amp_css_hacks_data() {
-		return array(
-			array(
+		return [
+			[
 				'.selector { !property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { $property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { &property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { *property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { )property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { =property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { %property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { +property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { @property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { ,property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { .property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { /property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { `property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { ]property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { #property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { ~property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { ?property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { :property: value; }',
-			),
-			array(
+			],
+			[
 				'.selector { |property: value; }',
-			),
-			array(
+			],
+			[
 				'_::selection, .selector:not([attr*=\'\']) {}',
-			),
-			array(
+			],
+			[
 				':root .selector {}',
-			),
-			array(
+			],
+			[
 				'body:last-child .selector {}',
-			),
-			array(
+			],
+			[
 				'body:nth-of-type(1) .selector {}',
-			),
-			array(
+			],
+			[
 				'body:first-of-type .selector {}',
-			),
-			array(
+			],
+			[
 				'.selector:not([attr*=\'\']) {}',
-			),
-			array(
+			],
+			[
 				'.selector:not(*:root) {}',
-			),
-			array(
+			],
+			[
 				'.selector:not(*:root) {}',
-			),
-			array(
+			],
+			[
 				'body:empty .selector {}',
-			),
-			array(
+			],
+			[
 				'body:last-child .selector, x:-moz-any-link {}',
-			),
-			array(
+			],
+			[
 				'body:last-child .selector, x:-moz-any-link, x:default {}',
-			),
-			array(
+			],
+			[
 				'body:not(:-moz-handler-blocked) .selector {}',
-			),
-			array(
+			],
+			[
 				'_::-moz-progress-bar, body:last-child .selector {}',
-			),
-			array(
+			],
+			[
 				'_::-moz-range-track, body:last-child .selector {}',
-			),
-			array(
+			],
+			[
 				'_:-moz-tree-row(hover), .selector {}',
-			),
-			array(
+			],
+			[
 				'_::selection, .selector:not([attr*=\'\']) {}',
-			),
-			array(
+			],
+			[
 				'* html .selector  {}',
-			),
-			array(
+			],
+			[
 				'.unused-class.selector {}',
-			),
-			array(
+			],
+			[
 				'html > body .selector {}',
-			),
-			array(
+			],
+			[
 				'.selector, {}',
-			),
-			array(
+			],
+			[
 				'*:first-child+html .selector {}',
-			),
-			array(
+			],
+			[
 				'.selector, x:-IE7 {}',
-			),
-			array(
+			],
+			[
 				'*+html .selector {}',
-			),
-			array(
+			],
+			[
 				'body*.selector {}',
-			),
-			array(
+			],
+			[
 				'.selector\ {}',
-			),
-			array(
+			],
+			[
 				'html > /**/ body .selector {}',
-			),
-			array(
+			],
+			[
 				'head ~ /**/ body .selector {}',
-			),
-			array(
+			],
+			[
 				'_::selection, .selector:not([attr*=\'\']) {}',
-			),
-			array(
+			],
+			[
 				':root .selector {}',
-			),
-			array(
+			],
+			[
 				'body:last-child .selector {}',
-			),
-			array(
+			],
+			[
 				'body:nth-of-type(1) .selector {}',
-			),
-			array(
+			],
+			[
 				'body:first-of-type .selector {}',
-			),
-			array(
+			],
+			[
 				'.selector:not([attr*=\'\']) {}',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1022,15 +1022,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$html = "<html amp><head><meta charset=utf-8><style amp-custom>$input</style></head><body></body></html>";
 		$dom  = AMP_DOM_Utils::get_dom( $html );
 
-		$error_codes = array();
+		$error_codes = [];
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
@@ -1051,18 +1051,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		// Test with tree-shaking.
 		$dom         = AMP_DOM_Utils::get_dom( $html );
-		$error_codes = array();
+		$error_codes = [];
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
-		$this->assertEquals( array(), $error_codes );
+		$this->assertEquals( [], $error_codes );
 		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
 		$this->assertCount( 1, $actual_stylesheets );
 		$this->assertContains( 'dashicons.woff") format("woff")', $actual_stylesheets[0] );
@@ -1092,15 +1092,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$html .= '</head><body></body></html>';
 
 		$dom         = AMP_DOM_Utils::get_dom( $html );
-		$error_codes = array();
+		$error_codes = [];
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
-		$this->assertEquals( array(), $error_codes );
+		$this->assertEquals( [], $error_codes );
 		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
 		$this->assertCount( 1, $actual_stylesheets );
 
@@ -1146,18 +1146,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		<?php
 		$dom = AMP_DOM_Utils::get_dom( ob_get_clean() );
 
-		$error_codes = array();
+		$error_codes = [];
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
-		$this->assertEquals( array(), $error_codes );
+		$this->assertEquals( [], $error_codes );
 		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
 		$this->assertEquals( '.sidebar1{display:none}', $actual_stylesheets[0] );
 		$this->assertEquals( '.sidebar1.expanded{display:block}', $actual_stylesheets[1] );
@@ -1214,32 +1214,32 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$html .= '</head><body><span class="b" data-value="">...</span><span id="exists"></span></body></html>';
 		$dom   = AMP_DOM_Utils::get_dom( $html );
 
-		$error_codes = array();
+		$error_codes = [];
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
 
 		$this->assertEquals(
-			array(
+			[
 				'.b{color:blue}',
 				'#exists{color:white}',
 				'span{color:white}',
 				'@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}',
 				'.b{background:lightblue}',
 				'@media screen and (max-width: 1000px){@supports (display: grid){.b::before{content:"@media screen and (max-width: 1000px) {"}.b::after{content:"}"}}}@media print{@media print{@media print{.b{color:blue}}}}@media screen and (min-width: 750px) and (max-width: 999px){.b::before{content:"@media screen and (max-width: 1000px) {}";content:"@media screen and (max-width: 1000px) {}"}}',
-			),
+			],
 			array_values( $sanitizer->get_stylesheets() )
 		);
 
 		$this->assertEquals(
-			array( 'excessive_css' ),
+			[ 'excessive_css' ],
 			$error_codes
 		);
 	}
@@ -1284,17 +1284,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			<?php
 			$html = ob_get_clean();
 
-			$error_codes = array();
+			$error_codes = [];
 			$dom         = AMP_DOM_Utils::get_dom( $html );
 			$sanitizer   = new AMP_Style_Sanitizer(
 				$dom,
 				array_merge(
-					array(
+					[
 						'use_document_element'      => true,
 						'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 							$error_codes[] = $error['code'];
 						},
-					),
+					],
 					$sanitizer_args
 				)
 			);
@@ -1302,14 +1302,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$xpath = new DOMXPath( $dom );
 			$style = $xpath->query( '//style[ @amp-custom ]' )->item( 0 );
 
-			return array( $style, $error_codes );
+			return [ $style, $error_codes ];
 		};
 
 		// Test that it contains the comment with duplicate styles removed without tree shaking.
 		list( $style, $error_codes ) = $get_sanitized_dom(
-			array(
+			[
 				'include_manifest_comment' => 'never',
-			),
+			],
 			false
 		);
 		$this->assertEmpty( $error_codes );
@@ -1317,9 +1317,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		// Test that it contains the comment with duplicate styles removed without tree shaking.
 		list( $style, $error_codes ) = $get_sanitized_dom(
-			array(
+			[
 				'include_manifest_comment' => 'never',
-			),
+			],
 			false
 		);
 		$this->assertEmpty( $error_codes );
@@ -1327,9 +1327,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		// Test that it contains the comment with duplicate styles removed with tree shaking.
 		list( $style, $error_codes ) = $get_sanitized_dom(
-			array(
+			[
 				'include_manifest_comment' => 'always',
-			),
+			],
 			false
 		);
 		$this->assertEmpty( $error_codes );
@@ -1346,12 +1346,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		// Test that it contains the comment with duplicate styles removed with excessive CSS.
 		list( $style, $error_codes ) = $get_sanitized_dom(
-			array(
+			[
 				'include_manifest_comment' => 'when_excessive',
-			),
+			],
 			true
 		);
-		$this->assertEquals( array( 'excessive_css' ), $error_codes );
+		$this->assertEquals( [ 'excessive_css' ], $error_codes );
 		$this->assertInstanceOf( 'DOMComment', $style->previousSibling, 'Expected manifest comment to be present because excessive.' );
 		$comment = $style->previousSibling;
 		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
@@ -1378,9 +1378,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$sanitizer = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
@@ -1396,32 +1396,32 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * Return stylesheets that are to be fetched over HTTP.
 	 */
 	public function get_http_stylesheets() {
-		return array(
-			'external_file' => array(
+		return [
+			'external_file' => [
 				'https://stylesheets.example.com/style.css',
 				'text/css',
 				'html{background-color:lightblue}',
-				array(),
-			),
-			'dynamic_file' => array(
+				[],
+			],
+			'dynamic_file' => [
 				set_url_scheme( add_query_arg( 'action', 'kirki-styles', home_url() ), 'http' ),
 				'text/css',
 				'body{color:red}',
-				array(),
-			),
-			'local_css_file_outside_normal_dirs' => array(
+				[],
+			],
+			'local_css_file_outside_normal_dirs' => [
 				home_url( '/style.css' ),
 				'text/css',
 				'body{color:green}',
-				array(),
-			),
-			'not_css_file' => array(
+				[],
+			],
+			'not_css_file' => [
 				home_url( '/this.is.not.css' ),
 				'image/jpeg',
 				'JPEG...',
-				array( 'no_css_content_type' ),
-			),
-		);
+				[ 'no_css_content_type' ],
+			],
+		];
 	}
 
 	/**
@@ -1442,15 +1442,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			static function( $preempt, $request, $url ) use ( $href, &$request_count, $content_type, $response_body ) {
 				if ( set_url_scheme( $url, 'https' ) === set_url_scheme( $href, 'https' ) ) {
 					$request_count++;
-					$preempt = array(
-						'response' => array(
+					$preempt = [
+						'response' => [
 							'code'    => 200,
-						),
-						'headers' => array(
+						],
+						'headers' => [
 							'content-type' => $content_type,
-						),
+						],
 						'body' => $response_body,
-					);
+					];
 				}
 				return $preempt;
 			},
@@ -1462,20 +1462,20 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			$html = sprintf( '<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="%s"></head><body></body></html>', esc_url( $href ) ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 			$dom  = AMP_DOM_Utils::get_dom( $html );
 
-			$found_error_codes = array();
+			$found_error_codes = [];
 
 			$sanitizer = new AMP_Style_Sanitizer(
 				$dom,
-				array(
+				[
 					'use_document_element'      => true,
 					'validation_error_callback' => static function( $error ) use ( &$found_error_codes ) {
 						$found_error_codes[] = $error['code'];
 					},
-				)
+				]
 			);
 			$sanitizer->sanitize();
 			AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
-			return array( $found_error_codes, array_values( $sanitizer->get_stylesheets() ) );
+			return [ $found_error_codes, array_values( $sanitizer->get_stylesheets() ) ];
 		};
 
 		$this->assertEquals( 0, $request_count );
@@ -1510,37 +1510,37 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		}
 		$this->assertNotNull( $keyframes_max_size );
 
-		return array(
-			'style_amp_keyframes'              => array(
+		return [
+			'style_amp_keyframes'              => [
 				'<style amp-keyframes>@keyframes anim1 { from { opacity:0.0 } to { opacity:0.5 } } @media (min-width: 600px) {@keyframes anim1 { from { opacity:0.5 } to { opacity:1.0 } } }</style>',
 				'<style amp-keyframes="">@keyframes anim1{from{opacity:0}to{opacity:.5}}@media (min-width: 600px){@keyframes anim1{from{opacity:.5}to{opacity:1}}}</style>',
-				array(),
-			),
+				[],
+			],
 
-			'style_amp_keyframes_max_overflow' => array(
+			'style_amp_keyframes_max_overflow' => [
 				'<style amp-keyframes>@keyframes anim1 {} @media (min-width: 600px) {@keyframes ' . str_repeat( 'a', $keyframes_max_size + 1 ) . ' {} }</style>',
 				'',
-				array( 'excessive_css' ),
-			),
+				[ 'excessive_css' ],
+			],
 
-			'style_amp_keyframes_last_child'   => array(
+			'style_amp_keyframes_last_child'   => [
 				'<b>before</b> <style amp-keyframes>@keyframes anim1 { from { opacity:1; } to { opacity:0.5; } }</style> between <style amp-keyframes>@keyframes anim2 { from { opacity:0.25; } to { opacity:0.75; } }</style> as <b>after</b>',
 				'<b>before</b>  between  as <b>after</b><style amp-keyframes="">@keyframes anim1{from{opacity:1}to{opacity:.5}}@keyframes anim2{from{opacity:.25}to{opacity:.75}}</style>',
-				array(),
-			),
+				[],
+			],
 
-			'blacklisted_and_whitelisted_keyframe_properties' => array(
+			'blacklisted_and_whitelisted_keyframe_properties' => [
 				'<style amp-keyframes>@keyframes anim1 { 50% { width: 50%; animation-timing-function: ease; opacity: 0.5; height:10%; offset-distance: 50%; visibility: visible; transform: rotate(0.5turn); -webkit-transform: rotate(0.5turn); color:red; } }</style>',
 				'<style amp-keyframes="">@keyframes anim1{50%{animation-timing-function:ease;opacity:.5;offset-distance:50%;visibility:visible;transform:rotate(.5 turn);-webkit-transform:rotate(.5 turn)}}</style>',
-				array( 'illegal_css_property', 'illegal_css_property', 'illegal_css_property' ),
-			),
+				[ 'illegal_css_property', 'illegal_css_property', 'illegal_css_property' ],
+			],
 
-			'style_amp_keyframes_with_disallowed_rules' => array(
+			'style_amp_keyframes_with_disallowed_rules' => [
 				'<style amp-keyframes>body { color:red; opacity:1; } @keyframes anim1 { 50% { opacity:0.5 !important; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); }</style>',
 				'<style amp-keyframes="">@keyframes anim1{50%{opacity:.5}}</style>',
-				array( 'unrecognized_css', 'illegal_css_important', 'illegal_css_at_rule' ),
-			),
-		);
+				[ 'unrecognized_css', 'illegal_css_important', 'illegal_css_at_rule' ],
+			],
+		];
 	}
 
 	/**
@@ -1551,19 +1551,19 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param string $expected The markup to expect.
 	 * @param array  $expected_errors      Expected error codes.
 	 */
-	public function test_keyframe_sanitizer( $source, $expected = null, $expected_errors = array() ) {
+	public function test_keyframe_sanitizer( $source, $expected = null, $expected_errors = [] ) {
 		$expected    = isset( $expected ) ? $expected : $source;
 		$expected    = preg_replace( '#(?=</style>)#', "\n\n/*# sourceURL=amp-keyframes.css */", $expected );
 		$dom         = AMP_DOM_Utils::get_dom_from_content( $source );
-		$error_codes = array();
+		$error_codes = [];
 		$sanitizer   = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element' => true,
 				'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 					$error_codes[] = $error['code'];
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
@@ -1589,93 +1589,93 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$theme = new WP_Theme( 'twentyseventeen', ABSPATH . 'wp-content/themes' );
 
-		return array(
-			'url_without_path' => array(
+		return [
+			'url_without_path' => [
 				'https://example.com',
 				null,
 				'no_url_path',
-			),
-			'url_not_string' => array(
+			],
+			'url_not_string' => [
 				false,
 				null,
 				'url_not_string',
-			),
-			'theme_stylesheet_without_host' => array(
+			],
+			'theme_stylesheet_without_host' => [
 				'/wp-content/themes/twentyseventeen/style.css',
 				$theme->get_stylesheet_directory() . '/style.css',
-			),
-			'theme_stylesheet_with_host' => array(
+			],
+			'theme_stylesheet_with_host' => [
 				$theme->get_stylesheet_directory_uri() . '/style.css',
 				$theme->get_stylesheet_directory() . '/style.css',
-			),
-			'theme_stylesheet_with_relative_paths' => array(
+			],
+			'theme_stylesheet_with_relative_paths' => [
 				$theme->get_stylesheet_directory_uri() . '/foo/./bar/baz/../../../style.css',
 				$theme->get_stylesheet_directory() . '/style.css',
-			),
-			'theme_stylesheet_with_trailing_dot' => array(
+			],
+			'theme_stylesheet_with_trailing_dot' => [
 				$theme->get_stylesheet_directory_uri() . '/foo./bar.css',
 				null,
 				'file_path_not_found',
-			),
-			'dashicons_without_host' => array(
+			],
+			'dashicons_without_host' => [
 				'/wp-includes/css/dashicons.css',
 				ABSPATH . WPINC . '/css/dashicons.css',
-			),
-			'dashicons_with_host' => array(
+			],
+			'dashicons_with_host' => [
 				includes_url( 'css/dashicons.css' ),
 				ABSPATH . WPINC . '/css/dashicons.css',
-			),
-			'admin_without_host' => array(
+			],
+			'admin_without_host' => [
 				'/wp-admin/css/common.css',
 				ABSPATH . 'wp-admin/css/common.css',
-			),
-			'admin_with_host' => array(
+			],
+			'admin_with_host' => [
 				admin_url( 'css/common.css' ),
 				ABSPATH . 'wp-admin/css/common.css',
-			),
-			'admin_with_host_https' => array(
+			],
+			'admin_with_host_https' => [
 				set_url_scheme( admin_url( 'css/common.css' ), 'https' ),
 				ABSPATH . 'wp-admin/css/common.css',
-			),
-			'admin_with_host_http' => array(
+			],
+			'admin_with_host_http' => [
 				set_url_scheme( admin_url( 'css/common.css' ), 'http' ),
 				ABSPATH . 'wp-admin/css/common.css',
-			),
-			'admin_with_no_host_scheme' => array(
+			],
+			'admin_with_no_host_scheme' => [
 				preg_replace( '#^\w+:(?=//)#', '', admin_url( 'css/common.css' ) ),
 				ABSPATH . 'wp-admin/css/common.css',
-			),
-			'amp_disallowed_file_extension' => array(
+			],
+			'amp_disallowed_file_extension' => [
 				content_url( 'themes/twentyseventeen/index.php' ),
 				null,
 				'disallowed_file_extension',
-			),
-			'amp_file_path_not_found' => array(
+			],
+			'amp_file_path_not_found' => [
 				content_url( 'themes/twentyseventeen/404.css' ),
 				null,
 				'file_path_not_found',
-			),
-			'amp_file_path_illegal_linux' => array(
+			],
+			'amp_file_path_illegal_linux' => [
 				content_url( '../../../../../../../../../../../../../../../bad.css' ),
 				null,
 				'remaining_relativity',
-			),
-			'amp_file_path_illegal_windows' => array(
+			],
+			'amp_file_path_illegal_windows' => [
 				content_url( '..\..\..\..\..\..\..\..\..\..\..\..\..\..\..\bad.css' ),
 				null,
 				'file_path_not_allowed',
-			),
-			'amp_file_path_illegal_location' => array(
+			],
+			'amp_file_path_illegal_location' => [
 				site_url( 'outside/root.css' ),
 				null,
 				'file_path_not_allowed',
-			),
-			'amp_external_file' => array(
+			],
+			'amp_external_file' => [
 				'//s.w.org/wp-includes/css/dashicons.css',
 				false,
 				'external_file_url',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1692,7 +1692,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$dom = AMP_DOM_Utils::get_dom( '<html></html>' );
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom );
-		$actual    = $sanitizer->get_validated_url_file_path( $source, array( 'css' ) );
+		$actual    = $sanitizer->get_validated_url_file_path( $source, [ 'css' ] );
 		if ( isset( $error_code ) ) {
 			$this->assertInstanceOf( 'WP_Error', $actual );
 			$this->assertEquals( $error_code, $actual->get_error_code() );
@@ -1708,16 +1708,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @returns array data: URL data.
 	 */
 	public function get_data_urls() {
-		return array(
-			'url_with_spaces'      => array(
+		return [
+			'url_with_spaces'      => [
 				'html { background-image:url(url with spaces.png); }',
 				'html{background-image:url("urlwithspaces.png")}',
-			),
-			'data_url_with_spaces' => array(
+			],
+			'data_url_with_spaces' => [
 				'html { background: url(data:image/png; base64, ivborw0kggoaaaansuheugaaacwaaaascamaaaapwqozaaaabgdbtueaalgpc/xhbqaaaafzukdcak7ohokaaaamuexurczmzpf399fx1+bm5mzy9amaaadisurbvdjlvzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8ueowds88ly97kqytlijkktuybbruayvh5wohixmpi5we58ek028czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif/gwufyy8owepdyzsa3avcqpvovvzzz2vtnn2wu8qzvjddeto90gsy9mvlqtgysy231mxry6i2ggqjrty0l8fxcxfcbbhwrsyyaaaaaelftksuqmcc); }',
 				'html{background:url("data:image/png;base64,ivborw0kggoaaaansuheugaaacwaaaascamaaaapwqozaaaabgdbtueaalgpc/xhbqaaaafzukdcak7ohokaaaamuexurczmzpf399fx1+bm5mzy9amaaadisurbvdjlvzxbesmgces5/p8/t9furvcrmu73jwlzosgsiizurcjo/ad+eqjjb4hv8bft+idpqocx1wjosbfhh2xssxeiyn3uli/6mnree07uiwjev8ueowds88ly97kqytlijkktuybbruayvh5wohixmpi5we58ek028czwyuqdlkpg1bkb4nnm+veanfhqn1k4+gpt6ugqcvu2h2ovuif/gwufyy8owepdyzsa3avcqpvovvzzz2vtnn2wu8qzvjddeto90gsy9mvlqtgysy231mxry6i2ggqjrty0l8fxcxfcbbhwrsyyaaaaaelftksuqmcc")}',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1750,32 +1750,32 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_font_urls() {
-		return array(
-			'tangerine'   => array(
+		return [
+			'tangerine'   => [
 				'https://fonts.googleapis.com/css?family=Tangerine',
-				array(),
-			),
-			'tangerine2'  => array(
+				[],
+			],
+			'tangerine2'  => [
 				'//fonts.googleapis.com/css?family=Tangerine',
-				array(),
-			),
-			'tangerine3'  => array(
+				[],
+			],
+			'tangerine3'  => [
 				'http://fonts.googleapis.com/css?family=Tangerine',
-				array(),
-			),
-			'typekit'     => array(
+				[],
+			],
+			'typekit'     => [
 				'https://use.typekit.net/abc.css',
-				array(),
-			),
-			'fontscom'    => array(
+				[],
+			],
+			'fontscom'    => [
 				'https://fast.fonts.net/abc.css',
-				array(),
-			),
-			'fontawesome' => array(
+				[],
+			],
+			'fontawesome' => [
 				'https://maxcdn.bootstrapcdn.com/font-awesome/123/css/font-awesome.min.css',
-				array(),
-			),
-		);
+				[],
+			],
+		];
 	}
 
 	/**
@@ -1792,16 +1792,16 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$dom = AMP_DOM_Utils::get_dom( sprintf( '<html><head>%s</head></html>', $tag ) );
 
-		$validation_errors = array();
+		$validation_errors = [];
 
 		$sanitizer = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$validation_errors ) {
 					$validation_errors[] = $error;
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
 
@@ -1832,7 +1832,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$url       = 'https://fonts.googleapis.com/css?family=Tangerine';
 		$link      = amp_filter_font_style_loader_tag_with_crossorigin_anonymous( "<link rel='stylesheet' href='$url'>", 'font', $url ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$document  = AMP_DOM_Utils::get_dom( "<html><head>$link</head></html>" );
-		$sanitizer = new AMP_Style_Sanitizer( $document, array( 'use_document_element' => true ) );
+		$sanitizer = new AMP_Style_Sanitizer( $document, [ 'use_document_element' => true ] );
 		$sanitizer->sanitize();
 		$link = $document->getElementsByTagName( 'link' )->item( 0 );
 		$this->assertInstanceOf( 'DOMElement', $link );
@@ -1841,7 +1841,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		// Test that existing crossorigin attribute is not overridden.
 		$link      = amp_filter_font_style_loader_tag_with_crossorigin_anonymous( "<link crossorigin='use-credentials' rel='stylesheet' href='$url'>", 'font', $url ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$document  = AMP_DOM_Utils::get_dom( "<html><head>$link</head></html>" ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$sanitizer = new AMP_Style_Sanitizer( $document, array( 'use_document_element' => true ) );
+		$sanitizer = new AMP_Style_Sanitizer( $document, [ 'use_document_element' => true ] );
 		$sanitizer->sanitize();
 		$link = $document->getElementsByTagName( 'link' )->item( 0 );
 		$this->assertInstanceOf( 'DOMElement', $link );
@@ -1854,35 +1854,35 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_import_test_data() {
-		return array(
-			'local_css_files' => array(
-				array(
+		return [
+			'local_css_files' => [
+				[
 					admin_url( 'css/colors/../login.css' ),
 					includes_url( 'css/buttons.css' ),
-				),
+				],
 				'<style>div::after{content:"After login"}</style><div><input type="checkbox"><button class="wp-core-ui button"></button></div>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				0, // Zero HTTP requests.
 				null, // No preempting of request, as no external requests.
 				static function ( WP_UnitTestCase $test, $stylesheet ) {
-					$expected_order = array(
+					$expected_order = [
 						preg_quote( 'input[type="checkbox"]:disabled', '/' ),
 						preg_quote( '.wp-core-ui .button', '/' ),
 						preg_quote( 'div::after{content:"After login"}', '/' ),
-					);
+					];
 					$test->assertRegExp(
 						'/.*' . implode( '.*', $expected_order ) . '/s',
 						$stylesheet
 					);
 				},
-			),
+			],
 
-			'local_css_with_import_failure_rejecting' => array(
-				array(
+			'local_css_with_import_failure_rejecting' => [
+				[
 					admin_url( 'css/local-does-not-exist.css' ),
 					'https://bogus.example.com/remote-does-not-exist.css',
 					admin_url( 'css/colors/../login.css' ),
 					'https://bogus.example.com/remote-also-does-not-exist.css',
-				),
+				],
 				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style><body class="locale-he-il"><div class="login message"></div><table class="form-table"><td></td></table></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				3, // Three HTTP requests (to bogus.example.com). The local-does-not-exist.css checks filesystem directly.
 				static function ( $requested_url ) {
@@ -1892,7 +1892,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					return null;
 				},
 				static function ( WP_UnitTestCase $test, $stylesheet ) {
-					$expected_order = array(
+					$expected_order = [
 						'local-does-not-exist.css',
 						'remote-does-not-exist.css',
 						'remote-also-does-not-exist.css',
@@ -1901,7 +1901,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'body.locale-he-il', // From imported l10n.css.
 						'.login .message', // From login.css.
 						'div::after{content:"End"}',
-					);
+					];
 
 					$previous = -1;
 					foreach ( $expected_order as $i => $expected ) {
@@ -1911,18 +1911,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						$previous = $position;
 					}
 				},
-				array(
+				[
 					'auto_reject' => true,
-				),
-			),
+				],
+			],
 
-			'local_css_with_import_failure_accepting' => array(
-				array(
+			'local_css_with_import_failure_accepting' => [
+				[
 					admin_url( 'css/local-does-not-exist.css' ),
 					'https://bogus.example.com/remote-does-not-exist.css',
 					admin_url( 'css/colors/../login.css' ),
 					'https://bogus.example.com/remote-also-does-not-exist.css',
-				),
+				],
 				'<style>div::after{content:"End"}</style><style>@import url("https://bogus.example.com/remote-finally-does-not-exist.css");</style><body class="locale-he-il"><div class="login message"></div><table class="form-table"><td></td></table></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				3, // Three HTTP requests (to bogus.example.com). The local-does-not-exist.css checks filesystem directly.
 				static function ( $requested_url ) {
@@ -1932,22 +1932,22 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					return null;
 				},
 				static function ( WP_UnitTestCase $test, $stylesheet ) {
-					$expected_absent = array(
+					$expected_absent = [
 						'local-does-not-exist.css',
 						'remote-does-not-exist.css',
 						'remote-also-does-not-exist.css',
 						'remote-finally-does-not-exist.css',
-					);
+					];
 					foreach ( $expected_absent as $expected ) {
 						$test->assertNotContains( $expected, $stylesheet, "Expected to not see $expected." );
 					}
 
-					$expected_order = array(
+					$expected_order = [
 						'.form-table td', // From imported forms.css.
 						'body.locale-he-il', // From imported l10n.css.
 						'.login .message', // From login.css.
 						'div::after{content:"End"}',
-					);
+					];
 
 					$previous = -1;
 					foreach ( $expected_order as $i => $expected ) {
@@ -1957,12 +1957,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						$previous = $position;
 					}
 				},
-				array(
+				[
 					'auto_reject' => false,
-				),
-			),
+				],
+			],
 
-			'dynamic_stylesheet_with_relative_import' => array(
+			'dynamic_stylesheet_with_relative_import' => [
 				includes_url( '/dynamic/import-buttons.php' ),
 				'<style>div::after{content:"After import-buttons"}</style><body class="wp-core-ui"><div><button class="button"></button></div></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				1,
@@ -1978,9 +1978,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						$stylesheet
 					);
 				},
-			),
+			],
 
-			'dynamic_stylesheet_with_absolute_import' => array(
+			'dynamic_stylesheet_with_absolute_import' => [
 				includes_url( '/dynamic/import-buttons.php' ),
 				'<style>div::after{content:"After import-buttons2"}</style><body class="wp-core-ui"><div><button class="button"></button></div></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				1,
@@ -1996,9 +1996,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						$stylesheet
 					);
 				},
-			),
+			],
 
-			'dynamic_stylesheet_with_nested_dynamic_stylesheet' => array(
+			'dynamic_stylesheet_with_nested_dynamic_stylesheet' => [
 				includes_url( '/dynamic/import-buttons.php' ),
 				'<style>div::after{content:"After import-buttons2"}</style><body><div></div></body>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 				2,
@@ -2017,8 +2017,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						$stylesheet
 					);
 				},
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -2034,7 +2034,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param callable     $assert                      Function that runs the assertions.
 	 * @param array        $options                     Additional options.
 	 */
-	public function test_css_import( $stylesheet_urls, $style_element, $expected_http_request_count, $mock_response, $assert, $options = array() ) {
+	public function test_css_import( $stylesheet_urls, $style_element, $expected_http_request_count, $mock_response, $assert, $options = [] ) {
 		$stylesheet_urls = (array) $stylesheet_urls;
 
 		$markup  = '<html><head>';
@@ -2059,14 +2059,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				if ( $mock_response ) {
 					$body = $mock_response( $url, $stylesheet_urls );
 					if ( null !== $body ) {
-						$preempt = array(
-							'response' => array(
+						$preempt = [
+							'response' => [
 								'code'    => is_wp_error( $body ) ? 404 : 200,
 								'message' => is_wp_error( $body ) ? 'Not Found' : 'OK',
-							),
-							'headers'  => array( 'content-type' => 'text/css' ),
+							],
+							'headers'  => [ 'content-type' => 'text/css' ],
 							'body'     => is_wp_error( $body ) ? '' : $body,
-						);
+						];
 					}
 				}
 				return $preempt;
@@ -2083,10 +2083,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$sanitizer = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => 'AMP_Validation_Manager::add_validation_error',
-			)
+			]
 		);
 		$sanitizer->sanitize();
 
@@ -2112,9 +2112,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom( $markup );
 		$sanitizer = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		$stylesheets = array_values( $sanitizer->get_stylesheets() );
@@ -2144,7 +2144,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		<html amp>
 			<head>
 				<meta charset="utf-8">
-				<?php wp_print_styles( array( 'dashicons' ) ); ?>
+				<?php wp_print_styles( [ 'dashicons' ] ); ?>
 				<style>span::after { content:"⚡️"; }</style>
 			</head>
 			<body>
@@ -2174,9 +2174,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom( $html );
 		$sanitizer = new AMP_Style_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element' => true,
-			)
+			]
 		);
 
 		$sanitizer->sanitize();
@@ -2202,7 +2202,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'DOMElement', $link );
 		$this->assertEquals( 'body', $link->parentNode->nodeName );
 
-		$sanitizer_args = array( 'use_document_element' => true );
+		$sanitizer_args = [ 'use_document_element' => true ];
 
 		$sanitizer = new AMP_Style_Sanitizer( $dom, $sanitizer_args );
 		$sanitizer->sanitize();
@@ -2243,8 +2243,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			return ob_get_clean();
 		};
 
-		return array(
-			'admin_bar_included' => array(
+		return [
+			'admin_bar_included' => [
 				function () use ( $render_template ) {
 					$this->go_to( home_url() );
 					show_admin_bar( true );
@@ -2261,7 +2261,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					add_action( 'wp_enqueue_scripts', 'twentyten_scripts_styles' );
 					AMP_Theme_Support::add_hooks();
 					wp_add_inline_style( 'admin-bar', '.admin-bar-inline-style{ color:red }' );
-					wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+					wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 					add_action(
 						'wp_footer',
@@ -2299,9 +2299,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$this->assertNotContains( 'admin-bar', $amphtml_dom->getElementsByTagName( 'body' )->item( 0 )->getAttribute( 'class' ) );
 					$this->assertEmpty( $amphtml_dom->getElementById( 'wpadminbar' ) );
 				},
-			),
+			],
 			// @todo Add other scenarios in the future.
-		);
+		];
 	}
 
 	/**
@@ -2337,13 +2337,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$original_dom = AMP_DOM_Utils::get_dom( $html );
 		$amphtml_dom  = clone $original_dom;
 
-		$error_codes = array();
-		$args        = array(
+		$error_codes = [];
+		$args        = [
 			'use_document_element'      => true,
 			'validation_error_callback' => static function( $error ) use ( &$error_codes ) {
 				$error_codes[] = $error['code'];
 			},
-		);
+		];
 
 		$sanitizer = new AMP_Img_Sanitizer( $amphtml_dom, $args );
 		$sanitizer->sanitize();

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -16,9 +16,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 	}
 
 	public function get_attr_spec_rule_data() {
-		return array(
-			'test_attr_spec_rule_mandatory_pass' => array(
-				array(
+		return [
+			'test_attr_spec_rule_mandatory_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-img',
 					'attribute_name' => 'src',
@@ -26,11 +26,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_mandatory',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_mandatory_alternate_attr_pass' => array(
-				array(
+			],
+			'test_attr_spec_rule_mandatory_alternate_attr_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-img',
 					'attribute_name' => 'src',
@@ -39,11 +39,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_mandatory',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_mandatory_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_mandatory_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-img',
 					'attribute_name' => 'src',
@@ -51,11 +51,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_mandatory',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_mandatory_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_mandatory_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-img',
 					'attribute_name' => 'alt',
@@ -63,12 +63,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_mandatory',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
+			],
 
-			'test_attr_spec_rule_value_pass' => array(
-				array(
+			'test_attr_spec_rule_value_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'template',
 					'attribute_name' => 'type',
@@ -76,11 +76,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_value_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'template',
 					'attribute_name' => 'type',
@@ -88,11 +88,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_value_not_applicable' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_not_applicable' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'template',
 					'attribute_name' => 'type',
@@ -100,12 +100,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_value',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
+			],
 
-			'test_attr_spec_rule_value_casei_lower_pass' => array(
-				array(
+			'test_attr_spec_rule_value_casei_lower_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'type',
@@ -113,11 +113,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_value_casei_upper_pass' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_casei_upper_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'type',
@@ -125,11 +125,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_value_casei_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_casei_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'type',
@@ -137,11 +137,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_value_casei_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_casei_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'template',
 					'attribute_name' => 'type',
@@ -149,12 +149,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
+			],
 
-			'test_attr_spec_rule_value_regex_pass' => array(
-				array(
+			'test_attr_spec_rule_value_regex_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'target',
@@ -162,11 +162,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_value_regex_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_regex_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'target',
@@ -174,11 +174,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_value_regex_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_regex_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'target',
@@ -186,12 +186,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_value_regex',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
+			],
 
-			'test_attr_spec_rule_value_regex_casei_lower_pass' => array(
-				array(
+			'test_attr_spec_rule_value_regex_casei_lower_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-playbuzz',
 					'attribute_name' => 'data-comments',
@@ -199,11 +199,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_value_regex_casei_upper_pass' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_regex_casei_upper_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-playbuzz',
 					'attribute_name' => 'data-comments',
@@ -211,11 +211,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_value_regex_casei_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_regex_casei_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-playbuzz',
 					'attribute_name' => 'data-comments',
@@ -223,11 +223,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_value_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_value_regex_casei_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_value_regex_casei_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-playbuzz',
 					'attribute_name' => 'data-comments',
@@ -235,11 +235,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_value_regex_casei',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'test_attr_spec_rule_disallowed_relative_pass' => array(
-				array(
+			],
+			'test_attr_spec_rule_disallowed_relative_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'data-share-endpoint',
@@ -247,11 +247,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_disallowed_relative',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_disallowed_relative_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_disallowed_relative_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'data-share-endpoint',
@@ -259,11 +259,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_disallowed_relative',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_disallowed_relative_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_disallowed_relative_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'data-share-endpoint',
@@ -271,12 +271,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_disallowed_relative',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
+			],
 
-			'test_attr_spec_rule_disallowed_empty_pass' => array(
-				array(
+			'test_attr_spec_rule_disallowed_empty_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-user-notification',
 					'attribute_name' => 'data-dismiss-href',
@@ -284,11 +284,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_disallowed_empty',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_disallowed_empty_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_disallowed_empty_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-user-notification',
 					'attribute_name' => 'data-dismiss-href',
@@ -296,11 +296,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_disallowed_empty',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_disallowed_empty_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_disallowed_empty_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-user-notification',
 					'attribute_name' => 'data-dismiss-href',
@@ -308,11 +308,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_disallowed_empty',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'test_attr_spec_rule_blacklisted_value_regex_pass' => array(
-				array(
+			],
+			'test_attr_spec_rule_blacklisted_value_regex_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'rel',
@@ -320,11 +320,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_blacklisted_value_regex',
-				),
+				],
 				'expected' => AMP_Rule_Spec::PASS,
-			),
-			'test_attr_spec_rule_blacklisted_value_regex_fail' => array(
-				array(
+			],
+			'test_attr_spec_rule_blacklisted_value_regex_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'rel',
@@ -332,11 +332,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_blacklisted_value_regex',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_blacklisted_value_regex_fail_2' => array(
-				array(
+			],
+			'test_attr_spec_rule_blacklisted_value_regex_fail_2' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'rel',
@@ -344,11 +344,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'check_attr_spec_rule_blacklisted_value_regex',
-				),
+				],
 				'expected' => AMP_Rule_Spec::FAIL,
-			),
-			'test_attr_spec_rule_blacklisted_value_regex_na' => array(
-				array(
+			],
+			'test_attr_spec_rule_blacklisted_value_regex_na' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'a',
 					'attribute_name' => 'rel',
@@ -356,10 +356,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => false,
 					'include_attr_value' => false,
 					'func_name' => 'check_attr_spec_rule_blacklisted_value_regex',
-				),
+				],
 				'expected' => AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -398,15 +398,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 
-		$got = $this->invoke_method( $sanitizer, $data['func_name'], array( $node, $data['attribute_name'], $attr_spec_rule ) );
+		$got = $this->invoke_method( $sanitizer, $data['func_name'], [ $node, $data['attribute_name'], $attr_spec_rule ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $source, wp_json_encode( $data ) ) );
 	}
 
 	public function get_is_allowed_attribute_data() {
-		return array(
-			'test_is_amp_allowed_attribute_whitelisted_regex_pass' => array(
-				array(
+		return [
+			'test_is_amp_allowed_attribute_whitelisted_regex_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'data-whatever-else-you-want',
@@ -414,11 +414,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_global_attribute_pass' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_global_attribute_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'itemid',
@@ -426,11 +426,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_tag_spec_pass' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_tag_spec_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'media',
@@ -438,11 +438,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_disallowed_attr_fail' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_disallowed_attr_fail' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-social-share',
 					'attribute_name' => 'bad-attr',
@@ -450,12 +450,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => false,
-			),
+			],
 
-			'test_is_amp_allowed_attribute_layout_height_pass' => array(
-				array(
+			'test_is_amp_allowed_attribute_layout_height_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-ad',
 					'attribute_name' => 'height',
@@ -463,11 +463,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_layout_heights_pass' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_layout_heights_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-ad',
 					'attribute_name' => 'heights',
@@ -475,11 +475,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_layout_width_pass' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_layout_width_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-ad',
 					'attribute_name' => 'width',
@@ -487,11 +487,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_layout_sizes_pass' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_layout_sizes_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-ad',
 					'attribute_name' => 'sizes',
@@ -499,11 +499,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-			'test_is_amp_allowed_attribute_layout_layout_pass' => array(
-				array(
+			],
+			'test_is_amp_allowed_attribute_layout_layout_pass' => [
+				[
 					'rule_spec_index' => 0,
 					'tag_name' => 'amp-ad',
 					'attribute_name' => 'layout',
@@ -511,10 +511,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 					'include_attr' => true,
 					'include_attr_value' => true,
 					'func_name' => 'is_amp_allowed_attribute',
-				),
+				],
 				'expected' => true,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -554,84 +554,84 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 		$attr      = $node->getAttributeNode( $data['attribute_name'] );
 
-		$got = $this->invoke_method( $sanitizer, $data['func_name'], array( $attr, $attr_spec_list ) );
+		$got = $this->invoke_method( $sanitizer, $data['func_name'], [ $attr, $attr_spec_list ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $source, wp_json_encode( $data ) ) );
 	}
 
 	public function get_remove_node_data() {
-		return array(
-			'remove_single_bad_tag' => array(
-				array(
+		return [
+			'remove_single_bad_tag' => [
+				[
 					'source' => '<bad-tag></bad-tag>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'',
-			),
-			'remove_bad_tag_with_single_empty_parent' => array(
-				array(
+			],
+			'remove_bad_tag_with_single_empty_parent' => [
+				[
 					'source' => '<div><bad-tag></bad-tag></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'',
-			),
-			'remove_bad_tag_with_multiple_empty_parents' => array(
-				array(
+			],
+			'remove_bad_tag_with_multiple_empty_parents' => [
+				[
 					'source' => '<div><p><bad-tag></bad-tag></p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'',
-			),
-			'remove_bad_tag_leave_siblings' => array(
-				array(
+			],
+			'remove_bad_tag_leave_siblings' => [
+				[
 					'source' => '<bad-tag></bad-tag><p>Good Data</p>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'remove_bad_tag_and_empty_parent_leave_parent_siblings' => array(
-				array(
+			],
+			'remove_bad_tag_and_empty_parent_leave_parent_siblings' => [
+				[
 					'source' => '<div><bad-tag></bad-tag></div><p>Good Data</p>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'remove_bad_tag_and_multiple_empty_parent_leave_parent_siblings' => array(
-				array(
+			],
+			'remove_bad_tag_and_multiple_empty_parent_leave_parent_siblings' => [
+				[
 					'source' => '<div><div><bad-tag></bad-tag></div></div><p>Good Data</p>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'remove_bad_tag_leave_empty_siblings_and_parent' => array(
-				array(
+			],
+			'remove_bad_tag_leave_empty_siblings_and_parent' => [
+				[
 					'source'   => '<div><br><bad-tag></bad-tag></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><br></div>',
-			),
-			'remove_single_bad_tag_with_non-empty_parent' => array(
-				array(
+			],
+			'remove_single_bad_tag_with_non-empty_parent' => [
+				[
 					'source' => '<div><bad-tag></bad-tag><p>Good Data</p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-			'remove_bad_tag_and_empty_parent_leave_non-empty_grandparent' => array(
-				array(
+			],
+			'remove_bad_tag_and_empty_parent_leave_non-empty_grandparent' => [
+				[
 					'source' => '<div><div><bad-tag></bad-tag></div><p>Good Data</p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-			'remove_bad_tag_and_empty_grandparent_leave_non-empty_greatgrandparent' => array(
-				array(
+			],
+			'remove_bad_tag_and_empty_grandparent_leave_non-empty_greatgrandparent' => [
+				[
 					'source' => '<div><div><div><bad-tag></bad-tag></div></div><p>Good Data</p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -643,7 +643,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 
-		$this->invoke_method( $sanitizer, 'remove_node', array( $node ) );
+		$this->invoke_method( $sanitizer, 'remove_node', [ $node ] );
 
 		$got = AMP_DOM_Utils::get_content_from_dom( $dom );
 
@@ -652,120 +652,120 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 
 
 	public function get_replace_node_with_children_data() {
-		return array(
-			'text_child' => array(
-				array(
+		return [
+			'text_child' => [
+				[
 					'source' => '<bad-tag>Good Data</bad-tag>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'Good Data',
-			),
-			'comment_child' => array(
-				array(
+			],
+			'comment_child' => [
+				[
 					'source' => '<bad-tag><!-- Good Data --></bad-tag>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<!-- Good Data -->',
-			),
-			'single_child' => array(
-				array(
+			],
+			'single_child' => [
+				[
 					'source' => '<bad-tag><p>Good Data</p></bad-tag>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'multiple_children' => array(
-				array(
+			],
+			'multiple_children' => [
+				[
 					'source' => '<bad-tag><p>Good Data</p><p>More Good Data</p></bad-tag>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p><p>More Good Data</p>',
-			),
-			'no_children' => array(
-				array(
+			],
+			'no_children' => [
+				[
 					'source' => '<bad-tag></bad-tag>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'',
-			),
-			'children_with_empty_parent' => array(
-				array(
+			],
+			'children_with_empty_parent' => [
+				[
 					'source' => '<div><bad-tag>Good Data</bad-tag></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div>Good Data</div>',
-			),
-			'no_children_empty_parent' => array(
-				array(
+			],
+			'no_children_empty_parent' => [
+				[
 					'source' => '<div><bad-tag></bad-tag></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'',
-			),
-			'children_multiple_empty_parents' => array(
-				array(
+			],
+			'children_multiple_empty_parents' => [
+				[
 					'source' => '<div><p><bad-tag>Good Data</bad-tag></p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-			'no_children_multiple_empty_parents' => array(
-				array(
+			],
+			'no_children_multiple_empty_parents' => [
+				[
 					'source' => '<div><p><bad-tag></bad-tag></p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'',
-			),
-			'no_children_leave_siblings' => array(
-				array(
+			],
+			'no_children_leave_siblings' => [
+				[
 					'source' => '<bad-tag></bad-tag><p>Good Data</p>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'no_children_and_empty_parent_leave_parent_siblings' => array(
-				array(
+			],
+			'no_children_and_empty_parent_leave_parent_siblings' => [
+				[
 					'source' => '<div><bad-tag></bad-tag></div><p>Good Data</p>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'no_children_and_multiple_empty_parent_leave_parent_siblings' => array(
-				array(
+			],
+			'no_children_and_multiple_empty_parent_leave_parent_siblings' => [
+				[
 					'source' => '<div><div><bad-tag></bad-tag></div></div><p>Good Data</p>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<p>Good Data</p>',
-			),
-			'no_children_leave_empty_siblings_and_parent' => array(
-				array(
+			],
+			'no_children_leave_empty_siblings_and_parent' => [
+				[
 					'source'   => '<div><br><bad-tag></bad-tag></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><br></div>',
-			),
-			'no_childreng_with_non-empty_parent' => array(
-				array(
+			],
+			'no_childreng_with_non-empty_parent' => [
+				[
 					'source' => '<div><bad-tag></bad-tag><p>Good Data</p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-			'no_children_and_empty_parent_leave_non-empty_grandparent' => array(
-				array(
+			],
+			'no_children_and_empty_parent_leave_non-empty_grandparent' => [
+				[
 					'source' => '<div><div><bad-tag></bad-tag></div><p>Good Data</p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-			'no_children_and_empty_grandparent_leave_non-empty_greatgrandparent' => array(
-				array(
+			],
+			'no_children_and_empty_grandparent_leave_non-empty_greatgrandparent' => [
+				[
 					'source'   => '<div><div><div><bad-tag></bad-tag></div></div><p>Good Data</p></div>',
 					'tag_name' => 'bad-tag',
-				),
+				],
 				'<div><p>Good Data</p></div>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -777,7 +777,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 
-		$this->invoke_method( $sanitizer, 'replace_node_with_children', array( $node ) );
+		$this->invoke_method( $sanitizer, 'replace_node_with_children', [ $node ] );
 
 		$got = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$got = preg_replace( '/(?<=>)\s+(?=<)/', '', $got );
@@ -791,48 +791,48 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 	 * @return array Data.
 	 */
 	public function get_ancestor_with_matching_spec_name_data() {
-		return array(
-			'empty' => array(
-				array(
+		return [
+			'empty' => [
+				[
 					'source' => '',
 					'node_tag_name' => 'p',
 					'ancestor_tag_name' => 'article',
-				),
+				],
 				null,
-			),
-			'ancestor_is_immediate_parent' => array(
-				array(
+			],
+			'ancestor_is_immediate_parent' => [
+				[
 					'source' => '<article><p>Good Data</p><article>',
 					'node_tag_name' => 'p',
 					'ancestor_tag_name' => 'article',
-				),
+				],
 				'article',
-			),
-			'ancestor_is_distant_parent' => array(
-				array(
+			],
+			'ancestor_is_distant_parent' => [
+				[
 					'source' => '<article><div><div><div><p>Good Data</p></div></div></div><article>',
 					'node_tag_name' => 'p',
 					'ancestor_tag_name' => 'article',
-				),
+				],
 				'article',
-			),
-			'ancestor_has_attributes' => array(
-				array(
+			],
+			'ancestor_has_attributes' => [
+				[
 					'source' => '<form method="post"><div><div><div><p>Good Data</p></div></div></div><article>',
 					'node_tag_name' => 'p',
 					'ancestor_tag_name' => 'form [method=post]',
-				),
+				],
 				'form',
-			),
-			'ancestor_does_not_exist' => array(
-				array(
+			],
+			'ancestor_does_not_exist' => [
+				[
 					'source' => '<div><div><div><p>Good Data</p></div></div></div>',
 					'node_tag_name' => 'p',
 					'ancestor_tag_name' => 'article',
-				),
+				],
 				null,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -855,196 +855,196 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			$ancestor_node = null;
 		}
 
-		$got = $this->invoke_method( $sanitizer, 'get_ancestor_with_matching_spec_name', array( $node, $data['ancestor_tag_name'] ) );
+		$got = $this->invoke_method( $sanitizer, 'get_ancestor_with_matching_spec_name', [ $node, $data['ancestor_tag_name'] ] );
 
 		$this->assertEquals( $ancestor_node, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
 	public function get_validate_attr_spec_list_for_node_data() {
-		return array(
-			'no_attributes' => array(
-				array(
+		return [
+			'no_attributes' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(),
-				),
+					'attr_spec_list' => [],
+				],
 				0.5, // Because there are no mandatory attributes.
-			),
-			'attributes_no_spec' => array(
-				array(
+			],
+			'attributes_no_spec' => [
+				[
 					'source' => '<div attribute1 attribute2 attribute3></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(),
-				),
+					'attr_spec_list' => [],
+				],
 				0.5, // Because there are no mandatory attributes.
-			),
-			'attributes_alternative_names' => array(
-				array(
+			],
+			'attributes_alternative_names' => [
+				[
 					'source' => '<div attribute1 attribute2 attribute3></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
-							'alternative_names' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
+							'alternative_names' => [
 								'attribute1_alternative1',
 								'attribute1_alternative2',
 								'attribute1_alternative3',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				0.5, // Because there are no mandatory attributes.
-			),
-			'attributes_mandatory' => array(
-				array(
+			],
+			'attributes_mandatory' => [
+				[
 					'source' => '<div attribute1 attribute2 attribute3></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'mandatory' => true,
-						),
-					),
-				),
+						],
+					],
+				],
 				1,
-			),
-			'attributes_mandatory_alternative_name' => array(
-				array(
+			],
+			'attributes_mandatory_alternative_name' => [
+				[
 					'source' => '<div attribute1_alternative1 attribute2 attribute3></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'mandatory' => true,
-							'alternative_names' => array(
+							'alternative_names' => [
 								'attribute1_alternative1',
 								'attribute1_alternative2',
 								'attribute1_alternative3',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				1,
-			),
-			'attributes_value' => array(
-				array(
+			],
+			'attributes_value' => [
+				[
 					'source' => '<div attribute1="required_value"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'value' => 'required_value',
-						),
-					),
-				),
+						],
+					],
+				],
 				1,
-			),
-			'attributes_value_regex' => array(
-				array(
+			],
+			'attributes_value_regex' => [
+				[
 					'source' => '<div attribute1="this"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'value_regex' => '(this|that)',
-						),
-					),
-				),
+						],
+					],
+				],
 				1,
-			),
-			'attributes_value_casei' => array(
-				array(
+			],
+			'attributes_value_casei' => [
+				[
 					'source' => '<div attribute1="VALUE"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'value_casei' => 'value',
-						),
-					),
-				),
+						],
+					],
+				],
 				1,
-			),
-			'attributes_value_regex_casei' => array(
-				array(
+			],
+			'attributes_value_regex_casei' => [
+				[
 					'source' => '<div attribute1="THIS"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'value_regex_casei' => '(this|that)',
-						),
-					),
-				),
+						],
+					],
+				],
 				1,
-			),
-			'attributes_allow_relative_false_pass' => array(
-				array(
+			],
+			'attributes_allow_relative_false_pass' => [
+				[
 					'source' => '<div attribute1="http://example.com/relative/path/to/resource"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
-							'value_url' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
+							'value_url' => [
 								'allow_relative' => false,
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				2,
-			),
-			'attributes_allow_relative_false_fail' => array(
-				array(
+			],
+			'attributes_allow_relative_false_fail' => [
+				[
 					'source' => '<div attribute1="/relative/path/to/resource"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
-							'value_url' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
+							'value_url' => [
 								'allow_relative' => false,
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				0,
-			),
-			'attributes_allow_empty_false_pass' => array(
-				array(
+			],
+			'attributes_allow_empty_false_pass' => [
+				[
 					'source' => '<div attribute1="http://example.com/relative/path/to/resource"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
-							'value_url' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
+							'value_url' => [
 								'allow_empty' => false,
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				2,
-			),
-			'attributes_allow_empty_false_fail' => array(
-				array(
+			],
+			'attributes_allow_empty_false_fail' => [
+				[
 					'source' => '<div attribute1></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
-							'value_url' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
+							'value_url' => [
 								'allow_empty' => false,
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				0,
-			),
-			'attributes_blacklisted_regex' => array(
-				array(
+			],
+			'attributes_blacklisted_regex' => [
+				[
 					'source' => '<div attribute1="blacklisted_value"></div>',
 					'node_tag_name' => 'div',
-					'attr_spec_list' => array(
-						'attribute1' => array(
+					'attr_spec_list' => [
+						'attribute1' => [
 							'blacklisted_value_regex' => 'blacklisted_value',
-							'alternative_names' => array(
+							'alternative_names' => [
 								'attribute1_alternative1',
 								'attribute1_alternative2',
 								'attribute1_alternative3',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				0,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1056,117 +1056,117 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 
-		$got = $this->invoke_method( $sanitizer, 'validate_attr_spec_list_for_node', array( $node, $data['attr_spec_list'] ) );
+		$got = $this->invoke_method( $sanitizer, 'validate_attr_spec_list_for_node', [ $node, $data['attr_spec_list'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
 	public function get_check_attr_spec_rule_value_data() {
-		return array(
-			'no_attributes' => array(
-				array(
+		return [
+			'no_attributes' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(),
-				),
+					'attr_spec_rule' => [],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'value_pass' => array(
-				array(
+			],
+			'value_pass' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => 'value1',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_fail' => array(
-				array(
+			],
+			'value_fail' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => 'valuex',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'value_no_attr' => array(
-				array(
+			],
+			'value_no_attr' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => 'value1',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'value_empty_pass1' => array(
-				array(
+			],
+			'value_empty_pass1' => [
+				[
 					'source' => '<div attribute1=""></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => '',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_empty_pass2' => array(
-				array(
+			],
+			'value_empty_pass2' => [
+				[
 					'source' => '<div attribute1></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => '',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_empty_fail' => array(
-				array(
+			],
+			'value_empty_fail' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => '',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'value_alternative_attr_name_pass' => array(
-				array(
+			],
+			'value_alternative_attr_name_pass' => [
+				[
 					'source' => '<div attribute1_alternative1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => 'value1',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_alternative_attr_name_fail' => array(
-				array(
+			],
+			'value_alternative_attr_name_fail' => [
+				[
 					'source' => '<div attribute1_alternative1="value2"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value' => 'value1',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1178,142 +1178,142 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_value', array( $node, $data['attr_name'], $data['attr_spec_rule'] ) );
+		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_value', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
 	public function get_check_attr_spec_rule_value_casei_data() {
-		return array(
-			'no_attributes' => array(
-				array(
+		return [
+			'no_attributes' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(),
-				),
+					'attr_spec_rule' => [],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'value_pass' => array(
-				array(
+			],
+			'value_pass' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'value1',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_upper_pass' => array(
-				array(
+			],
+			'value_upper_pass' => [
+				[
 					'source' => '<div attribute1="VALUE1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'value1',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_fail' => array(
-				array(
+			],
+			'value_fail' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'valuex',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'value_no_attr' => array(
-				array(
+			],
+			'value_no_attr' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'value1',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'value_empty_pass1' => array(
-				array(
+			],
+			'value_empty_pass1' => [
+				[
 					'source' => '<div attribute1=""></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => '',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_empty_pass2' => array(
-				array(
+			],
+			'value_empty_pass2' => [
+				[
 					'source' => '<div attribute1></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => '',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_empty_fail' => array(
-				array(
+			],
+			'value_empty_fail' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => '',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'value_alternative_attr_name_pass' => array(
-				array(
+			],
+			'value_alternative_attr_name_pass' => [
+				[
 					'source' => '<div attribute1_alternative1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'value1',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_alternative_attr_name__upper_pass' => array(
-				array(
+			],
+			'value_alternative_attr_name__upper_pass' => [
+				[
 					'source' => '<div attribute1_alternative1="VALUE1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'value1',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_alternative_attr_name_fail' => array(
-				array(
+			],
+			'value_alternative_attr_name_fail' => [
+				[
 					'source' => '<div attribute1_alternative1="value2"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'value_casei' => 'value1',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1325,84 +1325,84 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_value_casei', array( $node, $data['attr_name'], $data['attr_spec_rule'] ) );
+		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_value_casei', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
 	public function get_check_attr_spec_rule_blacklisted_value_regex() {
-		return array(
-			'no_attributes' => array(
-				array(
+		return [
+			'no_attributes' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(),
-				),
+					'attr_spec_rule' => [],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'value_pass' => array(
-				array(
+			],
+			'value_pass' => [
+				[
 					'source' => '<div attribute1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'blacklisted_value_regex' => '(not_this|or_this)',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_fail' => array(
-				array(
+			],
+			'value_fail' => [
+				[
 					'source' => '<div attribute1="not_this"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'blacklisted_value_regex' => '(not_this|or_this)',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'value_no_attr' => array(
-				array(
+			],
+			'value_no_attr' => [
+				[
 					'source' => '<div></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'blacklisted_value_regex' => '(not_this|or_this)',
-					),
-				),
+					],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'value_alternative_attr_name_pass' => array(
-				array(
+			],
+			'value_alternative_attr_name_pass' => [
+				[
 					'source' => '<div attribute1_alternative1="value1"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'blacklisted_value_regex' => '(not_this|or_this)',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'value_alternative_attr_name_fail' => array(
-				array(
+			],
+			'value_alternative_attr_name_fail' => [
+				[
 					'source' => '<div attribute1_alternative1="not_this"></div>',
 					'node_tag_name' => 'div',
 					'attr_name' => 'attribute1',
-					'attr_spec_rule' => array(
+					'attr_spec_rule' => [
 						'blacklisted_value_regex' => '(not_this|or_this)',
-						'alternative_names' => array(
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1414,125 +1414,125 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_blacklisted_value_regex', array( $node, $data['attr_name'], $data['attr_spec_rule'] ) );
+		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_blacklisted_value_regex', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
 	public function get_check_attr_spec_rule_allowed_protocol() {
-		return array(
-			'no_attributes'             => array(
-				array(
+		return [
+			'no_attributes'             => [
+				[
 					'source'         => '<div></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(),
-				),
+					'attr_spec_rule' => [],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'protocol_pass'             => array(
-				array(
+			],
+			'protocol_pass'             => [
+				[
 					'source'         => '<div attribute1="http://example.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url' => array(
-							'protocol' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
+							'protocol' => [
 								'http',
 								'https',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'protocol_multiple_pass'    => array(
-				array(
+			],
+			'protocol_multiple_pass'    => [
+				[
 					'source'         => '<div attribute1="http://example.com, https://domain.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url' => array(
-							'protocol' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
+							'protocol' => [
 								'http',
 								'https',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'protocol_fail'             => array(
-				array(
+			],
+			'protocol_fail'             => [
+				[
 					'source'         => '<div attribute1="data://example.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url' => array(
-							'protocol' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
+							'protocol' => [
 								'http',
 								'https',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'protocol_multiple_fail'    => array(
-				array(
+			],
+			'protocol_multiple_fail'    => [
+				[
 					'source'         => '<img srcset="http://example.com, data://domain.com">',
 					'node_tag_name'  => 'img',
 					'attr_name'      => 'srcset',
-					'attr_spec_rule' => array(
-						'value_url' => array(
-							'protocol' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
+							'protocol' => [
 								'http',
 								'https',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'protocol_alternative_pass' => array(
-				array(
+			],
+			'protocol_alternative_pass' => [
+				[
 					'source'         => '<div attribute1_alternative1="http://example.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'alternative_names' => array(
+					'attr_spec_rule' => [
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-						'value_url'         => array(
-							'protocol' => array(
+						],
+						'value_url'         => [
+							'protocol' => [
 								'http',
 								'https',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'protocol_alternative_fail' => array(
-				array(
+			],
+			'protocol_alternative_fail' => [
+				[
 					'source'         => '<div attribute1_alternative1="data://example.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'alternative_names' => array(
+					'attr_spec_rule' => [
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-						'value_url'         => array(
-							'protocol' => array(
+						],
+						'value_url'         => [
+							'protocol' => [
 								'http',
 								'https',
-							),
-						),
-					),
-				),
+							],
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1544,139 +1544,139 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_allowed_protocol', array( $node, $data['attr_name'], $data['attr_spec_rule'] ) );
+		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_allowed_protocol', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
 	public function get_check_attr_spec_rule_disallowed_relative() {
-		return array(
-			'no_attributes'                                 => array(
-				array(
+		return [
+			'no_attributes'                                 => [
+				[
 					'source'         => '<div></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(),
-				),
+					'attr_spec_rule' => [],
+				],
 				AMP_Rule_Spec::NOT_APPLICABLE,
-			),
-			'disallowed_relative_pass'                      => array(
-				array(
+			],
+			'disallowed_relative_pass'                      => [
+				[
 					'source'         => '<div attribute1="http://example.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
 							'allow_relative' => false,
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'disallowed_relative_multiple_pass'             => array(
-				array(
+			],
+			'disallowed_relative_multiple_pass'             => [
+				[
 					'source'         => '<img srcset="http://example.com, http://domain.com/path/to/resource">',
 					'node_tag_name'  => 'img',
 					'attr_name'      => 'srcset',
-					'attr_spec_rule' => array(
-						'value_url' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
 							'allow_relative' => false,
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'disallowed_relative_alternative_pass'          => array(
-				array(
+			],
+			'disallowed_relative_alternative_pass'          => [
+				[
 					'source'         => '<div attribute1_alternative1="http://example.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url'         => array(
+					'attr_spec_rule' => [
+						'value_url'         => [
 							'allow_relative' => false,
-						),
-						'alternative_names' => array(
+						],
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'disallowed_relative_alternative_multiple_pass' => array(
-				array(
+			],
+			'disallowed_relative_alternative_multiple_pass' => [
+				[
 					'source'         => '<div attribute1_alternative1="http://example.com, http://domain.com"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url'         => array(
+					'attr_spec_rule' => [
+						'value_url'         => [
 							'allow_relative' => false,
-						),
-						'alternative_names' => array(
+						],
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::PASS,
-			),
-			'disallowed_relative_fail'                      => array(
-				array(
+			],
+			'disallowed_relative_fail'                      => [
+				[
 					'source'         => '<div attribute1="/relative/path/to/resource"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
 							'allow_relative' => false,
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'disallowed_relative_multiple_fail'             => array(
-				array(
+			],
+			'disallowed_relative_multiple_fail'             => [
+				[
 					'source'         => '<div attribute1="//domain.com, /relative/path/to/resource"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url' => array(
+					'attr_spec_rule' => [
+						'value_url' => [
 							'allow_relative' => false,
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'disallowed_relative_alternative_fail'          => array(
-				array(
+			],
+			'disallowed_relative_alternative_fail'          => [
+				[
 					'source'         => '<div attribute1_alternative1="/relative/path/to/resource"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'attribute1',
-					'attr_spec_rule' => array(
-						'value_url'         => array(
+					'attr_spec_rule' => [
+						'value_url'         => [
 							'allow_relative' => false,
-						),
-						'alternative_names' => array(
+						],
+						'alternative_names' => [
 							'attribute1_alternative1',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-			'disallowed_relative_alternative_multiple_fail' => array(
-				array(
+			],
+			'disallowed_relative_alternative_multiple_fail' => [
+				[
 					'source'         => '<div source_set="http://domain.com,  /relative/path/to/resource"></div>',
 					'node_tag_name'  => 'div',
 					'attr_name'      => 'srcset',
-					'attr_spec_rule' => array(
-						'value_url'         => array(
+					'attr_spec_rule' => [
+						'value_url'         => [
 							'allow_relative' => false,
-						),
-						'alternative_names' => array(
+						],
+						'alternative_names' => [
 							'source_set',
-						),
-					),
-				),
+						],
+					],
+				],
 				AMP_Rule_Spec::FAIL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1688,7 +1688,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_disallowed_relative', array( $node, $data['attr_name'], $data['attr_spec_rule'] ) );
+		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_disallowed_relative', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1701,7 +1701,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 	 * @param array  $parameters  Parameters.
 	 * @return mixed Result.
 	 */
-	public function invoke_method( &$object, $method_name, array $parameters = array() ) {
+	public function invoke_method( &$object, $method_name, array $parameters = [] ) {
 		$reflection = new ReflectionClass( get_class( $object ) );
 
 		$method = $reflection->getMethod( $method_name );

--- a/tests/php/test-amp-twitter-embed.php
+++ b/tests/php/test-amp-twitter-embed.php
@@ -2,66 +2,66 @@
 
 class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'                             => array(
+		return [
+			'no_embed'                             => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
-			'url_simple'                           => array(
+			],
+			'url_simple'                           => [
 				'https://twitter.com/wordpress/status/987437752164737025' . PHP_EOL,
 				'<p><amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
-			),
-			'url_with_big_tweet_id'                => array(
+			],
+			'url_with_big_tweet_id'                => [
 				'https://twitter.com/wordpress/status/705219971425574912' . PHP_EOL,
 				'<p><amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
-			),
+			],
 
-			'timeline_url_with_profile'            => array(
+			'timeline_url_with_profile'            => [
 				'https://twitter.com/wordpress' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="profile" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
-			),
-			'timeline_url_with_likes'              => array(
+			],
+			'timeline_url_with_likes'              => [
 				'https://twitter.com/wordpress/likes' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="likes" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
-			),
-			'timeline_url_with_list'               => array(
+			],
+			'timeline_url_with_list'               => [
 				'https://twitter.com/wordpress/lists/random_list' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random_list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
-			),
-			'timeline_url_with_list2'              => array(
+			],
+			'timeline_url_with_list2'              => [
 				'https://twitter.com/robertnyman/lists/web-gdes' . PHP_EOL,
 				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="web-gdes" data-timeline-owner-screen-name="robertnyman" layout="responsive" width="600" height="480"></amp-twitter></p>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_without_id'                 => array(
+			'shortcode_without_id'                 => [
 				'[tweet]' . PHP_EOL,
 				'' . PHP_EOL,
-			),
-			'shortcode_simple'                     => array(
+			],
+			'shortcode_simple'                     => [
 				'[tweet 987437752164737025]' . PHP_EOL,
 				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
-			),
-			'shortcode_with_tweet_attribute'       => array(
+			],
+			'shortcode_with_tweet_attribute'       => [
 				'[tweet tweet=987437752164737025]' . PHP_EOL,
 				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
-			),
-			'shortcode_with_big_tweet_id'          => array(
+			],
+			'shortcode_with_big_tweet_id'          => [
 				'[tweet 705219971425574912]' . PHP_EOL,
 				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
-			),
-			'shortcode_with_url'                   => array(
+			],
+			'shortcode_with_url'                   => [
 				'[tweet https://twitter.com/wordpress/status/987437752164737025]' . PHP_EOL,
 				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
-			),
-			'shortcode_with_url_with_big_tweet_id' => array(
+			],
+			'shortcode_with_url_with_big_tweet_id' => [
 				'[tweet https://twitter.com/wordpress/status/705219971425574912]' . PHP_EOL,
 				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>' . PHP_EOL,
-			),
-			'shortcode_with_non_numeric_tweet_id'  => array(
+			],
+			'shortcode_with_non_numeric_tweet_id'  => [
 				'[tweet abcd]' . PHP_EOL,
 				'' . PHP_EOL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -76,16 +76,16 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	}
 
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://twitter.com/altjoen/status/987437752164737025' . PHP_EOL,
-				array( 'amp-twitter' => true ),
-			),
-		);
+				[ 'amp-twitter' => true ],
+			],
+		];
 	}
 
 	/**
@@ -113,26 +113,26 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_raw_embed_dataset() {
-		return array(
-			'no_embed'                         => array(
+		return [
+			'no_embed'                         => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>',
-			),
-			'embed_blockquote_without_twitter' => array(
+			],
+			'embed_blockquote_without_twitter' => [
 				'<blockquote>lorem ipsum</blockquote>',
 				'<blockquote>lorem ipsum</blockquote>',
-			),
+			],
 
-			'blockquote_embed'                 => array(
+			'blockquote_embed'                 => [
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
-			),
+			],
 
-			'blockquote_embed_not_autop'       => array(
+			'blockquote_embed_not_autop'       => [
 				'<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
 				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter> ',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-video-sanitizer.php
+++ b/tests/php/test-amp-video-sanitizer.php
@@ -20,64 +20,64 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'no_videos' => array(
+		return [
+			'no_videos' => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				'<p>Lorem Ipsum Demet Delorit.</p>',
-			),
+			],
 
-			'simple_video' => array(
+			'simple_video' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
-				array(
+				[
 					'add_noscript_fallback' => true,
-				),
-			),
+				],
+			],
 
-			'simple_video_without_noscript' => array(
+			'simple_video_without_noscript' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a></amp-video>',
-				array(
+				[
 					'add_noscript_fallback' => false,
-				),
-			),
+				],
+			],
 
-			'video_without_dimensions' => array(
+			'video_without_dimensions' => [
 				'<video src="https://example.com/file.mp4"></video>',
 				'<amp-video src="https://example.com/file.mp4" height="400" layout="fixed-height" width="auto"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4"></video></noscript></amp-video>',
-			),
+			],
 
-			'autoplay_attribute' => array(
+			'autoplay_attribute' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" autoplay="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay></video></noscript></amp-video>',
-			),
+			],
 
-			'autoplay_attribute__false' => array(
+			'autoplay_attribute__false' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" autoplay="false"></video></noscript></amp-video>',
-			),
+			],
 
-			'video_with_whitelisted_attributes__enabled' => array(
+			'video_with_whitelisted_attributes__enabled' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" controls="" loop="" muted="" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls loop="true" muted="muted"></video></noscript></amp-video>',
-			),
+			],
 
-			'video_with_whitelisted_attributes__disabled' => array(
+			'video_with_whitelisted_attributes__disabled' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4" controls="false" loop="false" muted="false"></video></noscript></amp-video>',
-			),
+			],
 
-			'video_with_custom_attribute' => array(
+			'video_with_custom_attribute' => [
 				'<video width="300" height="300" src="https://example.com/video.mp4" onclick="foo()" data-foo="bar"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" data-foo="bar" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
-			),
+			],
 
-			'video_with_sizes_attribute_is_overridden' => array(
+			'video_with_sizes_attribute_is_overridden' => [
 				'<video width="300" height="200" src="https://example.com/file.mp4"></video>',
 				'<amp-video width="300" height="200" src="https://example.com/file.mp4" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video width="300" height="200" src="https://example.com/file.mp4"></video></noscript></amp-video>',
-			),
+			],
 
-			'video_with_children' => array(
+			'video_with_children' => [
 				'
 					<video width="480" height="300" poster="https://example.com/video-image.gif">
 						<source src="https://example.com/video.mp4" type="video/mp4">
@@ -97,24 +97,24 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-video>
 				',
-			),
+			],
 
-			'video_with_layout_from_editor_fill' => array(
+			'video_with_layout_from_editor_fill' => [
 				'<figure data-amp-layout="fill"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
 				'<figure data-amp-layout="fill" style="position:relative; width: 100%; height: 100px;"><amp-video src="https://example.com/file.mp4" layout="fill"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
-			),
+			],
 
-			'video_with_layout_from_editor_fixed' => array(
+			'video_with_layout_from_editor_fixed' => [
 				'<figure data-amp-layout="fixed"><video src="https://example.com/file.mp4" width="100"></video></figure>',
 				'<figure data-amp-layout="fixed"><amp-video src="https://example.com/file.mp4" width="100" layout="fixed" height="400"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" width="100"></video></noscript></amp-video></figure>',
-			),
+			],
 
-			'video_with_noloading_from_editor' => array(
+			'video_with_noloading_from_editor' => [
 				'<figure data-amp-noloading="true"><video src="https://example.com/file.mp4" height="100" width="100"></video></figure>',
 				'<figure data-amp-noloading="true"><amp-video src="https://example.com/file.mp4" height="100" width="100" noloading="" layout="responsive"><a href="https://example.com/file.mp4" fallback="">https://example.com/file.mp4</a><noscript><video src="https://example.com/file.mp4" height="100" width="100"></video></noscript></amp-video></figure>',
-			),
+			],
 
-			'multiple_same_video' => array(
+			'multiple_same_video' => [
 				'
 					<video src="https://example.com/video.mp4" width="480" height="300"></video>
 					<video src="https://example.com/video.mp4" width="480" height="300"></video>
@@ -127,9 +127,9 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
 					<amp-video src="https://example.com/video.mp4" width="480" height="300" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video src="https://example.com/video.mp4" width="480" height="300"></video></noscript></amp-video>
 				',
-			),
+			],
 
-			'multiple_different_videos' => array(
+			'multiple_different_videos' => [
 				'
 					<video src="https://example.com/video1.mp4" width="480" height="300"></video>
 					<video src="https://example.com/video2.ogv" width="300" height="480"></video>
@@ -140,14 +140,14 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 					<amp-video src="https://example.com/video2.ogv" width="300" height="480" layout="responsive"><a href="https://example.com/video2.ogv" fallback="">https://example.com/video2.ogv</a><noscript><video src="https://example.com/video2.ogv" width="300" height="480"></video></noscript></amp-video>
 					<amp-video src="https://example.com/video3.webm" height="100" width="200" layout="responsive"><a href="https://example.com/video3.webm" fallback="">https://example.com/video3.webm</a><noscript><video src="https://example.com/video3.webm" height="100" width="200"></video></noscript></amp-video>
 				',
-			),
+			],
 
-			'https_not_required' => array(
+			'https_not_required' => [
 				'<video width="300" height="300" src="http://example.com/video.mp4"></video>',
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
-			),
+			],
 
-			'http_video_with_children' => array(
+			'http_video_with_children' => [
 				'
 					<video width="480" height="300" poster="https://example.com/poster.jpeg">
 						<source src="http://example.com/video.mp4" type="video/mp4">
@@ -171,18 +171,18 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-video>
 				',
-			),
+			],
 
-			'amp_video_with_fallback' => array(
+			'amp_video_with_fallback' => [
 				'<amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video>',
 				null,
-			),
+			],
 
-			'video_with_fallback' => array(
+			'video_with_fallback' => [
 				'<div id="player"><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></div>',
 				'<div id="player"><!--noscript--><amp-video width="300" height="300" src="https://example.com/video.mp4" layout="responsive"><a href="https://example.com/video.mp4" fallback="">https://example.com/video.mp4</a><noscript><video width="300" height="300" src="https://example.com/video.mp4"></video></noscript></amp-video><!--/noscript--></div>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -194,7 +194,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	 * @param string $expected Expected.
 	 * @param array  $args     Sanitizer args.
 	 */
-	public function test_converter( $source, $expected = null, $args = array() ) {
+	public function test_converter( $source, $expected = null, $args = [] ) {
 		if ( null === $expected ) {
 			$expected = $source;
 		}
@@ -225,9 +225,9 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer(
 			$dom,
-			array(
+			[
 				'require_https_src' => true,
-			)
+			]
 		);
 		$sanitizer->sanitize();
 
@@ -243,7 +243,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__didnt_convert() {
 		$source   = '<p>Hello World</p>';
-		$expected = array();
+		$expected = [];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );
@@ -264,7 +264,7 @@ class AMP_Video_Converter_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_scripts__did_convert() {
 		$source   = '<video width="300" height="300" src="https://example.com/video.mp4"></video>';
-		$expected = array( 'amp-video' => true );
+		$expected = [ 'amp-video' => true ];
 
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Video_Sanitizer( $dom );

--- a/tests/php/test-amp-vimeo-embed.php
+++ b/tests/php/test-amp-vimeo-embed.php
@@ -2,33 +2,33 @@
 
 class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'                      => array(
+		return [
+			'no_embed'                      => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'url_simple'                    => array(
+			'url_simple'                    => [
 				'https://vimeo.com/172355597' . PHP_EOL,
 				'<p><amp-vimeo data-videoid="172355597" layout="responsive" width="600" height="338"></amp-vimeo></p>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_unnamed_attr_as_url' => array(
+			'shortcode_unnamed_attr_as_url' => [
 				'[vimeo https://vimeo.com/172355597]' . PHP_EOL,
 				'<amp-vimeo data-videoid="172355597" layout="responsive" width="600" height="338"></amp-vimeo>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_named_attr_url'      => array(
+			'shortcode_named_attr_url'      => [
 				'[vimeo url=https://vimeo.com/172355597]' . PHP_EOL,
 				'<amp-vimeo data-videoid="172355597" layout="responsive" width="600" height="338"></amp-vimeo>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_named_attr_id'       => array(
+			'shortcode_named_attr_id'       => [
 				'[vimeo id=172355597]' . PHP_EOL,
 				'<amp-vimeo data-videoid="172355597" layout="responsive" width="600" height="338"></amp-vimeo>' . PHP_EOL,
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -43,16 +43,16 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 	}
 
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://vimeo.com/172355597' . PHP_EOL,
-				array( 'amp-vimeo' => true ),
-			),
-		);
+				[ 'amp-vimeo' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-vine-embed.php
+++ b/tests/php/test-amp-vine-embed.php
@@ -2,16 +2,16 @@
 
 class AMP_Vine_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'   => array(
+		return [
+			'no_embed'   => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
-			'simple_url' => array(
+			],
+			'simple_url' => [
 				'https://vine.co/v/MdKjXez002d' . PHP_EOL,
 				'<p><amp-vine data-vineid="MdKjXez002d" layout="responsive" width="400" height="400"></amp-vine></p>' . PHP_EOL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -26,16 +26,16 @@ class AMP_Vine_Embed_Test extends WP_UnitTestCase {
 	}
 
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://vine.co/v/MdKjXez002d' . PHP_EOL,
-				array( 'amp-vine' => true ),
-			),
-		);
+				[ 'amp-vine' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp-youtube-embed.php
+++ b/tests/php/test-amp-youtube-embed.php
@@ -2,38 +2,38 @@
 
 class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 	public function get_conversion_data() {
-		return array(
-			'no_embed'                         => array(
+		return [
+			'no_embed'                         => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'url_simple'                       => array(
+			'url_simple'                       => [
 				'https://www.youtube.com/watch?v=kfVsfOSbJY0' . PHP_EOL,
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
-			),
+			],
 
-			'url_short'                        => array(
+			'url_short'                        => [
 				'https://youtu.be/kfVsfOSbJY0' . PHP_EOL,
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_querystring'             => array(
+			'url_with_querystring'             => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0&hl=en&fs=1&w=425&h=349' . PHP_EOL,
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
-			),
+			],
 
 			// Several reports of invalid URLs that have multiple `?` in the URL.
-			'url_with_querystring_and_extra_?' => array(
+			'url_with_querystring_and_extra_?' => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0?hl=en&fs=1&w=425&h=349' . PHP_EOL,
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube></p>' . PHP_EOL,
-			),
+			],
 
-			'shortcode_unnamed_attr_as_url'    => array(
+			'shortcode_unnamed_attr_as_url'    => [
 				'[youtube http://www.youtube.com/watch?v=kfVsfOSbJY0]' . PHP_EOL,
 				'<amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="600" height="338"></amp-youtube>' . PHP_EOL,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -48,16 +48,16 @@ class AMP_YouTube_Embed_Test extends WP_UnitTestCase {
 	}
 
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.youtube.com/watch?v=kfVsfOSbJY0' . PHP_EOL,
-				array( 'amp-youtube' => true ),
-			),
-		);
+				[ 'amp-youtube' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-amp.php
+++ b/tests/php/test-amp.php
@@ -32,34 +32,34 @@ class Test_AMP extends WP_UnitTestCase {
 
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => 'amp-templates',
-			)
+			]
 		);
 		$this->assertFalse( amp_is_canonical() );
 
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => false,
 				'template_dir'                 => 'amp-templates',
-			)
+			]
 		);
 		$this->assertTrue( amp_is_canonical() );
 
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => true,
-			)
+			]
 		);
 		$this->assertFalse( amp_is_canonical() );
 
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'custom_prop' => 'something',
-			)
+			]
 		);
 		$this->assertTrue( amp_is_canonical() );
 	}

--- a/tests/php/test-class-amp-admin-pointer.php
+++ b/tests/php/test-class-amp-admin-pointer.php
@@ -44,6 +44,6 @@ class Test_AMP_Admin_Pointers extends WP_UnitTestCase {
 	 */
 	public function test_init() {
 		$this->instance->init();
-		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $this->instance, 'enqueue_scripts' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', [ $this->instance, 'enqueue_scripts' ] ) );
 	}
 }

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -35,74 +35,74 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'both_dimensions_included' => array(
-				array(
+		return [
+			'both_dimensions_included' => [
+				[
 					'width'  => 100,
 					'height' => 100,
 					'layout' => 'responsive',
-				),
-				array(
+				],
+				[
 					'width'  => 100,
 					'height' => 100,
 					'layout' => 'responsive',
-				),
-			),
+				],
+			],
 
-			'both_dimensions_missing'  => array(
-				array(),
-				array(
+			'both_dimensions_missing'  => [
+				[],
+				[
 					'height' => 400,
 					'layout' => 'fixed-height',
 					'width'  => 'auto',
-				),
-			),
+				],
+			],
 
-			'both_dimensions_empty'    => array(
-				array(
+			'both_dimensions_empty'    => [
+				[
 					'width'  => '',
 					'height' => '',
-				),
-				array(
+				],
+				[
 					'height' => 400,
 					'layout' => 'fixed-height',
 					'width'  => 'auto',
-				),
-			),
+				],
+			],
 
-			'no_width'                 => array(
-				array(
+			'no_width'                 => [
+				[
 					'height' => 100,
-				),
-				array(
+				],
+				[
 					'height' => 100,
 					'layout' => 'fixed-height',
 					'width'  => 'auto',
-				),
-			),
+				],
+			],
 
-			'no_height'                => array(
-				array(
+			'no_height'                => [
+				[
 					'width' => 200,
-				),
-				array(
+				],
+				[
 					'height' => 400,
 					'layout' => 'fixed-height',
 					'width'  => 'auto',
-				),
-			),
+				],
+			],
 
-			'no_layout_specified'      => array(
-				array(
+			'no_layout_specified'      => [
+				[
 					'width'  => 100,
 					'height' => 100,
-				),
-				array(
+				],
+				[
 					'width'  => 100,
 					'height' => 100,
-				),
-			),
-		);
+				],
+			],
+		];
 	}
 
 	/**
@@ -114,7 +114,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param array $args                Args.
 	 * @covers AMP_Base_Sanitizer::set_layout()
 	 */
-	public function test_set_layout( $source_attributes, $expected_attributes, $args = array() ) {
+	public function test_set_layout( $source_attributes, $expected_attributes, $args = [] ) {
 		$sanitizer           = new AMP_Test_Stub_Sanitizer( new DOMDocument(), $args );
 		$returned_attributes = $sanitizer->set_layout( $source_attributes );
 		$this->assertEquals( $expected_attributes, $returned_attributes );
@@ -126,59 +126,59 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array Data.
 	 */
 	public function get_sanitize_dimension_data() {
-		return array(
-			'empty'                => array(
-				array( '', 'width' ),
+		return [
+			'empty'                => [
+				[ '', 'width' ],
 				'',
-			),
+			],
 
-			'empty_space'          => array(
-				array( ' ', 'width' ),
+			'empty_space'          => [
+				[ ' ', 'width' ],
 				'',
-			),
+			],
 
-			'int'                  => array(
-				array( 123, 'width' ),
+			'int'                  => [
+				[ 123, 'width' ],
 				123,
-			),
+			],
 
-			'int_as_string'        => array(
-				array( '123', 'width' ),
+			'int_as_string'        => [
+				[ '123', 'width' ],
 				123,
-			),
+			],
 
-			'with_px'              => array(
-				array( '567px', 'width' ),
+			'with_px'              => [
+				[ '567px', 'width' ],
 				567,
-			),
+			],
 
-			'100%_width__with_max' => array(
-				array( '100%', 'width' ),
+			'100%_width__with_max' => [
+				[ '100%', 'width' ],
 				600,
-				array( 'content_max_width' => 600 ),
-			),
+				[ 'content_max_width' => 600 ],
+			],
 
-			'100%_width__no_max'   => array(
-				array( '100%', 'width' ),
+			'100%_width__no_max'   => [
+				[ '100%', 'width' ],
 				'',
-			),
+			],
 
-			'50%_width__with_max'  => array(
-				array( '50%', 'width' ),
+			'50%_width__with_max'  => [
+				[ '50%', 'width' ],
 				300,
-				array( 'content_max_width' => 600 ),
-			),
+				[ 'content_max_width' => 600 ],
+			],
 
-			'%_height'             => array(
-				array( '100%', 'height' ),
+			'%_height'             => [
+				[ '100%', 'height' ],
 				'',
-			),
+			],
 
-			'non_int'              => array(
-				array( 'abcd', 'width' ),
+			'non_int'              => [
+				[ 'abcd', 'width' ],
 				'',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -190,7 +190,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @dataProvider get_sanitize_dimension_data
 	 * @covers AMP_Base_Sanitizer::sanitize_dimension()
 	 */
-	public function test_sanitize_dimension( $source_params, $expected_value, $args = array() ) {
+	public function test_sanitize_dimension( $source_params, $expected_value, $args = [] ) {
 		$sanitizer                 = new AMP_Test_Stub_Sanitizer( new DOMDocument(), $args );
 		list( $value, $dimension ) = $source_params;
 
@@ -215,29 +215,29 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$child->setAttribute( 'src', 'http://example.com/bad.js?ver=123' );
 		$parent->appendChild( $child );
 
-		$expected_error = array(
+		$expected_error = [
 			'code'            => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
 			'node_name'       => $child->nodeName,
 			'parent_name'     => $parent_tag_name,
-			'node_attributes' => array(
+			'node_attributes' => [
 				'id'  => 'foo',
 				'src' => 'http://example.com/bad.js?ver=__normalized__',
-			),
+			],
 			'foo'             => 'bar',
 			'sources'         => null,
 			'type'            => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
-		);
+		];
 
 		// Test forcibly sanitized with filter.
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		$this->assertEquals( $child, $parent->firstChild );
 		$sanitizer = new AMP_Iframe_Sanitizer(
 			$dom_document,
-			array(
+			[
 				'validation_error_callback' => 'AMP_Validation_Manager::add_validation_error',
-			)
+			]
 		);
-		$sanitizer->remove_invalid_child( $child, array( 'foo' => 'bar' ) );
+		$sanitizer->remove_invalid_child( $child, [ 'foo' => 'bar' ] );
 		$this->assertEquals( null, $parent->firstChild );
 		$this->assertCount( 0, AMP_Validation_Manager::$validation_results );
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
@@ -253,19 +253,19 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		add_filter( 'amp_validation_error_sanitized', '__return_false' );
 		AMP_Validation_Manager::reset_validation_results();
 		$parent->appendChild( $child );
-		$sanitizer->remove_invalid_child( $child, array( 'foo' => 'bar' ) );
+		$sanitizer->remove_invalid_child( $child, [ 'foo' => 'bar' ] );
 		$this->assertEquals( $child, $parent->firstChild );
 		$this->assertCount( 1, AMP_Validation_Manager::$validation_results );
 		$this->assertEquals(
-			array(
+			[
 				'error'     => $expected_error,
 				'sanitized' => false,
-			),
+			],
 			AMP_Validation_Manager::$validation_results[0]
 		);
 
 		// Make sure the validation error is not duplicated since it was not sanitized.
-		$sanitizer->remove_invalid_child( $child, array( 'foo' => 'bar' ) );
+		$sanitizer->remove_invalid_child( $child, [ 'foo' => 'bar' ] );
 		$this->assertCount( 1, AMP_Validation_Manager::$validation_results );
 		AMP_Validation_Manager::$validation_results = null;
 	}
@@ -284,27 +284,27 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( '<amp-video id="bar" onload="someFunc()"></amp-video>' );
 		$sanitizer = new AMP_Video_Sanitizer(
 			$dom,
-			array(
+			[
 				'validation_error_callback' => static function( $error, $context ) use ( $that ) {
 					$that->assertEquals(
-						array(
+						[
 							'node_name'          => 'onload',
 							'parent_name'        => 'amp-video',
 							'code'               => 'invalid_attribute',
 							'element_attributes' =>
-								array(
+								[
 									'id'     => 'bar',
 									'onload' => 'someFunc()',
-								),
+								],
 							'type'               => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
-						),
+						],
 						$error
 					);
 					$that->assertInstanceOf( 'DOMAttr', $context['node'] );
 					$that->assertEquals( 'onload', $context['node']->nodeName );
 					return true;
 				},
-			)
+			]
 		);
 		$element   = $dom->getElementsByTagName( 'amp-video' )->item( 0 );
 		$this->assertTrue( $sanitizer->remove_invalid_attribute( $element, 'onload' ) );
@@ -314,27 +314,27 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( '<amp-video id="bar" onload="someFunc()"></amp-video>' );
 		$sanitizer = new AMP_Video_Sanitizer(
 			$dom,
-			array(
+			[
 				'validation_error_callback' => static function( $error, $context ) use ( $that ) {
 					$that->assertEquals(
-						array(
+						[
 							'node_name'          => 'onload',
 							'parent_name'        => 'amp-video',
 							'code'               => 'invalid_attribute',
 							'element_attributes' =>
-								array(
+								[
 									'id'     => 'bar',
 									'onload' => 'someFunc()',
-								),
+								],
 							'type'               => AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
-						),
+						],
 						$error
 					);
 					$that->assertInstanceOf( 'DOMAttr', $context['node'] );
 					$that->assertEquals( 'onload', $context['node']->nodeName );
 					return false;
 				},
-			)
+			]
 		);
 		$element   = $dom->getElementsByTagName( 'amp-video' )->item( 0 );
 		$this->assertFalse( $sanitizer->remove_invalid_attribute( $element, 'onload' ) );
@@ -355,13 +355,13 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 		$figure->setAttribute( 'data-amp-noloading', 'true' );
 		$figure->setAttribute( 'data-amp-layout', 'fixed' );
 
-		$sanitizer = new AMP_Test_Stub_Sanitizer( new DOMDocument(), array() );
+		$sanitizer = new AMP_Test_Stub_Sanitizer( new DOMDocument(), [] );
 		$amp_args  = $sanitizer->get_data_amp_attributes( $amp_img );
 
-		$expected_args = array(
+		$expected_args = [
 			'layout'    => 'fixed',
 			'noloading' => 'true',
-		);
+		];
 
 		$this->assertEquals( $expected_args, $amp_args );
 	}
@@ -372,20 +372,20 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers AMP_Base_Sanitizer::filter_data_amp_attributes()
 	 */
 	public function test_filter_data_amp_attributes() {
-		$amp_data   = array(
+		$amp_data   = [
 			'noloading' => true,
 			'invalid'   => 123,
-		);
-		$attributes = array(
+		];
+		$attributes = [
 			'width' => 100,
-		);
-		$sanitizer  = new AMP_Test_Stub_Sanitizer( new DOMDocument(), array() );
+		];
+		$sanitizer  = new AMP_Test_Stub_Sanitizer( new DOMDocument(), [] );
 		$attributes = $sanitizer->filter_data_amp_attributes( $attributes, $amp_data );
 
-		$expected = array(
+		$expected = [
 			'width'              => 100,
 			'data-amp-noloading' => '',
-		);
+		];
 		$this->assertEquals( $expected, $attributes );
 	}
 
@@ -395,23 +395,23 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers AMP_Base_Sanitizer::filter_attachment_layout_attributes()
 	 */
 	public function test_filter_attachment_layout_attributes() {
-		$sanitizer    = new AMP_Test_Stub_Sanitizer( new DOMDocument(), array() );
+		$sanitizer    = new AMP_Test_Stub_Sanitizer( new DOMDocument(), [] );
 		$tag          = 'figure';
 		$dom_document = new DOMDocument( '1.0', 'utf-8' );
 		$figure       = $dom_document->createElement( $tag );
 		$amp_img      = $dom_document->createElement( 'amp-img' );
 		$layout       = 'fixed-height';
 		$figure->appendChild( $amp_img );
-		$attributes = array(
+		$attributes = [
 			'src' => '',
-		);
+		];
 
 		$attributes    = $sanitizer->filter_attachment_layout_attributes( $amp_img, $attributes, $layout );
-		$expected_atts = array(
+		$expected_atts = [
 			'src'    => '',
 			'height' => 400,
 			'width'  => 'auto',
-		);
+		];
 		$this->assertEquals( $expected_atts, $attributes );
 
 		$parent_style   = $figure->getAttribute( 'style' );

--- a/tests/php/test-class-amp-block-sanitizer.php
+++ b/tests/php/test-class-amp-block-sanitizer.php
@@ -16,32 +16,32 @@ class AMP_Block_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'no_figures'           => array(
+		return [
+			'no_figures'           => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				'<p>Lorem Ipsum Demet Delorit.</p>',
-			),
+			],
 
-			'more_than_one_child'  => array(
+			'more_than_one_child'  => [
 				'<figure class="wp-block-embed wp-embed-aspect-16-9 wp-has-aspect-ratio"><amp-facebook></amp-facebook><amp-facebook></amp-facebook></figure>',
 				'<figure class="wp-block-embed  wp-has-aspect-ratio"><amp-facebook></amp-facebook><amp-facebook></amp-facebook></figure>',
-			),
+			],
 
-			'no_wp_block_embed'    => array(
+			'no_wp_block_embed'    => [
 				'<figure><amp-facebook></amp-facebook></figure>',
 				'<figure><amp-facebook></amp-facebook></figure>',
-			),
+			],
 
-			'data_amp_noloading'   => array(
+			'data_amp_noloading'   => [
 				'<figure class="wp-block-embed" data-amp-noloading="true"><amp-facebook></amp-facebook></figure>',
 				'<figure class="wp-block-embed" data-amp-noloading="true"><amp-facebook noloading="" layout="fixed-height"></amp-facebook></figure>',
-			),
+			],
 
-			'data_amp_layout_fill' => array(
+			'data_amp_layout_fill' => [
 				'<figure class="wp-block-embed" data-amp-layout="fill"><amp-facebook width="100"></amp-facebook></figure>',
 				'<figure class="wp-block-embed" data-amp-layout="fill" style="position:relative; width: 100%; height: 400px;"><amp-facebook layout="fill"></amp-facebook></figure>',
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-class-amp-cli.php
+++ b/tests/php/test-class-amp-cli.php
@@ -19,8 +19,8 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-		add_filter( 'pre_http_request', array( $this, 'add_comment' ) );
-		AMP_CLI::$include_conditionals      = array();
+		add_filter( 'pre_http_request', [ $this, 'add_comment' ] );
+		AMP_CLI::$include_conditionals      = [];
 		AMP_CLI::$limit_type_validate_count = 100;
 	}
 
@@ -45,14 +45,14 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$this->assertEquals( $number_original_urls, AMP_CLI::count_urls_to_validate() );
 		AMP_CLI::$limit_type_validate_count = 100;
 
-		$category         = self::factory()->term->create( array( 'taxonomy' => 'category' ) );
+		$category         = self::factory()->term->create( [ 'taxonomy' => 'category' ] );
 		$number_new_posts = AMP_CLI::$limit_type_validate_count / 2;
-		$post_ids         = array();
+		$post_ids         = [];
 		for ( $i = 0; $i < $number_new_posts; $i++ ) {
 			$post_ids[] = self::factory()->post->create(
-				array(
-					'tax_input' => array( 'category' => $category ),
-				)
+				[
+					'tax_input' => [ 'category' => $category ],
+				]
 			);
 		}
 
@@ -66,12 +66,12 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$number_of_new_terms        = 20;
 		$expected_url_count        += $number_of_new_terms;
 		$taxonomy                   = 'category';
-		$terms_for_current_taxonomy = array();
+		$terms_for_current_taxonomy = [];
 		for ( $i = 0; $i < $number_of_new_terms; $i++ ) {
 			$terms_for_current_taxonomy[] = self::factory()->term->create(
-				array(
+				[
 					'taxonomy' => $taxonomy,
-				)
+				]
 			);
 		}
 
@@ -92,7 +92,7 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	 */
 	public function test_get_posts_that_support_amp() {
 		$number_of_posts = 20;
-		$ids             = array();
+		$ids             = [];
 		for ( $i = 0; $i < $number_of_posts; $i++ ) {
 			$ids[] = self::factory()->post->create();
 		}
@@ -107,7 +107,7 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 			AMP_Post_Meta_Box::STATUS_POST_META_KEY,
 			AMP_Post_Meta_Box::DISABLED_STATUS
 		);
-		$this->assertEquals( array(), AMP_CLI::get_posts_that_support_amp( array( $first_id ) ) );
+		$this->assertEquals( [], AMP_CLI::get_posts_that_support_amp( [ $first_id ] ) );
 
 		update_post_meta(
 			$first_id,
@@ -127,9 +127,9 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		// In Transitional Mode, the IDs should also include all of the newly-created posts.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => true,
-			)
+			]
 		);
 		$this->assertEquals( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) );
 
@@ -137,16 +137,16 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		 * If the WP-CLI command has an include argument, and is_singular isn't in it, no posts will have AMP enabled.
 		 * For example, wp amp validate-site --include=is_tag,is_category
 		 */
-		AMP_CLI::$include_conditionals = array( 'is_tag', 'is_category' );
-		$this->assertEquals( array(), AMP_CLI::get_posts_that_support_amp( $ids ) );
+		AMP_CLI::$include_conditionals = [ 'is_tag', 'is_category' ];
+		$this->assertEquals( [], AMP_CLI::get_posts_that_support_amp( $ids ) );
 
 		/*
 		 * If is_singular is in the WP-CLI argument, it should allow return these posts as being AMP-enabled.
 		 * For example, wp amp validate-site include=is_singular,is_category
 		 */
-		AMP_CLI::$include_conditionals = array( 'is_singular', 'is_category' );
+		AMP_CLI::$include_conditionals = [ 'is_singular', 'is_category' ];
 		$this->assertEmpty( array_diff( $ids, AMP_CLI::get_posts_that_support_amp( $ids ) ) );
-		AMP_CLI::$include_conditionals = array();
+		AMP_CLI::$include_conditionals = [];
 	}
 
 	/**
@@ -157,8 +157,8 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	public function test_does_taxonomy_support_amp() {
 		$custom_taxonomy = 'foo_custom_taxonomy';
 		register_taxonomy( $custom_taxonomy, 'post' );
-		$taxonomies_to_test = array( $custom_taxonomy, 'category', 'post_tag' );
-		AMP_Options_Manager::update_option( 'supported_templates', array( 'is_category', 'is_tag', sprintf( 'is_tax[%s]', $custom_taxonomy ) ) );
+		$taxonomies_to_test = [ $custom_taxonomy, 'category', 'post_tag' ];
+		AMP_Options_Manager::update_option( 'supported_templates', [ 'is_category', 'is_tag', sprintf( 'is_tax[%s]', $custom_taxonomy ) ] );
 
 		// When these templates are not unchecked in the 'AMP Settings' UI, these should be supported.
 		foreach ( $taxonomies_to_test as $taxonomy ) {
@@ -166,7 +166,7 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		}
 
 		// When the user has not checked the boxes for 'Categories' and 'Tags,' this should be false.
-		AMP_Options_Manager::update_option( 'supported_templates', array( 'is_author' ) );
+		AMP_Options_Manager::update_option( 'supported_templates', [ 'is_author' ] );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		foreach ( $taxonomies_to_test as $taxonomy ) {
 			$this->assertFalse( AMP_CLI::does_taxonomy_support_amp( $taxonomy ) );
@@ -190,12 +190,12 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		 * If the user passed allowed conditionals to the WP-CLI command like wp amp validate-site --include=is_category,is_tag
 		 * these should be supported taxonomies.
 		 */
-		AMP_CLI::$include_conditionals = array( 'is_category', 'is_tag' );
+		AMP_CLI::$include_conditionals = [ 'is_category', 'is_tag' ];
 		$this->assertTrue( AMP_CLI::does_taxonomy_support_amp( 'category' ) );
 		$this->assertTrue( AMP_CLI::does_taxonomy_support_amp( 'tag' ) );
 		$this->assertFalse( AMP_CLI::does_taxonomy_support_amp( 'author' ) );
 		$this->assertFalse( AMP_CLI::does_taxonomy_support_amp( 'search' ) );
-		AMP_CLI::$include_conditionals = array();
+		AMP_CLI::$include_conditionals = [];
 	}
 
 	/**
@@ -207,12 +207,12 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$author_conditional = 'is_author';
 		$search_conditional = 'is_search';
 
-		AMP_Options_Manager::update_option( 'supported_templates', array( $author_conditional ) );
+		AMP_Options_Manager::update_option( 'supported_templates', [ $author_conditional ] );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		$this->assertTrue( AMP_CLI::is_template_supported( $author_conditional ) );
 		$this->assertFalse( AMP_CLI::is_template_supported( $search_conditional ) );
 
-		AMP_Options_Manager::update_option( 'supported_templates', array( $search_conditional ) );
+		AMP_Options_Manager::update_option( 'supported_templates', [ $search_conditional ] );
 		$this->assertTrue( AMP_CLI::is_template_supported( $search_conditional ) );
 		$this->assertFalse( AMP_CLI::is_template_supported( $author_conditional ) );
 	}
@@ -224,15 +224,15 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	 */
 	public function test_get_posts_by_type() {
 		$number_posts_each_post_type = 20;
-		$post_types                  = get_post_types( array( 'public' => true ), 'names' );
+		$post_types                  = get_post_types( [ 'public' => true ], 'names' );
 
 		foreach ( $post_types as $post_type ) {
 			// Start the expected posts with the existing post(s).
 			$query          = new WP_Query(
-				array(
+				[
 					'fields'    => 'ids',
 					'post_type' => $post_type,
-				)
+				]
 			);
 			$expected_posts = $query->posts;
 
@@ -240,9 +240,9 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 				array_unshift(
 					$expected_posts,
 					self::factory()->post->create(
-						array(
+						[
 							'post_type' => $post_type,
-						)
+						]
 					)
 				);
 			}
@@ -265,20 +265,20 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	public function test_get_taxonomy_links() {
 		$number_links_each_taxonomy = 20;
 		$taxonomies                 = get_taxonomies(
-			array(
+			[
 				'public' => true,
-			)
+			]
 		);
 
 		foreach ( $taxonomies as $taxonomy ) {
 			// Begin the expected links with the term links that already exist.
-			$expected_links             = array_map( 'get_term_link', get_terms( array( 'taxonomy' => $taxonomy ) ) );
-			$terms_for_current_taxonomy = array();
+			$expected_links             = array_map( 'get_term_link', get_terms( [ 'taxonomy' => $taxonomy ] ) );
+			$terms_for_current_taxonomy = [];
 			for ( $i = 0; $i < $number_links_each_taxonomy; $i++ ) {
 				$terms_for_current_taxonomy[] = self::factory()->term->create(
-					array(
+					[
 						'taxonomy' => $taxonomy,
-					)
+					]
 				);
 			}
 
@@ -322,22 +322,22 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$second_author_url = get_author_posts_url( $second_author->ID, $second_author->user_nicename );
 
 		// Passing 0 as the offset argument should get the first author.
-		$this->assertEquals( array( $first_author_url ), $actual_urls = AMP_CLI::get_author_page_urls( 0, 1 ) );
+		$this->assertEquals( [ $first_author_url ], $actual_urls = AMP_CLI::get_author_page_urls( 0, 1 ) );
 
 		// Passing 1 as the offset argument should get the second author.
-		$this->assertEquals( array( $second_author_url ), $actual_urls = AMP_CLI::get_author_page_urls( 1, 1 ) );
+		$this->assertEquals( [ $second_author_url ], $actual_urls = AMP_CLI::get_author_page_urls( 1, 1 ) );
 
 		// If $include_conditionals is set and does not have is_author, this should not return a URL.
-		AMP_CLI::$include_conditionals = array( 'is_category' );
-		$this->assertEquals( array(), AMP_CLI::get_author_page_urls() );
+		AMP_CLI::$include_conditionals = [ 'is_category' ];
+		$this->assertEquals( [], AMP_CLI::get_author_page_urls() );
 
 		// If $include_conditionals is set and has is_author, this should return URLs.
-		AMP_CLI::$include_conditionals = array( 'is_author' );
+		AMP_CLI::$include_conditionals = [ 'is_author' ];
 		$this->assertEquals(
-			array( $first_author_url, $second_author_url ),
+			[ $first_author_url, $second_author_url ],
 			AMP_CLI::get_author_page_urls()
 		);
-		AMP_CLI::$include_conditionals = array();
+		AMP_CLI::$include_conditionals = [];
 	}
 
 	/**
@@ -350,13 +350,13 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$this->assertInternalType( 'string', AMP_CLI::get_search_page() );
 
 		// If $include_conditionals is set and does not have is_search, this should not return a URL.
-		AMP_CLI::$include_conditionals = array( 'is_author' );
+		AMP_CLI::$include_conditionals = [ 'is_author' ];
 		$this->assertEquals( null, AMP_CLI::get_search_page() );
 
 		// If $include_conditionals has is_search, this should return a URL.
-		AMP_CLI::$include_conditionals = array( 'is_search' );
+		AMP_CLI::$include_conditionals = [ 'is_search' ];
 		$this->assertInternalType( 'string', AMP_CLI::get_search_page() );
-		AMP_CLI::$include_conditionals = array();
+		AMP_CLI::$include_conditionals = [];
 	}
 
 	/**
@@ -371,14 +371,14 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$this->assertContains( $year, AMP_CLI::get_date_page() );
 
 		// If $include_conditionals is set and does not have is_date, this should not return a URL.
-		AMP_CLI::$include_conditionals = array( 'is_search' );
+		AMP_CLI::$include_conditionals = [ 'is_search' ];
 		$this->assertEquals( null, AMP_CLI::get_date_page() );
 
 		// If $include_conditionals has is_date, this should return a URL.
-		AMP_CLI::$include_conditionals = array( 'is_date' );
+		AMP_CLI::$include_conditionals = [ 'is_date' ];
 		$parsed_page_url               = wp_parse_url( AMP_CLI::get_date_page() );
 		$this->assertContains( $year, $parsed_page_url['query'] );
-		AMP_CLI::$include_conditionals = array();
+		AMP_CLI::$include_conditionals = [];
 	}
 
 	/**
@@ -389,9 +389,9 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	public function test_crawl_site() {
 		$number_of_posts = 20;
 		$number_of_terms = 30;
-		$posts           = array();
-		$post_permalinks = array();
-		$terms           = array();
+		$posts           = [];
+		$post_permalinks = [];
+		$terms           = [];
 
 		for ( $i = 0; $i < $number_of_posts; $i++ ) {
 			$post_id           = self::factory()->post->create();
@@ -429,7 +429,7 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 		$this->assertContains( $single_post_permalink, $this->get_validated_urls() );
 
 		$number_of_posts = 30;
-		$post_permalinks = array();
+		$post_permalinks = [];
 
 		for ( $i = 0; $i < $number_of_posts; $i++ ) {
 			$permalink         = get_permalink( self::factory()->post->create() );
@@ -448,14 +448,14 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	 */
 	public function get_inital_url_count() {
 		$total_count  = 'posts' === get_option( 'show_on_front' ) ? 1 : 0;
-		$post_query   = new WP_Query( array( 'post_type' => get_post_types( array( 'public' => true ), 'names' ) ) );
+		$post_query   = new WP_Query( [ 'post_type' => get_post_types( [ 'public' => true ], 'names' ) ] );
 		$total_count += $post_query->found_posts;
 
 		$term_query = new WP_Term_Query(
-			array(
-				'taxonomy' => get_taxonomies( array( 'public' => true ) ),
+			[
+				'taxonomy' => get_taxonomies( [ 'public' => true ] ),
 				'fields'   => 'ids',
-			)
+			]
 		);
 
 		$total_count += count( $term_query->terms );
@@ -473,11 +473,11 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	 */
 	public function get_validated_urls() {
 		$query = new WP_Query(
-			array(
+			[
 				'post_type'      => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
 				'posts_per_page' => 100,
 				'fields'         => 'ids',
-			)
+			]
 		);
 
 		return array_map(
@@ -494,27 +494,27 @@ class Test_AMP_CLI extends WP_UnitTestCase {
 	 * @return array The response, with a comment in the body.
 	 */
 	public function add_comment() {
-		$mock_validation = array(
-			'results' => array(
-				array(
-					'error'     => array(
+		$mock_validation = [
+			'results' => [
+				[
+					'error'     => [
 						'code' => 'foo',
-					),
+					],
 					'sanitized' => false,
-				),
-			),
+				],
+			],
 			'url'     => home_url( '/' ),
-		);
+		];
 
-		return array(
+		return [
 			'body'     => sprintf(
 				'<html amp><head></head><body></body><!--%s--></html>',
 				'AMP_VALIDATION:' . wp_json_encode( $mock_validation )
 			),
-			'response' => array(
+			'response' => [
 				'code'    => 200,
 				'message' => 'ok',
-			),
-		);
+			],
+		];
 	}
 }

--- a/tests/php/test-class-amp-comments-sanitizer.php
+++ b/tests/php/test-class-amp-comments-sanitizer.php
@@ -108,9 +108,9 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 	public function test_add_amp_live_list_comment_attributes() {
 		$instance = new AMP_Comments_Sanitizer(
 			$this->dom,
-			array(
+			[
 				'comments_live_list' => true,
-			)
+			]
 		);
 
 		$GLOBALS['post'] = self::factory()->post->create();
@@ -143,11 +143,11 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 
 				$update_time = strtotime( $comment_object->comment_date );
 				$children    = $comment_object->get_children(
-					array(
+					[
 						'format'       => 'flat',
 						'hierarchical' => 'flat',
 						'orderby'      => 'none',
-					)
+					]
 				);
 				foreach ( $children as $child_comment ) {
 					$update_time = max( strtotime( $child_comment->comment_date ), $update_time );
@@ -184,11 +184,11 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 	 * @return array An array of strings to add to the <form>.
 	 */
 	public function get_form_element_names() {
-		return array(
+		return [
 			'comment_post_ID',
 			'foo',
 			'bar',
-		);
+		];
 	}
 
 	/**
@@ -196,12 +196,12 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 	 *
 	 * @param WP_Comment[] $comments Comments.
 	 */
-	public function create_comments_list( $comments = array() ) {
+	public function create_comments_list( $comments = [] ) {
 		ob_start();
 
 		echo '<amp-live-list><ol items>';
 		wp_list_comments(
-			array(),
+			[],
 			$comments
 		);
 		echo '</ol></amp-live-list>';
@@ -216,23 +216,23 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 	 * @return WP_Comment[] $comments An array of WP_Comment instances.
 	 */
 	public function get_comments() {
-		$comments = array();
+		$comments = [];
 
 		for ( $i = 0; $i < 5; $i++ ) {
 			$comment = self::factory()->comment->create_and_get(
-				array(
+				[
 					'comment_date' => gmdate( 'Y-m-d H:i:s', time() + $i ), // Ensure each comment has a different date.
-				)
+				]
 			);
 
 			$comments[ $comment->comment_ID ] = $comment;
 
 			for ( $j = 0; $j < 3; $j++ ) {
 				$child = self::factory()->comment->create_and_get(
-					array(
+					[
 						'comment_parent' => $comment->comment_ID,
 						'comment_date'   => gmdate( 'Y-m-d H:i:s', time() + $i + $j ), // Ensure each comment has a different date.
-					)
+					]
 				);
 
 				$comments[ $child->comment_ID ] = $child;

--- a/tests/php/test-class-amp-content-sanitizer.php
+++ b/tests/php/test-class-amp-content-sanitizer.php
@@ -3,18 +3,18 @@
 class Test_AMP_Content_Sanitizer extends WP_UnitTestCase {
 	public function test__sanitize__unchanged() {
 		$source_html     = '<b>Hello</b>';
-		$expected_return = array( '<b>Hello</b>', array(), array() );
+		$expected_return = [ '<b>Hello</b>', [], [] ];
 
-		$actual_return = AMP_Content_Sanitizer::sanitize( $source_html, array( 'AMP_Test_Stub_Sanitizer' => array() ) );
+		$actual_return = AMP_Content_Sanitizer::sanitize( $source_html, [ 'AMP_Test_Stub_Sanitizer' => [] ] );
 
 		$this->assertEquals( $expected_return, $actual_return );
 	}
 
 	public function test__sanitize__append_with_scripts_and_styles() {
 		$source_html     = '<b>Hello</b>';
-		$expected_return = array( '<b>Hello</b><em>World</em>', array( 'scripts' ), array( 'styles' ) );
+		$expected_return = [ '<b>Hello</b><em>World</em>', [ 'scripts' ], [ 'styles' ] ];
 
-		$actual_return = AMP_Content_Sanitizer::sanitize( $source_html, array( 'AMP_Test_World_Sanitizer' => array() ) );
+		$actual_return = AMP_Content_Sanitizer::sanitize( $source_html, [ 'AMP_Test_World_Sanitizer' => [] ] );
 
 		$this->assertEquals( $expected_return, $actual_return );
 	}

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -95,14 +95,14 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );
 
 		$post_id = self::factory()->post->create(
-			array(
+			[
 				'post_title'   => 'Video',
 				'post_content' => sprintf(
 					"<!-- wp:video {\"id\":%d} -->\n<figure class=\"wp-block-video\"><video controls src=\"%s\"></video></figure>\n<!-- /wp:video -->",
 					$attachment_id,
 					wp_get_attachment_url( $attachment_id )
 				),
-			)
+			]
 		);
 
 		$handler = new AMP_Core_Block_Handler();

--- a/tests/php/test-class-amp-dom-utils.php
+++ b/tests/php/test-class-amp-dom-utils.php
@@ -22,14 +22,14 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	public function test_add_attributes_to_node__no_attributes() {
 		$dom  = AMP_DOM_Utils::get_dom_from_content( '<p>Hello World</p>' );
 		$node = $dom->createElement( 'b' );
-		AMP_DOM_Utils::add_attributes_to_node( $node, array() );
+		AMP_DOM_Utils::add_attributes_to_node( $node, [] );
 		$this->assertFalse( $node->hasAttributes() );
 	}
 
 	public function test_add_attributes_to_node__attribute_without_value() {
 		$dom        = AMP_DOM_Utils::get_dom_from_content( '<p>Hello World</p>' );
 		$node       = $dom->createElement( 'div' );
-		$attributes = array( 'placeholder' => '' );
+		$attributes = [ 'placeholder' => '' ];
 		AMP_DOM_Utils::add_attributes_to_node( $node, $attributes );
 
 		$this->assertTrue( $node->hasAttributes() );
@@ -39,10 +39,10 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	public function test_add_attributes_to_node__attribute_with_value() {
 		$dom        = AMP_DOM_Utils::get_dom_from_content( '<p>Hello World</p>' );
 		$node       = $dom->createElement( 'div' );
-		$attributes = array(
+		$attributes = [
 			'class' => 'myClass',
 			'id'    => 'myId',
-		);
+		];
 		AMP_DOM_Utils::add_attributes_to_node( $node, $attributes );
 
 		$this->assertTrue( $node->hasAttributes() );
@@ -111,11 +111,11 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $original, $restored );
 
 		// Test malformed.
-		$malformed_html = array(
+		$malformed_html = [
 			'<amp-img width="123" [text]="..."</amp-img>',
 			'<amp-img width="123" [text="..."]></amp-img>',
 			'<amp-img width="123" [text]="..." *bad*></amp-img>',
-		);
+		];
 		foreach ( $malformed_html as $html ) {
 			$converted = AMP_DOM_Utils::convert_amp_bind_attributes( $html );
 			$this->assertNotContains( AMP_DOM_Utils::get_amp_bind_placeholder_prefix(), $converted, "Source: $html" );
@@ -158,17 +158,17 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function test_mustache_replacements() {
 
-		$data = array(
-			'foo' => array(
-				'bar' => array(
-					'baz' => array(),
-				),
-			),
-		);
+		$data = [
+			'foo' => [
+				'bar' => [
+					'baz' => [],
+				],
+			],
+		];
 
 		$html = implode(
 			"\n",
-			array(
+			[
 				'<!--amp-source-stack {"block_name":"core\/columns"}-->',
 				'<div class="wp-block-columns has-2-columns">',
 				'<!--amp-source-stack {"block_name":"core\/quote","block_attrs":{"layout":"column-1"}}-->',
@@ -183,7 +183,7 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 				'<script type="application/json">' . wp_json_encode( $data ) . '</script>',
 				'<template type="amp-mustache">Hello {{world}}! <a href="{{href}}" title="Hello {{name}}"><img src="{{src}}"></a><blockquote cite="{{cite}}">{{quote}}</blockquote></template>',
 				'<!-- /wp:html -->',
-			)
+			]
 		);
 
 		$dom   = AMP_DOM_Utils::get_dom_from_content( $html );
@@ -243,14 +243,14 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 * @return array An array of arrays holding an integer representation of iterations.
 	 */
 	public function get_table_row_iterations() {
-		return array(
-			array( 1 ),
-			array( 10 ),
-			array( 100 ),
-			array( 1000 ),
-			array( 10000 ),
-			array( 100000 ),
-		);
+		return [
+			[ 1 ],
+			[ 10 ],
+			[ 100 ],
+			[ 1000 ],
+			[ 10000 ],
+			[ 100000 ],
+		];
 	}
 
 	/**
@@ -355,90 +355,90 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 */
 	public function get_head_node_data() {
 		$dom = new DOMDocument();
-		return array(
-			array(
-				AMP_DOM_Utils::create_node( $dom, 'title', array() ),
+		return [
+			[
+				AMP_DOM_Utils::create_node( $dom, 'title', [] ),
 				true,
-			),
-			array(
+			],
+			[
 				AMP_DOM_Utils::create_node(
 					$dom,
 					'base',
-					array( 'href' => '/' )
+					[ 'href' => '/' ]
 				),
 				true,
-			),
-			array(
+			],
+			[
 				AMP_DOM_Utils::create_node(
 					$dom,
 					'script',
-					array( 'src' => 'http://example.com/test.js' )
+					[ 'src' => 'http://example.com/test.js' ]
 				),
 				true,
-			),
-			array(
-				AMP_DOM_Utils::create_node( $dom, 'style', array( 'media' => 'print' ) ),
+			],
+			[
+				AMP_DOM_Utils::create_node( $dom, 'style', [ 'media' => 'print' ] ),
 				true,
-			),
-			array(
-				AMP_DOM_Utils::create_node( $dom, 'noscript', array() ),
+			],
+			[
+				AMP_DOM_Utils::create_node( $dom, 'noscript', [] ),
 				true,
-			),
-			array(
+			],
+			[
 				AMP_DOM_Utils::create_node(
 					$dom,
 					'link',
-					array(
+					[
 						'rel'  => 'stylesheet',
 						'href' => 'https://example.com/foo.css',
-					)
+					]
 				),
 				true,
-			),
-			array(
+			],
+			[
 				AMP_DOM_Utils::create_node(
 					$dom,
 					'meta',
-					array(
+					[
 						'name'    => 'foo',
 						'content' => 'https://example.com/foo.css',
-					)
+					]
 				),
 				true,
-			),
-			array(
+			],
+			[
 				$dom->createTextNode( " \n\t" ),
 				true,
-			),
-			array(
+			],
+			[
 				$dom->createTextNode( 'no' ),
 				false,
-			),
-			array(
+			],
+			[
 				$dom->createComment( 'hello world' ),
 				true,
-			),
-			array(
+			],
+			[
 				$dom->createProcessingInstruction( 'test' ),
 				false,
-			),
-			array(
+			],
+			[
 				$dom->createCDATASection( 'nope' ),
 				false,
-			),
-			array(
+			],
+			[
 				$dom->createEntityReference( 'bad' ),
 				false,
-			),
-			array(
+			],
+			[
 				$dom->createElementNS( 'http://www.w3.org/2000/svg', 'svg' ),
 				false,
-			),
-			array(
-				AMP_DOM_Utils::create_node( $dom, 'span', array() ),
+			],
+			[
+				AMP_DOM_Utils::create_node( $dom, 'span', [] ),
 				false,
-			),
-		);
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-class-amp-editor-blocks.php
+++ b/tests/php/test-class-amp-editor-blocks.php
@@ -37,18 +37,18 @@ class Test_AMP_Editor_Blocks extends WP_UnitTestCase {
 	public function test_init() {
 		$this->instance->init();
 		if ( function_exists( 'register_block_type' ) ) {
-			$this->assertEquals( 10, has_filter( 'wp_kses_allowed_html', array( $this->instance, 'whitelist_block_atts_in_wp_kses_allowed_html' ) ) );
+			$this->assertEquals( 10, has_filter( 'wp_kses_allowed_html', [ $this->instance, 'whitelist_block_atts_in_wp_kses_allowed_html' ] ) );
 
 			// Because amp_is_canonical() is false, these should not be hooked.
-			$this->assertFalse( has_filter( 'the_content', array( $this->instance, 'tally_content_requiring_amp_scripts' ) ) );
-			$this->assertFalse( has_action( 'wp_print_footer_scripts', array( $this->instance, 'print_dirty_amp_scripts' ) ) );
+			$this->assertFalse( has_filter( 'the_content', [ $this->instance, 'tally_content_requiring_amp_scripts' ] ) );
+			$this->assertFalse( has_action( 'wp_print_footer_scripts', [ $this->instance, 'print_dirty_amp_scripts' ] ) );
 
 			add_theme_support( 'amp' );
 			$this->instance->init();
 
 			// Now that amp_is_canonical() is true, these action hooks should be added.
-			$this->assertEquals( 10, has_filter( 'the_content', array( $this->instance, 'tally_content_requiring_amp_scripts' ) ) );
-			$this->assertEquals( 10, has_action( 'wp_print_footer_scripts', array( $this->instance, 'print_dirty_amp_scripts' ) ) );
+			$this->assertEquals( 10, has_filter( 'the_content', [ $this->instance, 'tally_content_requiring_amp_scripts' ] ) );
+			$this->assertEquals( 10, has_action( 'wp_print_footer_scripts', [ $this->instance, 'print_dirty_amp_scripts' ] ) );
 			remove_theme_support( 'amp' );
 		}
 	}

--- a/tests/php/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/php/test-class-amp-gallery-block-sanitizer.php
@@ -16,42 +16,42 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_data() {
-		return array(
-			'no_ul'                               => array(
+		return [
+			'no_ul'                               => [
 				'<p>Lorem Ipsum Demet Delorit.</p>',
 				'<p>Lorem Ipsum Demet Delorit.</p>',
-			),
+			],
 
-			'no_a_no_amp_img'                     => array(
+			'no_a_no_amp_img'                     => [
 				'<ul class="amp-carousel"><div></div></ul>',
 				'<ul class="amp-carousel"><div></div></ul>',
-			),
+			],
 
-			'no_amp_carousel'                     => array(
+			'no_amp_carousel'                     => [
 				'<ul><a><amp-img></amp-img></a></ul>',
 				'<ul><a><amp-img></amp-img></a></ul>',
-			),
+			],
 
-			'no_block_class'                      => array(
+			'no_block_class'                      => [
 				'<ul data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
 				'<ul data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-			),
+			],
 
-			'data_amp_with_carousel'              => array(
+			'data_amp_with_carousel'              => [
 				'<ul class="wp-block-gallery" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
 				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></amp-carousel>',
-			),
+			],
 
-			'data_amp_with_lightbox'              => array(
+			'data_amp_with_lightbox'              => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></a></figure></li></ul><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
-			),
+			],
 
-			'data_amp_with_lightbox_and_carousel' => array(
+			'data_amp_with_lightbox_and_carousel' => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="1234" height="567"></amp-img></a></figure></li></ul>',
 				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><amp-img src="http://example.com/img.png" width="1234" height="567" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -71,7 +71,7 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Gallery_Block_Sanitizer(
 			$dom,
-			array( 'content_max_width' => 600 )
+			[ 'content_max_width' => 600 ]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
@@ -85,22 +85,22 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_reader_mode_data() {
-		return array(
-			'no_block_class'                      => array(
+		return [
+			'no_block_class'                      => [
 				'<ul data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
 				'<ul data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-			),
+			],
 
-			'data_amp_with_lightbox'              => array(
+			'data_amp_with_lightbox'              => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
 				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
-			),
+			],
 
-			'data_amp_with_lightbox_and_carousel' => array(
+			'data_amp_with_lightbox_and_carousel' => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
 				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -118,7 +118,7 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Gallery_Block_Sanitizer(
 			$dom,
-			array( 'carousel_required' => true )
+			[ 'carousel_required' => true ]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/tests/php/test-class-amp-gfycat-embed-handler.php
+++ b/tests/php/test-class-amp-gfycat-embed-handler.php
@@ -49,28 +49,28 @@ class AMP_Gfycat_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_conversion_data() {
-		return array(
-			'no_embed'        => array(
+		return [
+			'no_embed'        => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'url_simple'      => array(
+			'url_simple'      => [
 				'https://gfycat.com/tautwhoppingcougar' . PHP_EOL,
 				'<p><amp-gfycat width="500" height="281" data-gfyid="tautwhoppingcougar"></amp-gfycat></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_detail' => array(
+			'url_with_detail' => [
 				'https://gfycat.com/gifs/detail/tautwhoppingcougar' . PHP_EOL,
 				'<p><amp-gfycat width="500" height="281" data-gfyid="tautwhoppingcougar"></amp-gfycat></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_params' => array(
+			'url_with_params' => [
 				'https://gfycat.com/gifs/detail/tautwhoppingcougar?foo=bar' . PHP_EOL,
 				'<p><amp-gfycat width="500" height="281" data-gfyid="tautwhoppingcougar"></amp-gfycat></p>' . PHP_EOL,
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -94,16 +94,16 @@ class AMP_Gfycat_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.gfycat.com/gifs/detail/tautwhoppingcougar' . PHP_EOL,
-				array( 'amp-gfycat' => true ),
-			),
-		);
+				[ 'amp-gfycat' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-class-amp-http.php
+++ b/tests/php/test-class-amp-http.php
@@ -28,8 +28,8 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-		AMP_HTTP::$headers_sent          = array();
-		AMP_HTTP::$purged_amp_query_vars = array();
+		AMP_HTTP::$headers_sent          = [];
+		AMP_HTTP::$purged_amp_query_vars = [];
 	}
 
 	/**
@@ -40,12 +40,12 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	public function test_send_header_no_args() {
 		AMP_HTTP::send_header( 'Foo', 'Bar' );
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'Foo',
 				'value'       => 'Bar',
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 	}
@@ -59,17 +59,17 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		AMP_HTTP::send_header(
 			'Foo',
 			'Bar',
-			array(
+			[
 				'replace' => false,
-			)
+			]
 		);
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'Foo',
 				'value'       => 'Bar',
 				'replace'     => false,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 	}
@@ -83,17 +83,17 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		AMP_HTTP::send_header(
 			'Foo',
 			'Bar',
-			array(
+			[
 				'status_code' => 400,
-			)
+			]
 		);
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'Foo',
 				'value'       => 'Bar',
 				'replace'     => true,
 				'status_code' => 400,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 	}
@@ -138,14 +138,14 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	 */
 	public function test_purge_amp_query_vars() {
 		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification
-		$bad_query_vars = array(
+		$bad_query_vars = [
 			'amp_latest_update_time' => '1517199956',
 			'amp_last_check_time'    => '1517599126',
 			'__amp_source_origin'    => home_url(),
-		);
-		$ok_query_vars  = array(
+		];
+		$ok_query_vars  = [
 			'bar' => 'baz',
-		);
+		];
 		$all_query_vars = array_merge( $bad_query_vars, $ok_query_vars );
 
 		$_SERVER['QUERY_STRING'] = build_query( $all_query_vars );
@@ -160,7 +160,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 			$this->assertContains( "$key=$value", $_SERVER['REQUEST_URI'] );
 		}
 
-		AMP_HTTP::$purged_amp_query_vars = array();
+		AMP_HTTP::$purged_amp_query_vars = [];
 		AMP_HTTP::purge_amp_query_vars();
 		$this->assertEqualSets( AMP_HTTP::$purged_amp_query_vars, $bad_query_vars );
 
@@ -203,7 +203,7 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 
 		$hosts = AMP_HTTP::get_amp_cache_hosts();
 
-		$expected = array(
+		$expected = [
 			'cdn.ampproject.org',
 			'example-org.cdn.ampproject.org',
 			'example-org.amp.cloudflare.com',
@@ -211,13 +211,13 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 			'example-com.cdn.ampproject.org',
 			'example-com.amp.cloudflare.com',
 			'example-com.bing-amp.com',
-		);
+		];
 		$this->assertEqualSets( $expected, $hosts );
 
-		$extra_allowed_redirect_hosts = array(
+		$extra_allowed_redirect_hosts = [
 			'example.net',
 			'example.info',
-		);
+		];
 
 		$this->assertEqualSets(
 			array_merge( $extra_allowed_redirect_hosts, $expected ),
@@ -233,137 +233,137 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 	public function test_send_cors_headers() {
 
 		// Initial case case.
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 		AMP_HTTP::send_cors_headers();
 		$this->assertEmpty( AMP_HTTP::$headers_sent );
 
 		// Try an invalid Origin header.
-		AMP_HTTP::$headers_sent          = array();
-		AMP_HTTP::$purged_amp_query_vars = array();
+		AMP_HTTP::$headers_sent          = [];
+		AMP_HTTP::$purged_amp_query_vars = [];
 		$_SERVER['HTTP_ORIGIN']          = 'https://evil.example.com';
 		AMP_HTTP::send_cors_headers();
 		$this->assertEmpty( AMP_HTTP::$headers_sent );
 
 		// Try an invalid __amp_source_origin.
-		AMP_HTTP::$headers_sent          = array();
-		AMP_HTTP::$purged_amp_query_vars = array();
+		AMP_HTTP::$headers_sent          = [];
+		AMP_HTTP::$purged_amp_query_vars = [];
 		unset( $_SERVER['HTTP_ORIGIN'] );
 		$_GET['__amp_source_origin'] = 'https://evil.example.com';
 		AMP_HTTP::send_cors_headers();
 		$this->assertEmpty( AMP_HTTP::$headers_sent );
 
 		// Try an allowed Origin header.
-		AMP_HTTP::$headers_sent          = array();
-		AMP_HTTP::$purged_amp_query_vars = array();
+		AMP_HTTP::$headers_sent          = [];
+		AMP_HTTP::$purged_amp_query_vars = [];
 		$_SERVER['HTTP_ORIGIN']          = home_url();
 		AMP_HTTP::send_cors_headers();
 		$this->assertEquals(
-			array(
-				array(
+			[
+				[
 					'name'        => 'Access-Control-Allow-Origin',
 					'value'       => home_url(),
 					'replace'     => false,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Access-Control-Allow-Credentials',
 					'value'       => 'true',
 					'replace'     => true,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Vary',
 					'value'       => 'Origin',
 					'replace'     => false,
 					'status_code' => null,
-				),
-			),
+				],
+			],
 			AMP_HTTP::$headers_sent
 		);
 
 		// The __amp_source_origin is specified but the Origin header is not.
-		AMP_HTTP::$headers_sent      = array();
+		AMP_HTTP::$headers_sent      = [];
 		$_GET['__amp_source_origin'] = 'https://cdn.ampproject.org';
 		$_SERVER['REQUEST_METHOD']   = 'POST';
 		unset( $_SERVER['HTTP_ORIGIN'] );
 		AMP_HTTP::purge_amp_query_vars();
 		AMP_HTTP::send_cors_headers();
 		$this->assertEquals(
-			array(
-				array(
+			[
+				[
 					'name'        => 'Access-Control-Allow-Origin',
 					'value'       => 'https://cdn.ampproject.org',
 					'replace'     => false,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Access-Control-Allow-Credentials',
 					'value'       => 'true',
 					'replace'     => true,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Vary',
 					'value'       => 'Origin',
 					'replace'     => false,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'AMP-Access-Control-Allow-Source-Origin',
 					'value'       => 'https://cdn.ampproject.org',
 					'replace'     => true,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Access-Control-Expose-Headers',
 					'value'       => 'AMP-Access-Control-Allow-Source-Origin',
 					'replace'     => false,
 					'status_code' => null,
-				),
-			),
+				],
+			],
 			AMP_HTTP::$headers_sent
 		);
 
 		// The Origin header and the __amp_source_origin are both specified.
-		AMP_HTTP::$headers_sent      = array();
+		AMP_HTTP::$headers_sent      = [];
 		$_GET['__amp_source_origin'] = home_url();
 		$_SERVER['REQUEST_METHOD']   = 'POST';
 		$_SERVER['HTTP_ORIGIN']      = 'https://cdn.ampproject.org';
 		AMP_HTTP::purge_amp_query_vars();
 		AMP_HTTP::send_cors_headers();
 		$this->assertEquals(
-			array(
-				array(
+			[
+				[
 					'name'        => 'Access-Control-Allow-Origin',
 					'value'       => 'https://cdn.ampproject.org',
 					'replace'     => false,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Access-Control-Allow-Credentials',
 					'value'       => 'true',
 					'replace'     => true,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Vary',
 					'value'       => 'Origin',
 					'replace'     => false,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'AMP-Access-Control-Allow-Source-Origin',
 					'value'       => home_url(),
 					'replace'     => true,
 					'status_code' => null,
-				),
-				array(
+				],
+				[
 					'name'        => 'Access-Control-Expose-Headers',
 					'value'       => 'AMP-Access-Control-Allow-Source-Origin',
 					'replace'     => false,
 					'status_code' => null,
-				),
-			),
+				],
+			],
 			AMP_HTTP::$headers_sent
 		);
 	}
@@ -378,10 +378,10 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		$_SERVER['REQUEST_METHOD']                        = 'POST';
 		AMP_HTTP::purge_amp_query_vars();
 		AMP_HTTP::handle_xhr_request();
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'wp_redirect', array( 'AMP_HTTP', 'intercept_post_request_redirect' ) ) );
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_post_redirect', array( 'AMP_HTTP', 'filter_comment_post_redirect' ) ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'wp_redirect', [ 'AMP_HTTP', 'intercept_post_request_redirect' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_post_redirect', [ 'AMP_HTTP', 'filter_comment_post_redirect' ] ) );
 		$this->assertEquals(
-			array( 'AMP_HTTP', 'handle_wp_die' ),
+			[ 'AMP_HTTP', 'handle_wp_die' ],
 			apply_filters( 'wp_die_handler', '__return_true' )
 		);
 	}
@@ -405,104 +405,104 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		);
 
 		$redirecting_json = wp_json_encode(
-			array(
+			[
 				'message'     => __( 'Redirecting…', 'amp' ),
 				'redirecting' => true,
-			)
+			]
 		);
 
 		// Test redirecting to full URL with HTTPS protocol.
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 		ob_start();
 		AMP_HTTP::intercept_post_request_redirect( $url );
 		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'AMP-Redirect-To',
 				'value'       => $url,
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'Access-Control-Expose-Headers',
 				'value'       => 'AMP-Redirect-To',
 				'replace'     => false,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 
 		// Test redirecting to non-HTTPS URL.
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 		ob_start();
 		$url = home_url( '/', 'http' );
 		AMP_HTTP::intercept_post_request_redirect( $url );
 		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'AMP-Redirect-To',
 				'value'       => preg_replace( '#^\w+:#', '', $url ),
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'Access-Control-Expose-Headers',
 				'value'       => 'AMP-Redirect-To',
 				'replace'     => false,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 
 		// Test redirecting to host-less location.
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 		ob_start();
 		AMP_HTTP::intercept_post_request_redirect( '/new-location/' );
 		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'AMP-Redirect-To',
 				'value'       => set_url_scheme( home_url( '/new-location/' ), 'https' ),
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 
 		// Test redirecting to scheme-less location.
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 		ob_start();
 		$url = home_url( '/new-location/' );
 		AMP_HTTP::intercept_post_request_redirect( substr( $url, strpos( $url, ':' ) + 1 ) );
 		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'AMP-Redirect-To',
 				'value'       => set_url_scheme( home_url( '/new-location/' ), 'https' ),
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 
 		// Test redirecting to empty location.
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 		ob_start();
 		AMP_HTTP::intercept_post_request_redirect( '' );
 		$this->assertEquals( $redirecting_json, ob_get_clean() );
 		$this->assertContains(
-			array(
+			[
 				'name'        => 'AMP-Redirect-To',
 				'value'       => set_url_scheme( home_url(), 'https' ),
 				'replace'     => true,
 				'status_code' => null,
-			),
+			],
 			AMP_HTTP::$headers_sent
 		);
 	}
@@ -548,9 +548,9 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$post    = self::factory()->post->create_and_get();
 		$comment = self::factory()->comment->create_and_get(
-			array(
+			[
 				'comment_post_ID' => $post->ID,
-			)
+			]
 		);
 		$url     = get_comment_link( $comment );
 
@@ -564,9 +564,9 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		// Test with comments_live_list.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'comments_live_list' => true,
-			)
+			]
 		);
 		add_filter(
 			'amp_comment_posted_message',

--- a/tests/php/test-class-amp-hulu-embed-handler.php
+++ b/tests/php/test-class-amp-hulu-embed-handler.php
@@ -26,13 +26,13 @@ class AMP_Hulu_Embed_Test extends WP_UnitTestCase {
 				if ( false === strpos( $url, '771496' ) ) {
 					return $pre;
 				}
-				return array(
+				return [
 					'body'     => '{"title":"Out of the Box / Run Down Race Car (Doc McStuffins)","author_name":"Disney Junior","type":"video","provider_name":"Hulu","air_date":"Fri Mar 23 00:00:00 UTC 2012","embed_url":"//www.hulu.com/embed.html?eid=_hHzwnAcj3RrXMJFDDvkuw","thumbnail_url":"http://ib.huluim.com/video/60528019?size=240x180&caller=h1o&img=i","width":500,"thumbnail_width":500,"provider_url":"//www.hulu.com/","thumbnail_height":375,"cache_age":3600,"version":"1.0","large_thumbnail_url":"http://ib.huluim.com/video/60528019?size=512x288&caller=h1o&img=i","height":289,"large_thumbnail_width":512,"html":"<iframe width=\\"500\\" height=\\"289\\" src=\\"//www.hulu.com/embed.html?eid=_hHzwnAcj3RrXMJFDDvkuw\\" frameborder=\\"0\\" scrolling=\\"no\\" webkitAllowFullScreen mozallowfullscreen allowfullscreen> </iframe>","duration":1446.25,"large_thumbnail_height":288}',
-					'response' => array(
+					'response' => [
 						'code'    => 200,
 						'message' => 'OK',
-					),
-				);
+					],
+				];
 			},
 			10,
 			3
@@ -55,23 +55,23 @@ class AMP_Hulu_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_conversion_data() {
-		return array(
-			'no_embed'        => array(
+		return [
+			'no_embed'        => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'url_simple'      => array(
+			'url_simple'      => [
 				'https://www.hulu.com/watch/771496' . PHP_EOL,
 				'<p><amp-hulu width="500" height="289" data-eid="771496"></amp-hulu></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_params' => array(
+			'url_with_params' => [
 				'https://www.hulu.com/watch/771496?foo=bar' . PHP_EOL,
 				'<p><amp-hulu width="500" height="289" data-eid="771496"></amp-hulu></p>' . PHP_EOL,
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -95,16 +95,16 @@ class AMP_Hulu_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.hulu.com/watch/771496' . PHP_EOL,
-				array( 'amp-hulu' => true ),
-			),
-		);
+				[ 'amp-hulu' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-class-amp-imgur-embed-handler.php
+++ b/tests/php/test-class-amp-imgur-embed-handler.php
@@ -26,13 +26,13 @@ class AMP_Imgur_Embed_Test extends WP_UnitTestCase {
 				if ( false === strpos( $url, 'f462IUj' ) ) {
 					return $pre;
 				}
-				return array(
+				return [
 					'body' => '{"version":"1.0","type":"rich","provider_name":"Imgur","provider_url":"https:\\/\\/imgur.com","width":500,"height":750,"html":"<blockquote class=\\"imgur-embed-pub\\" lang=\\"en\\" data-id=\\"f462IUj\\"><a href=\\"https:\\/\\/imgur.com\\/f462IUj\\">Getting that beach body ready<\\/a><\\/blockquote><script async src=\\"\\/\\/s.imgur.com\\/min\\/embed.js\\" charset=\\"utf-8\\"><\\/script>"}', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'response' => array(
+				'response' => [
 					'code'    => 200,
 					'message' => 'OK',
-				),
-				);
+				],
+				];
 			},
 			10,
 			3
@@ -62,28 +62,28 @@ class AMP_Imgur_Embed_Test extends WP_UnitTestCase {
 			$width  = 500;
 			$height = 750;
 		}
-		return array(
-			'no_embed'        => array(
+		return [
+			'no_embed'        => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
-			),
+			],
 
-			'url_simple'      => array(
+			'url_simple'      => [
 				'https://imgur.com/f462IUj' . PHP_EOL,
 				'<p><amp-imgur width="' . $width . '" height="' . $height . '" data-imgur-id="f462IUj"></amp-imgur></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_detail' => array(
+			'url_with_detail' => [
 				'https://imgur.com/gallery/f462IUj' . PHP_EOL,
 				'<p><amp-imgur width="' . $width . '" height="' . $height . '" data-imgur-id="f462IUj"></amp-imgur></p>' . PHP_EOL,
-			),
+			],
 
-			'url_with_params' => array(
+			'url_with_params' => [
 				'https://imgur.com/gallery/f462IUj?foo=bar' . PHP_EOL,
 				'<p><amp-imgur width="' . $width . '" height="' . $height . '" data-imgur-id="f462IUj"></amp-imgur></p>' . PHP_EOL,
-			),
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -107,16 +107,16 @@ class AMP_Imgur_Embed_Test extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_scripts_data() {
-		return array(
-			'not_converted' => array(
+		return [
+			'not_converted' => [
 				'<p>Hello World.</p>',
-				array(),
-			),
-			'converted'     => array(
+				[],
+			],
+			'converted'     => [
 				'https://www.imgur.com/gallery/f462IUj' . PHP_EOL,
-				array( 'amp-imgur' => true ),
-			),
-		);
+				[ 'amp-imgur' => true ],
+			],
+		];
 	}
 
 	/**

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -51,10 +51,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 */
 	public function test_init() {
 		$this->instance->init();
-		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $this->instance, 'enqueue_admin_assets' ) ) );
-		$this->assertEquals( 10, has_action( 'enqueue_block_editor_assets', array( $this->instance, 'enqueue_block_assets' ) ) );
-		$this->assertEquals( 10, has_action( 'post_submitbox_misc_actions', array( $this->instance, 'render_status' ) ) );
-		$this->assertEquals( 10, has_action( 'save_post', array( $this->instance, 'save_amp_status' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', [ $this->instance, 'enqueue_admin_assets' ] ) );
+		$this->assertEquals( 10, has_action( 'enqueue_block_editor_assets', [ $this->instance, 'enqueue_block_assets' ] ) );
+		$this->assertEquals( 10, has_action( 'post_submitbox_misc_actions', [ $this->instance, 'render_status' ] ) );
+		$this->assertEquals( 10, has_action( 'save_post', [ $this->instance, 'save_amp_status' ] ) );
 	}
 
 	/**
@@ -103,12 +103,12 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// If a post type doesn't have AMP enabled, the script shouldn't be enqueued.
 		register_post_type(
 			'secret',
-			array( 'public' => false )
+			[ 'public' => false ]
 		);
 		$GLOBALS['post'] = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => 'secret',
-			)
+			]
 		);
 		$this->instance->enqueue_block_assets();
 		$this->assertFalse( wp_script_is( AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ) );
@@ -120,7 +120,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 
 		$block_script = wp_scripts()->registered[ AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE ];
 		$this->assertEqualSets(
-			array(
+			[
 				'lodash',
 				'moment',
 				'wp-block-editor',
@@ -135,7 +135,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 				'wp-plugins',
 				'wp-polyfill',
 				'wp-server-side-render',
-			),
+			],
 			$block_script->deps
 		);
 		$this->assertEquals( AMP_Post_Meta_Box::BLOCK_ASSET_HANDLE, $block_script->handle );
@@ -167,9 +167,9 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$post = self::factory()->post->create_and_get();
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'administrator',
-				)
+				]
 			)
 		);
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
@@ -178,19 +178,19 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 
 		// This is not in AMP 'canonical mode' but rather reader or transitional mode.
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		$output = get_echo( array( $this->instance, 'render_status' ), array( $post ) );
+		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
 		$this->assertContains( $amp_status_markup, $output );
 		$this->assertContains( $checkbox_enabled, $output );
 
 		// This is in AMP-first mode with a template that can be rendered.
 		add_theme_support( AMP_Theme_Support::SLUG );
-		$output = get_echo( array( $this->instance, 'render_status' ), array( $post ) );
+		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
 		$this->assertContains( $amp_status_markup, $output );
 		$this->assertContains( $checkbox_enabled, $output );
 
 		// Post type no longer supports AMP, so no status input.
 		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
-		$output = get_echo( array( $this->instance, 'render_status' ), array( $post ) );
+		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
 		$this->assertContains( 'post type does not support it', $output );
 		$this->assertNotContains( $checkbox_enabled, $output );
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
@@ -198,7 +198,7 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// No template is available to render the post.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
-		$output = get_echo( array( $this->instance, 'render_status' ), array( $post ) );
+		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
 		$this->assertContains( 'no supported templates to display this in AMP.', wp_strip_all_tags( $output ) );
 		$this->assertNotContains( $checkbox_enabled, $output );
 
@@ -206,13 +206,13 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'subscriber',
-				)
+				]
 			)
 		);
 
-		$output = get_echo( array( $this->instance, 'render_status' ), array( $post ) );
+		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
 		$this->assertEmpty( $output );
 	}
 
@@ -222,10 +222,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 * @see AMP_Post_Meta_Box::get_status_and_errors()
 	 */
 	public function test_get_status_and_errors() {
-		$expected_status_and_errors = array(
+		$expected_status_and_errors = [
 			'status' => 'enabled',
-			'errors' => array(),
-		);
+			'errors' => [],
+		];
 
 		// A post of type post shouldn't have errors, and AMP should be enabled.
 		$post = self::factory()->post->create_and_get();
@@ -244,10 +244,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// If post type doesn't support AMP, this method should return AMP as being disabled.
 		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		$this->assertEquals(
-			array(
+			[
 				'status' => 'disabled',
-				'errors' => array( 'post-type-support' ),
-			),
+				'errors' => [ 'post-type-support' ],
+			],
 			$this->instance->get_status_and_errors( $post )
 		);
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
@@ -256,10 +256,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		$this->assertEquals(
-			array(
+			[
 				'status' => 'disabled',
-				'errors' => array( 'no_matching_template' ),
-			),
+				'errors' => [ 'no_matching_template' ],
+			],
 			$this->instance->get_status_and_errors( $post )
 		);
 	}
@@ -271,39 +271,39 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 	 */
 	public function test_get_error_messages() {
 		$this->assertEquals(
-			array( 'Your site does not allow AMP to be disabled.' ),
-			$this->instance->get_error_messages( AMP_Post_Meta_Box::ENABLED_STATUS, array( 'status_immutable' ) )
+			[ 'Your site does not allow AMP to be disabled.' ],
+			$this->instance->get_error_messages( AMP_Post_Meta_Box::ENABLED_STATUS, [ 'status_immutable' ] )
 		);
 
 		$this->assertEquals(
-			array( 'Your site does not allow AMP to be enabled.' ),
-			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, array( 'status_immutable' ) )
+			[ 'Your site does not allow AMP to be enabled.' ],
+			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'status_immutable' ] )
 		);
 
-		$messages = $this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, array( 'template_unsupported' ) );
+		$messages = $this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'template_unsupported' ] );
 		$this->assertContains( 'There are no', $messages[0] );
 		$this->assertContains( 'page=amp-options', $messages[0] );
 
 		$this->assertEquals(
-			array( 'AMP cannot be enabled on password protected posts.' ),
-			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, array( 'password-protected' ) )
+			[ 'AMP cannot be enabled on password protected posts.' ],
+			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'password-protected' ] )
 		);
 
-		$messages = $this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, array( 'post-type-support' ) );
+		$messages = $this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'post-type-support' ] );
 		$this->assertContains( 'AMP cannot be enabled because this', $messages[0] );
 		$this->assertContains( 'page=amp-options', $messages[0] );
 
 		$this->assertEquals(
-			array(
+			[
 				'A plugin or theme has disabled AMP support.',
 				'Unavailable for an unknown reason.',
-			),
-			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, array( 'skip-post', 'unknown-error' ) )
+			],
+			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'skip-post', 'unknown-error' ] )
 		);
 
 		$this->assertEquals(
-			array( 'Unavailable for an unknown reason.' ),
-			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, array( 'unknown-error' ) )
+			[ 'Unavailable for an unknown reason.' ],
+			$this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'unknown-error' ] )
 		);
 	}
 
@@ -320,9 +320,9 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// Setup for success.
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'administrator',
-				)
+				]
 			)
 		);
 		$_POST[ AMP_Post_Meta_Box::NONCE_NAME ]        = wp_create_nonce( AMP_Post_Meta_Box::NONCE_ACTION );
@@ -338,10 +338,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create();
 		delete_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY );
 		wp_update_post(
-			array(
+			[
 				'ID'         => $post_id,
 				'post_title' => 'updated',
-			)
+			]
 		);
 		$this->assertTrue( (bool) get_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) );
 
@@ -349,10 +349,10 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$_POST[ AMP_Post_Meta_Box::STATUS_INPUT_NAME ] = 'enabled';
 		delete_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY );
 		wp_update_post(
-			array(
+			[
 				'ID'         => $post_id,
 				'post_title' => 'updated',
-			)
+			]
 		);
 		$this->assertEquals( AMP_Post_Meta_Box::ENABLED_STATUS, get_post_meta( $post_id, AMP_Post_Meta_Box::STATUS_POST_META_KEY, true ) );
 	}

--- a/tests/php/test-class-amp-nav-menu-toggle-sanitizer.php
+++ b/tests/php/test-class-amp-nav-menu-toggle-sanitizer.php
@@ -37,59 +37,59 @@ class Test_AMP_Nav_Menu_Toggle_Sanitizer extends WP_UnitTestCase {
 			return ' on="tap:AMP.setState({ navMenuToggledOn: ! navMenuToggledOn })" aria-expanded="false" [aria-expanded]="navMenuToggledOn ? \'true\' : \'false\'"' . ( ! empty( $toggle_class ) ? ' [class]="&quot;' . $class . '&quot; + ( navMenuToggledOn ? &quot; ' . $toggle_class . '&quot; : \'\' )"' : '' );
 		};
 
-		return array(
-			'container_before_toggle' => array(
+		return [
+			'container_before_toggle' => [
 				'<html>' . $head . '<body>' . $container . $toggle . '</body></html>',
 				'<html>' . $head . '<body>' . $amp_state . str_replace( '></div>', $amp_get_container_attrs( 'nav-menu-wrapper' ) . '></div>', $container ) . str_replace( '>Toggle', $amp_get_toggle_attrs() . '>Toggle', $toggle ) . '</body></html>',
-				array(
+				[
 					'nav_container_id'           => $container_id,
 					'menu_button_id'             => $toggle_id,
 					'nav_container_toggle_class' => 'toggled-on',
 					'menu_button_toggle_class'   => 'toggled-on',
-				),
-			),
-			'toggle_before_container' => array(
+				],
+			],
+			'toggle_before_container' => [
 				'<html>' . $head . '<body>' . $toggle . $container . '</body></html>',
 				'<html>' . $head . '<body>' . str_replace( '>Toggle', $amp_get_toggle_attrs() . '>Toggle', $toggle ) . $amp_state . str_replace( '></div>', $amp_get_container_attrs( 'nav-menu-wrapper' ) . '></div>', $container ) . '</body></html>',
-				array(
+				[
 					'nav_container_id'           => $container_id,
 					'menu_button_id'             => $toggle_id,
 					'nav_container_toggle_class' => 'toggled-on',
 					'menu_button_toggle_class'   => 'toggled-on',
-				),
-			),
-			'container_is_body'       => array(
+				],
+			],
+			'container_is_body'       => [
 				'<html>' . $head . '<body>' . $container . $toggle . '</body></html>',
 				'<html>' . $head . '<body' . $amp_get_container_attrs( '', 'nav-menu-toggled-on' ) . '>' . $amp_state . $container . str_replace( '>Toggle', $amp_get_toggle_attrs( '', '' ) . '>Toggle', $toggle ) . '</body></html>',
-				array(
+				[
 					'nav_container_xpath'        => '//body',
 					'menu_button_id'             => $toggle_id,
 					'nav_container_toggle_class' => 'nav-menu-toggled-on',
-				),
-			),
-			'container_is_html'       => array(
+				],
+			],
+			'container_is_html'       => [
 				'<html>' . $head . '<body>' . $container . $toggle . '</body></html>',
 				'<html' . $amp_get_container_attrs( '', 'nav-menu-toggled-on' ) . '>' . $head . '<body>' . $amp_state . $container . str_replace( '>Toggle', $amp_get_toggle_attrs( '', '' ) . '>Toggle', $toggle ) . '</body></html>',
-				array(
+				[
 					'nav_container_xpath'        => '//html',
 					'menu_button_id'             => $toggle_id,
 					'nav_container_toggle_class' => 'nav-menu-toggled-on',
-				),
-			),
-			'no_container_provided'   => array(
+				],
+			],
+			'no_container_provided'   => [
 				'<html>' . $head . '<body>' . $container . $toggle . '</body></html>',
 				'<html>' . $head . '<body>' . $container . '</body></html>',
-				array(
+				[
 					'menu_button_id'             => $toggle_id,
 					'nav_container_toggle_class' => 'toggled-on',
-				),
-			),
-			'no_arguments_provided'   => array(
+				],
+			],
+			'no_arguments_provided'   => [
 				'<html>' . $head . '<body>' . $container . $toggle . '</body></html>',
 				'<html>' . $head . '<body>' . $container . $toggle . '</body></html>',
-				array(),
-			),
-		);
+				[],
+			],
+		];
 	}
 
 	/**
@@ -104,7 +104,7 @@ class Test_AMP_Nav_Menu_Toggle_Sanitizer extends WP_UnitTestCase {
 	 * @covers AMP_Nav_Menu_Toggle_Sanitizer::get_nav_container()
 	 * @covers AMP_Nav_Menu_Toggle_Sanitizer::get_menu_button()
 	 */
-	public function test_converter( $source, $expected, $args = array() ) {
+	public function test_converter( $source, $expected, $args = [] ) {
 		$dom       = AMP_DOM_Utils::get_dom( $source );
 		$sanitizer = new AMP_Nav_Menu_Toggle_Sanitizer( $dom, $args );
 

--- a/tests/php/test-class-amp-options-menu.php
+++ b/tests/php/test-class-amp-options-menu.php
@@ -43,7 +43,7 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 	 */
 	public function test_init() {
 		$this->instance->init();
-		$this->assertEquals( 9, has_action( 'admin_menu', array( $this->instance, 'add_menu_items' ) ) );
+		$this->assertEquals( 9, has_action( 'admin_menu', [ $this->instance, 'add_menu_items' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_post_amp_analytics_options', 'AMP_Options_Manager::handle_analytics_submit' ) );
 	}
 
@@ -57,9 +57,9 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'administrator',
-				)
+				]
 			)
 		);
 
@@ -92,9 +92,9 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 	public function test_render_screen_for_admin_user() {
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'administrator',
-				)
+				]
 			)
 		);
 

--- a/tests/php/test-class-amp-playlist-embed-handler.php
+++ b/tests/php/test-class-amp-playlist-embed-handler.php
@@ -101,7 +101,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$this->instance->enqueue_styles();
 		$style = wp_styles()->registered[ $playlist_shortcode ];
 		$this->assertContains( $playlist_shortcode, wp_styles()->queue );
-		$this->assertEquals( array( 'wp-mediaelement' ), $style->deps );
+		$this->assertEquals( [ 'wp-mediaelement' ], $style->deps );
 		$this->assertEquals( $playlist_shortcode, $style->handle );
 		$this->assertEquals( amp_get_asset_url( 'css/amp-playlist-shortcode.css' ), $style->src );
 		$this->assertEquals( AMP__VERSION, $style->ver );
@@ -145,56 +145,56 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * @covers AMP_Playlist_Embed_Handler::get_thumb_dimensions()
 	 */
 	public function test_get_thumb_dimensions() {
-		$dimensions = array(
+		$dimensions = [
 			'height' => 60,
 			'width'  => 60,
-		);
-		$track      = array(
+		];
+		$track      = [
 			'thumb' => $dimensions,
-		);
+		];
 		$this->assertEquals( $dimensions, $this->instance->get_thumb_dimensions( $track ) );
 
-		$dimensions = array(
+		$dimensions = [
 			'height' => 68,
 			'width'  => 59,
-		);
-		$track      = array(
+		];
+		$track      = [
 			'thumb' => $dimensions,
-		);
+		];
 		$this->assertEquals( $dimensions, $this->instance->get_thumb_dimensions( $track ) );
 
-		$dimensions          = array(
+		$dimensions          = [
 			'height' => 70,
 			'width'  => 80.5,
-		);
-		$expected_dimensions = array(
+		];
+		$expected_dimensions = [
 			'height' => 52,
 			'width'  => 60,
-		);
-		$track               = array(
+		];
+		$track               = [
 			'thumb' => $dimensions,
-		);
+		];
 		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
 
-		$dimensions          = array(
+		$dimensions          = [
 			'width' => 80.5,
-		);
-		$track               = array(
+		];
+		$track               = [
 			'thumb' => $dimensions,
-		);
-		$expected_dimensions = array(
+		];
+		$expected_dimensions = [
 			'height' => 48,
 			'width'  => 60,
-		);
+		];
 		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
 
-		$track               = array(
-			'thumb' => array(),
-		);
-		$expected_dimensions = array(
+		$track               = [
+			'thumb' => [],
+		];
+		$expected_dimensions = [
 			'height' => AMP_Playlist_Embed_Handler::DEFAULT_THUMB_HEIGHT,
 			'width'  => AMP_Playlist_Embed_Handler::DEFAULT_THUMB_WIDTH,
-		);
+		];
 		$this->assertEquals( $expected_dimensions, $this->instance->get_thumb_dimensions( $track ) );
 	}
 
@@ -207,7 +207,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 */
 	public function test_audio_playlist() {
 		$attr     = $this->get_attributes( 'audio' );
-		$playlist = $this->instance->audio_playlist( array() );
+		$playlist = $this->instance->audio_playlist( [] );
 		$this->assertEquals( '', $playlist );
 
 		$data     = $this->instance->get_data( $attr );
@@ -231,7 +231,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$state_id    = 'fooId1';
 		$expected_on = 'tap:AMP.setState({&quot;' . $state_id . '&quot;:{&quot;selectedIndex&quot;:0}})';
 
-		$tracks = get_echo( array( $this->instance, 'print_tracks' ), array( $state_id, $data['tracks'] ) );
+		$tracks = get_echo( [ $this->instance, 'print_tracks' ], [ $state_id, $data['tracks'] ] );
 		$this->assertContains( '<div class="wp-playlist-tracks">', $tracks );
 		$this->assertContains( $state_id, $tracks );
 		$this->assertContains( $expected_on, $tracks );
@@ -240,7 +240,7 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$data        = $this->instance->get_data( $attr );
 		$expected_on = 'tap:AMP.setState({&quot;' . $state_id . '&quot;:{&quot;selectedIndex&quot;:0}})';
 
-		$tracks = get_echo( array( $this->instance, 'print_tracks' ), array( $state_id, $data['tracks'] ) );
+		$tracks = get_echo( [ $this->instance, 'print_tracks' ], [ $state_id, $data['tracks'] ] );
 		$this->assertContains( $expected_on, $tracks );
 	}
 
@@ -265,23 +265,23 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	public function test_get_title() {
 		$caption = 'Example caption';
 		$title   = 'Media Title';
-		$track   = array(
+		$track   = [
 			'caption' => $caption,
-		);
+		];
 
 		$this->assertEquals( $caption, $this->instance->get_title( $track ) );
 
-		$track = array(
+		$track = [
 			'title' => $title,
-		);
+		];
 		$this->assertEquals( $title, $this->instance->get_title( $track ) );
 
-		$track = array(
+		$track = [
 			'caption' => $caption,
 			'title'   => $title,
-		);
+		];
 		$this->assertEquals( $caption, $this->instance->get_title( $track ) );
-		$this->assertEquals( null, $this->instance->get_title( array() ) );
+		$this->assertEquals( null, $this->instance->get_title( [] ) );
 	}
 
 	/**
@@ -303,15 +303,15 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 			return;
 		}
 
-		$files = array(
+		$files = [
 			$this->file_1,
 			$this->file_2,
-		);
+		];
 		$ids   = $this->get_file_ids( $files, $mime_type );
-		return array(
+		return [
 			'ids'  => implode( ',', $ids ),
 			'type' => $type,
-		);
+		];
 	}
 
 	/**
@@ -322,15 +322,15 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	 * @return array $ids The IDs of the test files.
 	 */
 	public function get_file_ids( $files, $mime_type ) {
-		$ids = array();
+		$ids = [];
 		foreach ( $files as $file ) {
 			$ids[] = self::factory()->attachment->create_object(
 				$file,
 				0,
-				array(
+				[
 					'post_mime_type' => $mime_type,
 					'post_type'      => 'attachment',
-				)
+				]
 			);
 		}
 		return $ids;

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -30,26 +30,26 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	public function test_get_eligible_post_types() {
 		register_post_type(
 			'book',
-			array(
+			[
 				'label'  => 'Book',
 				'public' => true,
-			)
+			]
 		);
 		register_post_type(
 			'secret',
-			array(
+			[
 				'label'  => 'Secret',
 				'public' => false,
-			)
+			]
 		);
 
 		$this->assertEqualSets(
-			array(
+			[
 				'post',
 				'page',
 				'attachment',
 				'book',
-			),
+			],
 			AMP_Post_Type_Support::get_eligible_post_types()
 		);
 	}
@@ -63,19 +63,19 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		register_post_type(
 			'book',
-			array(
+			[
 				'label'  => 'Book',
 				'public' => true,
-			)
+			]
 		);
 		register_post_type(
 			'poem',
-			array(
+			[
 				'label'  => 'Poem',
 				'public' => true,
-			)
+			]
 		);
-		AMP_Options_Manager::update_option( 'supported_post_types', array( 'post', 'poem' ) );
+		AMP_Options_Manager::update_option( 'supported_post_types', [ 'post', 'poem' ] );
 
 		AMP_Post_Type_Support::add_post_type_support();
 		$this->assertTrue( post_type_supports( 'post', AMP_Post_Type_Support::SLUG ) );
@@ -92,27 +92,27 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		register_post_type(
 			'book',
-			array(
+			[
 				'label'  => 'Book',
 				'public' => true,
-			)
+			]
 		);
 
 		// Post type support.
-		$book_id = self::factory()->post->create( array( 'post_type' => 'book' ) );
-		$this->assertEquals( array( 'post-type-support' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
+		$book_id = self::factory()->post->create( [ 'post_type' => 'book' ] );
+		$this->assertEquals( [ 'post-type-support' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		add_post_type_support( 'book', AMP_Post_Type_Support::SLUG );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
 		// Password-protected.
 		add_filter( 'post_password_required', '__return_true' );
-		$this->assertEquals( array( 'password-protected' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
+		$this->assertEquals( [ 'password-protected' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		remove_filter( 'post_password_required', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
 		// Skip-post.
 		add_filter( 'amp_skip_post', '__return_true' );
-		$this->assertEquals( array( 'skip-post' ), AMP_Post_Type_Support::get_support_errors( $book_id ) );
+		$this->assertEquals( [ 'skip-post' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		remove_filter( 'amp_skip_post', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 	}

--- a/tests/php/test-class-amp-service-worker.php
+++ b/tests/php/test-class-amp-service-worker.php
@@ -36,13 +36,13 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		remove_all_actions( 'wp_front_service_worker' );
 
 		AMP_Service_Worker::init();
-		$this->assertSame( 10, has_filter( 'query_vars', array( 'AMP_Service_Worker', 'add_query_var' ) ) );
-		$this->assertSame( 10, has_action( 'parse_request', array( 'AMP_Service_Worker', 'handle_service_worker_iframe_install' ) ) );
-		$this->assertSame( 10, has_action( 'wp', array( 'AMP_Service_Worker', 'add_install_hooks' ) ) );
+		$this->assertSame( 10, has_filter( 'query_vars', [ 'AMP_Service_Worker', 'add_query_var' ] ) );
+		$this->assertSame( 10, has_action( 'parse_request', [ 'AMP_Service_Worker', 'handle_service_worker_iframe_install' ] ) );
+		$this->assertSame( 10, has_action( 'wp', [ 'AMP_Service_Worker', 'add_install_hooks' ] ) );
 
-		$this->assertSame( 10, has_action( 'wp_front_service_worker', array( 'AMP_Service_Worker', 'add_cdn_script_caching' ) ) );
-		$this->assertFalse( has_action( 'wp_front_service_worker', array( 'AMP_Service_Worker', 'add_image_caching' ) ) );
-		$this->assertFalse( has_action( 'wp_front_service_worker', array( 'AMP_Service_Worker', 'add_google_fonts_caching' ) ) );
+		$this->assertSame( 10, has_action( 'wp_front_service_worker', [ 'AMP_Service_Worker', 'add_cdn_script_caching' ] ) );
+		$this->assertFalse( has_action( 'wp_front_service_worker', [ 'AMP_Service_Worker', 'add_image_caching' ] ) );
+		$this->assertFalse( has_action( 'wp_front_service_worker', [ 'AMP_Service_Worker', 'add_google_fonts_caching' ] ) );
 	}
 
 	/**
@@ -58,19 +58,19 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 
 		add_theme_support(
 			'amp',
-			array(
-				'service_worker' => array(
+			[
+				'service_worker' => [
 					'cdn_script_caching'   => false,
 					'image_caching'        => true,
 					'google_fonts_caching' => true,
-				),
-			)
+				],
+			]
 		);
 
 		AMP_Service_Worker::init();
-		$this->assertFalse( has_action( 'wp_front_service_worker', array( 'AMP_Service_Worker', 'add_cdn_script_caching' ) ) );
-		$this->assertSame( 10, has_action( 'wp_front_service_worker', array( 'AMP_Service_Worker', 'add_image_caching' ) ) );
-		$this->assertSame( 10, has_action( 'wp_front_service_worker', array( 'AMP_Service_Worker', 'add_google_fonts_caching' ) ) );
+		$this->assertFalse( has_action( 'wp_front_service_worker', [ 'AMP_Service_Worker', 'add_cdn_script_caching' ] ) );
+		$this->assertSame( 10, has_action( 'wp_front_service_worker', [ 'AMP_Service_Worker', 'add_image_caching' ] ) );
+		$this->assertSame( 10, has_action( 'wp_front_service_worker', [ 'AMP_Service_Worker', 'add_google_fonts_caching' ] ) );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 	 * @covers \AMP_Service_Worker::add_query_var()
 	 */
 	public function test_add_query_var() {
-		$query_vars = AMP_Service_Worker::add_query_var( array( 'foo' ) );
+		$query_vars = AMP_Service_Worker::add_query_var( [ 'foo' ] );
 		$this->assertSame( 'foo', $query_vars[0] );
 		$this->assertCount( 2, $query_vars );
 		$this->assertInternalType( 'string', $query_vars[1] );
@@ -132,12 +132,12 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		$urls = AMP_Service_Worker::get_precached_script_cdn_urls();
 
 		$this->assertArraySubset(
-			array(
+			[
 				wp_scripts()->registered['amp-runtime']->src,
 				wp_scripts()->registered['amp-bind']->src,
 				wp_scripts()->registered['amp-form']->src,
 				wp_scripts()->registered['amp-install-serviceworker']->src,
-			),
+			],
 			$urls
 		);
 
@@ -148,9 +148,9 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		);
 		add_theme_support(
 			'amp',
-			array(
+			[
 				'comments_live_list' => true,
-			)
+			]
 		);
 		$this->assertContains(
 			wp_scripts()->registered['amp-live-list']->src,
@@ -165,12 +165,12 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		add_filter(
 			'amp_analytics_entries',
 			static function () {
-				return array(
-					array(
+				return [
+					[
 						'type'   => 'foo',
 						'config' => '{}',
-					),
-				);
+					],
+				];
 			}
 		);
 		$this->assertContains(
@@ -193,14 +193,14 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		$this->go_to( get_permalink( $post_id ) );
 
 		AMP_Service_Worker::add_install_hooks();
-		$this->assertSame( 10, has_action( 'amp_post_template_footer', array( 'AMP_Service_Worker', 'install_service_worker' ) ) );
-		$this->assertFalse( has_action( 'wp_footer', array( 'AMP_Service_Worker', 'install_service_worker' ) ) );
+		$this->assertSame( 10, has_action( 'amp_post_template_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
+		$this->assertFalse( has_action( 'wp_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
 
 		add_theme_support( 'amp' );
 		$this->assertTrue( is_amp_endpoint() );
 		AMP_Service_Worker::add_install_hooks();
-		$this->assertSame( 10, has_action( 'wp_footer', array( 'AMP_Service_Worker', 'install_service_worker' ) ) );
-		$this->assertFalse( has_action( 'wp_print_scripts', array( 'AMP_Service_Worker', 'wp_print_service_workers' ) ) );
+		$this->assertSame( 10, has_action( 'wp_footer', [ 'AMP_Service_Worker', 'install_service_worker' ] ) );
+		$this->assertFalse( has_action( 'wp_print_scripts', [ 'AMP_Service_Worker', 'wp_print_service_workers' ] ) );
 	}
 
 	/**
@@ -209,7 +209,7 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 	 * @covers \AMP_Service_Worker::install_service_worker()
 	 */
 	public function test_install_service_worker() {
-		$output = get_echo( array( 'AMP_Service_Worker', 'install_service_worker' ) );
+		$output = get_echo( [ 'AMP_Service_Worker', 'install_service_worker' ] );
 
 		$this->assertContains( '<amp-install-serviceworker', $output );
 	}

--- a/tests/php/test-class-amp-story-post-type.php
+++ b/tests/php/test-class-amp-story-post-type.php
@@ -30,7 +30,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		global $wp_styles;
 		$wp_styles = null;
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 	}
 
 	/**
@@ -41,7 +41,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	public function tearDown() {
 		global $wp_rewrite;
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE ] );
 		unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
 
 		$wp_rewrite->set_permalink_structure( false );
@@ -58,11 +58,11 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	public function test_requires_opt_in() {
 		unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
 		$this->assertFalse( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) );
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
 		$this->assertTrue( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) );
 	}
@@ -73,18 +73,18 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Post_Type::the_single_story_card()
 	 */
 	public function test_the_single_story_card() {
-		$featured_image_dimensions = array( array( 1200, 1300 ), array( 1300, 1400 ), array( 1400, 1500 ) );
+		$featured_image_dimensions = [ [ 1200, 1300 ], [ 1300, 1400 ], [ 1400, 1500 ] ];
 		$stories                   = $this->create_story_posts_with_featured_images( $featured_image_dimensions );
 
 		foreach ( $stories as $story ) {
 			$card_markup = get_echo(
-				array( 'AMP_Story_Post_Type', 'the_single_story_card' ),
-				array(
-					array(
+				[ 'AMP_Story_Post_Type', 'the_single_story_card' ],
+				[
+					[
 						'post' => $story,
 						'size' => AMP_Story_Post_Type::STORY_LANDSCAPE_IMAGE_SIZE,
-					),
-				)
+					],
+				]
 			);
 			$this->assertContains( get_the_permalink( $story->ID ), $card_markup );
 			$this->assertContains( ' class="latest_stories__link"', $card_markup );
@@ -94,21 +94,21 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		$first_story = reset( $stories );
 		$card_markup = get_echo(
-			array( 'AMP_Story_Post_Type', 'the_single_story_card' ),
-			array(
-				array(
+			[ 'AMP_Story_Post_Type', 'the_single_story_card' ],
+			[
+				[
 					'post'         => $first_story,
 					'size'         => AMP_Story_Post_Type::STORY_LANDSCAPE_IMAGE_SIZE,
 					'disable_link' => true,
-				),
-			)
+				],
+			]
 		);
 		$this->assertNotContains( '<a', $card_markup );
 
 		// If the 'post' argument isn't either an int or a WP_Post, this shouldn't output anything.
 		$card_markup = get_echo(
-			array( 'AMP_Story_Post_Type', 'the_single_story_card' ),
-			array( array( 'post' => 'foo post' ) )
+			[ 'AMP_Story_Post_Type', 'the_single_story_card' ],
+			[ [ 'post' => 'foo post' ] ]
 		);
 		$this->assertEmpty( $card_markup );
 	}
@@ -122,10 +122,10 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		$template          = '/srv/www/baz.php';
 		$wrong_type        = 'post';
 		$correct_type      = 'embed';
-		$wrong_templates   = array( 'embed-testimonal.php', 'embed.php' );
+		$wrong_templates   = [ 'embed-testimonal.php', 'embed.php' ];
 		$correct_template  = sprintf( 'embed-%s.php', AMP_Story_Post_Type::POST_TYPE_SLUG );
 		$expected_template = 'embed-amp-story.php';
-		$correct_templates = array( $correct_template, 'embed.php' );
+		$correct_templates = [ $correct_template, 'embed.php' ];
 
 		$this->assertEquals( $template, AMP_Story_Post_Type::get_embed_template( $template, $wrong_type, $correct_templates ) );
 		$this->assertEquals( $template, AMP_Story_Post_Type::get_embed_template( $template, $correct_type, $wrong_templates ) );
@@ -150,7 +150,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_style_is( AMP_Story_Post_Type::STORY_CARD_CSS_SLUG ) );
 
 		// Now that the conditional is satisfied, this should enqueue the stylesheet.
-		$amp_story_post = self::factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+		$amp_story_post = self::factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		$this->go_to( add_query_arg( 'embed', '', get_post_permalink( $amp_story_post ) ) );
 		AMP_Story_Post_Type::enqueue_embed_styling();
 	}
@@ -174,33 +174,33 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		$wp_rewrite->add_permastruct( AMP_Story_Post_Type::POST_TYPE_SLUG, AMP_Story_Post_Type::REWRITE_SLUG . '/%' . AMP_Story_Post_Type::POST_TYPE_SLUG . '%' );
 
 		// The second argument is an empty array, so this should simply exit.
-		$this->assertEmpty( AMP_Story_Post_Type::override_story_embed_callback( null, array() ) );
+		$this->assertEmpty( AMP_Story_Post_Type::override_story_embed_callback( null, [] ) );
 
 		// The conditional is not satisfied, so this should return null.
 		$wrong_url   = 'https://incorrect-domain.com/example-story';
-		$wrong_block = array(
-			'attrs'     => array( 'url' => $wrong_url ),
+		$wrong_block = [
+			'attrs'     => [ 'url' => $wrong_url ],
 			'blockName' => 'core/incorrect-block',
-		);
+		];
 		$this->assertEquals( null, AMP_Story_Post_Type::override_story_embed_callback( null, $wrong_block ) );
 
 		// The conditional is only partially satisfied, as the URL is still wrong.
 		$correct_block_name = 'core-embed/wordpress';
 		$wrong_url          = 'https://incorrect-domain.com/example-story';
-		$wrong_block        = array(
-			'attrs'     => array( 'url' => $wrong_url ),
+		$wrong_block        = [
+			'attrs'     => [ 'url' => $wrong_url ],
 			'blockName' => $correct_block_name,
-		);
+		];
 		$this->assertEquals( null, AMP_Story_Post_Type::override_story_embed_callback( null, $wrong_block ) );
 
 		// The conditional is now satisfied, so this should return the overriden callback.
-		$story_posts    = $this->create_story_posts_with_featured_images( array( 400, 400 ) );
+		$story_posts    = $this->create_story_posts_with_featured_images( [ 400, 400 ] );
 		$amp_story_post = reset( $story_posts );
 		$correct_url    = get_post_permalink( $amp_story_post );
-		$correct_block  = array(
-			'attrs'     => array( 'url' => $correct_url ),
+		$correct_block  = [
+			'attrs'     => [ 'url' => $correct_url ],
 			'blockName' => $correct_block_name,
-		);
+		];
 
 		$overriden_render_callback = AMP_Story_Post_Type::override_story_embed_callback( null, $correct_block );
 		$this->assertContains( get_permalink( $amp_story_post ), $overriden_render_callback );
@@ -208,10 +208,10 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		// This should override the callback even if the site uses HTTPS and the permalink uses HTTP.
 		$_SERVER['HTTPS'] = 'on';
-		$correct_block    = array(
-			'attrs'     => array( 'url' => set_url_scheme( $correct_url, 'http' ) ),
+		$correct_block    = [
+			'attrs'     => [ 'url' => set_url_scheme( $correct_url, 'http' ) ],
 			'blockName' => $correct_block_name,
-		);
+		];
 
 		$overriden_render_callback = AMP_Story_Post_Type::override_story_embed_callback( null, $correct_block );
 		$this->assertContains( get_permalink( $amp_story_post ), $overriden_render_callback );
@@ -232,33 +232,33 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 		$this->assertNotNull( $latest_stories_block );
 		$this->assertEquals(
-			array(
-				'className'     => array(
+			[
+				'className'     => [
 					'type' => 'string',
-				),
-				'storiesToShow' => array(
+				],
+				'storiesToShow' => [
 					'type'    => 'number',
 					'default' => 5,
-				),
-				'order'         => array(
+				],
+				'order'         => [
 					'type'    => 'string',
 					'default' => 'desc',
-				),
-				'orderBy'       => array(
+				],
+				'orderBy'       => [
 					'type'    => 'string',
 					'default' => 'date',
-				),
-				'useCarousel'   => array(
+				],
+				'useCarousel'   => [
 					'type'    => 'boolean',
 					'default' => true,
-				),
-			),
+				],
+			],
 			$latest_stories_block->attributes
 		);
 		$this->assertEquals( null, $latest_stories_block->editor_script );
 		$this->assertEquals( null, $latest_stories_block->editor_style );
 		$this->assertEquals( $block_name, $latest_stories_block->name );
-		$this->assertEquals( array( 'AMP_Story_Post_Type', 'render_block_latest_stories' ), $latest_stories_block->render_callback );
+		$this->assertEquals( [ 'AMP_Story_Post_Type', 'render_block_latest_stories' ], $latest_stories_block->render_callback );
 		$this->assertEquals( null, $latest_stories_block->script );
 		$this->assertEquals( null, $latest_stories_block->style );
 	}
@@ -271,16 +271,16 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	public function test_render_block_latest_stories() {
 		AMP_Story_Post_Type::register();
 
-		$attributes = array(
+		$attributes = [
 			'storiesToShow' => 10,
 			'order'         => 'desc',
 			'orderBy'       => 'date',
 			'useCarousel'   => true,
-		);
+		];
 
 		// Create mock AMP story posts to test.
 		$minimum_height = 200;
-		$dimensions     = array( array( $minimum_height, 200 ), array( 300, 400 ), array( 500, 600 ) );
+		$dimensions     = [ [ $minimum_height, 200 ], [ 300, 400 ], [ 500, 600 ] ];
 		$this->create_story_posts_with_featured_images( $dimensions );
 		$rendered_block = AMP_Story_Post_Type::render_block_latest_stories( $attributes );
 		$this->assertContains( '<amp-carousel', $rendered_block );
@@ -305,13 +305,13 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		$this->assertEquals( $initial_output, AMP_Story_Post_Type::remove_title_from_embed( $initial_output, $wrong_post ) );
 
 		// The post type is correct, but the <blockquote> does not have the expected class, so this should again return the same $output.
-		$correct_post              = self::factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+		$correct_post              = self::factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		$block_quote_without_class = '<blockquote>Example Title</blockquote>';
 		$output_with_blockquote    = $block_quote_without_class . $initial_output;
 		$this->assertEquals( $output_with_blockquote, AMP_Story_Post_Type::remove_title_from_embed( $output_with_blockquote, $correct_post ) );
 
 		// All of the conditions are satisfied, so this should remove the <blockquote> and the elements it contains.
-		$correct_post           = self::factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+		$correct_post           = self::factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		$block_quote            = '<blockquote class="wp-embedded-content">Example Title</blockquote>';
 		$output_with_blockquote = $block_quote . $initial_output;
 		$this->assertEquals( $initial_output, AMP_Story_Post_Type::remove_title_from_embed( $output_with_blockquote, $correct_post ) );
@@ -331,7 +331,7 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		$this->assertEquals( $original_embed_markup, AMP_Story_Post_Type::change_embed_iframe_attributes( $original_embed_markup, $non_amp_story ) );
 
 		// This is an AMP story embed, but the markup doesn't have an <iframe>, so it shouldn't be changed.
-		$amp_story                   = self::factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+		$amp_story                   = self::factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		$embed_markup_without_iframe = '<div class="wp-embed"><img alt=baz src="https://example.com/baz.jpeg></div>';
 		$this->assertEquals( $embed_markup_without_iframe, AMP_Story_Post_Type::change_embed_iframe_attributes( $embed_markup_without_iframe, $amp_story ) );
 
@@ -354,18 +354,18 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @return array $posts An array of WP_Post objects of the amp_story post type.
 	 */
 	public function create_story_posts_with_featured_images( $featured_images ) {
-		$stories = array();
+		$stories = [];
 		foreach ( $featured_images as $dimensions ) {
 			$new_story = self::factory()->post->create_and_get(
-				array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG )
+				[ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ]
 			);
 			$stories[] = $new_story;
 
 			// Create the featured image.
 			$thumbnail_id = wp_insert_attachment(
-				array(
+				[
 					'post_mime_type' => 'image/jpeg',
-				),
+				],
 				'https://example.com/foo-image.jpeg',
 				$new_story->ID
 			);
@@ -373,10 +373,10 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 
 			wp_update_attachment_metadata(
 				$thumbnail_id,
-				array(
+				[
 					'width'  => $dimensions[0],
 					'height' => $dimensions[1],
-				)
+				]
 			);
 		}
 
@@ -403,12 +403,12 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		add_filter(
 			'amp_story_auto_ads_configuration',
 			static function() {
-				return array(
-					'ad-attributes' => array(
+				return [
+					'ad-attributes' => [
 						'type'      => 'doubleclick',
 						'data-slot' => '/30497360/a4a/amp_story_dfp_example',
-					),
-				);
+					],
+				];
 			}
 		);
 

--- a/tests/php/test-class-amp-story-templates.php
+++ b/tests/php/test-class-amp-story-templates.php
@@ -28,7 +28,7 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 			}
 		}
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
 	}
 
@@ -42,10 +42,10 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 		$amp_story_templates->init();
 
 		$this->assertTrue( post_type_exists( 'amp_story' ) );
-		$this->assertEquals( 10, has_action( 'rest_wp_block_query', array( $amp_story_templates, 'filter_rest_wp_block_query' ) ) );
-		$this->assertEquals( 10, has_action( 'save_post_wp_block', array( $amp_story_templates, 'flag_template_as_modified' ) ) );
-		$this->assertEquals( 10, has_action( 'user_has_cap', array( $amp_story_templates, 'filter_user_has_cap' ) ) );
-		$this->assertEquals( 10, has_action( 'pre_get_posts', array( $amp_story_templates, 'filter_pre_get_posts' ) ) );
+		$this->assertEquals( 10, has_action( 'rest_wp_block_query', [ $amp_story_templates, 'filter_rest_wp_block_query' ] ) );
+		$this->assertEquals( 10, has_action( 'save_post_wp_block', [ $amp_story_templates, 'flag_template_as_modified' ] ) );
+		$this->assertEquals( 10, has_action( 'user_has_cap', [ $amp_story_templates, 'filter_user_has_cap' ] ) );
+		$this->assertEquals( 10, has_action( 'pre_get_posts', [ $amp_story_templates, 'filter_pre_get_posts' ] ) );
 	}
 
 	/**
@@ -54,23 +54,23 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Templates::filter_user_has_cap()
 	 */
 	public function test_filter_user_has_cap() {
-		$story_id = self::factory()->post->create( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+		$story_id = self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		wp_set_object_terms( $story_id, AMP_Story_Templates::TEMPLATES_TERM, AMP_Story_Templates::TEMPLATES_TAXONOMY );
 
 		$amp_story_templates = new AMP_Story_Templates();
 		$amp_story_templates->init();
 
-		$allcaps = array(
+		$allcaps = [
 			'edit_others_posts'    => true,
 			'edit_published_posts' => true,
-		);
-		$args    = array(
+		];
+		$args    = [
 			0 => 'edit_post',
 			2 => $story_id,
-		);
+		];
 
-		$capabilities = $amp_story_templates->filter_user_has_cap( $allcaps, array(), $args );
+		$capabilities = $amp_story_templates->filter_user_has_cap( $allcaps, [], $args );
 		$this->assertTrue( has_term( AMP_Story_Templates::TEMPLATES_TERM, AMP_Story_Templates::TEMPLATES_TAXONOMY, $args[2] ) );
-		$this->assertEquals( array(), $capabilities );
+		$this->assertEquals( [], $capabilities );
 	}
 }

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -52,7 +52,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Validation_Manager::reset_validation_results();
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		remove_theme_support( 'custom-header' );
-		$_REQUEST                = array(); // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		$_REQUEST                = []; // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
 		$_SERVER['QUERY_STRING'] = '';
 		unset( $_SERVER['REQUEST_URI'] );
 		unset( $_SERVER['REQUEST_METHOD'] );
@@ -60,7 +60,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		if ( isset( $GLOBALS['wp_customize'] ) ) {
 			$GLOBALS['wp_customize']->stop_previewing_theme();
 		}
-		AMP_HTTP::$headers_sent = array();
+		AMP_HTTP::$headers_sent = [];
 	}
 
 	/**
@@ -72,13 +72,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$_REQUEST['__amp_source_origin'] = 'foo';
 		$_GET['__amp_source_origin']     = 'foo';
 		AMP_Theme_Support::init();
-		$this->assertFalse( has_action( 'widgets_init', array( self::TESTED_CLASS, 'register_widgets' ) ) );
-		$this->assertFalse( has_action( 'wp', array( self::TESTED_CLASS, 'finish_init' ) ) );
+		$this->assertFalse( has_action( 'widgets_init', [ self::TESTED_CLASS, 'register_widgets' ] ) );
+		$this->assertFalse( has_action( 'wp', [ self::TESTED_CLASS, 'finish_init' ] ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::init();
-		$this->assertEquals( 10, has_action( 'widgets_init', array( self::TESTED_CLASS, 'register_widgets' ) ) );
-		$this->assertEquals( PHP_INT_MAX, has_action( 'wp', array( self::TESTED_CLASS, 'finish_init' ) ) );
+		$this->assertEquals( 10, has_action( 'widgets_init', [ self::TESTED_CLASS, 'register_widgets' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_action( 'wp', [ self::TESTED_CLASS, 'finish_init' ] ) );
 	}
 
 	/**
@@ -89,10 +89,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers \AMP_Theme_Support::get_theme_support_args()
 	 */
 	public function test_read_theme_support_bad_args_array() {
-		$args = array(
+		$args = [
 			AMP_Theme_Support::PAIRED_FLAG => false,
-			'invalid_param_key'            => array(),
-		);
+			'invalid_param_key'            => [],
+		];
 		add_theme_support( AMP_Theme_Support::SLUG, $args );
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
@@ -108,11 +108,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_read_theme_support_bad_available_callback() {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'available_callback' => static function() {
 					return (bool) wp_rand( 0, 1 );
 				},
-			)
+			]
 		);
 		AMP_Theme_Support::read_theme_support();
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );
@@ -140,14 +140,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array( AMP_Theme_Support::PAIRED_FLAG => false )
+			[ AMP_Theme_Support::PAIRED_FLAG => false ]
 		);
 		$this->assertEquals( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Options_Manager::get_option( 'theme_support' ) );
 		AMP_Theme_Support::read_theme_support();
 		$this->assertEquals( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array( AMP_Theme_Support::PAIRED_FLAG => true )
+			[ AMP_Theme_Support::PAIRED_FLAG => true ]
 		);
 		AMP_Theme_Support::read_theme_support();
 		$this->assertEquals( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
@@ -165,20 +165,20 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
 
 		// Test that standard via option trumps transitional in theme.
-		$args = array(
+		$args = [
 			'templates_supported'          => 'all',
 			AMP_Theme_Support::PAIRED_FLAG => true,
 			'comments_live_list'           => true,
-		);
+		];
 		add_theme_support( AMP_Theme_Support::SLUG, $args );
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG ); // Will override the theme support flag.
 		AMP_Theme_Support::read_theme_support();
 		$this->assertEquals(
 			array_merge(
 				$args,
-				array(
+				[
 					AMP_Theme_Support::PAIRED_FLAG => false, // The Standard user option overrides the theme flag.
-				)
+				]
 			),
 			AMP_Theme_Support::get_theme_support_args()
 		);
@@ -195,7 +195,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_option() );
 		$this->assertSame( AMP_Theme_Support::STANDARD_MODE_SLUG, AMP_Theme_Support::get_support_mode_added_via_theme() );
 		$this->assertSame( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
-		$this->assertEquals( array( AMP_Theme_Support::PAIRED_FLAG => true ), AMP_Theme_Support::get_theme_support_args() );
+		$this->assertEquals( [ AMP_Theme_Support::PAIRED_FLAG => true ], AMP_Theme_Support::get_theme_support_args() );
 
 		// Test that no support via theme can be overridden with option.
 		remove_theme_support( AMP_Theme_Support::SLUG );
@@ -229,13 +229,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::finish_init()
 	 */
 	public function test_finish_init() {
-		$post_id = self::factory()->post->create( array( 'post_title' => 'Test' ) );
+		$post_id = self::factory()->post->create( [ 'post_title' => 'Test' ] );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => true,
 				'template_dir'                 => 'amp',
-			)
+			]
 		);
 
 		// Test transitional mode singular, where not on endpoint that it causes amphtml link to be added.
@@ -256,16 +256,16 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_action( 'wp_head', 'amp_add_amphtml_link' );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => false,
 				'template_dir'                 => 'amp',
-			)
+			]
 		);
 		$this->go_to( get_permalink( $post_id ) );
 		$this->assertTrue( is_amp_endpoint() );
 		AMP_Theme_Support::finish_init();
 		$this->assertFalse( has_action( 'wp_head', 'amp_add_amphtml_link' ) );
-		$this->assertEquals( 10, has_filter( 'index_template_hierarchy', array( 'AMP_Theme_Support', 'filter_amp_template_hierarchy' ) ), 'Expected add_amp_template_filters to have been called since template_dir is not empty' );
+		$this->assertEquals( 10, has_filter( 'index_template_hierarchy', [ 'AMP_Theme_Support', 'filter_amp_template_hierarchy' ] ), 'Expected add_amp_template_filters to have been called since template_dir is not empty' );
 		$this->assertEquals( 20, has_action( 'wp_head', 'amp_add_generator_metadata' ), 'Expected add_hooks to have been called' );
 	}
 
@@ -315,9 +315,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_ensure_proper_amp_location_transitional() {
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => './',
-			)
+			]
 		);
 		$e = null;
 
@@ -395,9 +395,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_is_paired_available() {
 
 		// Establish initial state.
-		$post_id = self::factory()->post->create( array( 'post_title' => 'Test' ) );
+		$post_id = self::factory()->post->create( [ 'post_title' => 'Test' ] );
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
+		query_posts( [ 'p' => $post_id ] ); // phpcs:ignore
 		$this->assertTrue( is_singular() );
 
 		// Transitional support is not available if theme support is not present or canonical.
@@ -408,9 +408,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Transitional mode is available once template_dir is supplied.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => 'amp-templates',
-			)
+			]
 		);
 		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
 
@@ -418,7 +418,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_filter( 'amp_skip_post', '__return_true' );
 		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
 		$this->assertTrue( is_singular() );
-		query_posts( array( 's' => 'test' ) ); // phpcs:ignore
+		query_posts( [ 's' => 'test' ] ); // phpcs:ignore
 		$this->assertTrue( is_search() );
 		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
 		remove_filter( 'amp_skip_post', '__return_true' );
@@ -426,9 +426,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Check that mode=paired works.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => true,
-			)
+			]
 		);
 		add_filter(
 			'amp_supportable_templates',
@@ -438,11 +438,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				return $supportable_templates;
 			}
 		);
-		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
+		query_posts( [ 'p' => $post_id ] ); // phpcs:ignore
 		$this->assertTrue( is_singular() );
 		$this->assertTrue( AMP_Theme_Support::is_paired_available() );
 
-		query_posts( array( 's' => $post_id ) ); // phpcs:ignore
+		query_posts( [ 's' => $post_id ] ); // phpcs:ignore
 		$this->assertTrue( is_search() );
 		$this->assertFalse( AMP_Theme_Support::is_paired_available() );
 	}
@@ -457,9 +457,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
 		$this->assertFalse( AMP_Theme_Support::is_customize_preview_iframe() );
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager(
-			array(
+			[
 				'messenger_channel' => 'baz',
-			)
+			]
 		);
 		$this->assertFalse( AMP_Theme_Support::is_customize_preview_iframe() );
 		$GLOBALS['wp_customize']->start_previewing_theme();
@@ -482,7 +482,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		foreach ( $template_types as $template_type ) {
 			$template_type = preg_replace( '|[^a-z0-9-]+|', '', $template_type );
 
-			$this->assertEquals( 10, has_filter( "{$template_type}_template_hierarchy", array( self::TESTED_CLASS, 'filter_amp_template_hierarchy' ) ) );
+			$this->assertEquals( 10, has_filter( "{$template_type}_template_hierarchy", [ self::TESTED_CLASS, 'filter_amp_template_hierarchy' ] ) );
 		}
 	}
 
@@ -542,7 +542,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$wp_query     = null;
 		$availability = AMP_Theme_Support::get_template_availability();
 		$this->assertInternalType( 'array', $availability );
-		$this->assertEquals( array( 'no_query_available' ), $availability['errors'] );
+		$this->assertEquals( [ 'no_query_available' ], $availability['errors'] );
 		$this->assertFalse( $availability['supported'] );
 		$this->assertNull( $availability['immutable'] );
 		$this->assertNull( $availability['template'] );
@@ -551,7 +551,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		$this->go_to( get_permalink( self::factory()->post->create() ) );
 		$availability = AMP_Theme_Support::get_template_availability();
-		$this->assertEquals( array( 'no_theme_support' ), $availability['errors'] );
+		$this->assertEquals( [ 'no_theme_support' ], $availability['errors'] );
 		$this->assertFalse( $availability['supported'] );
 		$this->assertNull( $availability['immutable'] );
 		$this->assertNull( $availability['template'] );
@@ -568,38 +568,38 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->go_to( get_permalink( self::factory()->post->create() ) );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'available_callback' => '__return_true',
-			)
+			]
 		);
 		AMP_Theme_Support::init();
 		$availability = AMP_Theme_Support::get_template_availability();
 		$this->assertEquals(
 			$availability,
-			array(
+			[
 				'supported' => true,
 				'immutable' => true,
 				'template'  => null,
-				'errors'    => array(),
-			)
+				'errors'    => [],
+			]
 		);
 
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'available_callback' => '__return_false',
-			)
+			]
 		);
 		AMP_Theme_Support::init();
 		$availability = AMP_Theme_Support::get_template_availability();
 		$this->assertEquals(
 			$availability,
-			array(
+			[
 				'supported' => false,
 				'immutable' => true,
 				'template'  => null,
-				'errors'    => array( 'available_callback' ),
-			)
+				'errors'    => [ 'available_callback' ],
+			]
 		);
 	}
 
@@ -612,7 +612,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		remove_action( 'parse_query', 'wp_hide_admin_bar_offline' );
 		global $wp_query;
 		$post_id = self::factory()->post->create();
-		query_posts( array( 'p' => $post_id ) ); // phpcs:ignore
+		query_posts( [ 'p' => $post_id ] ); // phpcs:ignore
 
 		// Test successful match of singular template.
 		$this->assertTrue( is_singular() );
@@ -636,40 +636,40 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertNull( $wp_query ); // Make sure it is reset.
 
 		// Test nested hierarchy.
-		AMP_Options_Manager::update_option( 'supported_templates', array( 'is_special', 'is_custom' ) );
+		AMP_Options_Manager::update_option( 'supported_templates', [ 'is_special', 'is_custom' ] );
 		add_filter(
 			'amp_supportable_templates',
 			static function( $templates ) {
-				$templates['is_single']        = array(
+				$templates['is_single']        = [
 					'label'     => 'Single post',
 					'supported' => false,
 					'parent'    => 'is_singular',
-				);
-				$templates['is_special']       = array(
+				];
+				$templates['is_special']       = [
 					'label'    => 'Special post',
 					'parent'   => 'is_single',
 					'callback' => static function( WP_Query $query ) {
 						return $query->is_singular() && 'special' === get_post( $query->get_queried_object_id() )->post_name;
 					},
-				);
-				$templates['is_page']          = array(
+				];
+				$templates['is_page']          = [
 					'label'     => 'Page',
 					'supported' => true,
 					'parent'    => 'is_singular',
-				);
-				$templates['is_custom']        = array(
+				];
+				$templates['is_custom']        = [
 					'label'    => 'Custom',
 					'callback' => static function( WP_Query $query ) {
 						return false !== $query->get( 'custom', false );
 					},
-				);
-				$templates['is_custom[thing]'] = array(
+				];
+				$templates['is_custom[thing]'] = [
 					'label'    => 'Custom Thing',
 					'parent'   => 'is_custom',
 					'callback' => static function( WP_Query $query ) {
 						return 'thing' === $query->get( 'custom', false );
 					},
-				);
+				];
 				return $templates;
 			}
 		);
@@ -687,10 +687,10 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 'is_single', $availability['template'] );
 
 		$special_id   = self::factory()->post->create(
-			array(
+			[
 				'post_type' => 'post',
 				'post_name' => 'special',
-			)
+			]
 		);
 		$availability = AMP_Theme_Support::get_template_availability( get_post( $special_id ) );
 		$this->assertTrue( $availability['supported'] );
@@ -698,12 +698,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertFalse( $availability['immutable'] );
 
 		remove_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
-		$availability = AMP_Theme_Support::get_template_availability( self::factory()->post->create_and_get( array( 'post_type' => 'page' ) ) );
+		$availability = AMP_Theme_Support::get_template_availability( self::factory()->post->create_and_get( [ 'post_type' => 'page' ] ) );
 		$this->assertFalse( $availability['supported'] );
-		$this->assertEquals( array( 'post-type-support' ), $availability['errors'] );
+		$this->assertEquals( [ 'post-type-support' ], $availability['errors'] );
 		$this->assertEquals( 'is_page', $availability['template'] );
 		add_post_type_support( 'page', AMP_Post_Type_Support::SLUG );
-		$availability = AMP_Theme_Support::get_template_availability( self::factory()->post->create_and_get( array( 'post_type' => 'page' ) ) );
+		$availability = AMP_Theme_Support::get_template_availability( self::factory()->post->create_and_get( [ 'post_type' => 'page' ] ) );
 		$this->assertTrue( $availability['supported'] );
 
 		// Test is_custom.
@@ -730,16 +730,16 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$custom_post_type = 'book';
 		register_post_type(
 			$custom_post_type,
-			array(
+			[
 				'has_archive'        => true,
 				'publicly_queryable' => true,
-			)
+			]
 		);
 		self::factory()->post->create(
-			array(
+			[
 				'post_type'  => $custom_post_type,
 				'post_title' => 'test',
-			)
+			]
 		);
 
 		// Test that when doing a post_type archive, we get the post type archive as expected.
@@ -771,23 +771,23 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		register_taxonomy(
 			'accolade',
 			'post',
-			array(
+			[
 				'public' => true,
-			)
+			]
 		);
 		register_taxonomy(
 			'complaint',
 			'post',
-			array(
+			[
 				'public' => false,
-			)
+			]
 		);
 		register_post_type(
 			'announcement',
-			array(
+			[
 				'public'      => true,
 				'has_archive' => true,
-			)
+			]
 		);
 
 		// Test default case with non-static front page.
@@ -821,8 +821,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 'is_archive', $supportable_templates['is_post_type_archive[announcement]']['parent'] );
 
 		// Test static homepage and page for posts.
-		$page_on_front  = self::factory()->post->create( array( 'post_type' => 'page' ) );
-		$page_for_posts = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$page_on_front  = self::factory()->post->create( [ 'post_type' => 'page' ] );
+		$page_for_posts = self::factory()->post->create( [ 'post_type' => 'page' ] );
 		update_option( 'show_on_front', 'page' );
 		update_option( 'page_for_posts', $page_for_posts );
 		update_option( 'page_on_front', $page_on_front );
@@ -842,12 +842,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				$templates['is_category']['supported'] = false;
 				$templates['is_singular']['supported'] = true;
 
-				$templates['is_custom'] = array(
+				$templates['is_custom'] = [
 					'label'    => 'Custom',
 					'callback' => static function( WP_Query $query ) {
 						return false !== $query->get( 'custom', false );
 					},
-				);
+				];
 				return $templates;
 			}
 		);
@@ -865,9 +865,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'templates_supported' => 'all',
-			)
+			]
 		);
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::STANDARD_MODE_SLUG );
 		AMP_Theme_Support::read_theme_support();
@@ -883,12 +883,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
-				'templates_supported' => array(
+			[
+				'templates_supported' => [
 					'is_date'   => true,
 					'is_author' => false,
-				),
-			)
+				],
+			]
 		);
 		AMP_Theme_Support::init();
 		$supportable_templates = AMP_Theme_Support::get_supportable_templates();
@@ -914,7 +914,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$this->assertFalse( has_action( 'wp_head', 'print_emoji_detection_script' ) );
 		$this->assertFalse( has_action( 'wp_print_styles', 'print_emoji_styles' ) );
-		$this->assertEquals( 10, has_action( 'wp_print_styles', array( 'AMP_Theme_Support', 'print_emoji_styles' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_print_styles', [ 'AMP_Theme_Support', 'print_emoji_styles' ] ) );
 		$this->assertEquals( 10, has_filter( 'the_title', 'wp_staticize_emoji' ) );
 		$this->assertEquals( 10, has_filter( 'the_excerpt', 'wp_staticize_emoji' ) );
 		$this->assertEquals( 10, has_filter( 'the_content', 'wp_staticize_emoji' ) );
@@ -922,21 +922,21 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'widget_text', 'wp_staticize_emoji' ) );
 
 		$this->assertEquals( 20, has_action( 'wp_head', 'amp_add_generator_metadata' ) );
-		$this->assertEquals( 0, has_action( 'wp_enqueue_scripts', array( self::TESTED_CLASS, 'enqueue_assets' ) ) );
+		$this->assertEquals( 0, has_action( 'wp_enqueue_scripts', [ self::TESTED_CLASS, 'enqueue_assets' ] ) );
 
-		$this->assertEquals( 1000, has_action( 'wp_enqueue_scripts', array( self::TESTED_CLASS, 'dequeue_customize_preview_scripts' ) ) );
-		$this->assertEquals( 10, has_filter( 'customize_partial_render', array( self::TESTED_CLASS, 'filter_customize_partial_render' ) ) );
+		$this->assertEquals( 1000, has_action( 'wp_enqueue_scripts', [ self::TESTED_CLASS, 'dequeue_customize_preview_scripts' ] ) );
+		$this->assertEquals( 10, has_filter( 'customize_partial_render', [ self::TESTED_CLASS, 'filter_customize_partial_render' ] ) );
 		$this->assertEquals( 10, has_action( 'wp_footer', 'amp_print_analytics' ) );
-		$this->assertEquals( 10, has_action( 'admin_bar_init', array( self::TESTED_CLASS, 'init_admin_bar' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_bar_init', [ self::TESTED_CLASS, 'init_admin_bar' ] ) );
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-		$this->assertEquals( $priority, has_action( 'template_redirect', array( self::TESTED_CLASS, 'start_output_buffering' ) ) );
+		$this->assertEquals( $priority, has_action( 'template_redirect', [ self::TESTED_CLASS, 'start_output_buffering' ] ) );
 
-		$this->assertEquals( 10, has_filter( 'comment_form_defaults', array( self::TESTED_CLASS, 'filter_comment_form_defaults' ) ) );
-		$this->assertEquals( 10, has_filter( 'comment_reply_link', array( self::TESTED_CLASS, 'filter_comment_reply_link' ) ) );
-		$this->assertEquals( 10, has_filter( 'cancel_comment_reply_link', array( self::TESTED_CLASS, 'filter_cancel_comment_reply_link' ) ) );
-		$this->assertEquals( 100, has_action( 'comment_form', array( self::TESTED_CLASS, 'amend_comment_form' ) ) );
+		$this->assertEquals( 10, has_filter( 'comment_form_defaults', [ self::TESTED_CLASS, 'filter_comment_form_defaults' ] ) );
+		$this->assertEquals( 10, has_filter( 'comment_reply_link', [ self::TESTED_CLASS, 'filter_comment_reply_link' ] ) );
+		$this->assertEquals( 10, has_filter( 'cancel_comment_reply_link', [ self::TESTED_CLASS, 'filter_cancel_comment_reply_link' ] ) );
+		$this->assertEquals( 100, has_action( 'comment_form', [ self::TESTED_CLASS, 'amend_comment_form' ] ) );
 		$this->assertFalse( has_action( 'comment_form', 'wp_comment_form_unfiltered_html_nonce' ) );
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'get_header_image_tag', array( self::TESTED_CLASS, 'amend_header_image_with_video_header' ) ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'get_header_image_tag', [ self::TESTED_CLASS, 'amend_header_image_with_video_header' ] ) );
 	}
 
 	/**
@@ -948,7 +948,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_register_widgets() {
 		global $wp_widget_factory;
 		remove_all_actions( 'widgets_init' );
-		$wp_widget_factory->widgets = array();
+		$wp_widget_factory->widgets = [];
 		wp_widgets_init();
 		AMP_Theme_Support::register_widgets();
 
@@ -989,18 +989,18 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Test AMP-first.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( amp_is_canonical() );
-		$output = get_echo( array( 'AMP_Theme_Support', 'amend_comment_form' ) );
+		$output = get_echo( [ 'AMP_Theme_Support', 'amend_comment_form' ] );
 		$this->assertNotContains( '<input type="hidden" name="redirect_to"', $output );
 
 		// Test transitional AMP.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => 'amp-templates',
-			)
+			]
 		);
 		$this->assertFalse( amp_is_canonical() );
-		$output = get_echo( array( 'AMP_Theme_Support', 'amend_comment_form' ) );
+		$output = get_echo( [ 'AMP_Theme_Support', 'amend_comment_form' ] );
 		$this->assertContains( '<input type="hidden" name="redirect_to"', $output );
 	}
 
@@ -1013,18 +1013,18 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$template_dir = 'amp-templates';
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				'template_dir' => $template_dir,
-			)
+			]
 		);
-		$templates          = array(
+		$templates          = [
 			'single-post-example.php',
 			'single-post.php',
 			'single.php',
-		);
+		];
 		$filtered_templates = AMP_Theme_Support::filter_amp_template_hierarchy( $templates );
 
-		$expected_templates = array();
+		$expected_templates = [];
 		foreach ( $templates as $template ) {
 			$expected_templates[] = $template_dir . '/' . $template;
 			$expected_templates[] = $template;
@@ -1043,9 +1043,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$home_url = home_url( '/' );
 		$this->assertEquals( $home_url, AMP_Theme_Support::get_current_canonical_url() );
 
-		$added_query_vars = array(
+		$added_query_vars = [
 			'foo' => 'bar',
-		);
+		];
 		$wp->query_vars   = $added_query_vars;
 		$this->assertEquals( add_query_arg( $added_query_vars, $home_url ), AMP_Theme_Support::get_current_canonical_url() );
 
@@ -1076,12 +1076,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		global $post;
 		$post     = self::factory()->post->create_and_get();
 		$defaults = AMP_Theme_Support::filter_comment_form_defaults(
-			array(
+			[
 				'title_reply_to'      => 'Reply To',
 				'title_reply'         => 'Reply',
 				'cancel_reply_before' => '',
 				'title_reply_before'  => '',
-			)
+			]
 		);
 		$this->assertContains( AMP_Theme_Support::get_comment_form_state_id( get_the_ID() ), $defaults['title_reply_before'] );
 		$this->assertContains( 'replyToName ?', $defaults['title_reply_before'] );
@@ -1173,24 +1173,24 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @return array
 	 */
 	public function get_schema_script_data() {
-		return array(
-			'schema_org_not_present'        => array(
+		return [
+			'schema_org_not_present'        => [
 				'',
 				1,
-			),
-			'schema_org_present'            => array(
-				wp_json_encode( array( '@context' => 'http://schema.org' ) ),
+			],
+			'schema_org_present'            => [
+				wp_json_encode( [ '@context' => 'http://schema.org' ] ),
 				1,
-			),
-			'schema_org_output_not_escaped' => array(
+			],
+			'schema_org_output_not_escaped' => [
 				'{"@context":"http://schema.org"',
 				1,
-			),
-			'schema_org_another_key'        => array(
-				wp_json_encode( array( '@anothercontext' => 'https://schema.org' ) ),
+			],
+			'schema_org_another_key'        => [
+				wp_json_encode( [ '@anothercontext' => 'https://schema.org' ] ),
 				1,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -1218,19 +1218,19 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// Ensure AMP_Theme_Support::is_customize_preview_iframe() is true.
 		require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager(
-			array(
+			[
 				'messenger_channel' => 'baz',
-			)
+			]
 		);
 		$GLOBALS['wp_customize']->start_previewing_theme();
 		$customize_preview = 'customize-preview';
 		$preview_style     = 'example-preview-style';
-		wp_enqueue_style( $preview_style, home_url( '/' ), array( $customize_preview ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_enqueue_style( $preview_style, home_url( '/' ), [ $customize_preview ] ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		AMP_Theme_Support::dequeue_customize_preview_scripts();
 		$this->assertTrue( wp_style_is( $preview_style ) );
 		$this->assertTrue( wp_style_is( $customize_preview ) );
 
-		wp_enqueue_style( $preview_style, home_url( '/' ), array( $customize_preview ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+		wp_enqueue_style( $preview_style, home_url( '/' ), [ $customize_preview ] ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		wp_enqueue_style( $customize_preview );
 		// Ensure AMP_Theme_Support::is_customize_preview_iframe() is false.
 		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
@@ -1385,16 +1385,16 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 
 		wp();
-		$prepare_response_args = array(
+		$prepare_response_args = [
 			'enable_response_caching' => false,
-		);
+		];
 
 		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$original_html = $this->get_original_html();
 
 		$call_prepare_response = static function() use ( $original_html, &$prepare_response_args ) {
-			AMP_HTTP::$headers_sent                     = array();
-			AMP_Validation_Manager::$validation_results = array();
+			AMP_HTTP::$headers_sent                     = [];
+			AMP_Validation_Manager::$validation_results = [];
 			return AMP_Theme_Support::prepare_response( $original_html, $prepare_response_args );
 		};
 
@@ -1406,7 +1406,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertNotContains( 'handle=', $sanitized_html );
 		$this->assertEquals( 2, substr_count( $sanitized_html, '<!-- wp_print_scripts -->' ) );
 
-		$ordered_contains = array(
+		$ordered_contains = [
 			'<html amp="">',
 			'<meta charset="' . get_bloginfo( 'charset' ) . '">',
 			'<meta name="viewport" content="width=device-width">',
@@ -1437,7 +1437,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'<script type="application/ld+json">{"@context"',
 			'<link rel="canonical" href="',
 			'</head>',
-		);
+		];
 
 		$last_position        = -1;
 		$prev_ordered_contain = '';
@@ -1461,7 +1461,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<noscript><audio', $sanitized_html );
 		$this->assertContains( '<amp-audio', $sanitized_html );
 
-		$removed_nodes = array();
+		$removed_nodes = [];
 		foreach ( AMP_Validation_Manager::$validation_results as $result ) {
 			if ( $result['sanitized'] && isset( $result['error']['node_name'] ) ) {
 				$node_name = $result['error']['node_name'];
@@ -1475,11 +1475,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertContains( '<button>no-onclick</button>', $sanitized_html );
 		$this->assertCount( 5, AMP_Validation_Manager::$validation_results );
 		$this->assertEquals(
-			array(
+			[
 				'onclick' => 1,
 				'handle'  => 3,
 				'script'  => 1,
-			),
+			],
 			$removed_nodes
 		);
 
@@ -1594,7 +1594,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_post_processor_cache_effectiveness() {
 		wp();
 		$original_html = $this->get_original_html();
-		$args          = array( 'enable_response_caching' => true );
+		$args          = [ 'enable_response_caching' => true ];
 		wp_using_ext_object_cache( true ); // turn on external object cache flag.
 		$this->reset_post_processor_cache_effectiveness();
 		AMP_Options_Manager::update_option( 'enable_response_caching', true );
@@ -1604,8 +1604,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			// Simulate dynamic changes in the content.
 			$original_html = str_replace( 'dynamic-id-', "dynamic-id-{$num_calls}-", $original_html );
 
-			AMP_HTTP::$headers_sent                     = array();
-			AMP_Validation_Manager::$validation_results = array();
+			AMP_HTTP::$headers_sent                     = [];
+			AMP_Validation_Manager::$validation_results = [];
 			AMP_Theme_Support::prepare_response( $original_html, $args );
 
 			$caches_for_url = wp_cache_get( AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_KEY, AMP_Theme_Support::POST_PROCESSOR_CACHE_EFFECTIVENESS_GROUP );
@@ -1654,7 +1654,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'wp_enqueue_scripts',
 			static function() {
 				wp_enqueue_script( 'amp-list' );
-			wp_enqueue_style( 'my-font', 'https://fonts.googleapis.com/css?family=Tangerine', array(), null ); // phpcs:ignore
+			wp_enqueue_style( 'my-font', 'https://fonts.googleapis.com/css?family=Tangerine', [], null ); // phpcs:ignore
 			}
 		);
 		add_action(
@@ -1695,7 +1695,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 
 		// Specify file paths for stylesheets not available in src.
-		foreach ( array( 'wp-block-library', 'wp-block-library-theme' ) as $src_style_handle ) {
+		foreach ( [ 'wp-block-library', 'wp-block-library-theme' ] as $src_style_handle ) {
 			if ( wp_style_is( $src_style_handle, 'registered' ) ) {
 				wp_styles()->registered[ $src_style_handle ]->src = amp_get_asset_url( 'css/amp-default.css' ); // A dummy path.
 			}
@@ -1826,14 +1826,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->go_to( home_url( '/?amp' ) );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => true,
-			)
+			]
 		);
 		add_filter(
 			'amp_content_sanitizers',
 			static function( $sanitizers ) {
-				$sanitizers['AMP_Theme_Support_Sanitizer_Counter'] = array();
+				$sanitizers['AMP_Theme_Support_Sanitizer_Counter'] = [];
 				return $sanitizers;
 			}
 		);
@@ -1853,7 +1853,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		<?php
 		$original_html = trim( ob_get_clean() );
 
-		$redirects = array();
+		$redirects = [];
 		add_filter(
 			'wp_redirect',
 			static function( $url ) use ( &$redirects ) {
@@ -1864,31 +1864,31 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		AMP_Theme_Support_Sanitizer_Counter::$count = 0;
 		AMP_Validation_Manager::reset_validation_results();
-		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, array( 'enable_response_caching' => true ) );
+		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ 'enable_response_caching' => true ] );
 		$this->assertStringStartsWith( 'Redirecting to non-AMP version', $sanitized_html );
 		$this->assertCount( 1, $redirects );
 		$this->assertEquals( home_url( '/' ), $redirects[0] );
 		$this->assertEquals( 1, AMP_Theme_Support_Sanitizer_Counter::$count );
 
 		AMP_Validation_Manager::reset_validation_results();
-		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, array( 'enable_response_caching' => true ) );
+		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ 'enable_response_caching' => true ] );
 		$this->assertStringStartsWith( 'Redirecting to non-AMP version', $sanitized_html );
 		$this->assertCount( 2, $redirects );
 		$this->assertEquals( home_url( '/' ), $redirects[0] );
 		$this->assertEquals( 1, AMP_Theme_Support_Sanitizer_Counter::$count, 'Expected sanitizer to not be invoked.' );
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Manager::add_validation_error_sourcing();
 
 		AMP_Validation_Manager::reset_validation_results();
-		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, array( 'enable_response_caching' => true ) );
+		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ 'enable_response_caching' => true ] );
 		$this->assertStringStartsWith( 'Redirecting to non-AMP version', $sanitized_html );
 		$this->assertCount( 3, $redirects );
 		$this->assertEquals( home_url( '/?amp_validation_errors=1' ), $redirects[0] );
 		$this->assertEquals( 2, AMP_Theme_Support_Sanitizer_Counter::$count, 'Expected sanitizer be invoked after validation changed.' );
 
 		AMP_Validation_Manager::reset_validation_results();
-		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, array( 'enable_response_caching' => true ) );
+		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ 'enable_response_caching' => true ] );
 		$this->assertStringStartsWith( 'Redirecting to non-AMP version', $sanitized_html );
 		$this->assertCount( 4, $redirects );
 		$this->assertEquals( home_url( '/?amp_validation_errors=1' ), $redirects[0] );
@@ -1918,20 +1918,20 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 */
 	public function test_whitelist_layout_in_wp_kses_allowed_html() {
 		$attribute             = 'data-amp-layout';
-		$image_no_dimensions   = array(
-			'img' => array(
+		$image_no_dimensions   = [
+			'img' => [
 				$attribute => true,
-			),
-		);
+			],
+		];
 		$image_with_dimensions = array_merge(
 			$image_no_dimensions,
-			array(
+			[
 				'height' => '100',
 				'width'  => '100',
-			)
+			]
 		);
 
-		$this->assertEquals( array(), AMP_Theme_Support::whitelist_layout_in_wp_kses_allowed_html( array() ) );
+		$this->assertEquals( [], AMP_Theme_Support::whitelist_layout_in_wp_kses_allowed_html( [] ) );
 		$this->assertEquals( $image_no_dimensions, AMP_Theme_Support::whitelist_layout_in_wp_kses_allowed_html( $image_no_dimensions ) );
 
 		$context = AMP_Theme_Support::whitelist_layout_in_wp_kses_allowed_html( $image_with_dimensions );
@@ -1962,9 +1962,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// If theme support is present, but there isn't a header video selected, the callback should again return the image.
 		add_theme_support(
 			'custom-header',
-			array(
+			[
 				'video' => true,
-			)
+			]
 		);
 
 		// There's a YouTube URL as the header video.

--- a/tests/php/test-class-amp-vimeo-embed-handler.php
+++ b/tests/php/test-class-amp-vimeo-embed-handler.php
@@ -38,30 +38,30 @@ class Test_AMP_Vimeo_Embed_Handler extends WP_UnitTestCase {
 		$this->handler->register_embed();
 		$youtube_id   = 'XOY3ZUO6P0k';
 		$youtube_src  = 'https://youtu.be/' . $youtube_id;
-		$attr_youtube = array(
+		$attr_youtube = [
 			'src' => $youtube_src,
-		);
+		];
 
 		$youtube_shortcode = $this->handler->video_override( '', $attr_youtube );
 		$this->assertEquals( '', $youtube_shortcode );
 
 		$vimeo_id        = '64086087';
 		$vimeo_src       = 'https://vimeo.com/' . $vimeo_id;
-		$attr_vimeo      = array(
+		$attr_vimeo      = [
 			'src' => $vimeo_src,
-		);
+		];
 		$yimeo_shortcode = $this->handler->video_override( '', $attr_vimeo );
 		$this->assertContains( '<amp-vimeo', $yimeo_shortcode );
 		$this->assertContains( $vimeo_id, $yimeo_shortcode );
 
 		$daily_motion_id        = 'x6bacgf';
 		$daily_motion_src       = 'http://www.dailymotion.com/video/' . $daily_motion_id;
-		$attr_daily_motion      = array(
+		$attr_daily_motion      = [
 			'src' => $daily_motion_src,
-		);
+		];
 		$daily_motion_shortcode = $this->handler->video_override( '', $attr_daily_motion );
 		$this->assertEquals( '', $daily_motion_shortcode );
-		$no_attributes = $this->handler->video_override( '', array() );
+		$no_attributes = $this->handler->video_override( '', [] );
 		$this->assertEquals( '', $no_attributes );
 		remove_all_filters( 'wp_video_shortcode_override' );
 	}

--- a/tests/php/test-class-amp-widget-archives.php
+++ b/tests/php/test-class-amp-widget-archives.php
@@ -65,17 +65,17 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 	public function test_widget() {
 		wp();
 		$this->assertTrue( is_amp_endpoint() );
-		$arguments = array(
+		$arguments = [
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',
 			'before_title'  => '<h2>',
 			'after_title'   => '</h2>',
-		);
-		$instance  = array(
+		];
+		$instance  = [
 			'title'    => 'Test Archives Widget',
 			'dropdown' => 1,
-		);
-		$output    = get_echo( array( $this->widget, 'widget' ), array( $arguments, $instance ) );
+		];
+		$output    = get_echo( [ $this->widget, 'widget' ], [ $arguments, $instance ] );
 
 		$this->assertContains( 'on="change:AMP.navigateTo(url=event.value)"', $output );
 		$this->assertNotContains( 'onchange=', $output );

--- a/tests/php/test-class-amp-widget-categories.php
+++ b/tests/php/test-class-amp-widget-categories.php
@@ -65,17 +65,17 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 	public function test_widget() {
 		wp();
 		$this->assertTrue( is_amp_endpoint() );
-		$arguments = array(
+		$arguments = [
 			'before_widget' => '<div>',
 			'after_widget'  => '</div>',
 			'before_title'  => '<h2>',
 			'after_title'   => '</h2>',
-		);
-		$instance  = array(
+		];
+		$instance  = [
 			'title'    => 'Test Categories Widget',
 			'dropdown' => 1,
-		);
-		$output    = get_echo( array( $this->widget, 'widget' ), array( $arguments, $instance ) );
+		];
+		$output    = get_echo( [ $this->widget, 'widget' ], [ $arguments, $instance ] );
 
 		$this->assertContains( 'on="change:', $output );
 		$this->assertNotContains( '<script type=', $output );

--- a/tests/php/test-class-amp-widget-text.php
+++ b/tests/php/test-class-amp-widget-text.php
@@ -57,9 +57,9 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 		$this->assertTrue( is_amp_endpoint() );
 		$video            = '<video src="http://example.com" height="100" width="200"></video>';
 		$video_only_width = '<video src="http://example.com/this-video" width="500">';
-		$this->assertEquals( $video, $this->widget->inject_video_max_width_style( array( $video ) ) );
-		$this->assertEquals( $video_only_width, $this->widget->inject_video_max_width_style( array( $video_only_width ) ) );
-		$this->assertEquals( '', $this->widget->inject_video_max_width_style( array( '' ) ) );
+		$this->assertEquals( $video, $this->widget->inject_video_max_width_style( [ $video ] ) );
+		$this->assertEquals( $video_only_width, $this->widget->inject_video_max_width_style( [ $video_only_width ] ) );
+		$this->assertEquals( '', $this->widget->inject_video_max_width_style( [ '' ] ) );
 	}
 
 }

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -38,9 +38,9 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 		$this->handler->register_embed();
 		$youtube_id   = 'XOY3ZUO6P0k';
 		$youtube_src  = 'https://youtu.be/' . $youtube_id;
-		$attr_youtube = array(
+		$attr_youtube = [
 			'src' => $youtube_src,
-		);
+		];
 
 		$youtube_shortcode = $this->handler->video_override( '', $attr_youtube );
 		$this->assertContains( '<amp-youtube', $youtube_shortcode );
@@ -48,20 +48,20 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 
 		$vimeo_id        = '64086087';
 		$vimeo_src       = 'https://vimeo.com/' . $vimeo_id;
-		$attr_vimeo      = array(
+		$attr_vimeo      = [
 			'src' => $vimeo_src,
-		);
+		];
 		$yimeo_shortcode = $this->handler->video_override( '', $attr_vimeo );
 		$this->assertEquals( '', $yimeo_shortcode );
 
 		$daily_motion_id        = 'x6bacgf';
 		$daily_motion_src       = 'http://www.dailymotion.com/video/' . $daily_motion_id;
-		$attr_daily_motion      = array(
+		$attr_daily_motion      = [
 			'src' => $daily_motion_src,
-		);
+		];
 		$daily_motion_shortcode = $this->handler->video_override( '', $attr_daily_motion );
 		$this->assertEquals( '', $daily_motion_shortcode );
-		$no_attributes = $this->handler->video_override( '', array() );
+		$no_attributes = $this->handler->video_override( '', [] );
 		$this->assertEquals( '', $no_attributes );
 		remove_all_filters( 'wp_video_shortcode_override' );
 	}

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -19,137 +19,137 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 *                 identified during sanitization.
 	 */
 	public function get_body_data() {
-		return array(
-			'empty_doc'                                    => array(
+		return [
+			'empty_doc'                                    => [
 				'',
 				'',
-			),
+			],
 
-			'a-test'                                       => array(
+			'a-test'                                       => [
 				'<a on="tap:see-image-lightbox" role="button" class="button button-secondary play" tabindex="0">Show Image</a>',
-			),
+			],
 
-			'a4a'                                          => array(
+			'a4a'                                          => [
 				'<amp-ad width="300" height="400" type="fake" data-use-a4a="true" data-vars-analytics-var="bar" src="fake_amp.json"><div placeholder=""></div><div fallback=""></div></amp-ad>',
 				null, // No change.
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'ads'                                          => array(
+			'ads'                                          => [
 				'<amp-ad width="300" height="250" type="a9" data-aax_size="300x250" data-aax_pubname="test123" data-aax_src="302"><div placeholder=""></div><div fallback=""></div></amp-ad>',
 				null, // No change.
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'adsense'                                      => array(
+			'adsense'                                      => [
 				'<amp-ad width="300" height="250" type="adsense" data-ad-client="ca-pub-2005682797531342" data-ad-slot="7046626912"><div placeholder=""></div><div fallback=""></div></amp-ad>',
 				null, // No change.
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'amp-3q-player'                                => array(
+			'amp-3q-player'                                => [
 				'<amp-3q-player data-id="c8dbe7f4-7f7f-11e6-a407-0cc47a188158" layout="responsive" width="480" height="270"></amp-3q-player>',
 				null,
-				array( 'amp-3q-player' ),
-			),
+				[ 'amp-3q-player' ],
+			],
 
-			'amp-ad'                                       => array(
+			'amp-ad'                                       => [
 				'<amp-ad width="300" height="250" type="foo"></amp-ad>',
 				null, // No change.
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'amp-sticky-ad'                                => array(
+			'amp-sticky-ad'                                => [
 				'<amp-sticky-ad layout="nodisplay"><amp-ad width="320" height="50" type="doubleclick" data-slot="/35096353/amptesting/formats/sticky"></amp-ad></amp-sticky-ad>',
 				null,
-				array( 'amp-ad', 'amp-sticky-ad' ),
-			),
+				[ 'amp-ad', 'amp-sticky-ad' ],
+			],
 
-			'amp-sticky-ad-bad-children'                   => array(
+			'amp-sticky-ad-bad-children'                   => [
 				'<amp-sticky-ad layout="nodisplay"><span>not allowed</span><amp-ad width="320" height="50" type="doubleclick" data-slot="/35096353/amptesting/formats/sticky"></amp-ad><i>not ok</i></amp-sticky-ad>',
 				'',
-				array(),
-			),
+				[],
+			],
 
-			'amp-animation'                                => array(
+			'amp-animation'                                => [
 				'<amp-animation layout="nodisplay"><span>bad</span><script type="application/json">{}</script><strong>very bad</strong></amp-animation>',
 				'<amp-animation layout="nodisplay"><script type="application/json">{}</script></amp-animation>',
-				array( 'amp-animation' ),
-			),
+				[ 'amp-animation' ],
+			],
 
-			'amp-call-tracking'                            => array(
+			'amp-call-tracking'                            => [
 				'<amp-call-tracking config="https://example.com/calltracking.json"><b>bad</b>--and not great: <a href="tel:123456789">+1 (23) 456-789</a><i>more bad</i>not great</amp-call-tracking>',
 				'<amp-call-tracking config="https://example.com/calltracking.json">--and not great: <a href="tel:123456789">+1 (23) 456-789</a>not great</amp-call-tracking>',
-				array( 'amp-call-tracking' ),
-			),
+				[ 'amp-call-tracking' ],
+			],
 
-			'amp-call-tracking_blacklisted_config'         => array(
+			'amp-call-tracking_blacklisted_config'         => [
 				'<amp-call-tracking config="__amp_source_origin"><a href="tel:123456789">+1 (23) 456-789</a></amp-call-tracking>',
 				'',
-				array(), // Important: This needs to be empty because the amp-call-tracking is stripped.
-			),
+				[], // Important: This needs to be empty because the amp-call-tracking is stripped.
+			],
 
-			'amp-embed'                                    => array(
+			'amp-embed'                                    => [
 				'<amp-embed type="taboola" width="400" height="300" layout="responsive"></amp-embed>',
 				null, // No change.
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'amp-facebook-comments'                        => array(
+			'amp-facebook-comments'                        => [
 				'<amp-facebook-comments width="486" height="657" data-href="http://example.com/baz" layout="responsive" data-numposts="5"></amp-facebook-comments>',
 				null, // No change.
-				array( 'amp-facebook-comments' ),
-			),
+				[ 'amp-facebook-comments' ],
+			],
 
-			'amp-facebook-comments_missing_required_attribute' => array(
+			'amp-facebook-comments_missing_required_attribute' => [
 				'<amp-facebook-comments width="486" height="657" layout="responsive" data-numposts="5"></amp-facebook-comments>',
 				'',
-				array(), // Empty because invalid.
-			),
+				[], // Empty because invalid.
+			],
 
-			'amp-facebook-like'                            => array(
+			'amp-facebook-like'                            => [
 				'<amp-facebook-like width="90" height="20" data-href="http://example.com/baz" layout="fixed" data-layout="button_count"></amp-facebook-like>',
 				null, // No change.
-				array( 'amp-facebook-like' ),
-			),
+				[ 'amp-facebook-like' ],
+			],
 
-			'amp-facebook-like_missing_required_attribute' => array(
+			'amp-facebook-like_missing_required_attribute' => [
 				'<amp-facebook-like width="90" height="20" layout="fixed" data-layout="button_count"></amp-facebook-like>',
 				'',
-				array(), // Empty because invalid.
-			),
+				[], // Empty because invalid.
+			],
 
-			'amp-fit-text'                                 => array(
+			'amp-fit-text'                                 => [
 				'<amp-fit-text width="300" height="200" layout="responsive">Lorem ipsum</amp-fit-text>',
 				null, // No change.
-				array( 'amp-fit-text' ),
-			),
+				[ 'amp-fit-text' ],
+			],
 
-			'amp-gist'                                     => array(
+			'amp-gist'                                     => [
 				'<amp-gist layout="fixed-height" data-gistid="a19" height="1613"></amp-gist>',
 				null, // No change.
-				array( 'amp-gist' ),
-			),
+				[ 'amp-gist' ],
+			],
 
-			'amp-gist_missing_mandatory_attribute'         => array(
+			'amp-gist_missing_mandatory_attribute'         => [
 				'<amp-gist layout="fixed-height" height="1613"></amp-gist>',
 				'',
-				array(),
-			),
+				[],
+			],
 
-			'amp-iframe'                                   => array(
+			'amp-iframe'                                   => [
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="https://www.example.com"></amp-iframe>',
 				null, // No change.
-				array( 'amp-iframe' ),
-			),
+				[ 'amp-iframe' ],
+			],
 
-			'amp-iframe_incorrect_protocol'                => array(
+			'amp-iframe_incorrect_protocol'                => [
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="masterprotocol://www.example.com"></amp-iframe>',
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0"></amp-iframe>',
-				array( 'amp-iframe' ),
-			),
+				[ 'amp-iframe' ],
+			],
 
-			'amp-ima-video'                                => array(
+			'amp-ima-video'                                => [
 				'
 					<amp-ima-video width="640" height="360" data-tag="https://example.com/foo" layout="responsive" data-src="https://example.com/bar">
 						<source src="https://example.com/foo.mp4" type="video/mp4">
@@ -159,122 +159,122 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-ima-video>
 				',
 				null, // No change.
-				array( 'amp-ima-video' ),
-			),
+				[ 'amp-ima-video' ],
+			],
 
-			'amp-ima-video_missing_required_attribute'     => array(
+			'amp-ima-video_missing_required_attribute'     => [
 				'<amp-ima-video width="640" height="360" layout="responsive" data-src="https://example.com/bar"></amp-ima-video>',
 				'',
-			),
+			],
 
-			'amp-imgur'                                    => array(
+			'amp-imgur'                                    => [
 				'<amp-imgur data-imgur-id="54321" layout="responsive" width="540" height="663"></amp-imgur>',
 				null, // No change.
-				array( 'amp-imgur' ),
-			),
+				[ 'amp-imgur' ],
+			],
 
-			'amp-install-serviceworker'                    => array(
+			'amp-install-serviceworker'                    => [
 				'<amp-install-serviceworker src="https://www.emample.com/worker.js" data-iframe-src="https://www.example.com/serviceworker.html" layout="nodisplay"></amp-install-serviceworker>',
 				null, // No change.
-				array( 'amp-install-serviceworker' ),
-			),
+				[ 'amp-install-serviceworker' ],
+			],
 
-			'amp-izlesene'                                 => array(
+			'amp-izlesene'                                 => [
 				'<amp-izlesene data-videoid="4321" layout="responsive" width="432" height="123"></amp-izlesene>',
 				null, // No change.
-				array( 'amp-izlesene' ),
-			),
+				[ 'amp-izlesene' ],
+			],
 
-			'amp-mathml'                                   => array(
+			'amp-mathml'                                   => [
 				'<amp-mathml layout="container" inline data-formula="\[x = {-b \pm \sqrt{b^2-4ac} \over 2a}.\]"></amp-mathml>',
 				null, // No change.
-				array( 'amp-mathml' ),
-			),
+				[ 'amp-mathml' ],
+			],
 
-			'amp-riddle-quiz'                              => array(
+			'amp-riddle-quiz'                              => [
 				'<amp-riddle-quiz layout="responsive" width="600" height="400" data-riddle-id="25799"></amp-riddle-quiz>',
 				null, // No change.
-				array( 'amp-riddle-quiz' ),
-			),
+				[ 'amp-riddle-quiz' ],
+			],
 
-			'amp-wistia-player'                            => array(
+			'amp-wistia-player'                            => [
 				'<amp-wistia-player data-media-hashed-id="u8p9wq6mq8" width="512" height="360"></amp-wistia-player>',
 				null, // No change.
-				array( 'amp-wistia-player' ),
-			),
+				[ 'amp-wistia-player' ],
+			],
 
-			'amp-byside-content'                           => array(
+			'amp-byside-content'                           => [
 				'<amp-byside-content data-webcare-id="D6604AE5D0" data-channel="" data-lang="pt" data-fid="" data-label="amp-number" layout="fixed" width="120" height="40"></amp-byside-content>',
 				null, // No change.
-				array( 'amp-byside-content' ),
-			),
+				[ 'amp-byside-content' ],
+			],
 
-			'amp-bind-macro'                               => array(
+			'amp-bind-macro'                               => [
 				'<amp-bind-macro id="circleArea" arguments="radius" expression="3.14 * radius * radius"></amp-bind-macro>',
 				null, // No change.
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
-			'amp-nexxtv-player'                            => array(
+			'amp-nexxtv-player'                            => [
 				'<amp-nexxtv-player data-mediaid="123ABC" data-client="4321"></amp-nexxtv-player>',
 				null, // No change.
-				array( 'amp-nexxtv-player' ),
-			),
+				[ 'amp-nexxtv-player' ],
+			],
 
-			'amp-playbuzz'                                 => array(
+			'amp-playbuzz'                                 => [
 				'<amp-playbuzz src="id-from-the-content-here" height="500" data-item-info="true" data-share-buttons="true" data-comments="true"></amp-playbuzz>',
 				null, // No change.
-				array( 'amp-playbuzz' ),
-			),
+				[ 'amp-playbuzz' ],
+			],
 
-			'amp-playbuzz_no_src'                          => array(
+			'amp-playbuzz_no_src'                          => [
 				'<amp-playbuzz height="500" data-item-info="true"></amp-playbuzz>',
 				null, // @todo This actually should be stripped because .
-				array( 'amp-playbuzz' ),
-			),
+				[ 'amp-playbuzz' ],
+			],
 
 			// AMP-NEXT-PAGE > [separator].
-			'reference-point-amp-next-page-separator'      => array(
+			'reference-point-amp-next-page-separator'      => [
 				'<amp-next-page src="https://example.com/config.json"><div separator><h1>Keep reading</h1></div></amp-next-page>',
 				null,
-				array( 'amp-next-page' ),
-			),
+				[ 'amp-next-page' ],
+			],
 
 			// amp-next-page extension .json configuration.
-			'reference-point-amp-next-page-json-config'    => array(
+			'reference-point-amp-next-page-json-config'    => [
 				'<amp-next-page><script type="application/json">{"pages": []}</script></amp-next-page>',
 				null,
-				array( 'amp-next-page' ),
-			),
+				[ 'amp-next-page' ],
+			],
 
-			'reference-point-amp-carousel-lightbox-exclude' => array(
+			'reference-point-amp-carousel-lightbox-exclude' => [
 				'<amp-carousel width="400" height="300" layout="responsive" type="slides" lightbox=""><amp-img src="/awesome.png" width="300" height="300" lightbox=""></amp-img><amp-img src="/awesome.png" width="300" height="300" lightbox-exclude=""></amp-img></amp-carousel>',
 				null,
-				array( 'amp-carousel', 'amp-lightbox-gallery' ),
-			),
+				[ 'amp-carousel', 'amp-lightbox-gallery' ],
+			],
 
-			'reference-point-lightbox-thumbnail-id'        => array(
+			'reference-point-lightbox-thumbnail-id'        => [
 				'<amp-img src="/awesome.png" width="300" height="300" lightbox lightbox-thumbnail-id="a"></amp-img>',
 				null,
-				array( 'amp-lightbox-gallery' ),
-			),
+				[ 'amp-lightbox-gallery' ],
+			],
 
-			'lightbox-with-amp-carousel'                   => array(
+			'lightbox-with-amp-carousel'                   => [
 				'<amp-carousel lightbox width="1600" height="900" layout="responsive" type="slides"><amp-img src="image1" width="200" height="100"></amp-img><amp-img src="image1" width="200" height="100"></amp-img><amp-img src="image1" width="200" height="100"></amp-img></amp-carousel>',
 				null,
-				array( 'amp-lightbox-gallery', 'amp-carousel' ),
-			),
+				[ 'amp-lightbox-gallery', 'amp-carousel' ],
+			],
 
-			'reference-points-amp-live-list'               => array(
+			'reference-points-amp-live-list'               => [
 				'<amp-live-list id="my-live-list" data-poll-interval="15000" data-max-items-per-page="20"><button update on="tap:my-live-list.update">You have updates!</button><div items></div><div pagination></div></amp-live-list>',
 				null,
-				array( 'amp-live-list' ),
-			),
+				[ 'amp-live-list' ],
+			],
 
 			'reference-points-amp-story'                   => call_user_func(
 				static function () {
 					$html = str_replace(
-						array( "\n", "\t" ),
+						[ "\n", "\t" ],
 						'',
 						'
 						<amp-story standalone supports-landscape title="My Story" publisher="The AMP Team" publisher-logo-src="https://example.com/logo/1x1.png" poster-portrait-src="https://example.com/my-story/poster/3x4.jpg" poster-square-src="https://example.com/my-story/poster/1x1.jpg" poster-landscape-src="https://example.com/my-story/poster/4x3.jpg" background-audio="my.mp3">
@@ -323,104 +323,104 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						'
 					);
 
-					return array(
+					return [
 						$html,
 						preg_replace( '#<\w+[^>]*>bad</\w+>#', '', $html ),
-						array( 'amp-story', 'amp-analytics', 'amp-twitter' ),
-					);
+						[ 'amp-story', 'amp-analytics', 'amp-twitter' ],
+					];
 				}
 			),
 
-			'reference-points-bad'                         => array(
+			'reference-points-bad'                         => [
 				'<div lightbox-thumbnail-id update items pagination separator option selected disabled>BAD REFERENCE POINTS</div>',
 				'<div>BAD REFERENCE POINTS</div>',
-				array(),
-			),
+				[],
+			],
 
-			'amp-position-observer'                        => array(
+			'amp-position-observer'                        => [
 				'<amp-position-observer intersection-ratios="1"></amp-position-observer>',
 				null, // No change.
-				array( 'amp-position-observer' ),
-			),
+				[ 'amp-position-observer' ],
+			],
 
-			'amp-twitter'                                  => array(
+			'amp-twitter'                                  => [
 				'<amp-twitter width="321" height="543" layout="responsive" data-tweetid="98765"></amp-twitter>',
 				null, // No change.
-				array( 'amp-twitter' ),
-			),
+				[ 'amp-twitter' ],
+			],
 
-			'amp-user-notification'                        => array(
+			'amp-user-notification'                        => [
 				'<amp-user-notification layout="nodisplay" id="amp-user-notification1" data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP" data-dismiss-href="https://example.com/api/echo/post">This site uses cookies to personalize content.<a class="btn" on="tap:amp-user-notification1.dismiss">I accept</a></amp-user-notification>',
 				'<amp-user-notification layout="nodisplay" id="amp-user-notification1" data-show-if-href="https://example.com/api/show?timestamp=TIMESTAMP" data-dismiss-href="https://example.com/api/echo/post">This site uses cookies to personalize content.<a class="btn" on="tap:amp-user-notification1.dismiss">I accept</a></amp-user-notification>',
-				array( 'amp-user-notification' ),
-			),
+				[ 'amp-user-notification' ],
+			],
 
-			'amp-video'                                    => array(
+			'amp-video'                                    => [
 				'<amp-video width="432" height="987" src="/video/location.mp4"></amp-video>',
 				null, // No change.
-				array( 'amp-video' ),
-			),
+				[ 'amp-video' ],
+			],
 
-			'amp_video_children'                           => array(
+			'amp_video_children'                           => [
 				'<amp-video width="432" height="987"><track kind="subtitles" src="https://example.com/sampleChapters.vtt" srclang="en"><source src="foo.webm" type="video/webm"><source src="foo.ogg" type="video/ogg"><div placeholder>Placeholder</div><span fallback>Fallback</span></amp-video>',
 				null, // No change.
-				array( 'amp-video' ),
-			),
+				[ 'amp-video' ],
+			],
 
-			'amp_audio_children'                           => array(
+			'amp_audio_children'                           => [
 				'<amp-audio><track kind="subtitles" src="https://example.com/sampleChapters.vtt" srclang="en"><source src="foo.mp3" type="audio/mp3"><source src="foo.wav" type="audio/wav"><div placeholder>Placeholder</div><span fallback>Fallback</span></amp-audio>',
 				null, // No change.
-				array( 'amp-audio' ),
-			),
+				[ 'amp-audio' ],
+			],
 
-			'amp-vk'                                       => array(
+			'amp-vk'                                       => [
 				'<amp-vk width="500" height="300" data-embedtype="post" layout="responsive"></amp-vk>',
 				null, // No change.
-				array( 'amp-vk' ),
-			),
+				[ 'amp-vk' ],
+			],
 
-			'amp-apester-media'                            => array(
+			'amp-apester-media'                            => [
 				'<amp-apester-media height="444" data-apester-media-id="57a336dba187a2ca3005e826" layout="fixed-height"></amp-apester-media>',
 				'<amp-apester-media height="444" data-apester-media-id="57a336dba187a2ca3005e826" layout="fixed-height"></amp-apester-media>',
-				array( 'amp-apester-media' ),
-			),
+				[ 'amp-apester-media' ],
+			],
 
-			'button'                                       => array(
+			'button'                                       => [
 				'<button on="tap:AMP.setState(foo=\'foo\', isButtonDisabled=true, textClass=\'redBackground\', imgSrc=\'https://ampbyexample.com/img/Shetland_Sheepdog.jpg\', imgSize=200, imgAlt=\'Sheepdog\', videoSrc=\'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4\')">Click me</button>',
 				null,
-			),
+			],
 
-			'brid-player'                                  => array(
+			'brid-player'                                  => [
 				'<amp-brid-player data-dynamic="abc" data-partner="264" data-player="4144" data-video="13663" layout="responsive" width="480" height="270"></amp-brid-player>',
 				null,
-				array( 'amp-brid-player' ),
-			),
+				[ 'amp-brid-player' ],
+			],
 
-			'brightcove'                                   => array(
+			'brightcove'                                   => [
 				'<amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove>',
 				'<amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove>',
-				array( 'amp-brightcove' ),
-			),
+				[ 'amp-brightcove' ],
+			],
 
-			'carousel_slides'                              => array(
+			'carousel_slides'                              => [
 				'<amp-carousel width="400" height="300" layout="responsive" type="slides" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout="fill"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove><amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="381" height="381" layout="responsive"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="358" height="204" layout="responsive" controls=""></amp-video></amp-carousel><amp-carousel width="auto" height="300" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="300" height="300"></amp-brightcove><amp-vimeo data-videoid="27246366" width="300" height="300"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="300" height="300"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="300" height="300"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="300" height="300" controls=""></amp-video></amp-carousel>',
 				'<amp-carousel width="400" height="300" layout="responsive" type="slides" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" layout="fill"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300" layout="responsive"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="480" height="270"></amp-brightcove><amp-vimeo data-videoid="27246366" width="500" height="281"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="381" height="381" layout="responsive"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="358" height="204" layout="responsive" controls=""></amp-video></amp-carousel><amp-carousel width="auto" height="300" controls=""><div>hello world</div><amp-img src="https://lh3.googleusercontent.com/pSECrJ82R7-AqeBCOEPGPM9iG9OEIQ_QXcbubWIOdkY=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/5rcQ32ml8E5ONp9f9-Rf78IofLb9QjS5_0mqsY1zEFc=w400-h300-no-n" width="400" height="300"></amp-img><amp-img src="https://lh3.googleusercontent.com/Z4gtm5Bkxyv21Z2PtbTf95Clb9AE4VTR6olbBKYrenM=w400-h300-no-n" width="400" height="300"></amp-img><amp-soundcloud height="300" layout="fixed-height" data-trackid="243169232"></amp-soundcloud><amp-youtube data-videoid="mGENRKrdoGY" width="400" height="300"></amp-youtube><amp-anim src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no" width="400" height="300"><amp-img placeholder="" src="https://lh3.googleusercontent.com/qNn8GDz8Jfd-s9lt3Nc4lJeLjVyEaqGJTk1vuCUWazCmAeOBVjSWDD0SMTU7x0zhVe5UzOTKR0n-kN4SXx7yElvpKYvCMaRyS_g-jydhJ_cEVYmYPiZ_j1Y9de43mlKxU6s06uK1NAlpbSkL_046amEKOdgIACICkuWfOBwlw2hUDfjPOWskeyMrcTu8XOEerCLuVqXugG31QC345hz3lUyOlkdT9fMYVUynSERGNzHba7bXMOxKRe3izS5DIWUgJs3oeKYqA-V8iqgCvneD1jj0Ff68V_ajm4BDchQubBJU0ytXVkoWh27ngeEHubpnApOS6fcGsjPxeuMjnzAUtoTsiXz2FZi1mMrxrblJ-kZoAq1DJ95cnoqoa2CYq3BTgq2E8BRe2paNxLJ5GXBCTpNdXMpVJc6eD7ceijQyn-2qanilX-iK3ChbOq0uBHMvsdoC_LsFOu5KzbbNH71vM3DPkvDGmHJmF67Vj8sQ6uBrLnzpYlCyN4-Y9frR8zugDcqX5Q=w400-h300-no-k" width="400" height="300"></amp-img></amp-anim><amp-audio src="https://ia801402.us.archive.org/16/items/EDIS-SRP-0197-06/EDIS-SRP-0197-06.mp3"></amp-audio><amp-brightcove data-account="906043040001" data-video-id="1401169490001" data-player="180a5658-8be8-4f33-8eba-d562ab41b40c" layout="responsive" width="300" height="300"></amp-brightcove><amp-vimeo data-videoid="27246366" width="300" height="300"></amp-vimeo><amp-dailymotion data-videoid="x3rdtfy" width="300" height="300"></amp-dailymotion><amp-vine data-vineid="MdKjXez002d" width="300" height="300"></amp-vine><amp-video src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4" width="300" height="300" controls=""></amp-video></amp-carousel>',
-				array( 'amp-anim', 'amp-audio', 'amp-brightcove', 'amp-carousel', 'amp-dailymotion', 'amp-soundcloud', 'amp-video', 'amp-vimeo', 'amp-vine', 'amp-youtube' ),
-			),
+				[ 'amp-anim', 'amp-audio', 'amp-brightcove', 'amp-carousel', 'amp-dailymotion', 'amp-soundcloud', 'amp-video', 'amp-vimeo', 'amp-vine', 'amp-youtube' ],
+			],
 
-			'carousel_simple'                              => array(
+			'carousel_simple'                              => [
 				'<amp-carousel width="450" height="300"></amp-carousel>',
 				null,
-				array( 'amp-carousel' ),
-			),
+				[ 'amp-carousel' ],
+			],
 
-			'carousel_lightbox'                            => array(
+			'carousel_lightbox'                            => [
 				'<amp-carousel width="450" height="300" delay="100" arrows [slide]="foo" autoplay loop lightbox></amp-carousel>',
 				null,
-				array( 'amp-bind', 'amp-carousel', 'amp-lightbox-gallery' ),
-			),
+				[ 'amp-bind', 'amp-carousel', 'amp-lightbox-gallery' ],
+			],
 
-			'base_carousel'                                => array(
+			'base_carousel'                                => [
 				'
 					<amp-base-carousel width="4" height="3" auto-advance="true" layout="responsive" heights="(min-width: 600px) calc(100% * 4 * 3 / 2), calc(100% * 3 * 3 / 2)" visible-count="(min-width: 600px) 4, 3" advance-count="(min-width: 600px) 4, 3">
 						<div lightbox-thumbnail-id="food">first slide</div>
@@ -428,132 +428,132 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-base-carousel>
 				',
 				null,
-				array( 'amp-base-carousel' ),
-			),
+				[ 'amp-base-carousel' ],
+			],
 
-			'amp-dailymotion'                              => array(
+			'amp-dailymotion'                              => [
 				'<amp-dailymotion data-videoid="x3rdtfy" width="500" height="281" dock></amp-dailymotion><h4>Default (responsive)</h4><amp-dailymotion data-videoid="x3rdtfy" width="500" height="281" layout="responsive"></amp-dailymotion><h4>Custom</h4><amp-dailymotion data-videoid="x3rdtfy" data-endscreen-enable="false" data-sharing-enable="false" data-ui-highlight="444444" data-ui-logo="false" data-info="false" width="640" height="360"></amp-dailymotion>',
 				null,
-				array( 'amp-dailymotion', 'amp-video-docking' ),
-			),
+				[ 'amp-dailymotion', 'amp-video-docking' ],
+			],
 
 			// Try to test for NAME_VALUE_PARENT_DISPATCH.
-			'amp_ima_video'                                => array(
+			'amp_ima_video'                                => [
 				'<amp-ima-video width="640" height="360" layout="responsive" data-tag="ads.xml" data-poster="poster.png"><source src="foo.mp4" type="video/mp4"><source src="foo.webm" type="video/webm"><track label="English subtitles" kind="subtitles" srclang="en" src="https://example.com/subtitles.vtt"><script type="application/json">{"locale": "en", "numRedirects": 4}</script></amp-ima-video>',
 				null, // No change.
-				array( 'amp-ima-video' ),
-			),
+				[ 'amp-ima-video' ],
+			],
 
 			// Try to test for NAME_VALUE_DISPATCH.
-			'doubleclick-1'                                => array(
+			'doubleclick-1'                                => [
 				'<amp-ad width="480" height="75" type="doubleclick" data-slot="/4119129/mobile_ad_banner" data-multi-size="320x50" class="dashedborder"></amp-ad>',
 				'<amp-ad width="480" height="75" type="doubleclick" data-slot="/4119129/mobile_ad_banner" data-multi-size="320x50" class="dashedborder"></amp-ad>',
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
 			// Try to test for NAME_DISPATCH.
-			'nav_dispatch_key'                             => array(
+			'nav_dispatch_key'                             => [
 				'<nav><a href="https://example.com">Example</a></nav>',
 				null,
-			),
+			],
 
-			'json_linked_data'                             => array(
+			'json_linked_data'                             => [
 				'<script type="application/ld+json">{"@context":"http:\/\/schema.org"}</script>',
 				null, // No Change.
-			),
+			],
 
-			'json_linked_data_with_bad_cdata'              => array(
+			'json_linked_data_with_bad_cdata'              => [
 				'<script type="application/ld+json"><!-- {"@context":"http:\/\/schema.org"} --></script>',
 				'',
-			),
+			],
 
-			'facebook'                                     => array(
+			'facebook'                                     => [
 				'<amp-facebook width="552" height="303" layout="responsive" data-href="https://www.facebook.com/zuck/posts/10102593740125791"></amp-facebook><h1>More Posts</h1>',
 				'<amp-facebook width="552" height="303" layout="responsive" data-href="https://www.facebook.com/zuck/posts/10102593740125791"></amp-facebook><h1>More Posts</h1>',
-				array( 'amp-facebook' ),
-			),
+				[ 'amp-facebook' ],
+			],
 
-			'font'                                         => array(
+			'font'                                         => [
 				'<amp-font layout="nodisplay" font-family="Comic AMP" timeout="2000"></amp-font><amp-font layout="nodisplay" font-family="Comic AMP Bold" timeout="3000" font-weight="bold"></amp-font>',
 				'<amp-font layout="nodisplay" font-family="Comic AMP" timeout="2000"></amp-font><amp-font layout="nodisplay" font-family="Comic AMP Bold" timeout="3000" font-weight="bold"></amp-font>',
-				array( 'amp-font' ),
-			),
+				[ 'amp-font' ],
+			],
 
-			'form'                                         => array(
+			'form'                                         => [
 				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"></fieldset></form>',
 				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"></fieldset></form>',
-				array( 'amp-form' ),
-			),
+				[ 'amp-form' ],
+			],
 
-			'gfycat'                                       => array(
+			'gfycat'                                       => [
 				'<amp-gfycat data-gfyid="BareSecondaryFlamingo" width="225" height="400"></amp-gfycat>',
 				'<amp-gfycat data-gfyid="BareSecondaryFlamingo" width="225" height="400"></amp-gfycat>',
-				array( 'amp-gfycat' ),
-			),
+				[ 'amp-gfycat' ],
+			],
 
-			'h2'                                           => array(
+			'h2'                                           => [
 				'<h2>Example Text</h2>',
-			),
+			],
 
-			'empty_element'                                => array(
+			'empty_element'                                => [
 				'<br>',
-			),
+			],
 
-			'merge_two_attr_specs'                         => array(
+			'merge_two_attr_specs'                         => [
 				'<div submit-success>Whatever</div>',
 				'<div>Whatever</div>',
-			),
+			],
 
-			'attribute_value_blacklisted_by_regex_removed' => array(
+			'attribute_value_blacklisted_by_regex_removed' => [
 				'<a href="__amp_source_origin">Click me.</a>',
 				'<a href="">Click me.</a>',
-			),
+			],
 
-			'host_relative_url_allowed'                    => array(
+			'host_relative_url_allowed'                    => [
 				'<a href="/path/to/content">Click me.</a>',
-			),
+			],
 
-			'protocol_relative_url_allowed'                => array(
+			'protocol_relative_url_allowed'                => [
 				'<a href="//example.com/path/to/content">Click me.</a>',
-			),
+			],
 
-			'node_with_whiteilsted_protocol_http_allowed'  => array(
+			'node_with_whiteilsted_protocol_http_allowed'  => [
 				'<a href="http://example.com/path/to/content">Click me.</a>',
-			),
+			],
 
-			'node_with_whiteilsted_protocol_https_allowed' => array(
+			'node_with_whiteilsted_protocol_https_allowed' => [
 				'<a href="https://example.com/path/to/content">Click me.</a>',
-			),
+			],
 
-			'node_with_whiteilsted_protocol_other_allowed' => array(
+			'node_with_whiteilsted_protocol_other_allowed' => [
 				implode(
 					'',
-					array(
+					[
 						'<a href="fb-messenger://example.com/path/to/content">Click me.</a>',
 						'<a href="webcal:foo">Click me.</a>',
 						'<a href="whatsapp:foo">Click me.</a>',
 						'<a href="web+mastodon:follow/@handle@instance">Click me.</a>',
-					)
+					]
 				),
-			),
+			],
 
-			'attribute_value_valid'                        => array(
+			'attribute_value_valid'                        => [
 				'<template type="amp-mustache">Hello {{world}}! <a href="{{user_url}}" title="{{user_name}}">Homepage</a> User content: {{{some_formatting}}} A guy with Mustache: :-{). {{#returning}}Welcome back!{{/returning}} {{^returning}}Welcome for the first time!{{/returning}} </template>',
 				null,
-				array( 'amp-mustache' ),
-			),
+				[ 'amp-mustache' ],
+			],
 
-			'attribute_value_invalid'                      => array(
+			'attribute_value_invalid'                      => [
 				// type is mandatory, so the node is removed.
 				'<template type="bad-type">Template Data</template>',
 				'',
-				array(), // No scripts because removed.
-			),
+				[], // No scripts because removed.
+			],
 
 			'attribute_amp_accordion_value'                => call_user_func(
 				static function() {
 					$html = str_replace(
-						array( "\n", "\t" ),
+						[ "\n", "\t" ],
 						'',
 						'
 						<amp-accordion class="sample" disable-session-states="">
@@ -581,158 +581,158 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						'
 					);
 
-					return array(
+					return [
 						$html,
 						preg_replace( '#<\w+>bad</\w+>#', '', $html ),
-						array( 'amp-accordion' ),
-					);
+						[ 'amp-accordion' ],
+					];
 				}
 			),
 
-			'attribute_value_with_blacklisted_regex_removed' => array(
+			'attribute_value_with_blacklisted_regex_removed' => [
 				'<a rel="import">Click me.</a>',
 				'<a>Click me.</a>',
-			),
+			],
 
-			'attribute_value_with_blacklisted_multi-part_regex_removed' => array(
+			'attribute_value_with_blacklisted_multi-part_regex_removed' => [
 				'<a rel="something else import">Click me.</a>',
 				'<a>Click me.</a>',
-			),
+			],
 
-			'attribute_value_with_required_regex'          => array(
+			'attribute_value_with_required_regex'          => [
 				'<a target="_blank">Click me.</a>',
-			),
+			],
 
-			'attribute_value_with_disallowed_required_regex_removed' => array(
+			'attribute_value_with_disallowed_required_regex_removed' => [
 				'<a target="_not_blank">Click me.</a>',
 				'<a>Click me.</a>',
-			),
+			],
 
-			'attribute_value_with_required_value_casei_lower' => array(
+			'attribute_value_with_required_value_casei_lower' => [
 				'<a type="text/html">Click.me.</a>',
-			),
+			],
 
-			'attribute_value_with_required_value_casei_upper' => array(
+			'attribute_value_with_required_value_casei_upper' => [
 				'<a type="TEXT/HTML">Click.me.</a>',
-			),
+			],
 
-			'attribute_value_with_required_value_casei_mixed' => array(
+			'attribute_value_with_required_value_casei_mixed' => [
 				'<a type="TeXt/HtMl">Click.me.</a>',
-			),
+			],
 
-			'attribute_value_with_bad_value_casei_removed' => array(
+			'attribute_value_with_bad_value_casei_removed' => [
 				'<a type="bad_type">Click.me.</a>',
 				'<a>Click.me.</a>',
-			),
+			],
 
-			'attribute_value_with_value_regex_casei_lower' => array(
+			'attribute_value_with_value_regex_casei_lower' => [
 				'<amp-dailymotion data-videoid="abc"></amp-dailymotion>',
 				null, // No change.
-				array( 'amp-dailymotion' ),
-			),
+				[ 'amp-dailymotion' ],
+			],
 
-			'attribute_value_with_value_regex_casei_upper' => array(
+			'attribute_value_with_value_regex_casei_upper' => [
 				'<amp-dailymotion data-videoid="ABC"></amp-dailymotion>',
 				null, // No change.
-				array( 'amp-dailymotion' ),
-			),
+				[ 'amp-dailymotion' ],
+			],
 
-			'attribute_value_with_bad_value_regex_casei_removed' => array(
+			'attribute_value_with_bad_value_regex_casei_removed' => [
 				// data-ui-logo should be true|false.
 				'<amp-dailymotion data-videoid="123" data-ui-logo="maybe"></amp-dailymotion>',
 				'<amp-dailymotion data-videoid="123"></amp-dailymotion>',
-				array( 'amp-dailymotion' ),
-			),
+				[ 'amp-dailymotion' ],
+			],
 
-			'attribute_bad_attr_with_no_value_removed'     => array(
+			'attribute_bad_attr_with_no_value_removed'     => [
 				'<amp-ad type="adsense" bad-attr-no-value><div fallback>something here</div></amp-ad>',
 				'<amp-ad type="adsense"><div fallback>something here</div></amp-ad>',
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'attribute_bad_attr_with_value_removed'        => array(
+			'attribute_bad_attr_with_value_removed'        => [
 				'<amp-ad type="adsense" bad-attr="some-value">something here</amp-ad>',
 				'<amp-ad type="adsense">something here</amp-ad>',
-				array( 'amp-ad' ),
-			),
+				[ 'amp-ad' ],
+			],
 
-			'remove_node_with_invalid_mandatory_attribute' => array(
+			'remove_node_with_invalid_mandatory_attribute' => [
 				// script only allows application/json, nothing else.
 				'<script type="type/javascript">console.log()</script>',
 				'',
-			),
+			],
 
-			'remove_node_without_mandatory_attribute'      => array(
+			'remove_node_without_mandatory_attribute'      => [
 				'<script>console.log()</script>',
 				'',
-			),
+			],
 
-			'remove_script_with_async_attribute'           => array(
+			'remove_script_with_async_attribute'           => [
 				'<script async src="//cdn.someecards.com/assets/embed/embed-v1.07.min.js" charset="utf-8"></script>', // phpcs:ignore
 				'',
-			),
+			],
 
-			'remove_invalid_json_script'                   => array(
+			'remove_invalid_json_script'                   => [
 				'<script type="application/json" class="wp-playlist-script">{}</script>',
 				'',
-			),
+			],
 
-			'allow_node_with_valid_mandatory_attribute'    => array(
+			'allow_node_with_valid_mandatory_attribute'    => [
 				'<amp-analytics><script type="application/json"></script></amp-analytics>',
 				null, // No change.
-				array( 'amp-analytics' ),
-			),
+				[ 'amp-analytics' ],
+			],
 
-			'nodes_with_non_whitelisted_tags_replaced_by_children' => array(
+			'nodes_with_non_whitelisted_tags_replaced_by_children' => [
 				'<invalid_tag>this is some text inside the invalid node</invalid_tag>',
 				'this is some text inside the invalid node',
-			),
+			],
 
-			'empty_parent_nodes_of_non_whitelisted_tags_removed' => array(
+			'empty_parent_nodes_of_non_whitelisted_tags_removed' => [
 				'<div><span><span><invalid_tag></invalid_tag></span></span></div>',
 				'',
-			),
+			],
 
-			'non_empty_parent_nodes_of_non_whitelisted_tags_removed' => array(
+			'non_empty_parent_nodes_of_non_whitelisted_tags_removed' => [
 				'<div><span><span class="not-empty"><invalid_tag></invalid_tag></span></span></div>',
 				'<div><span><span class="not-empty"></span></span></div>',
-			),
+			],
 
-			'replace_non_whitelisted_node_with_children'   => array(
+			'replace_non_whitelisted_node_with_children'   => [
 				'<p>This is some text <invalid_tag>with a disallowed tag</invalid_tag> in the middle of it.</p>',
 				'<p>This is some text with a disallowed tag in the middle of it.</p>',
-			),
+			],
 
-			'remove_attribute_on_node_with_missing_mandatory_parent' => array(
+			'remove_attribute_on_node_with_missing_mandatory_parent' => [
 				'<div submit-success>This is a test.</div>',
 				'<div>This is a test.</div>',
-			),
+			],
 
-			'leave_attribute_on_node_with_present_mandatory_parent' => array(
+			'leave_attribute_on_node_with_present_mandatory_parent' => [
 				'<form action-xhr="form.php" method="post" target="_top"><div submit-success>This is a test.</div></form>',
 				null,
-				array( 'amp-form' ),
-			),
+				[ 'amp-form' ],
+			],
 
-			'disallowed_empty_attr_removed'                => array(
+			'disallowed_empty_attr_removed'                => [
 				'<amp-user-notification data-dismiss-href></amp-user-notification>',
 				'<amp-user-notification></amp-user-notification>',
-				array( 'amp-user-notification' ),
-			),
+				[ 'amp-user-notification' ],
+			],
 
-			'allowed_empty_attr'                           => array(
+			'allowed_empty_attr'                           => [
 				'<a border=""></a>',
-			),
+			],
 
-			'remove_node_with_disallowed_ancestor_and_disallowed_child_nodes' => array(
+			'remove_node_with_disallowed_ancestor_and_disallowed_child_nodes' => [
 				'<amp-sidebar><amp-app-banner>This node is not allowed here.</amp-app-banner><nav><i>bad</i><ul><li>Hello</li></ul><ol><li>Hello</li></ol><i>bad</i></nav><amp-app-banner>This node is not allowed here.</amp-app-banner></amp-sidebar>',
 				'<amp-sidebar><nav><ul><li>Hello</li></ul><ol><li>Hello</li></ol></nav></amp-sidebar>',
-				array( 'amp-sidebar' ),
-			),
+				[ 'amp-sidebar' ],
+			],
 
-			'amp_story_with_amp_sidebar'                   => array(
+			'amp_story_with_amp_sidebar'                   => [
 				str_replace(
-					array( "\n", "\t" ),
+					[ "\n", "\t" ],
 					'',
 					'
 						<amp-story standalone title="Stories in AMP - Hello World" publisher="AMP Project" publisher-logo-src="https://ampbyexample.com/favicons/coast-228x228.png" poster-portrait-src="https://ampbyexample.com/img/story_dog2_portrait.jpg">
@@ -753,12 +753,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					'
 				),
 				null,
-				array( 'amp-sidebar', 'amp-story' ),
-			),
+				[ 'amp-sidebar', 'amp-story' ],
+			],
 
-			'amp_sidebar_with_autoscroll'                  => array(
+			'amp_sidebar_with_autoscroll'                  => [
 				str_replace(
-					array( "\n", "\t" ),
+					[ "\n", "\t" ],
 					'',
 					'
 						<amp-sidebar id="sidebar1" layout="nodisplay" side="right">
@@ -777,224 +777,224 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					'
 				),
 				null,
-				array( 'amp-sidebar' ),
-			),
+				[ 'amp-sidebar' ],
+			],
 
-			'remove_node_without_mandatory_ancestor'       => array(
+			'remove_node_without_mandatory_ancestor'       => [
 				'<div>All I have is this div, when all you want is a noscript tag.<audio>Sweet tunes</audio></div>',
 				'<div>All I have is this div, when all you want is a noscript tag.</div>',
-			),
+			],
 
-			'amp-img_with_good_protocols'                  => array(
+			'amp-img_with_good_protocols'                  => [
 				'<amp-img src="https://example.com/resource1" srcset="https://example.com/resource1 320w, https://example.com/resource2 480w"></amp-img>',
-			),
+			],
 
-			'amp-img_with_relative_urls_containing_colons' => array(
+			'amp-img_with_relative_urls_containing_colons' => [
 				'<amp-img src="/winning:yes.jpg" width="100" height="200"></amp-img>',
-			),
+			],
 
-			'allowed_tag_only'                             => array(
+			'allowed_tag_only'                             => [
 				'<p>Text</p><img src="/path/to/file.jpg">',
 				'<p>Text</p>',
-			),
+			],
 
-			'disallowed_attributes'                        => array(
+			'disallowed_attributes'                        => [
 				'<a href="/path/to/file.jpg" style="border: 1px solid red !important;">Link</a>',
 				'<a href="/path/to/file.jpg">Link</a>',
-			),
+			],
 
-			'onclick_attribute'                            => array(
+			'onclick_attribute'                            => [
 				'<a href="/path/to/file.jpg" onclick="alert(e);">Link</a>',
 				'<a href="/path/to/file.jpg">Link</a>',
-			),
+			],
 
-			'on_attribute'                                 => array(
+			'on_attribute'                                 => [
 				'<button on="tap:my-lightbox">Tap Me</button>',
-			),
+			],
 
-			'multiple_disallowed_attributes'               => array(
+			'multiple_disallowed_attributes'               => [
 				'<a href="/path/to/file.jpg" style="border: 1px solid red !important;" onclick="alert(e);">Link</a>',
 				'<a href="/path/to/file.jpg">Link</a>',
-			),
+			],
 
-			'attribute_recursive'                          => array(
+			'attribute_recursive'                          => [
 				'<div style="border: 1px solid red !important;"><a href="/path/to/file.jpg" onclick="alert(e);">Hello World</a></div>',
 				'<div><a href="/path/to/file.jpg">Hello World</a></div>',
-			),
+			],
 
-			'no_strip_amp_tags'                            => array(
+			'no_strip_amp_tags'                            => [
 				'<amp-img src="http://example.com/path/to/file.jpg" width="300" height="300"></amp-img>',
-			),
+			],
 
-			'a_with_attachment_rel'                        => array(
+			'a_with_attachment_rel'                        => [
 				'<a href="http://example.com" rel="wp-att-1686">Link</a>',
-			),
+			],
 
-			'a_with_invalid_name'                          => array(
+			'a_with_invalid_name'                          => [
 				'<a name=shadowRoot>Shadow Root!</a>',
 				'<a>Shadow Root!</a>',
-			),
+			],
 
-			'a_with_attachment_rel_plus_another_valid_value' => array(
+			'a_with_attachment_rel_plus_another_valid_value' => [
 				'<a href="http://example.com" rel="attachment wp-att-1686">Link</a>',
-			),
+			],
 
-			'a_with_rev'                                   => array(
+			'a_with_rev'                                   => [
 				'<a href="http://example.com" rev="footnote">Link</a>',
-			),
+			],
 
-			'a_with_target_blank'                          => array(
+			'a_with_target_blank'                          => [
 				'<a href="http://example.com" target="_blank">Link</a>',
-			),
+			],
 
-			'a_with_target_uppercase_blank'                => array(
+			'a_with_target_uppercase_blank'                => [
 				'<a href="http://example.com" target="_BLANK">Link</a>',
 				'<a href="http://example.com">Link</a>',
-			),
+			],
 
-			'a_with_target_new'                            => array(
+			'a_with_target_new'                            => [
 				'<a href="http://example.com" target="_new">Link</a>',
 				'<a href="http://example.com">Link</a>',
-			),
+			],
 
-			'a_with_target_self'                           => array(
+			'a_with_target_self'                           => [
 				'<a href="http://example.com" target="_self">Link</a>',
-			),
+			],
 
-			'a_with_target_invalid'                        => array(
+			'a_with_target_invalid'                        => [
 				'<a href="http://example.com" target="boom">Link</a>',
 				'<a href="http://example.com">Link</a>',
-			),
+			],
 
-			'a_with_href_invalid'                          => array(
+			'a_with_href_invalid'                          => [
 				'<a href="some%20random%20text">Link</a>',
-			),
+			],
 
-			'a_with_href_scheme_tel'                       => array(
+			'a_with_href_scheme_tel'                       => [
 				'<a href="tel:4166669999">Call Me, Maybe</a>',
-			),
+			],
 
-			'a_with_href_scheme_sms'                       => array(
+			'a_with_href_scheme_sms'                       => [
 				'<a href="sms:4166669999">SMS Me, Maybe</a>',
-			),
+			],
 
-			'a_with_href_scheme_mailto'                    => array(
+			'a_with_href_scheme_mailto'                    => [
 				'<a href="mailto:email@example.com">Email Me, Maybe</a>',
-			),
+			],
 
-			'a_with_href_relative'                         => array(
+			'a_with_href_relative'                         => [
 				'<a href="/home">Home</a>',
-			),
+			],
 
-			'a_with_anchor'                                => array(
+			'a_with_anchor'                                => [
 				'<a href="#section2">Home</a>',
-			),
+			],
 
-			'a_is_anchor'                                  => array(
+			'a_is_anchor'                                  => [
 				'<a name="section2"></a>',
-			),
+			],
 
-			'a_is_achor_with_id'                           => array(
+			'a_is_achor_with_id'                           => [
 				'<a id="section3"></a>',
-			),
+			],
 
-			'a_empty'                                      => array(
+			'a_empty'                                      => [
 				'<a>Hello World</a>',
-			),
+			],
 
-			'a_empty_with_children_with_restricted_attributes' => array(
+			'a_empty_with_children_with_restricted_attributes' => [
 				'<a><span style="color: red !important;">Red</span>&amp;<span style="color: blue !important;">Orange</span></a>',
 				'<a><span>Red</span>&amp;<span>Orange</span></a>',
-			),
+			],
 
-			'spans_with_xml_namespaced_attributes'         => array(
+			'spans_with_xml_namespaced_attributes'         => [
 				'<p><span lang="es" xml:lang="es">hola</span><span xml:space="preserve">mundo</span></p>',
 				'<p><span lang="es">hola</span><span>mundo</span></p>',
-			),
+			],
 
-			'h1_with_size'                                 => array(
+			'h1_with_size'                                 => [
 				'<h1 size="1">Headline</h1>',
 				'<h1>Headline</h1>',
-			),
+			],
 
-			'font_tag'                                     => array(
+			'font_tag'                                     => [
 				'<font size="1">Headline</font>',
 				'Headline',
-			),
+			],
 
-			'span_with_custom_attr'                        => array(
+			'span_with_custom_attr'                        => [
 				'<span class="foo" custom="not-allowed">value</span>',
 				'<span class="foo">value</span>',
-			),
+			],
 
-			'a_with_custom_protocol'                       => array(
+			'a_with_custom_protocol'                       => [
 				'<a class="foo" href="custom:bad">value</a>',
 				'<a class="foo" href="">value</a>',
-			),
+			],
 
-			'a_with_wrong_host'                            => array(
+			'a_with_wrong_host'                            => [
 				'<a class="foo" href="http://foo bar">value</a>',
 				'<a class="foo" href="">value</a>',
-			),
-			'a_with_encoded_host'                          => array(
+			],
+			'a_with_encoded_host'                          => [
 				'<a class="foo" href="http://%65%78%61%6d%70%6c%65%2e%63%6f%6d/foo/">value</a>',
 				null,
-			),
-			'a_with_wrong_schemeless_host'                 => array(
+			],
+			'a_with_wrong_schemeless_host'                 => [
 				'<a class="foo" href="//bad domain with a space.com/foo">value</a>',
 				'<a class="foo" href="">value</a>',
-			),
-			'a_with_mail_host'                             => array(
+			],
+			'a_with_mail_host'                             => [
 				'<a class="foo" href="mail to:foo@bar.com">value</a>',
 				'<a class="foo" href="">value</a>',
-			),
+			],
 
 			// font is removed so we should check that other elements are checked as well.
-			'font_with_other_bad_elements'                 => array(
+			'font_with_other_bad_elements'                 => [
 				'<font size="1">Headline</font><span style="color: blue !important">Span</span>',
 				'Headline<span>Span</span>',
-			),
+			],
 
-			'amp_bind_attr'                                => array(
+			'amp_bind_attr'                                => [
 				'<p [text]="\'Hello \' + foo">Hello World</p><button on="tap:AMP.setState({foo: \'amp-bind\'})">Update</button>',
 				null, // No change.
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
-			'amp_bind_with_greater_than_symbol'            => array(
+			'amp_bind_with_greater_than_symbol'            => [
 				'<div class="home page-template-default page page-id-7 logged-in wp-custom-logo group-blog" [class]="minnow.bodyClasses.concat( minnow.navMenuExpanded ? \'sidebar-open\' : \'\' ).filter( className => \'\' != className )">hello</div>',
 				'<div class="home page-template-default page page-id-7 logged-in wp-custom-logo group-blog" [class]="minnow.bodyClasses.concat( minnow.navMenuExpanded ? \'sidebar-open\' : \'\' ).filter( className =&gt; \'\' != className )">hello</div>',
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
-			'amp_bad_bind_attr'                            => array(
+			'amp_bad_bind_attr'                            => [
 				'<a [href]=\'/\' [hidden]>test</a><p [text]="\'Hello \' + name" [unrecognized] title="Foo"><button [disabled]="" [type]=\'\'>Hello World</button></p>',
 				'<a [href]="/" [hidden]>test</a><p [text]="\'Hello \' + name" title="Foo"><button [disabled]="" [type]="">Hello World</button></p>',
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
-			'amp-state'                                    => array(
+			'amp-state'                                    => [
 				'<amp-state id="someNumber"><script type="application/json">4</script></amp-state>',
 				null,
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
-			'amp-state-bad'                                => array(
+			'amp-state-bad'                                => [
 				'<amp-state id="someNumber"><i>bad</i><script type="application/json">4</script></amp-state>',
 				'',
-				array(),
-			),
+				[],
+			],
 
-			'amp-state-src'                                => array(
+			'amp-state-src'                                => [
 				'<amp-state id="myRemoteState" src="https://data.com/articles.json"></amp-state>',
 				null,
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
 			// Adapted from <https://www.ampproject.org/docs/reference/components/amp-selector>.
-			'reference-points-amp_selector_and_carousel_with_boolean_attributes' => array(
+			'reference-points-amp_selector_and_carousel_with_boolean_attributes' => [
 				str_replace(
-					array( "\n", "\t" ),
+					[ "\n", "\t" ],
 					'',
 					'
 					<form action="/" method="get" target="_blank" id="form1">
@@ -1034,43 +1034,43 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					'
 				),
 				null, // No change.
-				array( 'amp-selector', 'amp-form', 'amp-carousel' ),
-			),
+				[ 'amp-selector', 'amp-form', 'amp-carousel' ],
+			],
 
-			'amp_live_list_sort'                           => array(
+			'amp_live_list_sort'                           => [
 				'<amp-live-list sort="ascending" data-poll-interval="15000" data-max-items-per-page="5" id="amp-live-list-insert-blog"><button update on="tap:amp-live-list-insert-blog.update" class="ampstart-btn ml1 caps">You have updates</button><div items><div id="A green landscape with trees." data-sort-time="20180317225019">Hello</div></div></amp-live-list>',
 				null, // No change.
-				array( 'amp-live-list' ),
-			),
+				[ 'amp-live-list' ],
+			],
 
-			'amp_consent'                                  => array(
+			'amp_consent'                                  => [
 				'<amp-consent media="all" noloading></amp-consent>',
 				null, // No change.
-				array( 'amp-consent' ),
-			),
+				[ 'amp-consent' ],
+			],
 
-			'amp_date_picker'                              => array(
+			'amp_date_picker'                              => [
 				'<amp-date-picker id="simple-date-picker" type="single" mode="overlay" layout="container" on="select:AMP.setState({date1: event.date, dateType1: event.id})" format="Y-MM-DD" open-after-select input-selector="[name=date1]" class="mr1 ml1 flex picker"><div class="ampstart-input inline-block mt1"><input class="border-none p0" name="date1" placeholder="Pick a date"></div><button class="ampstart-btn m1 caps" on="tap: simple-date-picker.clear">Clear</button></amp-date-picker>',
 				null, // No change.
-				array( 'amp-date-picker' ),
-			),
+				[ 'amp-date-picker' ],
+			],
 
-			'amp_date_picker_range'                        => array(
+			'amp_date_picker_range'                        => [
 				'<amp-date-picker type="range" minimum-nights="2" maximum-nights="4" mode="overlay" id="range-date-picker" on=" select: AMP.setState({ dates: event.dates, startDate: event.start, endDate: event.end })" format="YYYY-MM-DD" open-after-select min="2017-10-26" start-input-selector="#range-start" end-input-selector="#range-end" class="example-picker space-between"><div class="ampstart-input"><input class="border-none p0" id="range-start" placeholder="Start date"></div><div class="ampstart-input"><input class="border-none p0" id="range-end" placeholder="End date"></div><button class="ampstart-btn caps" on="tap:range-date-picker.clear">Clear</button><template type="amp-mustache" info-template><span [text]="(startDate &amp;&amp; endDate ? \'You picked \' + startDate.date + \' as start date and \' + endDate.date + \' as end date.\' : \'You will see your chosen dates here.\')"> You will see your chosen dates here.</span></template></amp-date-picker>',
 				null, // No change.
-				array( 'amp-date-picker', 'amp-bind', 'amp-mustache' ),
-			),
+				[ 'amp-date-picker', 'amp-bind', 'amp-mustache' ],
+			],
 
-			'amp-delight-player'                           => array(
+			'amp-delight-player'                           => [
 				'<amp-delight-player data-content-id="-987521" layout="responsive" width="400" height="300"></amp-delight-player>',
 				null, // No change.
-				array( 'amp-delight-player' ),
-			),
+				[ 'amp-delight-player' ],
+			],
 
-			'amp-img-layout-allowed'                       => array(
+			'amp-img-layout-allowed'                       => [
 				implode(
 					'',
-					array(
+					[
 						'<amp-img src="/img1.png" width="50" height="50" layout="fill"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="fixed"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="fixed-height"></amp-img>',
@@ -1078,49 +1078,49 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						'<amp-img src="/img1.png" width="50" height="50" layout="intrinsic"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="nodisplay"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="responsive"></amp-img>',
-					)
+					]
 				),
 				null, // No change.
-				array(),
-			),
+				[],
+			],
 
-			'amp-img-layout-illegal'                       => array(
+			'amp-img-layout-illegal'                       => [
 				'<amp-img src="/img1.png" width="50" height="50" layout="container"></amp-img>',
 				'<amp-img src="/img1.png" width="50" height="50"></amp-img>',
-				array(),
-			),
+				[],
+			],
 
-			'amp-img-layout-unknown'                       => array(
+			'amp-img-layout-unknown'                       => [
 				'<amp-img src="/img1.png" width="50" height="50" layout="bogus-value"></amp-img>',
 				'<amp-img src="/img1.png" width="50" height="50"></amp-img>',
-				array(),
-			),
+				[],
+			],
 
-			'non-layout-span-element-attrs'                => array(
+			'non-layout-span-element-attrs'                => [
 				'<span id="test" width="1" height="1" heights="(min-width:500px) 200px, 80%" sizes="(min-width: 650px) 50vw, 100vw" layout="nodisplay" [height]="1" [width]="1">Test</span>',
 				'<span id="test">Test</span>',
-				array(),
-			),
+				[],
+			],
 
-			'non-layout-col-element-attrs'                 => array(
+			'non-layout-col-element-attrs'                 => [
 				'<table><col class="foo" width="123" style="background:red !important;"><col class="bar" style="background:green !important;" width="12%"><col class="baz" style="background:blue !important;" width="2*"><tr><td>1</td><td>2</td><td>3</td></tr></table>',
 				'<table><col class="foo"><col class="bar"><col class="baz"><tr><td>1</td><td>2</td><td>3</td></tr></table>',
-				array(),
-			),
+				[],
+			],
 
-			'amp-geo'                                      => array(
+			'amp-geo'                                      => [
 				'<amp-geo layout="nodisplay"><script type="application/json">{ "AmpBind": true, "ISOCountryGroups": { "nafta": [ "ca", "mx", "us", "unknown" ], "waldo": [ "unknown" ], "anz": [ "au", "nz" ] } }</script></amp-geo>',
 				null,
-				array( 'amp-geo' ),
-			),
+				[ 'amp-geo' ],
+			],
 
-			'amp-geo-bad-children'                         => array(
+			'amp-geo-bad-children'                         => [
 				'<amp-geo layout="nodisplay"><div>bad</div><script type="application/json">{ "AmpBind": true, "ISOCountryGroups": { "nafta": [ "ca", "mx", "us", "unknown" ], "waldo": [ "unknown" ], "anz": [ "au", "nz" ] } }</script></amp-geo>',
 				'',
-				array(),
-			),
+				[],
+			],
 
-			'amp-addthis-valid'                            => array(
+			'amp-addthis-valid'                            => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1130,10 +1130,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-responsive-layout'                => array(
+			'amp-addthis-responsive-layout'                => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1144,10 +1144,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-custom-share-attributes'          => array(
+			'amp-addthis-custom-share-attributes'          => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1161,10 +1161,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-wordpress-mode'                   => array(
+			'amp-addthis-wordpress-mode'                   => [
 				'
 					<!-- AddThis WordPress Mode -->
 					<amp-addthis
@@ -1176,10 +1176,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-wordpress-mode-no-render-without-class-name' => array(
+			'amp-addthis-wordpress-mode-no-render-without-class-name' => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1190,10 +1190,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-inline-using-widget-id'           => array(
+			'amp-addthis-inline-using-widget-id'           => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1203,10 +1203,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-inline-using-product-code'        => array(
+			'amp-addthis-inline-using-product-code'        => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1216,10 +1216,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-floating-using-product-code'      => array(
+			'amp-addthis-floating-using-product-code'      => [
 				'
 					<amp-addthis
 					  width="320"
@@ -1230,126 +1230,126 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-addthis>
 				',
 				null,
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-addthis-with-invalid-attribute'           => array(
+			'amp-addthis-with-invalid-attribute'           => [
 				'<amp-addthis width="320" height="240" data-pub-id="ra-5adf5f2869f63c7c" data-product-code="shin" data-share-url="mailto:foo@example.com"></amp-addthis>',
 				'<amp-addthis width="320" height="240" data-pub-id="ra-5adf5f2869f63c7c" data-product-code="shin" data-share-url=""></amp-addthis>',
-				array( 'amp-addthis' ),
-			),
+				[ 'amp-addthis' ],
+			],
 
-			'amp-3d-gltf'                                  => array(
+			'amp-3d-gltf'                                  => [
 				'<amp-3d-gltf layout="responsive" width="320" height="240" alpha="true" antialiasing="true" src="path/to/model.glb"></amp-3d-gltf>',
 				null,
-				array( 'amp-3d-gltf' ),
-			),
+				[ 'amp-3d-gltf' ],
+			],
 
-			'amp-date-countdown'                           => array(
+			'amp-date-countdown'                           => [
 				'<amp-date-countdown timestamp-seconds="2147483648" layout="fixed-height" height="50"><template type="amp-mustache"><p class="p1"> {{d}} days, {{h}} hours, {{m}} minutes and {{s}} seconds until <a href="https://en.wikipedia.org/wiki/Year_2038_problem">Y2K38</a>.</p></template></amp-date-countdown>',
 				null,
-				array( 'amp-date-countdown', 'amp-mustache' ),
-			),
+				[ 'amp-date-countdown', 'amp-mustache' ],
+			],
 
-			'amp-google-document-embed'                    => array(
+			'amp-google-document-embed'                    => [
 				'<amp-google-document-embed src="https://www.example.com/document.pdf" width="800" height="600" layout="responsive"></amp-google-document-embed>',
 				null,
-				array( 'amp-google-document-embed' ),
-			),
+				[ 'amp-google-document-embed' ],
+			],
 
-			'amp-orientation-observer'                     => array(
+			'amp-orientation-observer'                     => [
 				'<amp-orientation-observer on="beta:clockAnim1.seekTo(percent=event.percent)" layout="nodisplay"></amp-orientation-observer>',
 				null,
-				array( 'amp-orientation-observer' ),
-			),
+				[ 'amp-orientation-observer' ],
+			],
 
-			'amp-pan-zoom'                                 => array(
+			'amp-pan-zoom'                                 => [
 				'<amp-layout layout="responsive" width="4" height="3"><amp-pan-zoom layout="fill" disable-double-tap><svg focusable="false"> ... </svg></amp-pan-zoom></amp-layout>',
 				null,
-				array( 'amp-pan-zoom' ),
-			),
+				[ 'amp-pan-zoom' ],
+			],
 
-			'amp-yotpo'                                    => array(
+			'amp-yotpo'                                    => [
 				'<amp-yotpo width="550" height="700" layout="responsive" data-app-key="liSBkl621ZZsb88tsckAs6Bzx6jQeTJTv8CDf8y5" data-widget-type="MainWidget" data-product-id="9408616206" data-name="hockey skates" data-url="https://ranabram.myshopify.com/products/hockey-skates" data-image-url="https://ichef.bbci.co.uk/news/320/media/images/83351000/jpg/_83351965_explorer273lincolnshirewoldssouthpicturebynicholassilkstone.jpg" data-descriptipn="skates" data-yotpo-element-id="1"></amp-yotpo>',
 				null,
-				array( 'amp-yotpo' ),
-			),
+				[ 'amp-yotpo' ],
+			],
 
-			'amp-embedly'                                  => array(
+			'amp-embedly'                                  => [
 				'<amp-embedly-key value="12af2e3543ee432ca35ac30a4b4f656a" layout="nodisplay"></amp-embedly-key><amp-embedly-card data-url="https://twitter.com/AMPhtml/status/986750295077040128" layout="responsive" width="150" height="80" data-card-theme="dark" data-card-controls="0"></amp-embedly-card>',
 				null,
-				array( 'amp-embedly-card' ),
-			),
+				[ 'amp-embedly-card' ],
+			],
 
-			'amp-lightbox'                                 => array(
+			'amp-lightbox'                                 => [
 				'<amp-lightbox id="my-lightbox" [open]="true" animate-in="fly-in-top" layout="nodisplay"><div class="lightbox" on="tap:my-lightbox.close" role="button" tabindex="0"><h1>Hello World!</h1></div></amp-lightbox>',
 				null,
-				array( 'amp-lightbox', 'amp-bind' ),
-			),
+				[ 'amp-lightbox', 'amp-bind' ],
+			],
 
-			'amp-form-messages'                            => array(
+			'amp-form-messages'                            => [
 				'<form action-xhr="https://example.com/" method="post"><fieldset><input type="text" name="do-not-verify" no-verify><input type="text" name="firstName"></fieldset><div verify-error=""><template type="amp-mustache">There is a mistake in the form!{{#verifyErrors}}{{message}}{{/verifyErrors}}</template></div><div submitting=""><template type="amp-mustache">Form submitting... Thank you for waiting {{name}}.</template></div><div submit-success=""><template type="amp-mustache">Success! Thanks {{name}} for subscribing! Please make sure to check your email {{email}}to confirm! After that we\'ll start sending you weekly articles on {{#interests}}<b>{{name}}</b> {{/interests}}.</template></div><div submit-error><template type="amp-mustache">Oops! {{name}}, {{message}}.</template></div></form>',
 				null,
-				array( 'amp-form', 'amp-mustache' ),
-			),
+				[ 'amp-form', 'amp-mustache' ],
+			],
 
-			'amp-input-mask'                               => array(
+			'amp-input-mask'                               => [
 				'<form method="post" class="p2" action-xhr="/components/amp-inputmask/postal" target="_top"><label>Postal code: <input name="code" mask="L0L_0L0" mask-trim-zeros="3" placeholder="A1A 1A1"></label><input type="submit"><div submit-success><template type="amp-mustache"><p>You submitted: {{code}}</p></template></div></form>',
 				null,
-				array( 'amp-form', 'amp-inputmask', 'amp-mustache' ),
-			),
+				[ 'amp-form', 'amp-inputmask', 'amp-mustache' ],
+			],
 
-			'amp_textarea_without_autoexpand'              => array(
+			'amp_textarea_without_autoexpand'              => [
 				'<textarea name="without-autoexpand"></textarea>',
 				null,
-				array(),
-			),
+				[],
+			],
 
-			'amp_textarea_with_autoexpand_and_defaulttext' => array(
+			'amp_textarea_with_autoexpand_and_defaulttext' => [
 				'<textarea name="with-autoexpand" autoexpand [defaulttext]="hello" [text]="goodbye">hello</textarea>',
 				null,
-				array( 'amp-form', 'amp-bind' ),
-			),
+				[ 'amp-form', 'amp-bind' ],
+			],
 
-			'amp-viqeo-player'                             => array(
+			'amp-viqeo-player'                             => [
 				'<amp-viqeo-player data-profileid="184" data-videoid="b51b70cdbb06248f4438" width="640" height="360" layout="responsive"></amp-viqeo-player>',
 				null,
-				array( 'amp-viqeo-player' ),
-			),
+				[ 'amp-viqeo-player' ],
+			],
 
-			'amp-image-slider'                             => array(
+			'amp-image-slider'                             => [
 				'<amp-image-slider layout="responsive" width="100" height="200"><span>Not allowed</span><amp-img src="/green-apple.jpg" alt="A green apple"></amp-img><i>forbidden</i><amp-img src="/red-apple.jpg" alt="A red apple"></amp-img><div first>This apple is green</div><strong>not allowed</strong><div second>This apple is red</div><i>not</i> <span>ok</span></amp-image-slider>',
 				'<amp-image-slider layout="responsive" width="100" height="200"><amp-img src="/green-apple.jpg" alt="A green apple"></amp-img><amp-img src="/red-apple.jpg" alt="A red apple"></amp-img><div first>This apple is green</div><div second>This apple is red</div></amp-image-slider>',
-				array( 'amp-image-slider' ),
-			),
+				[ 'amp-image-slider' ],
+			],
 
-			'amp-image-slider-bad-children'                => array(
+			'amp-image-slider-bad-children'                => [
 				'<amp-image-slider layout="responsive" width="100" height="200"><amp-img src="/green-apple.jpg" alt="A green apple"></amp-img></amp-image-slider>',
 				'',
-				array(),
-			),
+				[],
+			],
 
-			'amp-fx-collection'                            => array(
+			'amp-fx-collection'                            => [
 				'<h1 amp-fx="parallax" data-parallax-factor="1.5">A title that moves faster than other content.</h1>',
 				null,
-				array( 'amp-fx-collection' ),
-			),
+				[ 'amp-fx-collection' ],
+			],
 
-			'amp-date-display'                             => array(
+			'amp-date-display'                             => [
 				'<amp-date-display datetime="2017-08-02T15:05:05.000" layout="fixed" width="360" height="20"><template type="amp-mustache"><div>{{dayName}} {{day}} {{monthName}} {{year}} {{hourTwoDigit}}:{{minuteTwoDigit}}:{{secondTwoDigit}}</div></template></amp-date-display>',
 				null,
-				array( 'amp-date-display', 'amp-mustache' ),
-			),
+				[ 'amp-date-display', 'amp-mustache' ],
+			],
 
-			'amp-list'                                     => array(
+			'amp-list'                                     => [
 				'<amp-list credentials="include" src="https://example.com/json/product.json?clientId=CLIENT_ID(myCookieId)"><template type="amp-mustache">Your personal offer: ${{price}}</template></amp-list>',
 				null,
-				array( 'amp-list', 'amp-mustache' ),
-			),
+				[ 'amp-list', 'amp-mustache' ],
+			],
 
-			'amp-list-load-more'                           => array(
+			'amp-list-load-more'                           => [
 				str_replace(
-					array( "\n", "\t" ),
+					[ "\n", "\t" ],
 					'',
 					'
 						<amp-list load-more="auto" src="https://www.load.more.example.com/" width="400" height="800">
@@ -1372,41 +1372,41 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					'
 				),
 				null,
-				array( 'amp-list', 'amp-mustache' ),
-			),
+				[ 'amp-list', 'amp-mustache' ],
+			],
 
-			'amp-recaptcha-input'                          => array(
+			'amp-recaptcha-input'                          => [
 				'<form action-xhr="/" target="_top" method="post"><amp-recaptcha-input layout="nodisplay" name="reCAPTCHA_body_key" data-sitekey="reCAPTCHA_site_key" data-action="reCAPTCHA_example_action"></amp-recaptcha-input></form>',
 				null,
-				array( 'amp-form', 'amp-recaptcha-input' ),
-			),
+				[ 'amp-form', 'amp-recaptcha-input' ],
+			],
 
 			// @todo The poster should not be allowed if there is a placeholder.
-			'amp-video-iframe'                             => array(
+			'amp-video-iframe'                             => [
 				'<amp-video-iframe src="https://example.com/video/" width="500" height="500" poster="https://example.com/poster.jpg" autoplay dock implements-media-session implements-rotate-to-fullscreen referrerpolicy></amp-video-iframe>',
 				null,
-				array( 'amp-video-iframe', 'amp-video-docking' ),
-			),
+				[ 'amp-video-iframe', 'amp-video-docking' ],
+			],
 
-			'amp-youtube'                                  => array(
+			'amp-youtube'                                  => [
 				'<amp-youtube id="myLiveChannel" data-live-channelid="UCB8Kb4pxYzsDsHxzBfnid4Q" width="358" height="204" layout="responsive" dock><amp-img src="https://i.ytimg.com/vi/Wm1fWz-7nLQ/hqdefault_live.jpg" placeholder layout="fill"></amp-img></amp-youtube>',
 				null,
-				array( 'amp-youtube', 'amp-video-docking' ),
-			),
+				[ 'amp-youtube', 'amp-video-docking' ],
+			],
 
-			'details'                                      => array(
+			'details'                                      => [
 				'<details open [open]="foo.state"><summary>Learn more</summary><p>You are educated</p></details>',
 				null,
-				array( 'amp-bind' ),
-			),
+				[ 'amp-bind' ],
+			],
 
-			'amp-plain-text-script-template'               => array(
+			'amp-plain-text-script-template'               => [
 				'<script type="text/plain" template="amp-mustache">Hello {{world}}!</script>',
 				null,
-				array( 'amp-mustache' ),
-			),
+				[ 'amp-mustache' ],
+			],
 
-			'amp-action-macro'                             => array(
+			'amp-action-macro'                             => [
 				// @todo Should calling AMP.setState() automatically cause the amp-bind extension to be added?
 				'
 					<amp-action-macro id="closeNavigations" execute="AMP.setState({nav1: \'close\', nav2: \'close})"></amp-action-macro>
@@ -1414,21 +1414,21 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					<div on="tap:closeNavigations.execute()">Close all</div>
 				',
 				null,
-				array( 'amp-action-macro' ),
-			),
+				[ 'amp-action-macro' ],
+			],
 
-			'amp-smart-links'                              => array(
+			'amp-smart-links'                              => [
 				'<amp-smartlinks layout="nodisplay" nrtv-account-name="examplepublisher" linkmate exclusive-links link-attribute="href" link-selector="a"></amp-smartlinks>',
 				null,
-				array( 'amp-smartlinks' ),
-			),
+				[ 'amp-smartlinks' ],
+			],
 
-			'amp-script-1'                                 => array(
+			'amp-script-1'                                 => [
 				'<amp-script layout="container" src="https://example.com/hello-world.js"><button id="hello">Insert Hello World!</button></amp-script>',
 				null,
-				array( 'amp-script' ),
-			),
-			'amp-script-2'                                 => array(
+				[ 'amp-script' ],
+			],
+			'amp-script-2'                                 => [
 				'
 					<amp-script layout="container" src="https://example.com/examples/amp-script/hello-world.js">
 						<div class="root">
@@ -1441,48 +1441,48 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-script>
 				',
 				null,
-				array( 'amp-script' ),
-			),
-			'amp-script-3'                                 => array(
+				[ 'amp-script' ],
+			],
+			'amp-script-3'                                 => [
 				'
 					<amp-script src="https://example.com/examples/amp-script/todomvc.ssr.js" layout="container">
 						<div><header class="header"><h1>todos</h1><input class="new-todo" placeholder="What needs to be done?" autofocus="true"></header></div>
 					</amp-script>
 				',
 				null,
-				array( 'amp-script' ),
-			),
+				[ 'amp-script' ],
+			],
 
-			'amp-script-4'                                 => array(
+			'amp-script-4'                                 => [
 				'
 					<amp-script layout="container" src="https://example.com/examples/amp-script/empty.js">
 						<div class="root">should be empty</div>
 					</amp-script>
 				',
 				null,
-				array( 'amp-script' ),
-			),
+				[ 'amp-script' ],
+			],
 
-			'amp_img_with_object_fit_position'             => array(
+			'amp_img_with_object_fit_position'             => [
 				'<amp-img src="http://placehold.it/400x500" width="300" height="300" object-fit="none" object-position="right top" layout="intrinsic"></amp-img>',
 				null,
-				array(),
-			),
+				[],
+			],
 
-			'amp_link_rewriter'                            => array(
+			'amp_link_rewriter'                            => [
 				'<amp-link-rewriter layout="nodisplay"><script type="application/json">{}</script></amp-link-rewriter>',
 				null,
-				array( 'amp-link-rewriter' ),
-			),
+				[ 'amp-link-rewriter' ],
+			],
 
-			'unique_constraint'                            => array(
+			'unique_constraint'                            => [
 				str_repeat( '<amp-geo layout="nodisplay"><script type="application/json">{}</script></amp-geo>', 2 ),
 				'<amp-geo layout="nodisplay"><script type="application/json">{}</script></amp-geo>',
-				array( 'amp-geo' ),
-				array( 'duplicate_element' ),
-			),
+				[ 'amp-geo' ],
+				[ 'duplicate_element' ],
+			],
 
-			'amp-autocomplete'                             => array(
+			'amp-autocomplete'                             => [
 				'
 					<form method="post" action-xhr="/form/echo-json/post" target="_blank" on="submit-success:AMP.setState({result: event.response})">
 						<amp-autocomplete id="autocomplete" filter="substring" min-characters="0">
@@ -1494,16 +1494,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</form>
 				',
 				null,
-				array( 'amp-form', 'amp-autocomplete' ),
-			),
+				[ 'amp-form', 'amp-autocomplete' ],
+			],
 
-			'amp-connatix-player'                          => array(
+			'amp-connatix-player'                          => [
 				'<amp-connatix-player data-player-id="03ef71d8-0941-4bff-94f2-74ca3580b497" layout="responsive" width="16" height="9"></amp-connatix-player>',
 				null,
-				array( 'amp-connatix-player' ),
-			),
+				[ 'amp-connatix-player' ],
+			],
 
-			'amp-truncate-text'                            => array(
+			'amp-truncate-text'                            => [
 				'
 					<amp-truncate-text layout="fixed" height="3em" width="20em">
 						Some text that may get truncated.
@@ -1512,20 +1512,20 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					</amp-truncate-text>
 				',
 				null,
-				array( 'amp-truncate-text' ),
-			),
+				[ 'amp-truncate-text' ],
+			],
 
-			'amp-user-location'                            => array(
+			'amp-user-location'                            => [
 				'
 					<button on="tap: location.request()">Use my location</button>
 					<amp-user-location id="location" on="approve:AMP.setState({located: true})" layout="nodisplay">
 					</amp-user-location>
 				',
 				null,
-				array( 'amp-user-location' ),
-			),
+				[ 'amp-user-location' ],
+			],
 
-		);
+		];
 	}
 
 	/**
@@ -1534,12 +1534,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 * @see AMP_Tag_And_Attribute_Sanitizer::is_missing_mandatory_attribute()
 	 */
 	public function test_is_missing_mandatory_attribute() {
-		$spec = array(
-			'data-gistid' => array(
+		$spec = [
+			'data-gistid' => [
 				'mandatory' => true,
-			),
-			'noloading'   => array(),
-		);
+			],
+			'noloading'   => [],
+		];
 		$dom  = new DomDocument();
 		$node = new DOMElement( 'amp-gist' );
 		$dom->appendChild( $node );
@@ -1564,18 +1564,18 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param array      $expected_scripts     The AMP component script names that are obtained through sanitization.
 	 * @param array|null $expected_error_codes Expected validation error codes.
 	 */
-	public function test_body_sanitizer( $source, $expected = null, $expected_scripts = array(), $expected_error_codes = null ) {
+	public function test_body_sanitizer( $source, $expected = null, $expected_scripts = [], $expected_error_codes = null ) {
 		$expected           = isset( $expected ) ? $expected : $source;
 		$dom                = AMP_DOM_Utils::get_dom_from_content( $source );
-		$actual_error_codes = array();
+		$actual_error_codes = [];
 		$sanitizer          = new AMP_Tag_And_Attribute_Sanitizer(
 			$dom,
-			array(
+			[
 				'validation_error_callback' => static function( $error ) use ( &$actual_error_codes ) {
 					$actual_error_codes[] = $error['code'];
 					return true;
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
@@ -1594,83 +1594,83 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 *                 identified during sanitization.
 	 */
 	public function get_html_data() {
-		$data = array(
-			'meta_charset_and_viewport_and_canonical' => array(
+		$data = [
+			'meta_charset_and_viewport_and_canonical' => [
 				'<html amp lang="ar" dir="rtl"><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"><meta name="viewport" content="width=device-width, minimum-scale=1"><base target="_blank"><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Tangerine"><link rel="canonical" href="self.html"><title>marhabaan bialealim!</title></head><body></body></html>', // phpcs:ignore
-			),
-			'script_tag_externals'                    => array(
+			],
+			'script_tag_externals'                    => [
 				'<html amp><head><meta charset="utf-8"><script async type="text/javascript" src="illegal.js"></script><script async src="illegal.js"></script><script src="illegal.js"></script><script type="text/javascript" src="illegal.js"></script></head><body></body></html>', // phpcs:ignore
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
-			),
-			'script_tag_inline'                       => array(
+			],
+			'script_tag_inline'                       => [
 				'<html amp><head><meta charset="utf-8"><script type="text/javascript">document.write("bad");</script></head><body></body></html>',
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
-			),
-			'style_external'                          => array(
+			],
+			'style_external'                          => [
 				'<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="https://example.com/test.css"></head><body></body></html>', // phpcs:ignore
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
-			),
-			'style_inline'                            => array(
+			],
+			'style_inline'                            => [
 				'<html amp><head><meta charset="utf-8"><style>body{}</style><style type="text/css">body{}</style></head><body></body></html>',
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
-			),
-			'bad_external_font'                       => array(
+			],
+			'bad_external_font'                       => [
 				'<html amp><head><meta charset="utf-8"><link rel="stylesheet" href="https://fonts.example.com/css?family=Bad"></head><body></body></html>', // phpcs:ignore
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
-			),
-			'bad_meta_ua_compatible'                  => array(
+			],
+			'bad_meta_ua_compatible'                  => [
 				'<html amp><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=9,chrome=1"></head><body></body></html>',
 				'<html amp><head><meta charset="utf-8"><meta content="IE=9,chrome=1"></head><body></body></html>', // Note the http-equiv is removed because the content violates its attribute spec.
-			),
-			'bad_meta_charset'                        => array(
+			],
+			'bad_meta_charset'                        => [
 				'<html amp><head><meta charset="latin-1"><title>Mojibake?</title></head><body></body></html>',
 				'<html amp><head><meta><title>Mojibake?</title></head><body></body></html>', // Note the charset attribute is removed because it violates the attribute spec, but the entire element is not removed because charset is not mandatory.
-			),
-			'bad_meta_viewport'                       => array(
+			],
+			'bad_meta_viewport'                       => [
 				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="maximum-scale=1.0"></head><body></body></html>',
 				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
-			),
-			'edge_meta_ua_compatible'                 => array(
+			],
+			'edge_meta_ua_compatible'                 => [
 				'<html amp><head><meta charset="utf-8"><meta http-equiv="X-UA-Compatible" content="IE=edge"></head><body></body></html>',
 				null, // No change.
-			),
-			'meta_viewport_extras'                    => array(
+			],
+			'meta_viewport_extras'                    => [
 				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,height=device-height,initial-scale=2,maximum-scale=3,minimum-scale=0.5,shrink-to-fit=yes,user-scalable=yes,viewport-fit=cover"></head><body></body></html>',
 				null, // No change.
-			),
-			'meta_og_property'                        => array(
+			],
+			'meta_og_property'                        => [
 				'<html amp><head><meta charset="utf-8"><meta property="og:site_name" content="AMP Site"></head><body></body></html>',
 				null, // No change.
-			),
-			'head_with_valid_amp_illegal_parent'      => array(
+			],
+			'head_with_valid_amp_illegal_parent'      => [
 				'<html amp><head><meta charset="utf-8"><amp-analytics id="75a1fdc3143c" type="googleanalytics"><script type="application/json">{"vars":{"account":"UA-XXXXXX-1"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}</script></amp-analytics></head><body></body></html>',
 				'<html amp><head><meta charset="utf-8"></head><body><amp-analytics id="75a1fdc3143c" type="googleanalytics"><script type="application/json">{"vars":{"account":"UA-XXXXXX-1"},"triggers":{"trackPageview":{"on":"visible","request":"pageview"}}}</script></amp-analytics></body></html>',
-				array( 'amp-analytics' ),
-			),
-			'head_with_invalid_nodes'                 => array(
+				[ 'amp-analytics' ],
+			],
+			'head_with_invalid_nodes'                 => [
 				'<html amp><head><meta charset="utf-8"><META NAME="foo" CONTENT="bar"><bad>bad!</bad> other</head><body></body></html>',
 				'<html amp><head><meta charset="utf-8"><meta name="foo" content="bar"></head><body>bad!<p> other</p></body></html>',
-			),
-			'head_with_duplicate_charset'             => array(
+			],
+			'head_with_duplicate_charset'             => [
 				'<html amp><head><meta charset="UTF-8"><meta charset="utf-8"><body><p>Content</p></body></html>',
 				'<html amp><head><meta charset="UTF-8"></head><body><p>Content</p></body></html>',
-				array(),
-				array( 'duplicate_element' ),
-			),
-			'head_with_duplicate_viewport'            => array(
+				[],
+				[ 'duplicate_element' ],
+			],
+			'head_with_duplicate_viewport'            => [
 				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,minimum-scale=1"><meta name="viewport" content="width=device-width"></head><body><p>Content</p></body></html>',
 				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,minimum-scale=1"></head><body><p>Content</p></body></html>',
-				array(),
-				array( 'duplicate_element' ),
-			),
-		);
+				[],
+				[ 'duplicate_element' ],
+			],
+		];
 
 		// Also include the body tests.
 		$html_doc_format = '<html amp><head><meta charset="utf-8"></head><body><!-- before -->%s<!-- after --></body></html>';
 		foreach ( $this->get_body_data() as $body_test ) {
-			$html_test = array(
+			$html_test = [
 				sprintf( $html_doc_format, array_shift( $body_test ) ),
-			);
+			];
 			$expected  = array_shift( $body_test );
 			if ( isset( $expected ) ) {
 				$expected = sprintf( $html_doc_format, $expected );
@@ -1695,19 +1695,19 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param array      $expected_scripts     The AMP component script names that are obtained through sanitization.
 	 * @param array|null $expected_error_codes Expected validation error codes.
 	 */
-	public function test_html_sanitizer( $source, $expected = null, $expected_scripts = array(), $expected_error_codes = null ) {
+	public function test_html_sanitizer( $source, $expected = null, $expected_scripts = [], $expected_error_codes = null ) {
 		$expected           = isset( $expected ) ? $expected : $source;
 		$dom                = AMP_DOM_Utils::get_dom( $source );
-		$actual_error_codes = array();
+		$actual_error_codes = [];
 		$sanitizer          = new AMP_Tag_And_Attribute_Sanitizer(
 			$dom,
-			array(
+			[
 				'use_document_element'      => true,
 				'validation_error_callback' => static function( $error ) use ( &$actual_error_codes ) {
 					$actual_error_codes[] = $error['code'];
 					return true;
 				},
-			)
+			]
 		);
 		$sanitizer->sanitize();
 		$content = AMP_DOM_Utils::get_content_from_dom_node( $dom, $dom->documentElement );
@@ -1729,62 +1729,62 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	public function test_replace_node_with_children_validation_errors() {
 		$that            = $this;
 		$error_index     = 0;
-		$content         = array();
-		$expected_errors = array();
+		$content         = [];
+		$expected_errors = [];
 
 		$content[]         = '<amp-image src="/none.jpg" width="100" height="100" alt="None"></amp-image>';
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'amp-image',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array(
+			'node_attributes' => [
 				'src'    => '/none.jpg',
 				'width'  => '100',
 				'height' => '100',
 				'alt'    => 'None',
-			),
-		);
+			],
+		];
 		$content[]         = '<baz class="baz-invalid"><p>Invalid baz parent element.</p></baz>';
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'baz',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array( 'class' => 'baz-invalid' ),
-		);
+			'node_attributes' => [ 'class' => 'baz-invalid' ],
+		];
 		$content[]         = '<amp-story-grid-layer class="a-invalid"><a href="">Invalid a tag.</a></amp-story-grid-layer>';
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'amp-story-grid-layer',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array( 'class' => 'a-invalid' ),
-		);
+			'node_attributes' => [ 'class' => 'a-invalid' ],
+		];
 		$content[]         = '<foo class="foo-invalid">Invalid foo tag.</foo>';
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'foo',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array( 'class' => 'foo-invalid' ),
-		);
+			'node_attributes' => [ 'class' => 'foo-invalid' ],
+		];
 		$content[]         = '<divs><foo>Invalid <span>nested elements</span></foo></divs>';
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'divs',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array(),
-		);
-		$expected_errors[] = array(
+			'node_attributes' => [],
+		];
+		$expected_errors[] = [
 			'node_name'       => 'foo',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array(),
-		);
+			'node_attributes' => [],
+		];
 		$content[]         = '<bazbar><span>Is an invalid "bar" tag.</span></bazbar>';
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'bazbar',
 			'parent_name'     => 'body',
 			'code'            => 'invalid_element',
-			'node_attributes' => array(),
-		);
+			'node_attributes' => [],
+		];
 		$content[]         = <<<EOB
 <div class="parent">
 	<p>Nesting valid and invalid elements.</p>
@@ -1792,41 +1792,41 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 	<bazfoo>Is an invalid "foo" tag <p>This should pass.</p></bazfoo>
 </div>
 EOB;
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'invalid_p',
 			'parent_name'     => 'div',
 			'code'            => 'invalid_element',
-			'node_attributes' => array( 'id' => 'invalid' ),
-		);
-		$expected_errors[] = array(
+			'node_attributes' => [ 'id' => 'invalid' ],
+		];
+		$expected_errors[] = [
 			'node_name'       => 'bazfoo',
 			'parent_name'     => 'div',
 			'code'            => 'invalid_element',
-			'node_attributes' => array(),
-		);
+			'node_attributes' => [],
+		];
 		$content[]         = <<<EOB
 <ul>
 	<li>hello</li>
 	<lili>world</lili>
 </ul>
 EOB;
-		$expected_errors[] = array(
+		$expected_errors[] = [
 			'node_name'       => 'lili',
 			'parent_name'     => 'ul',
 			'code'            => 'invalid_element',
-			'node_attributes' => array(),
-		);
+			'node_attributes' => [],
+		];
 
 		// Test validation error for nested invalid tags.
 		foreach ( $content as $dom_content ) {
 			$dom       = AMP_DOM_Utils::get_dom_from_content( $dom_content );
 			$sanitizer = new AMP_Tag_And_Attribute_Sanitizer(
 				$dom,
-				array(
+				[
 					'validation_error_callback' => static function( $error, $context ) use ( $that, $expected_errors, &$error_index ) {
-						$expected = $expected_errors[ $error_index ];
+						$expected         = $expected_errors[ $error_index ];
 						$expected['type'] = AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE;
-						$tag = $expected['node_name'];
+						$tag              = $expected['node_name'];
 						$that->assertEquals( $expected, $error );
 						$that->assertInstanceOf( 'DOMElement', $context['node'] );
 						$that->assertEquals( $tag, $context['node']->tagName );
@@ -1835,7 +1835,7 @@ EOB;
 
 						return true;
 					},
-				)
+				]
 			);
 			$sanitizer->sanitize();
 		}

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -39,7 +39,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$amp_post_type = get_post_type_object( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG );
 
 		$this->assertContains( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, get_post_types() );
-		$this->assertEquals( array(), get_all_post_type_supports( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$this->assertEquals( [], get_all_post_type_supports( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
 		$this->assertEquals( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, $amp_post_type->name );
 		$this->assertEquals( 'AMP Validated URLs', $amp_post_type->label );
 		$this->assertEquals( false, $amp_post_type->public );
@@ -83,28 +83,28 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_add_admin_hooks() {
 		AMP_Validated_URL_Post_Type::add_admin_hooks();
 
-		$this->assertEquals( 10, has_filter( 'dashboard_glance_items', array( self::TESTED_CLASS, 'filter_dashboard_glance_items' ) ) );
-		$this->assertEquals( 10, has_action( 'rightnow_end', array( self::TESTED_CLASS, 'print_dashboard_glance_styles' ) ) );
+		$this->assertEquals( 10, has_filter( 'dashboard_glance_items', [ self::TESTED_CLASS, 'filter_dashboard_glance_items' ] ) );
+		$this->assertEquals( 10, has_action( 'rightnow_end', [ self::TESTED_CLASS, 'print_dashboard_glance_styles' ] ) );
 
-		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( self::TESTED_CLASS, 'enqueue_edit_post_screen_scripts' ) ) );
-		$this->assertEquals( 10, has_action( 'add_meta_boxes', array( self::TESTED_CLASS, 'add_meta_boxes' ) ) );
-		$this->assertEquals( 10, has_action( 'edit_form_top', array( self::TESTED_CLASS, 'print_url_as_title' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', [ self::TESTED_CLASS, 'enqueue_edit_post_screen_scripts' ] ) );
+		$this->assertEquals( 10, has_action( 'add_meta_boxes', [ self::TESTED_CLASS, 'add_meta_boxes' ] ) );
+		$this->assertEquals( 10, has_action( 'edit_form_top', [ self::TESTED_CLASS, 'print_url_as_title' ] ) );
 
-		$this->assertEquals( 10, has_filter( 'the_title', array( self::TESTED_CLASS, 'filter_the_title_in_post_list_table' ) ) );
-		$this->assertEquals( 10, has_filter( 'restrict_manage_posts', array( self::TESTED_CLASS, 'render_post_filters' ) ) );
-		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_posts_columns', array( self::TESTED_CLASS, 'add_post_columns' ) ) );
-		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_columns', array( self::TESTED_CLASS, 'add_single_post_columns' ) ) );
-		$this->assertEquals( 10, has_action( 'manage_posts_custom_column', array( self::TESTED_CLASS, 'output_custom_column' ) ) );
-		$this->assertEquals( 10, has_filter( 'post_row_actions', array( self::TESTED_CLASS, 'filter_post_row_actions' ) ) );
-		$this->assertEquals( 10, has_filter( 'bulk_actions-edit-' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, array( self::TESTED_CLASS, 'filter_bulk_actions' ) ) );
+		$this->assertEquals( 10, has_filter( 'the_title', [ self::TESTED_CLASS, 'filter_the_title_in_post_list_table' ] ) );
+		$this->assertEquals( 10, has_filter( 'restrict_manage_posts', [ self::TESTED_CLASS, 'render_post_filters' ] ) );
+		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_posts_columns', [ self::TESTED_CLASS, 'add_post_columns' ] ) );
+		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_columns', [ self::TESTED_CLASS, 'add_single_post_columns' ] ) );
+		$this->assertEquals( 10, has_action( 'manage_posts_custom_column', [ self::TESTED_CLASS, 'output_custom_column' ] ) );
+		$this->assertEquals( 10, has_filter( 'post_row_actions', [ self::TESTED_CLASS, 'filter_post_row_actions' ] ) );
+		$this->assertEquals( 10, has_filter( 'bulk_actions-edit-' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, [ self::TESTED_CLASS, 'filter_bulk_actions' ] ) );
 		$this->assertEquals( 10, has_filter( 'bulk_actions-' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, '__return_false' ) );
-		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, array( self::TESTED_CLASS, 'handle_bulk_action' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_notices', array( self::TESTED_CLASS, 'print_admin_notice' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_action_' . AMP_Validated_URL_Post_Type::VALIDATE_ACTION, array( self::TESTED_CLASS, 'handle_validate_request' ) ) );
-		$this->assertEquals( 10, has_action( 'post_action_' . AMP_Validated_URL_Post_Type::UPDATE_POST_TERM_STATUS_ACTION, array( self::TESTED_CLASS, 'handle_validation_error_status_update' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_menu', array( self::TESTED_CLASS, 'add_admin_menu_new_invalid_url_count' ) ) );
+		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, [ self::TESTED_CLASS, 'handle_bulk_action' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', [ self::TESTED_CLASS, 'print_admin_notice' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_action_' . AMP_Validated_URL_Post_Type::VALIDATE_ACTION, [ self::TESTED_CLASS, 'handle_validate_request' ] ) );
+		$this->assertEquals( 10, has_action( 'post_action_' . AMP_Validated_URL_Post_Type::UPDATE_POST_TERM_STATUS_ACTION, [ self::TESTED_CLASS, 'handle_validation_error_status_update' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_new_invalid_url_count' ] ) );
 
-		$post = self::factory()->post->create_and_get( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$post = self::factory()->post->create_and_get( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$this->assertEquals( '', apply_filters( 'post_date_column_status', 'publish', $post ) );
 		$this->assertEquals( 'publish', apply_filters( 'post_date_column_status', 'publish', self::factory()->post->create_and_get() ) );
 
@@ -127,33 +127,33 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		unset( $submenu[ AMP_Options_Manager::OPTION_NAME ] );
 		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
 
-		$submenu[ AMP_Options_Manager::OPTION_NAME ] = array(
-			0 => array(
+		$submenu[ AMP_Options_Manager::OPTION_NAME ] = [
+			0 => [
 				0 => 'General',
 				1 => 'manage_options',
 				2 => 'amp-options',
 				3 => 'AMP Settings',
-			),
-			1 => array(
+			],
+			1 => [
 				0 => 'Analytics',
 				1 => 'manage_options',
 				2 => 'amp-analytics-options',
 				3 => 'AMP Analytics Options',
-			),
-			2 => array(
+			],
+			2 => [
 				0 => 'Invalid Pages',
 				1 => 'edit_posts',
 				2 => 'edit.php?post_type=amp_validated_url',
 				3 => 'Invalid AMP Pages (URLs)',
-			),
-		);
+			],
+		];
 
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array(
+			[
+				[
 					'code' => 'hello',
-				),
-			),
+				],
+			],
 			get_permalink( self::factory()->post->create() )
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
@@ -172,7 +172,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_get_invalid_url_validation_errors() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 		$post = self::factory()->post->create();
 		$this->assertEmpty( AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( get_permalink( $post ) ) );
@@ -192,11 +192,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		);
 
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'accepted' ),
-				array( 'code' => 'rejected' ),
-				array( 'code' => 'new' ),
-			),
+			[
+				[ 'code' => 'accepted' ],
+				[ 'code' => 'rejected' ],
+				[ 'code' => 'new' ],
+			],
 			get_permalink( $post )
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
@@ -214,7 +214,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( 'new', $error['data']['code'] );
 		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, $error['term_status'] );
 
-		$errors = AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( get_permalink( $post ), array( 'ignore_accepted' => true ) );
+		$errors = AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( get_permalink( $post ), [ 'ignore_accepted' => true ] );
 		$this->assertCount( 2, $errors );
 		$error = array_shift( $errors );
 		$this->assertEquals( 'rejected', $error['data']['code'] );
@@ -223,7 +223,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( 'new', $error['data']['code'] );
 		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, $error['term_status'] );
 
-		$summary = get_echo( array( 'AMP_Validated_URL_Post_Type', 'display_invalid_url_validation_error_counts_summary' ), array( $invalid_url_post_id ) );
+		$summary = get_echo( [ 'AMP_Validated_URL_Post_Type', 'display_invalid_url_validation_error_counts_summary' ], [ $invalid_url_post_id ] );
 		$this->assertContains( 'New Rejected: 1', $summary );
 		$this->assertContains( 'Accepted: 1', $summary );
 		$this->assertContains( 'Rejected: 1', $summary );
@@ -235,15 +235,15 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::get_invalid_url_post()
 	 */
 	public function test_get_invalid_url_post() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 		$post = self::factory()->post->create_and_get();
 		$this->assertEquals( null, AMP_Validated_URL_Post_Type::get_invalid_url_post( get_permalink( $post ) ) );
 
 		$invalid_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			get_permalink( $post )
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_post_id );
@@ -256,7 +256,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		// Test trashed.
 		wp_trash_post( $invalid_post_id );
 		$this->assertNull( AMP_Validated_URL_Post_Type::get_invalid_url_post( get_permalink( $post ) ) );
-		$args = array( 'include_trashed' => true );
+		$args = [ 'include_trashed' => true ];
 		$this->assertEquals(
 			$invalid_post_id,
 			AMP_Validated_URL_Post_Type::get_invalid_url_post( get_permalink( $post ), $args )->ID
@@ -264,16 +264,16 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		wp_untrash_post( $invalid_post_id );
 
 		// Test normalized.
-		$args = array( 'normalize' => false );
+		$args = [ 'normalize' => false ];
 		$url  = add_query_arg( 'utm_foo', 'bar', get_permalink( $post ) . '#baz' );
 		$url  = set_url_scheme( $url, 'http' );
 		$this->assertNull( AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, $args ) );
-		$args = array( 'normalize' => true );
+		$args = [ 'normalize' => true ];
 		$this->assertEquals( $invalid_post_id, AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, $args )->ID );
 		$this->assertEquals( $invalid_post_id, AMP_Validated_URL_Post_Type::get_invalid_url_post( $url )->ID );
 		$url = set_url_scheme( get_permalink( $post ), 'http' );
-		$this->assertNull( AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, array( 'normalize' => false ) ) );
-		$this->assertEquals( $invalid_post_id, AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, array( 'normalize' => true ) )->ID );
+		$this->assertNull( AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, [ 'normalize' => false ] ) );
+		$this->assertEquals( $invalid_post_id, AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, [ 'normalize' => true ] )->ID );
 	}
 
 	/**
@@ -282,7 +282,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::get_url_from_post()
 	 */
 	public function test_get_url_from_post() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 		$post = self::factory()->post->create_and_get();
 
@@ -290,9 +290,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertNull( AMP_Validated_URL_Post_Type::get_url_from_post( $post ) );
 
 		$invalid_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			get_permalink( $post )
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_post_id );
@@ -302,7 +302,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id )
 		);
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => false ] );
 		$this->assertEquals(
 			get_permalink( $post ),
 			AMP_Validated_URL_Post_Type::get_url_from_post( $invalid_post_id )
@@ -334,7 +334,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_store_validation_errors() {
 		global $post;
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 		$post = self::factory()->post->create_and_get();
 
@@ -352,54 +352,54 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			2
 		);
 
-		$errors = array(
-			array(
+		$errors = [
+			[
 				'code'    => 'accepted',
-				'sources' => array(
-					array(
+				'sources' => [
+					[
 						'type' => 'plugin',
 						'name' => 'amp',
 						'evil' => '<script>\o/</script>', // Test slash preservation and kses suspension.
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'code'    => 'rejected',
 				'evil'    => '<script>\o/</script>', // Test slash preservation and kses suspension.
-				'sources' => array(
-					array(
+				'sources' => [
+					[
 						'type' => 'theme',
 						'name' => 'twentyseventeen',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'code'    => 'rejected',
 				'evil'    => '<script>document.write( \'<a href="#" target="_blank" rel="noopener noreferrer">test</a>\' );</script>', // Test protection against wp_targeted_link_rel JSON corruption.
-				'sources' => array(
-					array(
+				'sources' => [
+					[
 						'type' => 'theme',
 						'name' => 'twentyseventeen',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'code'    => 'new',
-				'sources' => array(
-					array(
+				'sources' => [
+					[
 						'type' => 'core',
 						'name' => 'wp-includes',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
 			$errors,
 			get_permalink( $post ),
-			array(
+			[
 				'invalid_url_post' => 0,
-			)
+			]
 		);
 		$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
 		$this->assertNotEquals( $invalid_url_post_id, $post->ID, 'Passing an empty invalid_url_post should not re-use the global $post ever.' );
@@ -411,20 +411,20 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			AMP_Validated_URL_Post_Type::store_validation_errors(
 				$errors,
 				get_permalink( $post ),
-				array(
-					'queried_object' => array(
+				[
+					'queried_object' => [
 						'type' => 'post',
 						'id'   => $post->ID,
-					),
-				)
+					],
+				]
 			)
 		);
 		$this->assertEquals( 'publish', get_post_status( $invalid_url_post_id ) );
 		$this->assertEquals(
-			array(
+			[
 				'type' => 'post',
 				'id'   => $post->ID,
-			),
+			],
 			get_post_meta( $invalid_url_post_id, '_amp_queried_object', true )
 		);
 
@@ -434,9 +434,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			AMP_Validated_URL_Post_Type::store_validation_errors(
 				$errors,
 				home_url( '/something/else/' ),
-				array(
+				[
 					'invalid_url_post' => $invalid_url_post_id,
-				)
+				]
 			)
 		);
 
@@ -456,12 +456,12 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			)
 		);
 
-		$error_groups = array(
+		$error_groups = [
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-		);
+		];
 
 		foreach ( $errors as $i => $error ) {
 			$stored_error = $stored_errors[ $i ];
@@ -492,14 +492,14 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_get_validated_environment() {
 		switch_theme( 'twentysixteen' );
-		update_option( 'active_plugins', array( 'foo/foo.php', 'bar.php' ) );
+		update_option( 'active_plugins', [ 'foo/foo.php', 'bar.php' ] );
 		$old_env = AMP_Validated_URL_Post_Type::get_validated_environment();
 		$this->assertArrayHasKey( 'theme', $old_env );
 		$this->assertArrayHasKey( 'plugins', $old_env );
 		$this->assertEquals( 'twentysixteen', $old_env['theme'] );
 
 		switch_theme( 'twentyseventeen' );
-		update_option( 'active_plugins', array( 'foo/foo.php', 'baz.php' ) );
+		update_option( 'active_plugins', [ 'foo/foo.php', 'baz.php' ] );
 		$new_env = AMP_Validated_URL_Post_Type::get_validated_environment();
 		$this->assertNotEquals( $old_env, $new_env );
 		$this->assertEquals( 'twentyseventeen', $new_env['theme'] );
@@ -512,22 +512,22 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers AMP_Validated_URL_Post_Type::get_validated_environment()
 	 */
 	public function test_get_post_staleness() {
-		$error = array( 'code' => 'foo' );
+		$error = [ 'code' => 'foo' ];
 		switch_theme( 'twentysixteen' );
-		update_option( 'active_plugins', array( 'foo/foo.php', 'bar.php' ) );
+		update_option( 'active_plugins', [ 'foo/foo.php', 'bar.php' ] );
 
-		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors( array( $error ), home_url( '/' ) );
+		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors( [ $error ], home_url( '/' ) );
 		$this->assertInternalType( 'int', $invalid_url_post_id );
 		$this->assertEmpty( AMP_Validated_URL_Post_Type::get_post_staleness( $invalid_url_post_id ) );
 
-		update_option( 'active_plugins', array( 'foo/foo.php', 'baz.php' ) );
+		update_option( 'active_plugins', [ 'foo/foo.php', 'baz.php' ] );
 		$staleness = AMP_Validated_URL_Post_Type::get_post_staleness( $invalid_url_post_id );
 		$this->assertNotEmpty( $staleness );
 		$this->assertArrayHasKey( 'plugins', $staleness );
 		$this->assertArrayNotHasKey( 'theme', $staleness );
 
-		$this->assertEqualSets( array( 'baz.php' ), $staleness['plugins']['new'] );
-		$this->assertEqualSets( array( 'bar.php' ), $staleness['plugins']['old'] );
+		$this->assertEqualSets( [ 'baz.php' ], $staleness['plugins']['new'] );
+		$this->assertEqualSets( [ 'bar.php' ], $staleness['plugins']['old'] );
 
 		switch_theme( 'twentyseventeen' );
 		$next_staleness = AMP_Validated_URL_Post_Type::get_post_staleness( $invalid_url_post_id );
@@ -536,7 +536,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertSame( $next_staleness['plugins'], $staleness['plugins'] );
 
 		// Re-storing results updates freshness.
-		AMP_Validated_URL_Post_Type::store_validation_errors( array( $error ), home_url( '/' ), $invalid_url_post_id );
+		AMP_Validated_URL_Post_Type::store_validation_errors( [ $error ], home_url( '/' ), $invalid_url_post_id );
 		$this->assertEmpty( AMP_Validated_URL_Post_Type::get_post_staleness( $invalid_url_post_id ) );
 	}
 
@@ -546,18 +546,18 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers AMP_Validated_URL_Post_Type::add_post_columns()
 	 */
 	public function test_add_post_columns() {
-		$initial_columns = array(
+		$initial_columns = [
 			'cb' => '<input type="checkbox">',
-		);
+		];
 		$this->assertEquals(
 			array_keys(
 				array_merge(
 					$initial_columns,
-					array(
+					[
 						AMP_Validation_Error_Taxonomy::ERROR_STATUS => 'Status',
 						AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES => 'Invalid',
 						AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => 'Sources',
-					)
+					]
 				)
 			),
 			array_keys( AMP_Validated_URL_Post_Type::add_post_columns( $initial_columns ) )
@@ -571,14 +571,14 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_add_single_post_columns() {
 		$this->assertEquals(
-			array(
+			[
 				'cb'                          => '<input type="checkbox" />',
 				'error'                       => 'Error',
 				'status'                      => 'Status<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Status&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.&lt;/p&gt;"></div>',
 				'details'                     => 'Details<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Details&lt;/h3&gt;&lt;p&gt;The parent element of where the error occurred.&lt;/p&gt;"></div>',
 				'sources_with_invalid_output' => 'Sources',
 				'error_type'                  => 'Type',
-			),
+			],
 			AMP_Validated_URL_Post_Type::add_single_post_columns()
 		);
 	}
@@ -589,40 +589,40 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @return array $columns
 	 */
 	public function get_custom_columns() {
-		$source = array(
+		$source = [
 			'type' => 'plugin',
 			'name' => 'AMP',
-		);
-		$errors = array(
-			array(
+		];
+		$errors = [
+			[
 				'code'      => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
 				'node_name' => 'script',
-				'sources'   => array( $source ),
-			),
-			array(
+				'sources'   => [ $source ],
+			],
+			[
 				'code'      => AMP_Validation_Error_Taxonomy::INVALID_ATTRIBUTE_CODE,
 				'node_name' => 'onclick',
-				'sources'   => array( $source ),
-			),
-		);
+				'sources'   => [ $source ],
+			],
+		];
 
-		return array(
-			'invalid_element'       => array(
+		return [
+			'invalid_element'       => [
 				AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT,
 				'<strong class="source"><span class="dashicons dashicons-admin-plugins"></span>AMP</strong>',
 				$errors,
-			),
-			'removed_attributes'    => array(
+			],
+			'removed_attributes'    => [
 				AMP_Validation_Error_Taxonomy::FOUND_ELEMENTS_AND_ATTRIBUTES,
 				'onclick',
 				$errors,
-			),
-			'sources_invalid_input' => array(
+			],
+			'sources_invalid_input' => [
 				AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT,
 				'AMP',
 				$errors,
-			),
-		);
+			],
+		];
 	}
 
 	/**
@@ -639,7 +639,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		AMP_Validation_Manager::init();
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors( $errors, home_url( '/' ) );
 
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'output_custom_column' ), array( $column_name, $invalid_url_post_id ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'output_custom_column' ], [ $column_name, $invalid_url_post_id ] );
 		$this->assertContains( $expected_value, $output );
 	}
 
@@ -651,56 +651,56 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_render_sources_column() {
 		$theme_name    = 'foo-theme';
 		$post_id       = 9876;
-		$error_summary = array(
-			'removed_attributes'          => array(
+		$error_summary = [
+			'removed_attributes'          => [
 				'webkitallowfullscreen' => 1,
-			),
-			'removed_elements'            => array(),
-			'sources_with_invalid_output' => array(
+			],
+			'removed_elements'            => [],
+			'sources_with_invalid_output' => [
 				'embed' => true,
 				'hook'  => 'the_content',
-				'theme' => array( $theme_name ),
-			),
-		);
+				'theme' => [ $theme_name ],
+			],
+		];
 
 		// If there is an embed and a theme source, this should only output the embed icon.
-		$sources_column = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		$sources_column = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$this->assertEquals( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>Embed</strong>', $sources_column );
 
 		// If there is no embed source, but there is a theme, this should output the theme icon.
 		unset( $error_summary['sources_with_invalid_output']['embed'] );
-		$sources_column      = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		$sources_column      = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$expected_theme_icon = '<div class="source"><span class="dashicons dashicons-admin-appearance"></span><strong>' . $theme_name . '</strong></div>';
 		$this->assertEquals( $expected_theme_icon, $sources_column );
 
 		// If there is a plugin and theme source, this should output icons for both of them.
 		$plugin_name = 'baz-plugin';
-		$error_summary['sources_with_invalid_output']['plugin'] = array( $plugin_name );
+		$error_summary['sources_with_invalid_output']['plugin'] = [ $plugin_name ];
 		$expected_plugin_icon                                   = '<strong class="source"><span class="dashicons dashicons-admin-plugins"></span>' . $plugin_name . '</strong>';
 		unset( $error_summary['sources_with_invalid_output']['embed'] );
-		$sources_column = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		$sources_column = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$this->assertEquals( $expected_plugin_icon . $expected_theme_icon, $sources_column );
 
 		// If there is a 'core' source, it should appear in the column output.
-		$error_summary['sources_with_invalid_output']['core'] = array();
-		$sources_column                                       = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		$error_summary['sources_with_invalid_output']['core'] = [];
+		$sources_column                                       = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$this->assertContains( '<strong><span class="dashicons dashicons-wordpress-alt"></span>Other (0)</strong>', $sources_column );
 
 		// Even if there is a hook in the sources, it should not appear in the column if there is any other source.
 		$hook_name = 'wp_header';
-		$error_summary['sources_with_invalid_output']['hook'] = array( $hook_name );
-		$sources_column                                       = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		$error_summary['sources_with_invalid_output']['hook'] = [ $hook_name ];
+		$sources_column                                       = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$this->assertNotContains( $hook_name, $sources_column );
 
 		// If a hook is the only source, it should appear in the column.
-		$error_summary['sources_with_invalid_output'] = array( 'hook' => $hook_name );
-		$sources_column                               = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		$error_summary['sources_with_invalid_output'] = [ 'hook' => $hook_name ];
+		$sources_column                               = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$this->assertEquals( '<strong class="source"><span class="dashicons dashicons-wordpress-alt"></span>' . $hook_name . '</strong>', $sources_column );
 
 		// If there's no source in 'sources_with_invalid_output', this should output the theme name.
-		update_post_meta( $post_id, '_amp_validated_environment', array( 'theme' => $theme_name ) );
-		$error_summary['sources_with_invalid_output'] = array();
-		$sources_column                               = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_sources_column' ), array( $error_summary, $post_id ) );
+		update_post_meta( $post_id, '_amp_validated_environment', [ 'theme' => $theme_name ] );
+		$error_summary['sources_with_invalid_output'] = [];
+		$sources_column                               = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
 		$this->assertEquals( '<div class="source"><span class="dashicons dashicons-admin-appearance"></span>' . $theme_name . ' (?)</div>', $sources_column );
 	}
 
@@ -710,11 +710,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::filter_bulk_actions()
 	 */
 	public function test_filter_bulk_actions() {
-		$initial_action = array(
+		$initial_action = [
 			'edit'   => 'Edit',
 			'trash'  => 'Trash',
 			'delete' => 'Delete',
-		);
+		];
 		$actions        = AMP_Validated_URL_Post_Type::filter_bulk_actions( $initial_action );
 		$this->assertFalse( isset( $action['edit'] ) );
 		$this->assertEquals( 'Recheck', $actions[ AMP_Validated_URL_Post_Type::BULK_VALIDATE_ACTION ] );
@@ -729,19 +729,19 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_handle_bulk_action() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 
 		$invalid_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			home_url( '/' )
 		);
 
 		$initial_redirect = admin_url( 'plugins.php' );
-		$items            = array( $invalid_post_id );
+		$items            = [ $invalid_post_id ];
 		$urls_tested      = (string) count( $items );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = $urls_tested;
@@ -751,32 +751,32 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		$that   = $this;
 		$filter = static function() use ( $that ) {
-			return array(
+			return [
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
 					'AMP_VALIDATION:' . wp_json_encode(
-						array(
+						[
 							'results' => array_map(
 								static function( $error ) {
 									return array_merge(
 										compact( 'error' ),
-										array( 'sanitized' => false )
+										[ 'sanitized' => false ]
 									);
 								},
 								$that->get_mock_errors()
 							),
-						)
+						]
 					)
 				),
-			);
+			];
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 		$this->assertEquals(
 			add_query_arg(
-				array(
+				[
 					AMP_Validated_URL_Post_Type::URLS_TESTED      => $urls_tested,
 					AMP_Validated_URL_Post_Type::REMAINING_ERRORS => count( $items ),
-				),
+				],
 				$initial_redirect
 			),
 			AMP_Validated_URL_Post_Type::handle_bulk_action( $initial_redirect, AMP_Validated_URL_Post_Type::BULK_VALIDATE_ACTION, $items )
@@ -787,17 +787,17 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			static function() {
-				return array(
+				return [
 					'body' => '<html></html>',
-				);
+				];
 			}
 		);
 		$this->assertEquals(
 			add_query_arg(
-				array(
+				[
 					AMP_Validated_URL_Post_Type::URLS_TESTED => $urls_tested,
-					'amp_validate_error' => array( 'response_comment_absent' ),
-				),
+					'amp_validate_error' => [ 'response_comment_absent' ],
+				],
 				$initial_redirect
 			),
 			AMP_Validated_URL_Post_Type::handle_bulk_action( $initial_redirect, AMP_Validated_URL_Post_Type::BULK_VALIDATE_ACTION, $items )
@@ -813,11 +813,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertEmpty( $output );
 
 		$_GET['post_type'] = 'post';
-		$output            = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$output            = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertEmpty( $output );
 
 		set_current_screen( 'edit.php' );
@@ -825,23 +825,23 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		$_GET[ AMP_Validated_URL_Post_Type::REMAINING_ERRORS ] = '1';
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ]      = '1';
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertContains( 'The rechecked URL still has unaccepted validation errors', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = '2';
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertContains( 'The rechecked URLs still have unaccepted validation errors', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::REMAINING_ERRORS ] = '0';
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertContains( 'The rechecked URLs are free of unaccepted validation errors', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = '1';
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertContains( 'The rechecked URL is free of unaccepted validation errors', $output );
 
-		$_GET['amp_validate_error'] = array( 'http_request_failed' );
-		$output                     = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ) );
+		$_GET['amp_validate_error'] = [ 'http_request_failed' ];
+		$output                     = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertContains( 'Failed to fetch URL(s) to validate', $output );
 
 		unset( $GLOBALS['current_screen'] );
@@ -854,14 +854,14 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_handle_validate_request() {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Manager::init();
 
 		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			home_url( '/' )
 		);
 
@@ -879,24 +879,24 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		$that   = $this;
 		$filter = static function() use ( $that ) {
-			return array(
+			return [
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
 					'AMP_VALIDATION:' . wp_json_encode(
-						array(
+						[
 							'results' => array_map(
 								static function( $error ) {
 									return array_merge(
 										compact( 'error' ),
-										array( 'sanitized' => false )
+										[ 'sanitized' => false ]
 									);
 								},
 								$that->get_mock_errors()
 							),
-						)
+						]
 					)
 				),
-			);
+			];
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 
@@ -1000,37 +1000,37 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( 'missing_url', $r->get_error_code() );
 
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			home_url( '/' )
 		);
 		add_filter(
 			'pre_http_request',
 			static function() {
-				return array(
+				return [
 					'body' => sprintf(
 						'<html amp><head></head><body></body><!--%s--></html>',
 						'AMP_VALIDATION:' . wp_json_encode(
-							array(
-								'results' => array(
-									array(
+							[
+								'results' => [
+									[
 										'sanitized' => false,
-										'error'     => array(
+										'error'     => [
 											'code' => 'bar',
-										),
-									),
-									array(
+										],
+									],
+									[
 										'sanitized' => false,
-										'error'     => array(
+										'error'     => [
 											'code' => 'baz',
-										),
-									),
-								),
-							)
+										],
+									],
+								],
+							]
 						)
 					),
-				);
+				];
 			}
 		);
 
@@ -1059,34 +1059,34 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		global $post;
 		AMP_Validation_Manager::init();
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$_REQUEST[ AMP_Validated_URL_Post_Type::UPDATE_POST_TERM_STATUS_ACTION . '_nonce' ] = wp_create_nonce( AMP_Validated_URL_Post_Type::UPDATE_POST_TERM_STATUS_ACTION );
 		AMP_Validated_URL_Post_Type::handle_validation_error_status_update(); // No-op since no post.
 
-		$error = array( 'code' => 'foo' );
+		$error = [ 'code' => 'foo' ];
 
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array( $error ),
+			[ $error ],
 			home_url( '/' )
 		);
 		add_filter(
 			'pre_http_request',
 			static function() use ( $error ) {
-				return array(
+				return [
 					'body' => sprintf(
 						'<html amp><head></head><body></body><!--%s--></html>',
 						'AMP_VALIDATION:' . wp_json_encode(
-							array(
-								'results' => array(
-									array(
+							[
+								'results' => [
+									[
 										'sanitized' => false,
 										'error'     => $error,
-									),
-								),
-							)
+									],
+								],
+							]
 						)
 					),
-				);
+				];
 			}
 		);
 
@@ -1094,9 +1094,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		$errors = AMP_Validated_URL_Post_Type::get_invalid_url_validation_errors( $invalid_url_post_id );
 
-		$_POST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = array(
+		$_POST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = [
 			$errors[0]['term']->slug => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
-		);
+		];
 
 		add_filter(
 			'wp_redirect',
@@ -1144,15 +1144,15 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::render_link_to_error_index_screen()
 	 */
 	public function test_render_link_to_error_index_screen() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		global $current_screen;
 		set_current_screen( 'index.php' );
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ] );
 		$this->assertEmpty( $output );
 
 		set_current_screen( 'edit.php' );
 		$current_screen->post_type = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
-		$output                    = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ) );
+		$output                    = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ] );
 		$this->assertContains( 'View Error Index', $output );
 	}
 
@@ -1168,14 +1168,14 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( AMP_Validated_URL_Post_Type::STATUS_META_BOX, $side_meta_box['id'] );
 		$this->assertEquals( 'Status', $side_meta_box['title'] );
 		$this->assertEquals(
-			array(
+			[
 				self::TESTED_CLASS,
 				'print_status_meta_box',
-			),
+			],
 			$side_meta_box['callback']
 		);
 		$this->assertEquals(
-			array( '__back_compat_meta_box' => true ),
+			[ '__back_compat_meta_box' => true ],
 			$side_meta_box['args']
 		);
 
@@ -1191,7 +1191,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::get_terms_per_page()
 	 */
 	public function test_get_terms_per_page() {
-		$initial_counts = array( 0, 22, 1000 );
+		$initial_counts = [ 0, 22, 1000 ];
 
 		// If 'post.php' === $pagenow, this method should return the same value, no matter what argument is passed to it.
 		$GLOBALS['pagenow'] = 'post.php';
@@ -1235,7 +1235,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertFalse( isset( $_REQUEST['taxonomy'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Now that the post type is correct, this should add the taxonomy to $_REQUEST.
-		$correct_post_type = self::factory()->post->create( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$correct_post_type = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$_REQUEST['post']  = $correct_post_type;
 		AMP_Validated_URL_Post_Type::add_taxonomy();
 		$this->assertEquals( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, $_REQUEST['taxonomy'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -1248,18 +1248,18 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_print_status_meta_box() {
 		AMP_Validation_Manager::init();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			home_url( '/' )
 		);
 
 		$post_storing_error = get_post( $invalid_url_post_id );
 
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_status_meta_box' ), array( get_post( $invalid_url_post_id ) ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_status_meta_box' ], [ get_post( $invalid_url_post_id ) ] );
 
 		$this->assertContains( date_i18n( 'M j, Y @ H:i', strtotime( $post_storing_error->post_date ) ), $output );
 		$this->assertContains( 'Last checked:', $output );
@@ -1275,19 +1275,19 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_render_single_url_list_table() {
 		AMP_Validation_Error_Taxonomy::register();
-		$post_correct_post_type = self::factory()->post->create_and_get( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
-		$post_wrong_post_type   = self::factory()->post->create_and_get( array( 'post_type' => 'page' ) );
+		$post_correct_post_type = self::factory()->post->create_and_get( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
+		$post_wrong_post_type   = self::factory()->post->create_and_get( [ 'post_type' => 'page' ] );
 		$GLOBALS['hook_suffix'] = 'post.php';
 		$this->go_to( admin_url( 'post.php' ) );
 		set_current_screen( 'post.php' );
 		$GLOBALS['current_screen']->taxonomy = AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG;
 
 		// If the post type is wrong, so the conditional should be false, and this should not echo anything.
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ), array( $post_wrong_post_type ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ], [ $post_wrong_post_type ] );
 		$this->assertEmpty( $output );
 
 		// Now that the current user has permissions, this should output the correct markup.
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ), array( $post_correct_post_type ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ], [ $post_correct_post_type ] );
 		$this->assertContains( '<form class="search-form wp-clearfix" method="get">', $output );
 		$this->assertContains( '<div id="accept-reject-buttons" class="hidden">', $output );
 		$this->assertContains( '<button type="button" class="button action accept">', $output );
@@ -1303,26 +1303,26 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$post_wrong_post_type = self::factory()->post->create_and_get();
 
 		// The $post has the wrong post type, so the method should exit without echoing anything.
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ), array( $post_wrong_post_type ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_wrong_post_type ] );
 		$this->assertEmpty( $output );
 
 		// The post type is correct, but it doesn't have a validation URL associated with it, so this shouldn't output anything.
 		$post_correct_post_type = self::factory()->post->create_and_get(
-			array(
+			[
 				'post-type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-			)
+			]
 		);
-		$output                 = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ), array( $post_correct_post_type ) );
+		$output                 = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_correct_post_type ] );
 		$this->assertEmpty( $output );
 
 		// The post has the correct type and a validation URL in the title, so this should output markup.
 		$post_correct_post_type = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type'  => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
 				'post_title' => home_url(),
-			)
+			]
 		);
-		$output                 = get_echo( array( 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ), array( $post_correct_post_type ) );
+		$output                 = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_correct_post_type ] );
 		$this->assertContains( '<h2 class="amp-validated-url">', $output );
 		$this->assertContains( home_url(), $output );
 	}
@@ -1351,9 +1351,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		// The conditional should be true, and this should return the filtered $title.
 		$post_correct_post_type = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-			)
+			]
 		);
 		$this->assertEquals( '/baz', AMP_Validated_URL_Post_Type::filter_the_title_in_post_list_table( $title, $post_correct_post_type ) );
 	}
@@ -1373,12 +1373,12 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$number_of_accepted   = 5;
 
 		for ( $i = 0; $i < 40; $i++ ) {
-			$invalid_url_post      = self::factory()->post->create( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+			$invalid_url_post      = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 			$validation_error_term = self::factory()->term->create(
-				array(
+				[
 					'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-					'description' => wp_json_encode( array( 'code' => 'test' ), compact( 'i' ) ),
-				)
+					'description' => wp_json_encode( [ 'code' => 'test' ], compact( 'i' ) ),
+				]
 			);
 			if ( $i < 9 ) {
 				$status = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS;
@@ -1392,15 +1392,15 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			wp_update_term(
 				$validation_error_term,
 				AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-				array(
+				[
 					'term_group' => $status,
-				)
+				]
 			);
 
 			// Associate the validation error term with a URL.
 			wp_set_post_terms(
 				$invalid_url_post,
-				array( $validation_error_term ),
+				[ $validation_error_term ],
 				AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG
 			);
 
@@ -1412,15 +1412,15 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$wrong_which_second_argument   = 'bottom';
 
 		// This has an incorrect post type as the first argument, so it should not output anything.
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_post_filters' ), array( $wrong_post_type, $correct_which_second_argument ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $wrong_post_type, $correct_which_second_argument ] );
 		$this->assertEmpty( $output );
 
 		// This has an incorrect second argument, so again it should not output anything.
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_post_filters' ), array( $correct_post_type, $wrong_which_second_argument ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $correct_post_type, $wrong_which_second_argument ] );
 		$this->assertEmpty( $output );
 
 		// This is now on the invalid URL post type edit.php screen, so it should output a <select> element.
-		$output = get_echo( array( 'AMP_Validated_URL_Post_Type', 'render_post_filters' ), array( $correct_post_type, $correct_which_second_argument ) );
+		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $correct_post_type, $correct_which_second_argument ] );
 		$this->assertContains(
 			sprintf( 'With New Errors <span class="count">(%d)</span>', $number_of_new_errors ),
 			$output
@@ -1442,7 +1442,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 */
 	public function test_get_recheck_url() {
 		AMP_Validation_Manager::init();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors( $this->get_mock_errors(), home_url( '/' ) );
 		$link    = AMP_Validated_URL_Post_Type::get_recheck_url( get_post( $post_id ) );
 		$this->assertContains( AMP_Validated_URL_Post_Type::VALIDATE_ACTION, $link );
@@ -1457,19 +1457,19 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_filter_dashboard_glance_items() {
 
 		// There are no validation errors, so this should return the argument unchanged.
-		$this->assertEmpty( AMP_Validated_URL_Post_Type::filter_dashboard_glance_items( array() ) );
+		$this->assertEmpty( AMP_Validated_URL_Post_Type::filter_dashboard_glance_items( [] ) );
 
 		// Create validation errors, so that the method returns items.
 		$post_id = self::factory()->post->create();
 		AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'accepted' ),
-				array( 'code' => 'rejected' ),
-				array( 'code' => 'new' ),
-			),
+			[
+				[ 'code' => 'accepted' ],
+				[ 'code' => 'rejected' ],
+				[ 'code' => 'new' ],
+			],
 			get_permalink( $post_id )
 		);
-		$items = AMP_Validated_URL_Post_Type::filter_dashboard_glance_items( array() );
+		$items = AMP_Validated_URL_Post_Type::filter_dashboard_glance_items( [] );
 		$this->assertContains( '1 URL w/ new AMP errors', $items[0] );
 		$this->assertContains( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, $items[0] );
 		$this->assertContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $items[0] );
@@ -1484,7 +1484,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		global $post;
 		$meta_key               = '_amp_queried_object';
 		$test_post              = self::factory()->post->create_and_get();
-		$amp_validated_url_post = self::factory()->post->create_and_get( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$amp_validated_url_post = self::factory()->post->create_and_get( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 
 		// If $pagenow is not post.php, this should not filter the labels.
 		$GLOBALS['pagenow'] = 'edit.php';
@@ -1505,10 +1505,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		update_post_meta(
 			$amp_validated_url_post->ID,
 			$meta_key,
-			array(
+			[
 				'type' => 'post',
 				'id'   => $test_post->ID,
-			)
+			]
 		);
 		$this->assertEquals(
 			sprintf( 'Errors for: %s', $test_post->post_title ),
@@ -1520,10 +1520,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		update_post_meta(
 			$amp_validated_url_post->ID,
 			$meta_key,
-			array(
+			[
 				'type' => 'term',
 				'id'   => $term->term_id,
-			)
+			]
 		);
 		$this->assertEquals(
 			sprintf( 'Errors for: %s', $term->name ),
@@ -1535,10 +1535,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		update_post_meta(
 			$amp_validated_url_post->ID,
 			$meta_key,
-			array(
+			[
 				'type' => 'user',
 				'id'   => $user->ID,
-			)
+			]
 		);
 		$this->assertEquals(
 			sprintf( 'Errors for: %s', $user->display_name ),
@@ -1552,21 +1552,21 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::filter_post_row_actions()
 	 */
 	public function test_filter_post_row_actions() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
 		$validated_url   = home_url( '/' );
 		$invalid_post_id = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			$validated_url
 		);
 
-		$initial_actions = array(
+		$initial_actions = [
 			'trash' => sprintf( '<a href="%s" class="submitdelete" aria-label="Trash &#8220;%s&#8221;">Trash</a>', get_delete_post_link( $invalid_post_id ), $validated_url ),
-		);
+		];
 
 		$this->assertEquals( $initial_actions, AMP_Validated_URL_Post_Type::filter_post_row_actions( $initial_actions, self::factory()->post->create_and_get() ) );
 
@@ -1579,18 +1579,18 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertNotContains( 'Trash', $actions['delete'] );
 		$this->assertContains( 'Forget', $actions['delete'] );
 
-		$this->assertEquals( array(), AMP_Validated_URL_Post_Type::filter_post_row_actions( array(), null ) );
+		$this->assertEquals( [], AMP_Validated_URL_Post_Type::filter_post_row_actions( [], null ) );
 
-		$actions = array(
+		$actions = [
 			'trash'  => '',
 			'delete' => '',
-		);
+		];
 
 		$post = self::factory()->post->create_and_get(
-			array(
+			[
 				'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
 				'title'     => 'My Post',
-			)
+			]
 		);
 
 		$filtered_actions = AMP_Validated_URL_Post_Type::filter_post_row_actions( $actions, $post );
@@ -1607,11 +1607,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::filter_table_views()
 	 */
 	public function test_filter_table_views() {
-		$this->assertEquals( array(), AMP_Validated_URL_Post_Type::filter_table_views( array() ) );
+		$this->assertEquals( [], AMP_Validated_URL_Post_Type::filter_table_views( [] ) );
 
-		$views = array(
+		$views = [
 			'trash' => 'Trash',
-		);
+		];
 
 		$filtered_views = AMP_Validated_URL_Post_Type::filter_table_views( $views );
 
@@ -1626,22 +1626,22 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_filter_bulk_post_updated_messages() {
 		set_current_screen( 'index.php' );
 
-		$this->assertEquals( array(), AMP_Validated_URL_Post_Type::filter_bulk_post_updated_messages( array(), array() ) );
+		$this->assertEquals( [], AMP_Validated_URL_Post_Type::filter_bulk_post_updated_messages( [], [] ) );
 
 		set_current_screen( 'edit.php' );
 		get_current_screen()->id = sprintf( 'edit-%s', AMP_Validated_URL_Post_Type::POST_TYPE_SLUG );
 
-		$messages = array(
-			'post' => array(),
-		);
+		$messages = [
+			'post' => [],
+		];
 
 		$filtered_messages = AMP_Validated_URL_Post_Type::filter_bulk_post_updated_messages(
 			$messages,
-			array(
+			[
 				'deleted'   => 1,
 				'trashed'   => 99,
 				'untrashed' => 99,
-			)
+			]
 		);
 
 		$this->assertEquals( '%s validated URL forgotten.', $filtered_messages['post']['deleted'] );
@@ -1663,33 +1663,33 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * }
 	 */
 	public function get_mock_errors() {
-		return array(
-			array(
+		return [
+			[
 				'code'            => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
 				'node_name'       => 'script',
 				'parent_name'     => 'div',
-				'node_attributes' => array(),
-				'sources'         => array(
-					array(
+				'node_attributes' => [],
+				'sources'         => [
+					[
 						'type' => 'plugin',
 						'name' => 'amp',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'code'               => AMP_Validation_Error_Taxonomy::INVALID_ATTRIBUTE_CODE,
 				'node_name'          => 'onclick',
 				'parent_name'        => 'div',
-				'element_attributes' => array(
+				'element_attributes' => [
 					'onclick' => '',
-				),
-				'sources'            => array(
-					array(
+				],
+				'sources'            => [
+					[
 						'type' => 'plugin',
 						'name' => 'amp',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 	}
 }

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -30,13 +30,13 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * Resets the state after each test method.
 	 */
 	public function tearDown() {
-		$_REQUEST = array();
+		$_REQUEST = [];
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::read_theme_support();
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
 		remove_all_filters( 'amp_validation_error_sanitized' );
 		remove_all_filters( 'terms_clauses' );
-		AMP_Validation_Manager::$validation_error_status_overrides = array();
+		AMP_Validation_Manager::$validation_error_status_overrides = [];
 		parent::tearDown();
 	}
 
@@ -61,7 +61,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertFalse( $taxonomy_object->meta_box_cb );
 		$this->assertEquals( 'AMP Validation Error Index', $taxonomy_object->label );
 		$this->assertEquals( 'do_not_allow', $taxonomy_object->cap->assign_terms );
-		$this->assertEquals( array( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ), $taxonomy_object->object_type );
+		$this->assertEquals( [ AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ], $taxonomy_object->object_type );
 
 		$labels = $taxonomy_object->labels;
 		$this->assertEquals( 'AMP Validation Error Index', $labels->name );
@@ -110,10 +110,10 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Error_Taxonomy::get_term()
 	 */
 	public function test_get_term() {
-		$foo_error = array( 'code' => 'foo' );
-		$bar_error = array( 'code' => 'bar' );
+		$foo_error = [ 'code' => 'foo' ];
+		$bar_error = [ 'code' => 'bar' ];
 		AMP_Validated_URL_Post_Type::store_validation_errors(
-			array( $foo_error, $bar_error ),
+			[ $foo_error, $bar_error ],
 			home_url( '/' )
 		);
 		$foo_term_data = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( $foo_error );
@@ -133,23 +133,23 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( 0, AMP_Validation_Error_Taxonomy::delete_empty_terms() );
 
 		$post_id_1 = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-				array( 'code' => 'bar' ),
-				array( 'code' => 'baz' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+				[ 'code' => 'bar' ],
+				[ 'code' => 'baz' ],
+			],
 			home_url( '/1' )
 		);
 		$post_id_2 = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'foo' ),
-			),
+			[
+				[ 'code' => 'foo' ],
+			],
 			home_url( '/2' )
 		);
 		$post_id_3 = AMP_Validated_URL_Post_Type::store_validation_errors(
-			array(
-				array( 'code' => 'quux' ),
-			),
+			[
+				[ 'code' => 'quux' ],
+			],
 			home_url( '/3' )
 		);
 
@@ -181,28 +181,28 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( false ) );
 		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( null ) );
 		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( '0' ) );
-		$this->assertSame( array(), AMP_Validation_Error_Taxonomy::sanitize_term_status( '', array( 'multiple' => true ) ) );
+		$this->assertSame( [], AMP_Validation_Error_Taxonomy::sanitize_term_status( '', [ 'multiple' => true ] ) );
 		$this->assertNull( AMP_Validation_Error_Taxonomy::sanitize_term_status( '100' ) );
 		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( (string) AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS ) );
 		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS ) );
 		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( (string) AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS ) );
-		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, array( 'multiple' => false ) ) );
+		$this->assertSame( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, AMP_Validation_Error_Taxonomy::sanitize_term_status( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS, [ 'multiple' => false ] ) );
 
 		$this->assertEquals(
-			array(
+			[
 				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::sanitize_term_status(
 				implode(
 					',',
-					array(
+					[
 						AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 						AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 						121930,
-					)
+					]
 				),
-				array( 'multiple' => true )
+				[ 'multiple' => true ]
 			)
 		);
 	}
@@ -213,8 +213,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::prepare_term_group_in_sql()
 	 */
 	public function test_prepare_term_group_in_sql() {
-		$this->assertEquals( 'IN ( 1, 2, 3 )', AMP_Validation_Error_Taxonomy::prepare_term_group_in_sql( array( 1, 2, 3 ) ) );
-		$this->assertEquals( 'IN ( 0 )', AMP_Validation_Error_Taxonomy::prepare_term_group_in_sql( array( '"bad"' ) ) );
+		$this->assertEquals( 'IN ( 1, 2, 3 )', AMP_Validation_Error_Taxonomy::prepare_term_group_in_sql( [ 1, 2, 3 ] ) );
+		$this->assertEquals( 'IN ( 0 )', AMP_Validation_Error_Taxonomy::prepare_term_group_in_sql( [ '"bad"' ] ) );
 	}
 
 	/**
@@ -224,12 +224,12 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_prepare_validation_error_taxonomy_term() {
 		$error              = $this->get_mock_error();
-		$sources            = array(
-			array(
+		$sources            = [
+			[
 				'type' => 'plugin',
 				'name' => 'baz',
-			),
-		);
+			],
+		];
 		$error_with_sources = array_merge( $error, compact( 'sources' ) );
 		ksort( $error );
 
@@ -237,11 +237,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$term_slug   = md5( $description );
 		$this->assertEquals(
 			AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( $error_with_sources ),
-			array(
+			[
 				'slug'        => $term_slug,
 				'name'        => $term_slug,
 				'description' => $description,
-			)
+			]
 		);
 	}
 
@@ -257,19 +257,19 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$error_foo = array_merge(
 			$this->get_mock_error(),
-			array( 'foo' => 1 )
+			[ 'foo' => 1 ]
 		);
 		AMP_Validated_URL_Post_Type::store_validation_errors(
-			array( $error_foo ),
+			[ $error_foo ],
 			home_url( '/foo' )
 		);
 		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_foo ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => false,
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_foo )
 		);
 
@@ -277,46 +277,46 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$error_bar = array_merge(
 			$this->get_mock_error(),
-			array( 'bar' => 1 )
+			[ 'bar' => 1 ]
 		);
 		AMP_Validated_URL_Post_Type::store_validation_errors(
-			array( $error_bar ),
+			[ $error_bar ],
 			home_url( '/bar' )
 		);
 		$this->assertFalse( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_bar ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => false,
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_bar )
 		);
 
 		// New accepted, since canonical.
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
-			array(
+			[
 				AMP_Theme_Support::PAIRED_FLAG => false,
-			)
+			]
 		);
 		$this->assertTrue( amp_is_canonical() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$error_baz = array_merge(
 			$this->get_mock_error(),
-			array( 'baz' => 1 )
+			[ 'baz' => 1 ]
 		);
 		AMP_Validated_URL_Post_Type::store_validation_errors(
-			array( $error_baz ),
+			[ $error_baz ],
 			home_url( '/baz' )
 		);
 		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_baz ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => false,
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_baz )
 		);
 
@@ -327,17 +327,17 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		wp_update_term(
 			$term->term_id,
 			AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-			array(
+			[
 				'term_group' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-			)
+			]
 		);
 		$this->assertFalse( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_foo ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => false,
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_foo )
 		);
 
@@ -348,17 +348,17 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		wp_update_term(
 			$term->term_id,
 			AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-			array(
+			[
 				'term_group' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
-			)
+			]
 		);
 		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_bar ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => false,
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_bar )
 		);
 
@@ -367,11 +367,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		add_filter( 'amp_validation_error_sanitized', '__return_true' );
 		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_foo ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => 'with_filter',
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_foo )
 		);
 		remove_filter( 'amp_validation_error_sanitized', '__return_true' );
@@ -382,11 +382,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		AMP_Validation_Manager::$validation_error_status_overrides[ $term_data['slug'] ] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS;
 		$this->assertFalse( AMP_Validation_Error_Taxonomy::is_validation_error_sanitized( $error_bar ) );
 		$this->assertEquals(
-			array(
+			[
 				'forced'      => 'with_preview',
 				'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
 				'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
-			),
+			],
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_bar )
 		);
 	}
@@ -398,11 +398,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_accept_validation_errors() {
 		$error = $this->get_mock_error();
-		AMP_Validation_Error_Taxonomy::accept_validation_errors( array() );
+		AMP_Validation_Error_Taxonomy::accept_validation_errors( [] );
 		$this->assertNull( apply_filters( 'amp_validation_error_sanitized', null, $error ) );
 		remove_all_filters( 'amp_validation_error_sanitized' );
 
-		AMP_Validation_Error_Taxonomy::accept_validation_errors( array( self::MOCK_ACCEPTABLE_ERROR => true ) );
+		AMP_Validation_Error_Taxonomy::accept_validation_errors( [ self::MOCK_ACCEPTABLE_ERROR => true ] );
 		$this->assertTrue( apply_filters( 'amp_validation_error_sanitized', null, $error ) );
 		remove_all_filters( 'amp_validation_error_sanitized' );
 
@@ -421,27 +421,27 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_array_subset( $error, $error ) );
 
 		// The superset argument now has an extra key and value, but the superset still has all of the values of the subset.
-		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_array_subset( array_merge( $error, array( 'foo' => 'bar' ) ), $error ) );
+		$this->assertTrue( AMP_Validation_Error_Taxonomy::is_array_subset( array_merge( $error, [ 'foo' => 'bar' ] ), $error ) );
 
 		// The subset has a key and value that the superset doesn't have, so this should be false.
-		$this->assertFalse( AMP_Validation_Error_Taxonomy::is_array_subset( $error, array_merge( $error, array( 'foo' => 'bar' ) ) ) );
+		$this->assertFalse( AMP_Validation_Error_Taxonomy::is_array_subset( $error, array_merge( $error, [ 'foo' => 'bar' ] ) ) );
 
-		$sources = array(
-			array(
+		$sources = [
+			[
 				'type' => 'plugin',
 				'name' => 'foo',
-			),
-			array(
+			],
+			[
 				'type' => 'theme',
 				'name' => 'baz',
-			),
-		);
+			],
+		];
 
 		/**
 		 * Add only the plugin sources to the superset, but all of the sources to the subset.
 		 * This should make is_array_subset() false, as the superset does not have all of the values of the subset.
 		 */
-		$superset = array_merge( $error, array( 'sources' => array( $sources[0] ) ) );
+		$superset = array_merge( $error, [ 'sources' => [ $sources[0] ] ] );
 		$subset   = array_merge( $error, compact( 'sources' ) );
 		$this->assertFalse( AMP_Validation_Error_Taxonomy::is_array_subset( $superset, $subset ) );
 	}
@@ -456,18 +456,18 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( 0, AMP_Validation_Error_Taxonomy::get_validation_error_count() );
 
 		self::factory()->term->create(
-			array(
+			[
 				'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-			)
+			]
 		);
 		$this->assertEquals( 1, AMP_Validation_Error_Taxonomy::get_validation_error_count() );
 
 		$terms_to_add = 11;
 		for ( $i = 0; $i < $terms_to_add; $i++ ) {
 			self::factory()->term->create(
-				array(
+				[
 					'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-				)
+				]
 			);
 		}
 		$this->assertEquals( 1 + $terms_to_add, AMP_Validation_Error_Taxonomy::get_validation_error_count() );
@@ -488,7 +488,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( $initial_where, AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query ) );
 
 		// Only the first part of the conditional is met, so this still shouldn't filter the WHERE clause.
-		$wp_query->set( 'post_type', array( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$wp_query->set( 'post_type', [ AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$this->assertEquals( $initial_where, AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query ) );
 
 		// The entire conditional should now be true, so this should filter the WHERE clause.
@@ -519,42 +519,42 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_summarize_validation_errors() {
 		$attribute_node_name = 'button';
 		$element_node_name   = 'nonexistent-element';
-		$validation_errors   = array(
-			array(
+		$validation_errors   = [
+			[
 				'code'      => 'invalid_attribute',
 				'node_name' => $attribute_node_name,
-				'sources'   => array(
-					array(
+				'sources'   => [
+					[
 						'type' => 'plugin',
 						'name' => 'foo',
-					),
-				),
-			),
-			array(
+					],
+				],
+			],
+			[
 				'code'      => 'invalid_element',
 				'node_name' => $element_node_name,
-				'sources'   => array(
-					array(
+				'sources'   => [
+					[
 						'type' => 'theme',
 						'name' => 'bar',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 
 		$results          = AMP_Validation_Error_Taxonomy::summarize_validation_errors( $validation_errors );
-		$expected_results = array(
-			AMP_Validation_Error_Taxonomy::REMOVED_ATTRIBUTES => array(
+		$expected_results = [
+			AMP_Validation_Error_Taxonomy::REMOVED_ATTRIBUTES => [
 				$attribute_node_name => 1,
-			),
-			AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS => array(
+			],
+			AMP_Validation_Error_Taxonomy::REMOVED_ELEMENTS => [
 				$element_node_name => 1,
-			),
-			AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => array(
-				'plugin' => array( 'foo' ),
-				'theme'  => array( 'bar' ),
-			),
-		);
+			],
+			AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT => [
+				'plugin' => [ 'foo' ],
+				'theme'  => [ 'bar' ],
+			],
+		];
 		$this->assertEquals( $expected_results, $results );
 	}
 
@@ -572,32 +572,32 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		AMP_Validation_Error_Taxonomy::add_admin_hooks();
 		do_action( 'load-edit-tags.php' ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 
-		$this->assertEquals( 10, has_action( 'redirect_term_location', array( self::TESTED_CLASS, 'add_term_filter_query_var' ) ) );
-		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'add_group_terms_clauses_filter' ) ) );
-		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'add_error_type_clauses_filter' ) ) );
-		$this->assertEquals( 10, has_action( 'load-post.php', array( self::TESTED_CLASS, 'add_error_type_clauses_filter' ) ) );
-		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), array( self::TESTED_CLASS, 'render_taxonomy_filters' ) ) );
-		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), array( self::TESTED_CLASS, 'render_link_to_invalid_urls_screen' ) ) );
-		$this->assertEquals( 10, has_filter( 'user_has_cap', array( self::TESTED_CLASS, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ) ) );
-		$this->assertEquals( 10, has_filter( 'terms_clauses', array( self::TESTED_CLASS, 'filter_terms_clauses_for_description_search' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_notices', array( self::TESTED_CLASS, 'add_admin_notices' ) ) );
-		$this->assertEquals( 10, has_filter( 'tag_row_actions', array( self::TESTED_CLASS, 'filter_tag_row_actions' ) ) );
-		$this->assertEquals( 10, has_action( 'admin_menu', array( self::TESTED_CLASS, 'add_admin_menu_validation_error_item' ) ) );
-		$this->assertEquals( 10, has_filter( 'parse_term_query', array( self::TESTED_CLASS, 'parse_post_php_term_query' ) ) );
-		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_custom_column', array( self::TESTED_CLASS, 'filter_manage_custom_columns' ) ) );
-		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_sortable_columns', array( self::TESTED_CLASS, 'add_single_post_sortable_columns' ) ) );
-		$this->assertEquals( 10, has_filter( 'posts_where', array( self::TESTED_CLASS, 'filter_posts_where_for_validation_error_status' ) ) );
-		$this->assertEquals( 10, has_filter( 'post_action_' . AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION, array( self::TESTED_CLASS, 'handle_single_url_page_bulk_and_inline_actions' ) ) );
-		$this->assertEquals( 10, has_filter( 'post_action_' . AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION, array( self::TESTED_CLASS, 'handle_single_url_page_bulk_and_inline_actions' ) ) );
-		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( self::TESTED_CLASS, 'handle_validation_error_update' ) ) );
-		$this->assertEquals( 10, has_action( 'load-edit-tags.php', array( self::TESTED_CLASS, 'handle_inline_edit_request' ) ) );
+		$this->assertEquals( 10, has_action( 'redirect_term_location', [ self::TESTED_CLASS, 'add_term_filter_query_var' ] ) );
+		$this->assertEquals( 10, has_action( 'load-edit-tags.php', [ self::TESTED_CLASS, 'add_group_terms_clauses_filter' ] ) );
+		$this->assertEquals( 10, has_action( 'load-edit-tags.php', [ self::TESTED_CLASS, 'add_error_type_clauses_filter' ] ) );
+		$this->assertEquals( 10, has_action( 'load-post.php', [ self::TESTED_CLASS, 'add_error_type_clauses_filter' ] ) );
+		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), [ self::TESTED_CLASS, 'render_taxonomy_filters' ] ) );
+		$this->assertEquals( 10, has_action( sprintf( 'after-%s-table', AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), [ self::TESTED_CLASS, 'render_link_to_invalid_urls_screen' ] ) );
+		$this->assertEquals( 10, has_filter( 'user_has_cap', [ self::TESTED_CLASS, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ] ) );
+		$this->assertEquals( 10, has_filter( 'terms_clauses', [ self::TESTED_CLASS, 'filter_terms_clauses_for_description_search' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', [ self::TESTED_CLASS, 'add_admin_notices' ] ) );
+		$this->assertEquals( 10, has_filter( 'tag_row_actions', [ self::TESTED_CLASS, 'filter_tag_row_actions' ] ) );
+		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_validation_error_item' ] ) );
+		$this->assertEquals( 10, has_filter( 'parse_term_query', [ self::TESTED_CLASS, 'parse_post_php_term_query' ] ) );
+		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_custom_column', [ self::TESTED_CLASS, 'filter_manage_custom_columns' ] ) );
+		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG . '_sortable_columns', [ self::TESTED_CLASS, 'add_single_post_sortable_columns' ] ) );
+		$this->assertEquals( 10, has_filter( 'posts_where', [ self::TESTED_CLASS, 'filter_posts_where_for_validation_error_status' ] ) );
+		$this->assertEquals( 10, has_filter( 'post_action_' . AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION, [ self::TESTED_CLASS, 'handle_single_url_page_bulk_and_inline_actions' ] ) );
+		$this->assertEquals( 10, has_filter( 'post_action_' . AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION, [ self::TESTED_CLASS, 'handle_single_url_page_bulk_and_inline_actions' ] ) );
+		$this->assertEquals( 10, has_filter( 'handle_bulk_actions-edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, [ self::TESTED_CLASS, 'handle_validation_error_update' ] ) );
+		$this->assertEquals( 10, has_action( 'load-edit-tags.php', [ self::TESTED_CLASS, 'handle_inline_edit_request' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts' ) );
 
 		$cb              = '<input type="checkbox" />';
-		$initial_columns = array( 'cb' => $cb );
+		$initial_columns = [ 'cb' => $cb ];
 		$this->assertEquals(
 			array_keys(
-				array(
+				[
 					'cb'               => $cb,
 					'error'            => 'Error',
 					'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
@@ -605,7 +605,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 					'error_type'       => 'Type',
 					'created_date_gmt' => 'Last Seen',
 					'posts'            => 'Found URLs',
-				)
+				]
 			),
 			array_keys( apply_filters( 'manage_edit-' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_columns', $initial_columns ) ) // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
 		);
@@ -613,8 +613,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		// Assert that the 'query_vars' callback adds these query vars.
 		$this->assertEmpty(
 			array_diff(
-				array( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR ),
-				apply_filters( 'query_vars', array() )
+				[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR ],
+				apply_filters( 'query_vars', [] )
 			)
 		);
 	}
@@ -686,7 +686,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$_POST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR ] = $status_query_var_value;
 		$_POST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR ]   = null;
 		$expected_url = add_query_arg(
-			array( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => array( $status_query_var_value ) ),
+			[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR => [ $status_query_var_value ] ],
 			$initial_url
 		);
 		$this->assertEquals( $expected_url, AMP_Validation_Error_Taxonomy::add_term_filter_query_var( $initial_url, $correct_taxonomy ) );
@@ -701,9 +701,9 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		global $current_screen;
 
 		$initial_where   = 'foo';
-		$initial_clauses = array( 'where' => $initial_where );
+		$initial_clauses = [ 'where' => $initial_where ];
 		$type            = AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE;
-		$taxonomies      = array( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
+		$taxonomies      = [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ];
 
 		set_current_screen( 'front' );
 		$tested_filter = 'terms_clauses';
@@ -727,7 +727,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertContains( 'AND tt.description LIKE', $filtered_clauses['where'] );
 
 		// If $taxonomies does not have the AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, the filter should return the clauses unchanged.
-		$taxonomies = array( 'post_tag' );
+		$taxonomies = [ 'post_tag' ];
 		$this->assertEquals( $initial_clauses, apply_filters( $tested_filter, $initial_clauses, $taxonomies ) );
 	}
 
@@ -741,11 +741,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		set_current_screen( 'edit-tags.php' );
 		// Create one new error.
 		self::factory()->term->create(
-			array(
+			[
 				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 				'description' => wp_json_encode( $this->get_mock_error() ),
 				'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-			)
+			]
 		);
 
 		// When passing the wrong $taxonomy_name to the method, it should not output anything.
@@ -755,11 +755,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// When there are two new errors, the <option> text should be plural, and have a count of (2).
 		self::factory()->term->create(
-			array(
+			[
 				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 				'description' => wp_json_encode( $this->get_mock_error() ),
 				'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-			)
+			]
 		);
 		ob_start();
 		AMP_Validation_Error_Taxonomy::render_taxonomy_filters( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
@@ -772,14 +772,14 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::render_link_to_invalid_urls_screen()
 	 */
 	public function test_render_link_to_invalid_urls_screen() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		// When passing the wrong $taxonomy argument, this should not render anything.
-		$output = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ), array( 'category' ) );
+		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ], [ 'category' ] );
 		$this->assertEmpty( $output );
 
 		// When passing the correct taxonomy, this should render the link.
-		$output = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ), array( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ) );
+		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ], [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] );
 		$this->assertContains( 'View Validated URLs', $output );
 		$this->assertContains(
 			add_query_arg(
@@ -801,31 +801,31 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		set_current_screen( 'post.php' );
 
 		// When this is not on the correct screen, this should not render anything.
-		$output = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ) );
+		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ] );
 		$this->assertEmpty( $output );
 
 		set_current_screen( 'edit.php' );
 		$number_of_errors = 10;
 		for ( $i = 0; $i < $number_of_errors; $i++ ) {
-			$invalid_url_post      = self::factory()->post->create( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+			$invalid_url_post      = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 			$validation_error_term = self::factory()->term->create(
-				array(
+				[
 					'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 					'description' => wp_json_encode( $this->get_mock_error() ),
 					'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-				)
+				]
 			);
 
 			// Associate the validation error term with a URL so that it appears in a query.
 			wp_set_post_terms(
 				$invalid_url_post,
-				array( $validation_error_term ),
+				[ $validation_error_term ],
 				AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG
 			);
 		}
 
 		// When there are 10 accepted errors, the <option> element for it should end with (10).
-		$output = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ) );
+		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ] );
 		$this->assertContains(
 			sprintf(
 				'New Errors <span class="count">(%d)</span>',
@@ -842,7 +842,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_get_error_types() {
 		$this->assertEquals(
-			array( 'html_element_error', 'html_attribute_error', 'js_error', 'css_error' ),
+			[ 'html_element_error', 'html_attribute_error', 'js_error', 'css_error' ],
 			AMP_Validation_Error_Taxonomy::get_error_types()
 		);
 	}
@@ -857,24 +857,24 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$number_of_errors = 10;
 		for ( $i = 0; $i < $number_of_errors; $i++ ) {
 			self::factory()->term->create(
-				array(
+				[
 					'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 					'description' => wp_json_encode( $this->get_mock_error() ),
 					'term_group'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
-				)
+				]
 			);
 		}
 
 		// The strings below should be present.
-		$markup = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'render_error_type_filter' ) );
+		$markup = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_type_filter' ] );
 
-		$expected_to_contain = array(
+		$expected_to_contain = [
 			AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR,
 			AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE,
 			AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE,
 			AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE,
 			AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-		);
+		];
 
 		foreach ( $expected_to_contain as $expected ) {
 			$this->assertContains( $expected, $markup );
@@ -897,11 +897,11 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_render_clear_empty_button() {
 
-		$output = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'render_clear_empty_button' ) );
+		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_clear_empty_button' ] );
 		$this->assertEmpty( $output );
 
 		ob_start();
-		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors( array( $this->get_mock_error() ), home_url( '/' ) );
+		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors( [ $this->get_mock_error() ], home_url( '/' ) );
 		wp_delete_post( $post_id, true );
 		AMP_Validation_Error_Taxonomy::render_clear_empty_button();
 		$output = ob_get_clean();
@@ -914,24 +914,24 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox()
 	 */
 	public function test_filter_user_has_cap_for_hiding_term_list_table_checkbox() {
-		$initial_caps = array( 'manage_options' );
-		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, array(), array() ) );
+		$initial_caps = [ 'manage_options' ];
+		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, [], [] ) );
 
 		$term_id_with_description = self::factory()->term->create(
-			array(
-				'description' => wp_json_encode( array( 'foo' => 'bar' ) ),
-			)
+			[
+				'description' => wp_json_encode( [ 'foo' => 'bar' ] ),
+			]
 		);
-		$args                     = array( 'delete_term', null, $term_id_with_description );
-		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, array(), $args ) );
+		$args                     = [ 'delete_term', null, $term_id_with_description ];
+		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, [], $args ) );
 
 		$term_id_no_description = self::factory()->term->create(
-			array(
-				'description' => wp_json_encode( array( 'foo' => 'bar' ) ),
-			)
+			[
+				'description' => wp_json_encode( [ 'foo' => 'bar' ] ),
+			]
 		);
-		$args                   = array( 'delete_term', null, $term_id_no_description );
-		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, array(), $args ) );
+		$args                   = [ 'delete_term', null, $term_id_no_description ];
+		$this->assertEquals( $initial_caps, AMP_Validation_Error_Taxonomy::filter_user_has_cap_for_hiding_term_list_table_checkbox( $initial_caps, [], $args ) );
 	}
 
 	/**
@@ -943,14 +943,14 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		global $wpdb;
 
 		$initial_where = '((t.name LIKE \'foo\'))';
-		$clauses       = array( 'where' => $initial_where );
-		$args          = array( 'search' => 'baz' );
+		$clauses       = [ 'where' => $initial_where ];
+		$args          = [ 'search' => 'baz' ];
 
 		// The conditional shouldn't be true, so it shouldn't alter the 'where' clause.
-		$this->assertEquals( $clauses, AMP_Validation_Error_Taxonomy::filter_terms_clauses_for_description_search( $clauses, array(), $args ) );
+		$this->assertEquals( $clauses, AMP_Validation_Error_Taxonomy::filter_terms_clauses_for_description_search( $clauses, [], $args ) );
 
 		// The conditional should be true, so test the preg_replace() call for $clauses['where'].
-		$clauses = AMP_Validation_Error_Taxonomy::filter_terms_clauses_for_description_search( $clauses, array( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ), $args );
+		$clauses = AMP_Validation_Error_Taxonomy::filter_terms_clauses_for_description_search( $clauses, [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ], $args );
 		$this->assertContains( '(tt.description LIKE ', $clauses['where'] );
 		$this->assertContains( $wpdb->esc_like( $args['search'] ), $clauses['where'] );
 	}
@@ -965,7 +965,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		set_current_screen( 'edit.php' );
 
 		// Test that the method exits when the first conditional isn't true.
-		$message = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ) );
+		$message = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
 		$this->assertEmpty( $message );
 
 		// Test the first conditional, where the error is accepted.
@@ -973,7 +973,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$count                      = 5;
 		$_GET['amp_actioned_count'] = $count;
 		$current_screen->taxonomy   = AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG;
-		$message                    = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ) );
+		$message                    = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
 		$this->assertEquals(
 			sprintf( '<div class="notice notice-success is-dismissible"><p>Accepted %s errors. They will no longer block related URLs from being served as AMP.</p></div>', $count ),
 			$message
@@ -981,7 +981,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// Test the second conditional, where the error is rejected.
 		$_GET['amp_actioned'] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION;
-		$message              = get_echo( array( 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ) );
+		$message              = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'add_admin_notices' ] );
 		$this->assertEquals(
 			sprintf( '<div class="notice notice-success is-dismissible"><p>Rejected %s errors. They will continue to block related URLs from being served as AMP.</p></div>', $count ),
 			$message
@@ -998,9 +998,9 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		// Prevent an error in add_query_arg().
 		$_SERVER['REQUEST_URI'] = 'https://example.com';
 		AMP_Validation_Error_Taxonomy::register();
-		$initial_actions = array(
+		$initial_actions = [
 			'delete' => '<a href="#">Delete</a>',
-		);
+		];
 
 		// When the term isn't for the invalid post type taxonomy, the actions shouldn't be altered.
 		$term_other_taxonomy = self::factory()->term->create_and_get();
@@ -1008,10 +1008,10 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// The term is for this taxonomy, so this should filter the actions.
 		$term_this_taxonomy = self::factory()->term->create_and_get(
-			array(
+			[
 				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 				'description' => wp_json_encode( $this->get_mock_error() ),
-			)
+			]
 		);
 		$filtered_actions   = AMP_Validation_Error_Taxonomy::filter_tag_row_actions( $initial_actions, $term_this_taxonomy );
 		$accept_action      = $filtered_actions[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION ];
@@ -1030,16 +1030,16 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_add_admin_menu_validation_error_item() {
 		global $submenu;
 
-		$submenu = array();
+		$submenu = [];
 		AMP_Validation_Error_Taxonomy::register();
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Error_Taxonomy::add_admin_menu_validation_error_item();
-		$expected_submenu = array(
+		$expected_submenu = [
 			'Error Index',
 			'manage_categories',
 			'edit-tags.php?taxonomy=amp_validation_error&amp;post_type=amp_validated_url',
 			'Error Index',
-		);
+		];
 		$amp_options      = $submenu[ AMP_Options_Manager::OPTION_NAME ];
 		$this->assertEquals( $expected_submenu, end( $amp_options ) );
 	}
@@ -1070,7 +1070,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEmpty( $wp_term_query->query_vars );
 
 		// Now that $_GET['post'] has a post ID of the correct post type, it should be in the query var.
-		$post_id_correct_post_type = self::factory()->post->create( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$post_id_correct_post_type = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$_GET['post']              = $post_id_correct_post_type;
 		AMP_Validation_Error_Taxonomy::parse_post_php_term_query( $wp_term_query );
 		$this->assertEquals( $post_id_correct_post_type, $wp_term_query->query_vars['object_ids'] );
@@ -1116,10 +1116,10 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$validation_error = $this->get_mock_error();
 		$initial_content  = 'example initial content';
 		$term_id          = self::factory()->term->create(
-			array(
+			[
 				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 				'description' => wp_json_encode( $validation_error ),
-			)
+			]
 		);
 
 		// Test the 'error' block in the switch.
@@ -1159,23 +1159,23 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Error_Taxonomy::add_single_post_sortable_columns()
 	 */
 	public function test_add_single_post_sortable_columns() {
-		$initial_columns              = array(
+		$initial_columns              = [
 			'description' => 'description',
 			'links'       => 'count',
-		);
-		$columns_expected_to_be_added = array(
+		];
+		$columns_expected_to_be_added = [
 			'error'      => 'amp_validation_code',
 			'error_type' => 'amp_validation_error_type',
-		);
+		];
 		$this->assertEquals(
 			array_merge( $initial_columns, $columns_expected_to_be_added ),
 			AMP_Validation_Error_Taxonomy::add_single_post_sortable_columns( $initial_columns )
 		);
 
 		// In the unlikely case that the initial columns has an 'error' value, this method should overwrite it.
-		$initial_columns_with_error = array(
+		$initial_columns_with_error = [
 			'error' => 'foobar',
-		);
+		];
 		$this->assertEquals(
 			$columns_expected_to_be_added,
 			AMP_Validation_Error_Taxonomy::add_single_post_sortable_columns( $initial_columns_with_error )
@@ -1190,7 +1190,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_render_single_url_error_details() {
 		$validation_error         = self::get_mock_error();
 		$validation_error['code'] = AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE;
-		$term                     = self::factory()->term->create_and_get( array( 'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ) );
+		$term                     = self::factory()->term->create_and_get( [ 'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] );
 		$html                     = AMP_Validation_Error_Taxonomy::render_single_url_error_details( $validation_error, $term );
 		$this->assertContains( '<details open>', $html );
 	}
@@ -1202,28 +1202,28 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_get_translated_type_name() {
 		// When the error doesn't have a type, this should return null.
-		$error_without_type = array(
+		$error_without_type = [
 			'code' => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
-		);
+		];
 		$this->assertEmpty( AMP_Validation_Error_Taxonomy::get_translated_type_name( $error_without_type ) );
 
 		// When the error has a type that's not recognized, this should also return null.
-		$error_with_unrecognized_type = array(
+		$error_with_unrecognized_type = [
 			'type' => 'foobar',
-		);
+		];
 		$this->assertEmpty( AMP_Validation_Error_Taxonomy::get_translated_type_name( $error_with_unrecognized_type ) );
 
-		$translated_names = array(
+		$translated_names = [
 			AMP_Validation_Error_Taxonomy::HTML_ELEMENT_ERROR_TYPE => 'HTML Element',
 			AMP_Validation_Error_Taxonomy::HTML_ATTRIBUTE_ERROR_TYPE => 'HTML Attribute',
 			AMP_Validation_Error_Taxonomy::JS_ERROR_TYPE  => 'JavaScript',
 			AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE => 'CSS',
-		);
+		];
 
 		foreach ( $translated_names as $slug => $name ) {
-			$validation_error = array(
+			$validation_error = [
 				'type' => $slug,
-			);
+			];
 			$this->assertEquals( $name, AMP_Validation_Error_Taxonomy::get_translated_type_name( $validation_error ) );
 		}
 	}
@@ -1237,17 +1237,17 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		// Create a new error term.
 		$initial_accepted_status = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS;
 		$error_term              = self::factory()->term->create_and_get(
-			array(
+			[
 				'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
 				'description' => wp_json_encode( $this->get_mock_error() ),
-			)
+			]
 		);
-		wp_update_term( $error_term->term_id, AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, array( 'term_group' => $initial_accepted_status ) );
+		wp_update_term( $error_term->term_id, AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, [ 'term_group' => $initial_accepted_status ] );
 
 		// Because the action is incorrect, the tested method should exit and not update the validation error term.
 		$_REQUEST['action']   = 'incorrect-action';
-		$_POST['delete_tags'] = array( $error_term->term_id );
-		$correct_post_type    = self::factory()->post->create( array( 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ) );
+		$_POST['delete_tags'] = [ $error_term->term_id ];
+		$correct_post_type    = self::factory()->post->create( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] );
 		$this->assertEquals( get_term( $error_term->term_id )->term_group, $initial_accepted_status );
 
 		// Because the post type is wrong, the tested method should again return without updating the term.
@@ -1290,18 +1290,18 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$initial_redirect_to = 'https://example.com';
 
 		// The action argument isn't either an accepted or rejected status, so the redirect shouldn't change.
-		$this->assertEquals( $initial_redirect_to, AMP_Validation_Error_Taxonomy::handle_validation_error_update( $initial_redirect_to, 'unexpected-action', array() ) );
+		$this->assertEquals( $initial_redirect_to, AMP_Validation_Error_Taxonomy::handle_validation_error_update( $initial_redirect_to, 'unexpected-action', [] ) );
 
 		$action = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION;
 		$this->assertEquals(
 			add_query_arg(
-				array(
+				[
 					'amp_actioned'       => $action,
 					'amp_actioned_count' => 0,
-				),
+				],
 				$initial_redirect_to
 			),
-			AMP_Validation_Error_Taxonomy::handle_validation_error_update( $initial_redirect_to, $action, array() )
+			AMP_Validation_Error_Taxonomy::handle_validation_error_update( $initial_redirect_to, $action, [] )
 		);
 		$this->assertNotFalse( has_filter( 'pre_term_description', 'wp_filter_kses' ) );
 	}
@@ -1318,7 +1318,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 				throw new Exception( 'redirected' );
 			}
 		);
-		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors( array( $this->get_mock_error() ), home_url( '/' ) );
+		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors( [ $this->get_mock_error() ], home_url( '/' ) );
 		wp_delete_post( $post_id, true );
 		$_REQUEST = &$_POST; // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
 
@@ -1349,7 +1349,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'WPDieException', $exception );
 		$this->assertEquals( 1, AMP_Validation_Error_Taxonomy::get_validation_error_count() );
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$_REQUEST[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_CLEAR_EMPTY_ACTION . '_nonce' ] = wp_create_nonce( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_CLEAR_EMPTY_ACTION );
 		AMP_Validation_Error_Taxonomy::handle_clear_empty_terms_request();
 		$this->assertEquals( 0, AMP_Validation_Error_Taxonomy::get_validation_error_count() );
@@ -1361,19 +1361,19 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @return array $error Mock validation error.
 	 */
 	public function get_mock_error() {
-		return array(
+		return [
 			'at_rule'         => '-ms-viewport',
 			'code'            => self::MOCK_ACCEPTABLE_ERROR,
-			'node_attributes' => array(
+			'node_attributes' => [
 				'href'  => 'https://example.com',
 				'id'    => 'twentysixteen-style-css',
 				'media' => 'all',
 				'rel'   => 'stylesheet',
 				'type'  => 'text/css',
-			),
+			],
 			'node_name'       => 'link',
 			'parent_name'     => 'head',
 			'type'            => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-		);
+		];
 	}
 }

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -109,11 +109,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$GLOBALS['wp_registered_widgets'] = $this->original_wp_registered_widgets;
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Theme_Support::read_theme_support();
-		$_REQUEST = array();
+		$_REQUEST = [];
 		unset( $GLOBALS['current_screen'] );
 		AMP_Validation_Manager::$should_locate_sources = false;
-		AMP_Validation_Manager::$hook_source_stack     = array();
-		AMP_Validation_Manager::$validation_results    = array();
+		AMP_Validation_Manager::$hook_source_stack     = [];
+		AMP_Validation_Manager::$validation_results    = [];
 		AMP_Validation_Manager::reset_validation_results();
 		parent::tearDown();
 	}
@@ -139,19 +139,19 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'rest_api_init', self::TESTED_CLASS . '::add_rest_api_fields' ) );
 
 		$this->assertContains( AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR, wp_removable_query_args() );
-		$this->assertEquals( 101, has_action( 'admin_bar_menu', array( self::TESTED_CLASS, 'add_admin_bar_menu_items' ) ) );
+		$this->assertEquals( 101, has_action( 'admin_bar_menu', [ self::TESTED_CLASS, 'add_admin_bar_menu_items' ] ) );
 
-		$this->assertFalse( has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
+		$this->assertFalse( has_action( 'wp', [ self::TESTED_CLASS, 'wrap_widget_callbacks' ] ) );
 
 		// Make sure should_locate_sources arg is recognized.
 		remove_all_filters( 'amp_validation_error_sanitized' );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		AMP_Validation_Manager::init(
-			array(
+			[
 				'should_locate_sources' => true,
-			)
+			]
 		);
-		$this->assertEquals( 10, has_action( 'wp', array( self::TESTED_CLASS, 'wrap_widget_callbacks' ) ) );
+		$this->assertEquals( 10, has_action( 'wp', [ self::TESTED_CLASS, 'wrap_widget_callbacks' ] ) );
 	}
 
 	/**
@@ -160,11 +160,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::init()
 	 */
 	public function test_init_without_theme_or_stories_support() {
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE ] );
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
-		$this->assertFalse( has_action( 'save_post', array( 'AMP_Validation_Manager', 'handle_save_post_prompting_validation' ) ) );
+		$this->assertFalse( has_action( 'save_post', [ 'AMP_Validation_Manager', 'handle_save_post_prompting_validation' ] ) );
 	}
 
 	/**
@@ -176,12 +176,12 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		if ( ! AMP_Story_Post_Type::has_required_block_capabilities() ) {
 			$this->markTestSkipped( 'Environment does not support Stories.' );
 		}
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
-		$this->assertSame( 10, has_action( 'save_post', array( 'AMP_Validation_Manager', 'handle_save_post_prompting_validation' ) ) );
-		$this->assertFalse( has_action( 'admin_bar_menu', array( self::TESTED_CLASS, 'add_admin_bar_menu_items' ) ) );
+		$this->assertSame( 10, has_action( 'save_post', [ 'AMP_Validation_Manager', 'handle_save_post_prompting_validation' ] ) );
+		$this->assertFalse( has_action( 'admin_bar_menu', [ self::TESTED_CLASS, 'add_admin_bar_menu_items' ] ) );
 	}
 
 	/**
@@ -193,10 +193,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// Ensure that story posts can be validated even when theme support is absent.
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
 		if ( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
-			$post = $this->factory()->post->create( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+			$post = $this->factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 			$this->assertTrue( AMP_Validation_Manager::post_supports_validation( $post ) );
 		}
 
@@ -209,14 +209,14 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertTrue( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create() ) );
 
 		// Trashed posts are not validatable.
-		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create( array( 'post_status' => 'trash' ) ) ) );
+		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( $this->factory()->post->create( [ 'post_status' => 'trash' ] ) ) );
 
 		// An invalid post is not previewable.
 		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( 0 ) );
 
 		// Ensure non-viewable posts do not support validation.
-		register_post_type( 'not_viewable', array( 'publicly_queryable' => false ) );
-		$post = $this->factory()->post->create( array( 'post_type' => 'not_viewable' ) );
+		register_post_type( 'not_viewable', [ 'publicly_queryable' => false ] );
+		$post = $this->factory()->post->create( [ 'post_type' => 'not_viewable' ] );
 		$this->assertFalse( AMP_Validation_Manager::post_supports_validation( $post ) );
 	}
 
@@ -238,11 +238,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 	}
@@ -267,7 +267,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		// No admin bar item when no template available.
 		$this->go_to( home_url() );
 		add_theme_support( AMP_Theme_Support::SLUG );
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$this->assertTrue( AMP_Validation_Manager::has_cap() );
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
@@ -278,7 +278,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'all_templates_supported', true );
 
 		// Admin bar item available in AMP-first mode.
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => false ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => false ] );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -288,7 +288,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
 
 		// Admin bar item available in paired mode.
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -299,7 +299,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// Admin bar item available in paired mode with validation errors.
 		$_GET[ AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR ] = 3;
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
@@ -317,18 +317,18 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_add_validation_error_sourcing() {
 		AMP_Validation_Manager::add_validation_error_sourcing();
 		$this->assertEmpty( AMP_Validation_Manager::$validation_error_status_overrides );
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_content', array( self::TESTED_CLASS, 'decorate_filter_source' ) ) );
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_excerpt', array( self::TESTED_CLASS, 'decorate_filter_source' ) ) );
-		$this->assertEquals( PHP_INT_MAX, has_action( 'do_shortcode_tag', array( self::TESTED_CLASS, 'decorate_shortcode_source' ) ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_content', [ self::TESTED_CLASS, 'decorate_filter_source' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'the_excerpt', [ self::TESTED_CLASS, 'decorate_filter_source' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_action( 'do_shortcode_tag', [ self::TESTED_CLASS, 'decorate_shortcode_source' ] ) );
 
 		// Test overrides.
-		$validation_error_term_1 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( array( 'test' => 1 ) );
-		$validation_error_term_2 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( array( 'test' => 2 ) );
+		$validation_error_term_1 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( [ 'test' => 1 ] );
+		$validation_error_term_2 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( [ 'test' => 2 ] );
 		$_REQUEST[ AMP_Validation_Manager::VALIDATE_QUERY_VAR ] = AMP_Validation_Manager::get_amp_validate_nonce();
-		$_REQUEST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = array(
+		$_REQUEST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = [
 			$validation_error_term_1['slug'] => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 			$validation_error_term_2['slug'] => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS,
-		);
+		];
 		AMP_Validation_Manager::add_validation_error_sourcing();
 		$this->assertCount( 2, AMP_Validation_Manager::$validation_error_status_overrides );
 	}
@@ -349,7 +349,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$priority = has_filter( 'the_content', 'do_blocks' );
 		$this->assertNotFalse( $priority );
 		AMP_Validation_Manager::add_validation_error_sourcing();
-		$this->assertEquals( $priority - 1, has_filter( 'the_content', array( self::TESTED_CLASS, 'add_block_source_comments' ) ) );
+		$this->assertEquals( $priority - 1, has_filter( 'the_content', [ self::TESTED_CLASS, 'add_block_source_comments' ] ) );
 	}
 
 	/**
@@ -363,29 +363,29 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$_SERVER['REQUEST_METHOD'] = 'POST';
 		$GLOBALS['pagenow']        = 'post.php';
 
-		register_post_type( 'secret', array( 'public' => false ) );
-		$secret           = self::factory()->post->create_and_get( array( 'post_type' => 'secret' ) );
+		register_post_type( 'secret', [ 'public' => false ] );
+		$secret           = self::factory()->post->create_and_get( [ 'post_type' => 'secret' ] );
 		$_POST['post_ID'] = $secret->ID;
 		AMP_Validation_Manager::handle_save_post_prompting_validation( $secret->ID );
-		$this->assertFalse( has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );
+		$this->assertFalse( has_action( 'shutdown', [ 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ] ) );
 		$this->assertEmpty( AMP_Validation_Manager::validate_queued_posts_on_frontend() );
 
-		$auto_draft       = self::factory()->post->create_and_get( array( 'post_status' => 'auto-draft' ) );
+		$auto_draft       = self::factory()->post->create_and_get( [ 'post_status' => 'auto-draft' ] );
 		$_POST['post_ID'] = $auto_draft->ID;
 		AMP_Validation_Manager::handle_save_post_prompting_validation( $auto_draft->ID );
-		$this->assertFalse( has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );
+		$this->assertFalse( has_action( 'shutdown', [ 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ] ) );
 		$this->assertEmpty( AMP_Validation_Manager::validate_queued_posts_on_frontend() );
 
 		// Testing without $_POST context.
-		$post = self::factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'post' ] );
 		AMP_Validation_Manager::handle_save_post_prompting_validation( $post->ID );
-		$this->assertFalse( has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );
+		$this->assertFalse( has_action( 'shutdown', [ 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ] ) );
 
 		// Test success.
-		$post = self::factory()->post->create_and_get( array( 'post_type' => 'post' ) );
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'post' ] );
 		$_POST['post_ID'] = $post->ID;
 		AMP_Validation_Manager::handle_save_post_prompting_validation( $post->ID );
-		$this->assertEquals( 10, has_action( 'shutdown', array( 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ) ) );
+		$this->assertEquals( 10, has_action( 'shutdown', [ 'AMP_Validation_Manager', 'validate_queued_posts_on_frontend' ] ) );
 
 		add_filter(
 			'pre_http_request',
@@ -408,15 +408,15 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_add_rest_api_fields() {
 
 		// Test in a transitional context.
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Validation_Manager::add_rest_api_fields();
 		$post_types_non_canonical = array_intersect(
 			get_post_types_by_support( 'amp' ),
 			get_post_types(
-				array(
+				[
 					'show_in_rest' => true,
-				)
+				]
 			)
 		);
 		$this->assert_rest_api_field_present( $post_types_non_canonical );
@@ -439,12 +439,12 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			$field = $GLOBALS['wp_rest_additional_fields'][ $post_type ][ AMP_Validation_Manager::VALIDITY_REST_FIELD_NAME ];
 			$this->assertEquals(
 				$field['schema'],
-				array(
+				[
 					'description' => 'AMP validity status',
 					'type'        => 'object',
-				)
+				]
 			);
-			$this->assertEquals( $field['get_callback'], array( self::TESTED_CLASS, 'get_amp_validity_rest_field' ) );
+			$this->assertEquals( $field['get_callback'], [ self::TESTED_CLASS, 'get_amp_validity_rest_field' ] );
 		}
 	}
 
@@ -455,7 +455,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::validate_url()
 	 */
 	public function test_get_amp_validity_rest_field() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
@@ -470,11 +470,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		);
 
 		// Create an error custom post for the ID, so this will return the errors in the field.
-		$errors = array(
-			array(
+		$errors = [
+			[
 				'code' => 'test',
-			),
-		);
+			],
+		];
 		$this->create_custom_post(
 			$errors,
 			amp_get_permalink( $id )
@@ -489,7 +489,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			)
 		);
 
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		// GET request.
 		$field = AMP_Validation_Manager::get_amp_validity_rest_field(
@@ -503,13 +503,13 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			$field['results'],
 			array_map(
 				static function ( $error ) {
-					return array(
+					return [
 						'sanitized'   => false,
 						'error'       => $error,
 						'status'      => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 						'term_status' => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS,
 						'forced'      => false,
-					);
+					];
 				},
 				$errors
 			)
@@ -519,13 +519,13 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			static function() {
-				return array(
+				return [
 					'body'     => '<html><body></body><!--AMP_VALIDATION:{"results":[]}--></html>',
-					'response' => array(
+					'response' => [
 						'code'    => 200,
 						'message' => 'ok',
-					),
-				);
+					],
+				];
 			}
 		);
 		$field = AMP_Validation_Manager::get_amp_validity_rest_field(
@@ -546,9 +546,9 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_has_cap() {
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'subscriber',
-				)
+				]
 			)
 		);
 		$this->assertFalse( AMP_Validation_Manager::has_cap() );
@@ -581,25 +581,25 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		);
 
 		AMP_Validation_Manager::add_validation_error(
-			array(
+			[
 				'node_name'       => $this->node->nodeName,
 				'code'            => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
-				'node_attributes' => array(),
-			),
-			array(
+				'node_attributes' => [],
+			],
+			[
 				'node' => $this->node,
-			)
+			]
 		);
 
 		$this->assertCount( 1, AMP_Validation_Manager::$validation_results );
 		$this->assertEquals(
-			array(
+			[
 				'node_name'       => 'img',
-				'sources'         => array(),
+				'sources'         => [],
 				'code'            => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
-				'node_attributes' => array(),
+				'node_attributes' => [],
 				'filtered'        => true,
-			),
+			],
 			AMP_Validation_Manager::$validation_results[0]['error']
 		);
 	}
@@ -612,9 +612,9 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_add_validation_error_was_node_removed() {
 		$this->assertEmpty( AMP_Validation_Manager::$validation_results );
 		AMP_Validation_Manager::add_validation_error(
-			array(
+			[
 				'node' => $this->node,
-			)
+			]
 		);
 		$this->assertNotEmpty( AMP_Validation_Manager::$validation_results );
 	}
@@ -626,12 +626,12 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_reset_validation_results() {
 		AMP_Validation_Manager::add_validation_error(
-			array(
+			[
 				'code' => 'test',
-			)
+			]
 		);
 		AMP_Validation_Manager::reset_validation_results();
-		$this->assertEquals( array(), AMP_Validation_Manager::$validation_results );
+		$this->assertEquals( [], AMP_Validation_Manager::$validation_results );
 	}
 
 	/**
@@ -640,34 +640,34 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::print_edit_form_validation_status()
 	 */
 	public function test_print_edit_form_validation_status() {
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
 		$this->set_capability();
 		$post   = self::factory()->post->create_and_get();
-		$output = get_echo( array( 'AMP_Validation_Manager', 'print_edit_form_validation_status' ), array( $post ) );
+		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 
 		$this->assertNotContains( 'notice notice-warning', $output );
 
-		$validation_errors = array(
-			array(
+		$validation_errors = [
+			[
 				'code'            => AMP_Validation_Error_Taxonomy::INVALID_ELEMENT_CODE,
 				'node_name'       => $this->disallowed_tag_name,
 				'parent_name'     => 'div',
-				'node_attributes' => array(),
-				'sources'         => array(
-					array(
+				'node_attributes' => [],
+				'sources'         => [
+					[
 						'type' => 'plugin',
 						'name' => $this->plugin_name,
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
-		$output = get_echo( array( 'AMP_Validation_Manager', 'print_edit_form_validation_status' ), array( $post ) );
+		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 
 		// In 'Transitional' mode with 'auto_accept_sanitization' set to false.
 		$expected_notice_non_accepted_errors = 'There is content which fails AMP validation. Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.';
@@ -677,7 +677,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// In 'Standard' mode, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
 		add_theme_support( AMP_Theme_Support::SLUG );
-		$output = get_echo( array( 'AMP_Validation_Manager', 'print_edit_form_validation_status' ), array( $post ) );
+		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertContains( 'There is content which fails AMP validation. Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', $output );
 
 		/*
@@ -686,10 +686,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		 * as there are errors with 'New Rejected' status.
 		 */
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
-		add_theme_support( AMP_Theme_Support::SLUG, array( AMP_Theme_Support::PAIRED_FLAG => true ) );
+		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
-		$output = get_echo( array( 'AMP_Validation_Manager', 'print_edit_form_validation_status' ), array( $post ) );
+		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 	}
 
@@ -702,29 +702,29 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::remove_source_comments()
 	 */
 	public function test_source_comments() {
-		$source1 = array(
+		$source1 = [
 			'type'      => 'plugin',
 			'name'      => 'foo',
 			'shortcode' => 'test',
 			'function'  => __FUNCTION__,
-		);
-		$source2 = array(
+		];
+		$source2 = [
 			'type'     => 'theme',
 			'name'     => 'bar',
 			'function' => __FUNCTION__,
 			'hook'     => 'something',
-		);
+		];
 
 		$dom = AMP_DOM_Utils::get_dom_from_content(
 			implode(
 				'',
-				array(
+				[
 					AMP_Validation_Manager::get_source_comment( $source1, true ),
 					AMP_Validation_Manager::get_source_comment( $source2, true ),
 					'<b id="test">Test</b>',
 					AMP_Validation_Manager::get_source_comment( $source2, false ),
 					AMP_Validation_Manager::get_source_comment( $source1, false ),
-				)
+				]
 			)
 		);
 
@@ -733,7 +733,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		 *
 		 * @var DOMComment[] $comments
 		 */
-		$comments = array();
+		$comments = [];
 		$xpath    = new DOMXPath( $dom );
 		foreach ( $xpath->query( '//comment()' ) as $comment ) {
 			$comments[] = $comment;
@@ -779,16 +779,16 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$reflection_function = new ReflectionFunction( $latest_posts_block->render_callback );
 		$is_gutenberg = false !== strpos( $reflection_function->getFileName(), 'gutenberg' );
 
-		return array(
-			'paragraph'    => array(
+		return [
+			'paragraph'    => [
 				"<!-- wp:paragraph -->\n<p>Latest posts:</p>\n<!-- /wp:paragraph -->",
 				"<!--amp-source-stack {\"block_name\":\"core\/paragraph\",\"post_id\":{{post_id}},\"block_content_index\":0}-->\n<p>Latest posts:</p>\n<!--/amp-source-stack {\"block_name\":\"core\/paragraph\",\"post_id\":{{post_id}}}-->",
-				array(
+				[
 					'element' => 'p',
-					'blocks'  => array( 'core/paragraph' ),
-				),
-			),
-			'latest_posts' => array(
+					'blocks'  => [ 'core/paragraph' ],
+				],
+			],
+			'latest_posts' => [
 				'<!-- wp:latest-posts {"postsToShow":1,"categories":""} /-->',
 				sprintf(
 					'<!--amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_content_index":0,"block_attrs":{"postsToShow":1,"categories":""},"type":"%1$s","name":"%2$s","function":"%3$s"}--><ul class="wp-block-latest-posts wp-block-latest-posts__list"><li><a href="{{url}}">{{title}}</a></li></ul><!--/amp-source-stack {"block_name":"core\/latest-posts","post_id":{{post_id}},"block_attrs":{"postsToShow":1,"categories":""},"type":"%1$s","name":"%2$s","function":"%3$s"}-->',
@@ -796,23 +796,23 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 					$is_gutenberg ? 'gutenberg' : 'wp-includes',
 					$latest_posts_block->render_callback
 				),
-				array(
+				[
 					'element' => 'ul',
-					'blocks'  => array( 'core/latest-posts' ),
-				),
-			),
-			'columns'      => array(
+					'blocks'  => [ 'core/latest-posts' ],
+				],
+			],
+			'columns'      => [
 				"<!-- wp:columns -->\n<div class=\"wp-block-columns has-2-columns\">\n    <!-- wp:quote {\"layout\":\"column-1\",\"foo\":{\"bar\":1}} -->\n    <blockquote class=\"wp-block-quote layout-column-1\">\n        <p>A quotation!</p><cite>Famous</cite></blockquote>\n    <!-- /wp:quote -->\n\n    <!-- wp:html {\"layout\":\"column-2\"} -->\n    <div class=\"layout-column-2\">\n        <script>\n            document.write('Not allowed!');\n        </script>\n    </div>\n    <!-- /wp:html -->\n</div>\n<!-- /wp:columns -->",
 				"<!--amp-source-stack {\"block_name\":\"core\/columns\",\"post_id\":{{post_id}},\"block_content_index\":0}-->\n<div class=\"wp-block-columns has-2-columns\">\n\n\n\n<!--amp-source-stack {\"block_name\":\"core\/quote\",\"post_id\":{{post_id}},\"block_content_index\":1,\"block_attrs\":{\"layout\":\"column-1\",\"foo\":{\"bar\":1}}}-->\n    <blockquote class=\"wp-block-quote layout-column-1\">\n        <p>A quotation!</p><cite>Famous</cite></blockquote>\n    <!--/amp-source-stack {\"block_name\":\"core\/quote\",\"post_id\":{{post_id}}}--><!--amp-source-stack {\"block_name\":\"core\/html\",\"post_id\":{{post_id}},\"block_content_index\":2,\"block_attrs\":{\"layout\":\"column-2\"}}-->\n    <div class=\"layout-column-2\">\n        <script>\n            document.write('Not allowed!');\n        </script>\n    </div>\n    <!--/amp-source-stack {\"block_name\":\"core\/html\",\"post_id\":{{post_id}}}--></div>\n<!--/amp-source-stack {\"block_name\":\"core\/columns\",\"post_id\":{{post_id}}}-->",
-				array(
+				[
 					'element' => 'blockquote',
-					'blocks'  => array(
+					'blocks'  => [
 						'core/columns',
 						'core/quote',
-					),
-				),
-			),
-		);
+					],
+				],
+			],
+		];
 	}
 
 	/**
@@ -841,16 +841,16 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$rendered_block = do_blocks( AMP_Validation_Manager::add_block_source_comments( $content ) );
 
 		$expected = str_replace(
-			array(
+			[
 				'{{post_id}}',
 				'{{title}}',
 				'{{url}}',
-			),
-			array(
+			],
+			[
 				$post->ID,
 				get_the_title( $post ),
 				get_permalink( $post ),
-			),
+			],
 			$expected
 		);
 
@@ -896,12 +896,12 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		$sidebar_id = 'amp-sidebar';
 		register_sidebar(
-			array(
+			[
 				'id'           => $sidebar_id,
 				'after_widget' => '</li>',
-			)
+			]
 		);
-		$_wp_sidebars_widgets[ $sidebar_id ] = array( $widget_id );
+		$_wp_sidebars_widgets[ $sidebar_id ] = [ $widget_id ];
 
 		AMP_Theme_Support::start_output_buffering();
 		dynamic_sidebar( $sidebar_id );
@@ -939,20 +939,20 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::add_validation_error_sourcing();
 
 		add_action( $action_function_callback, '_amp_show_load_errors_admin_notice' );
-		add_action( $action_no_argument, array( $this, 'output_div' ) );
-		add_action( $action_one_argument, array( $this, 'output_notice' ) );
-		add_action( $action_two_arguments, array( $this, 'output_message' ), 10, 2 );
-		add_action( $action_no_output, array( $this, 'get_string' ), 10, 2 );
+		add_action( $action_no_argument, [ $this, 'output_div' ] );
+		add_action( $action_one_argument, [ $this, 'output_notice' ] );
+		add_action( $action_two_arguments, [ $this, 'output_message' ], 10, 2 );
+		add_action( $action_no_output, [ $this, 'get_string' ], 10, 2 );
 		add_action( $action_no_tag_output, 'the_ID' );
 		add_action( $action_core_output, 'edit_post_link' );
 		add_action( $action_no_output, '__return_false' );
 
 		// All of the callback functions remain as-is. They will only change for a given hook at the 'all' action.
 		$this->assertEquals( 10, has_action( $action_no_tag_output, 'the_ID' ) );
-		$this->assertEquals( 10, has_action( $action_no_output, array( $this, 'get_string' ) ) );
-		$this->assertEquals( 10, has_action( $action_no_argument, array( $this, 'output_div' ) ) );
-		$this->assertEquals( 10, has_action( $action_one_argument, array( $this, 'output_notice' ) ) );
-		$this->assertEquals( 10, has_action( $action_two_arguments, array( $this, 'output_message' ) ) );
+		$this->assertEquals( 10, has_action( $action_no_output, [ $this, 'get_string' ] ) );
+		$this->assertEquals( 10, has_action( $action_no_argument, [ $this, 'output_div' ] ) );
+		$this->assertEquals( 10, has_action( $action_one_argument, [ $this, 'output_notice' ] ) );
+		$this->assertEquals( 10, has_action( $action_two_arguments, [ $this, 'output_message' ] ) );
 
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_function_callback );
@@ -1027,13 +1027,13 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertEquals(
 			implode(
 				'',
-				array(
+				[
 					'<!--amp-source-stack {"type":"plugin","name":"amp","function":"{closure}","hook":"outer_action"}-->',
 					'<!--amp-source-stack {"type":"plugin","name":"amp","function":"{closure}","hook":"inner_action"}-->',
 					'<b>Hello</b>',
 					'<!--/amp-source-stack {"type":"plugin","name":"amp","function":"{closure}","hook":"inner_action"}-->',
 					'<!--/amp-source-stack {"type":"plugin","name":"amp","function":"{closure}","hook":"outer_action"}-->',
-				)
+				]
 			),
 			$output
 		);
@@ -1082,11 +1082,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		$expected_content = implode(
 			'',
-			array(
+			[
 				"<!--amp-source-stack $source_json-->",
 				'<p>before<!--amp-source-stack {"type":"plugin","name":"amp","function":"{closure}","shortcode":"test"}--><b>test</b><!--/amp-source-stack {"type":"plugin","name":"amp","function":"{closure}","shortcode":"test"}-->after</p>' . "\n",
 				"<!--/amp-source-stack $source_json-->",
-			)
+			]
 		);
 
 		$this->assertEquals(
@@ -1130,17 +1130,17 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_filter_wrapped_callback() {
 		$test_string     = 'Filter-amended Value';
-		$filter_callback = array(
+		$filter_callback = [
 			'function'      => static function ( $value ) use ( $test_string ) {
 				return $value . $test_string;
 			},
 			'accepted_args' => 1,
-			'source'        => array(
+			'source'        => [
 				'type' => 'plugin',
 				'name' => 'amp',
 				'hook' => 'foo',
-			),
-		);
+			],
+		];
 
 		$value = 'Some Value';
 		apply_filters( 'foo', $value );
@@ -1160,17 +1160,17 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_action_wrapped_callback() {
 		$test_string     = "<b class='\nfoo\nbar\n'>Cool!</b>";
-		$action_callback = array(
+		$action_callback = [
 			'function'      => static function() use ( $test_string ) {
 				echo $test_string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			},
 			'accepted_args' => 1,
-			'source'        => array(
+			'source'        => [
 				'type' => 'plugin',
 				'name' => 'amp',
 				'hook' => 'bar',
-			),
-		);
+			],
+		];
 
 		do_action( 'bar' ); // So that output buffering will be done.
 		$wrapped_callback = AMP_Validation_Manager::wrapped_callback( $action_callback );
@@ -1184,15 +1184,15 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
 		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
 
-		$action_callback = array(
-			'function'      => array( $this, 'get_string' ),
+		$action_callback = [
+			'function'      => [ $this, 'get_string' ],
 			'accepted_args' => 0,
-			'source'        => array(
+			'source'        => [
 				'type' => 'plugin',
 				'name' => 'amp',
 				'hook' => 'bar',
-			),
-		);
+			],
+		];
 
 		$wrapped_callback = AMP_Validation_Manager::wrapped_callback( $action_callback );
 		$this->assertInstanceOf( '\\AMP_Validation_Callback_Wrapper', $wrapped_callback );
@@ -1214,8 +1214,8 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$initial_content = '<html><body></body></html>';
 		$this->assertEquals( $initial_content, AMP_Validation_Manager::wrap_buffer_with_source_comments( $initial_content ) );
 
-		$earliest_source = array( 'plugin' => 'foo' );
-		$latest_source   = array( 'theme' => 'bar' );
+		$earliest_source = [ 'plugin' => 'foo' ];
+		$latest_source   = [ 'theme' => 'bar' ];
 
 		// Doesn't use array_merge, as wrap_buffer_with_source_comments() accesses this array with indices like 1 or 2.
 		AMP_Validation_Manager::$hook_source_stack[] = $earliest_source;
@@ -1268,14 +1268,14 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$html           = '<html><body><div id="wp-admin-bar-amp-validity"><a href="#"></a></div><span id="amp-admin-bar-item-status-icon"></span><br></body></html>';
 		$dom->loadHTML( $html );
 
-		$validation_results                         = array(
-			array(
-				'error'       => array( 'code' => 'invalid_attribute' ),
+		$validation_results                         = [
+			[
+				'error'       => [ 'code' => 'invalid_attribute' ],
 				'sanitized'   => false,
 				'slug'        => '98765b4',
 				'term_status' => 0,
-			),
-		);
+			],
+		];
 		AMP_Validation_Manager::$validation_results = $validation_results;
 
 		// should_validate_response() will be false, so finalize_validation() won't append the _RESULTS comment.
@@ -1300,11 +1300,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_filter_sanitizer_args() {
 		global $post;
 		$post       = self::factory()->post->create_and_get();
-		$sanitizers = array(
-			'AMP_Img_Sanitizer'      => array(),
-			'AMP_Form_Sanitizer'     => array(),
-			'AMP_Comments_Sanitizer' => array(),
-		);
+		$sanitizers = [
+			'AMP_Img_Sanitizer'      => [],
+			'AMP_Form_Sanitizer'     => [],
+			'AMP_Comments_Sanitizer' => [],
+		];
 
 		$expected_callback   = self::TESTED_CLASS . '::add_validation_error';
 		$filtered_sanitizers = AMP_Validation_Manager::filter_sanitizer_args( $sanitizers );
@@ -1326,33 +1326,33 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertEquals( 'no_published_post_url_available', $r->get_error_code() );
 		remove_filter( 'amp_pre_get_permalink', '__return_empty_string' );
 
-		$validation_error = array(
+		$validation_error = [
 			'code' => 'example',
-		);
+		];
 
-		$validation = array(
-			'results' => array(
-				array(
+		$validation = [
+			'results' => [
+				[
 					'error'     => $validation_error,
 					'sanitized' => false,
-				),
-			),
-		);
+				],
+			],
+		];
 
 		self::factory()->post->create();
 		$filter = static function() use ( $validation ) {
-			return array(
+			return [
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
 					'AMP_VALIDATION:' . wp_json_encode( $validation )
 				),
-			);
+			];
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 		$r = AMP_Validation_Manager::validate_after_plugin_activation();
 		remove_filter( 'pre_http_request', $filter );
-		$this->assertEquals( array( $validation_error ), $r );
-		$this->assertEquals( array( $validation_error ), get_transient( AMP_Validation_Manager::PLUGIN_ACTIVATION_VALIDATION_ERRORS_TRANSIENT_KEY ) );
+		$this->assertEquals( [ $validation_error ], $r );
+		$this->assertEquals( [ $validation_error ], get_transient( AMP_Validation_Manager::PLUGIN_ACTIVATION_VALIDATION_ERRORS_TRANSIENT_KEY ) );
 	}
 
 	/**
@@ -1363,19 +1363,19 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_validate_url() {
 		add_theme_support( AMP_Theme_Support::SLUG );
 
-		$validation_errors = array(
-			array(
+		$validation_errors = [
+			[
 				'code' => 'example',
-			),
-		);
+			],
+		];
 
 		// Test headers absent.
 		self::factory()->post->create();
 		$filter = static function() {
-			return array(
+			return [
 				'body'    => '',
-				'headers' => array(),
-			);
+				'headers' => [],
+			];
 		};
 		add_filter( 'pre_http_request', $filter );
 		$r = AMP_Validation_Manager::validate_url( home_url( '/' ) );
@@ -1395,18 +1395,18 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 				),
 				$url
 			);
-			$validation = array( 'results' => array() );
+			$validation = [ 'results' => [] ];
 			foreach ( $validation_errors as $error ) {
 				$sanitized            = false;
 				$validation['results'][] = compact( 'error', 'sanitized' );
 			}
 
-			return array(
+			return [
 				'body' => sprintf(
 					'<html amp><head></head><body></body><!--%s--></html>',
 					'AMP_VALIDATION:' . wp_json_encode( $validation )
 				),
-			);
+			];
 		};
 		add_filter( 'pre_http_request', $filter, 10, 3 );
 		$r = AMP_Validation_Manager::validate_url( $validated_url );
@@ -1423,26 +1423,26 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_print_plugin_notice() {
 		global $pagenow;
-		$output = get_echo( array( 'AMP_Validation_Manager', 'print_plugin_notice' ) );
+		$output = get_echo( [ 'AMP_Validation_Manager', 'print_plugin_notice' ] );
 		$this->assertEmpty( $output );
 		$pagenow          = 'plugins.php';
 		$_GET['activate'] = 'true';
 
 		set_transient(
 			AMP_Validation_Manager::PLUGIN_ACTIVATION_VALIDATION_ERRORS_TRANSIENT_KEY,
-			array(
-				array(
+			[
+				[
 					'code'    => 'example',
-					'sources' => array(
-						array(
+					'sources' => [
+						[
 							'type' => 'plugin',
 							'name' => 'foo-bar',
-						),
-					),
-				),
-			)
+						],
+					],
+				],
+			]
 		);
-		$output = get_echo( array( 'AMP_Validation_Manager', 'print_plugin_notice' ) );
+		$output = get_echo( [ 'AMP_Validation_Manager', 'print_plugin_notice' ] );
 		$this->assertContains( 'Warning: The following plugin may be incompatible with AMP', $output );
 		$this->assertContains( $this->plugin_name, $output );
 		$this->assertContains( 'More details', $output );
@@ -1467,7 +1467,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::enqueue_block_validation();
 
 		$script                = wp_scripts()->registered[ $slug ];
-		$expected_dependencies = array(
+		$expected_dependencies = [
 			'lodash',
 			'wp-block-editor',
 			'wp-components',
@@ -1477,7 +1477,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			'wp-hooks',
 			'wp-i18n',
 			'wp-polyfill',
-		);
+		];
 
 		$this->assertContains( 'js/amp-block-validation.js', $script->src );
 		$this->assertEqualSets( $expected_dependencies, $script->deps );
@@ -1505,12 +1505,12 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::enqueue_block_validation();
 		$this->assertNotContains( $slug, wp_scripts()->queue );
 
-		AMP_Options_Manager::update_option( 'experiences', array( AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ) );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
 		$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
 		AMP_Story_Post_Type::register();
 		if ( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
-			$post = $this->factory()->post->create_and_get( array( 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ) );
+			$post = $this->factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 			AMP_Validation_Manager::enqueue_block_validation();
 			$this->assertContains( $slug, wp_scripts()->queue );
 		}
@@ -1530,10 +1530,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		/** This filter is documented in wp-includes/post-template.php */
 		$markup = apply_filters( 'the_content', $markup );
-		$args   = array(
+		$args   = [
 			'content_max_width'         => ! empty( $content_width ) ? $content_width : AMP_Post_Template::CONTENT_MAX_WIDTH,
 			'validation_error_callback' => 'AMP_Validation_Manager::add_validation_error',
-		);
+		];
 
 		$results = AMP_Content_Sanitizer::sanitize( $markup, amp_get_content_sanitizers(), $args );
 		return $results[0];
@@ -1545,13 +1545,13 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function test_process_markup() {
 		$this->set_capability();
 		$this->process_markup( $this->valid_amp_img );
-		$this->assertEquals( array(), AMP_Validation_Manager::$validation_results );
+		$this->assertEquals( [], AMP_Validation_Manager::$validation_results );
 
 		AMP_Validation_Manager::reset_validation_results();
 		$video = '<video src="https://example.com/video">';
 		$this->process_markup( $video );
 		// This isn't valid AMP, but the sanitizer should convert it to an <amp-video>, without stripping anything.
-		$this->assertEquals( array(), AMP_Validation_Manager::$validation_results );
+		$this->assertEquals( [], AMP_Validation_Manager::$validation_results );
 
 		AMP_Validation_Manager::reset_validation_results();
 
@@ -1562,7 +1562,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::reset_validation_results();
 		$disallowed_style = '<div style="display:none"></div>';
 		$this->process_markup( $disallowed_style );
-		$this->assertEquals( array(), AMP_Validation_Manager::$validation_results );
+		$this->assertEquals( [], AMP_Validation_Manager::$validation_results );
 
 		AMP_Validation_Manager::reset_validation_results();
 		$invalid_video = '<video width="200" height="100"></video>';
@@ -1586,9 +1586,9 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	public function set_capability() {
 		wp_set_current_user(
 			self::factory()->user->create(
-				array(
+				[
 					'role' => 'administrator',
-				)
+				]
 			)
 		);
 	}
@@ -1641,7 +1641,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @param string $url    URL that the errors occur on. Defaults to the home page.
 	 * @return int|WP_Error $error_post The ID of new custom post, or an error.
 	 */
-	public function create_custom_post( $errors = array(), $url = null ) {
+	public function create_custom_post( $errors = [], $url = null ) {
 		if ( ! $url ) {
 			$url = home_url( '/' );
 		}


### PR DESCRIPTION
This is a bit of a follow-up to #2493.

The main plugin file, `amp.php`, is left untouched as it still should be parseable on PHP 5.2.

Also does not change `includes/sanitizers/class-amp-allowed-tags-generated.php` as it is auto-generated.