### PR TITLE
Resize blocks when amp-fit-text is turned off

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -41,19 +41,25 @@ class TextBlockEdit extends Component {
 			height,
 			width,
 			content,
+			ampFitText,
 		} = attributes;
 
 		const checkFontSize = (
-			prevProps.attributes.height === height &&
-			prevProps.attributes.width === width &&
-			prevProps.attributes.content === content
+			prevProps.attributes.height !== height ||
+			prevProps.attributes.width !== width ||
+			prevProps.attributes.content !== content
 		);
 
 		if ( checkFontSize ) {
 			maybeUpdateFontSize( this.props );
 		}
 
-		if ( ! isEqual( prevProps.fontSize, fontSize ) ) {
+		const checkBlockDimensions = (
+			! isEqual( prevProps.fontSize, fontSize ) ||
+			( prevProps.attributes.ampFitText !== ampFitText && ! ampFitText )
+		);
+
+		if ( checkBlockDimensions ) {
 			maybeUpdateBlockDimensions( this.props );
 		}
 	}

--- a/assets/src/stories-editor/components/with-meta-block-edit.js
+++ b/assets/src/stories-editor/components/with-meta-block-edit.js
@@ -36,22 +36,26 @@ class MetaBlockEdit extends Component {
 		const {
 			height,
 			width,
+			ampFitText,
 		} = attributes;
 
 		// If not selected, only change font size if height or width has changed.
 		const checkFontSize = (
 			isSelected ||
-			(
-				prevProps.attributes.height === height &&
-				prevProps.attributes.width === width
-			)
+			prevProps.attributes.height !== height ||
+			prevProps.attributes.width !== width
 		);
 
 		if ( checkFontSize ) {
 			maybeUpdateFontSize( this.props );
 		}
 
-		if ( ! isEqual( prevProps.fontSize, fontSize ) ) {
+		const checkBlockDimensions = (
+			! isEqual( prevProps.fontSize, fontSize ) ||
+			( prevProps.attributes.ampFitText !== ampFitText && ! ampFitText )
+		);
+
+		if ( checkBlockDimensions ) {
 			maybeUpdateBlockDimensions( this.props );
 		}
 	}


### PR DESCRIPTION
As pointed out during QA, the text blocks were not resizing properly when amp-fit-text was turned off. This PR addresses that.

Also, I noticed that #2797 did not reverse the conditions for when to apply these calculations.

Previously, it returned when dimensions and content were equal. Then, it was changed to perform the calculation when they are equal. Instead, calculation should happen when the attributes are **not** equal.

Fixes #2719.