### PR TITLE
Fix conversion of CSS selectors when HTML tag maps to multiple AMP tags

### DIFF
--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -3,11 +3,11 @@
  * Prevent cases of amp-img converted from img to appear with stretching by using object-fit to scale.
  * See <https://github.com/ampproject/amphtml/issues/21371#issuecomment-475443219>.
  * Also use object-fit:contain in worst case scenario when we can't figure out dimensions for an image.
+ * Additionally, in side of \AMP_Img_Sanitizer::determine_dimensions() it could $amp_img->setAttribute( 'object-fit', 'contain' )
+ * so that the following rules wouldn't be needed.
  */
 amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img,
-amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img,
-amp-img.amp-wp-unknown-size > img,
-amp-anim.amp-wp-unknown-size > img {
+amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img {
 	object-fit: contain;
 }
 

--- a/assets/css/amp-default.css
+++ b/assets/css/amp-default.css
@@ -5,7 +5,9 @@
  * Also use object-fit:contain in worst case scenario when we can't figure out dimensions for an image.
  */
 amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img,
-.amp-wp-unknown-size > img {
+amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img,
+amp-img.amp-wp-unknown-size > img,
+amp-anim.amp-wp-unknown-size > img {
 	object-fit: contain;
 }
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -233,6 +233,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 					$class = '';
 				}
 				if ( ! $dimensions ) {
+					// @todo Why not $node->setAttribute( 'object-fit', 'contain' )? The no need for the CSS rule in amp-default.css.
 					$class .= ' amp-wp-unknown-size';
 				}
 
@@ -254,6 +255,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 					$node->setAttribute( 'width', $width );
 					if ( ! isset( $dimensions['width'] ) ) {
+						// @todo Why not $node->setAttribute( 'object-fit', 'contain' )? The no need for the CSS rule in amp-default.css.
 						$class .= ' amp-wp-unknown-width';
 					}
 				}
@@ -266,6 +268,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 					$node->setAttribute( 'height', $height );
 					if ( ! isset( $dimensions['height'] ) ) {
+						// @todo Why not $node->setAttribute( 'object-fit', 'contain' )? The no need for the CSS rule in amp-default.css.
 						$class .= ' amp-wp-unknown-height';
 					}
 				}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -233,7 +233,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 					$class = '';
 				}
 				if ( ! $dimensions ) {
-					// @todo Why not $node->setAttribute( 'object-fit', 'contain' )? The no need for the CSS rule in amp-default.css.
+					$node->setAttribute( 'object-fit', 'contain' );
 					$class .= ' amp-wp-unknown-size';
 				}
 
@@ -255,7 +255,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 					$node->setAttribute( 'width', $width );
 					if ( ! isset( $dimensions['width'] ) ) {
-						// @todo Why not $node->setAttribute( 'object-fit', 'contain' )? The no need for the CSS rule in amp-default.css.
 						$class .= ' amp-wp-unknown-width';
 					}
 				}
@@ -268,7 +267,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 					$node->setAttribute( 'height', $height );
 					if ( ! isset( $dimensions['height'] ) ) {
-						// @todo Why not $node->setAttribute( 'object-fit', 'contain' )? The no need for the CSS rule in amp-default.css.
 						$class .= ' amp-wp-unknown-height';
 					}
 				}

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -168,7 +168,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_bad_src_url_get_fallback_dims' => [
 				'<img src="https://example.com/404.png" />',
-				'<amp-img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height"></noscript></amp-img>',
+				'<amp-img src="https://example.com/404.png" object-fit="contain" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://example.com/404.png" width="' . AMP_Img_Sanitizer::FALLBACK_WIDTH . '" height="' . AMP_Img_Sanitizer::FALLBACK_HEIGHT . '" class="amp-wp-unknown-size amp-wp-unknown-width amp-wp-unknown-height"></noscript></amp-img>',
 			],
 
 			'gif_image_conversion'                     => [

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -608,6 +608,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'div img{border:solid 1px red}',
 				'div amp-img,div amp-anim{border:solid 1px red}',
 			],
+			'amp-img-and-amp-anim' => [
+				sprintf( '<amp-img class="logo amp-wp-enforced-sizes" src="%s" width="200" height="100" layout="intrinsic"></amp-img><amp-anim class="spinner amp-wp-enforced-sizes" src="%s" width="200" height="100" layout="intrinsic"></amp-anim>', admin_url( 'images/wordpress-logo.png' ), admin_url( 'images/spinner-2x.gif' ) ),
+				'amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img,amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img{object-fit:contain}',
+				'amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img,amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img{object-fit:contain}',
+			],
 			'img_with_amp_img' => [
 				'<amp-img></amp-img>',
 				'amp-img img{background-color:red}',


### PR DESCRIPTION
Fixes #2792.

A CSS rule such as:

```css
amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img { 
   /* ... */
}
```

Was erroneously being converted into:

```css
amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img, 
amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > amp-img, 
amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > amp-anim { 
   /* ... */
}
```

It should not have been converted at all because the selector already mentioned an AMP component, an indicator that no conversion should be done.

This was breaking this rule:

https://github.com/ampproject/amp-wp/blob/2fe67959eb425b83273699c885881c85de1eb96b/assets/css/amp-default.css#L7-L10

Resulting in GIF images (in `amp-anim`) not getting the `object-fit:contain` style, and the result is that they were appearing as stretched. This PR fixes the selector mapping conversion logic to properly convert all HTML elements to their mapped AMP equivalents in selectors.

In general, this PR fixes the rendering of center-aligned animated GIFs, especially in the Classic block. For example, this `post_content`:

```html
Paragraph before image.

<img class="aligncenter size-full wp-image-2037" src="https://blog.amp.dev/wp-content/uploads/2018/05/webpackaging.gif" alt="webpackaging" width="394" height="786">

Paragraph after image
```

This PR also adds a missing `amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img` selector in the rule that applies `object-fit:constraint`.

It also eliminates the `.amp-wp-unknown-size > img {object-fit:constraint }` style rule since it was broken (erroneously the `img`  would get replaced with `amp-img` and `amp-anim`), and instead opting for a newer `object-fit=contain` attribute on the `amp-img`/`amp-anim` itself.