### PR TITLE
Convert 100% width Facebook widgets to fixed-height layout

### DIFF
--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -200,6 +200,10 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 			'width'  => $node->hasAttribute( 'data-width' ) ? $node->getAttribute( 'data-width' ) : $this->DEFAULT_WIDTH,
 			'height' => $node->hasAttribute( 'data-height' ) ? $node->getAttribute( 'data-height' ) : $this->DEFAULT_HEIGHT,
 		];
+		if ( '100%' === $attributes['width'] ) {
+			$attributes['layout'] = 'fixed-height';
+			$attributes['width']  = 'auto';
+		}
 
 		$node->removeAttribute( 'data-width' );
 		$node->removeAttribute( 'data-height' );

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -184,6 +184,13 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'<amp-facebook-comments layout="responsive" width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
 			],
 
+			'comments_full_width'   => [
+				'
+					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
+				',
+				'<amp-facebook-comments layout="fixed-height" width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
+			],
+
 			'comment_embed'         => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>


### PR DESCRIPTION
This addresses an issue identified in the AMP plugin forum: https://wordpress.org/support/topic/amp-error-on-facebook-widget-width/

Given input such as:

```html
<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
```

The AMP plugin is currently converting this into:

```html
<amp-facebook-comments layout="responsive" width="100%" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5">
```

This is an error because AMP does not allow percentage widths. So this PR causes the embed to be output instead as:

```html
<amp-facebook-comments layout="fixed-height" width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5">
```

This was done elsewhere in https://github.com/ampproject/amp-wp/pull/2712. Also related to https://github.com/ampproject/amp-wp/issues/2146.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3375776/amp.zip) (v1.2.1-alpha-20190710T044256Z-4a34c951)