### PR TITLE
Fix endless loop with manual font sizes.

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -43,17 +43,19 @@ class TextBlockEdit extends Component {
 			content,
 		} = attributes;
 
-		if (
+		const checkFontSize = (
 			prevProps.attributes.height === height &&
 			prevProps.attributes.width === width &&
-			prevProps.attributes.content === content &&
-			isEqual( prevProps.fontSize, fontSize )
-		) {
-			return;
+			prevProps.attributes.content === content
+		);
+
+		if ( checkFontSize ) {
+			maybeUpdateFontSize( this.props );
 		}
 
-		maybeUpdateFontSize( this.props );
-		maybeUpdateBlockDimensions( this.props );
+		if ( ! isEqual( prevProps.fontSize, fontSize ) ) {
+			maybeUpdateBlockDimensions( this.props );
+		}
 	}
 
 	onReplace( blocks ) {

--- a/assets/src/stories-editor/components/with-meta-block-edit.js
+++ b/assets/src/stories-editor/components/with-meta-block-edit.js
@@ -38,18 +38,23 @@ class MetaBlockEdit extends Component {
 			width,
 		} = attributes;
 
-		// If not selected, only proceed if height or width has changed.
-		if (
-			! isSelected &&
-			prevProps.attributes.height === height &&
-			prevProps.attributes.width === width &&
-			isEqual( prevProps.fontSize, fontSize )
-		) {
-			return;
+		// If not selected, only change font size if height or width has changed.
+		const checkFontSize = (
+			isSelected ||
+			(
+				! isSelected &&
+				prevProps.attributes.height === height &&
+				prevProps.attributes.width === width
+			)
+		);
+
+		if ( checkFontSize ) {
+			maybeUpdateFontSize( this.props );
 		}
 
-		maybeUpdateFontSize( this.props );
-		maybeUpdateBlockDimensions( this.props );
+		if ( ! isEqual( prevProps.fontSize, fontSize ) ) {
+			maybeUpdateBlockDimensions( this.props );
+		}
 	}
 
 	render() {

--- a/assets/src/stories-editor/components/with-meta-block-edit.js
+++ b/assets/src/stories-editor/components/with-meta-block-edit.js
@@ -42,7 +42,6 @@ class MetaBlockEdit extends Component {
 		const checkFontSize = (
 			isSelected ||
 			(
-				! isSelected &&
 				prevProps.attributes.height === height &&
 				prevProps.attributes.width === width
 			)


### PR DESCRIPTION
Fixes #2794 

Splits the conditions for executing `maybeUpdateFontSize` and `maybeUpdateBlockDimensions`.