### PR TITLE
Add pause button for video header

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2422,6 +2422,28 @@ class AMP_Theme_Support {
 					]
 				)
 			);
+
+			// @todo Also add this for amp-youtube?
+			$video_markup .= '<amp-state id="headerVideoPaused"><script type="application/json">false</script></amp-state>';
+			$video_markup .= sprintf(
+				'<button type="button" id="wp-custom-header-video-button" class="wp-custom-header-video-button wp-custom-header-video-play" [class]="%s" on="%s">',
+				esc_attr( '"wp-custom-header-video-button " + ( headerVideoPaused ? "wp-custom-header-video-play" : "wp-custom-header-video-pause" )' ),
+				esc_attr( 'tap:AMP.setState( { headerVideoPaused: ! headerVideoPaused } ),wp-custom-header-video.pause' ) // @todo There needs to be a way to play the video again, but there is no togglePlay action and there is no paused attribute on amp-video and thus no bindable [paused] attribute for us to connect to the headerVideoPaused state.
+			);
+			$video_markup .= sprintf(
+				'<span class="screen-reader-text" [text]="%s">%s</span>',
+				esc_attr(
+					sprintf(
+						'headerVideoPaused ? %s : %s',
+						wp_json_encode( __( 'Play background video', 'default' ), JSON_UNESCAPED_UNICODE ),
+						wp_json_encode( __( 'Pause background video', 'default' ), JSON_UNESCAPED_UNICODE )
+					)
+				),
+				esc_html__( 'Pause background video', 'default' )
+			);
+			$video_markup .= '<svg class="icon icon-pause" [hidden]="headerVideoPaused" aria-hidden="true" role="img"><use href="#icon-pause" xlink:href="#icon-pause"></use></svg>';
+			$video_markup .= '<svg class="icon icon-play" [hidden]="! headerVideoPaused" hidden aria-hidden="true" role="img"><use href="#icon-play" xlink:href="#icon-play"></use></svg>';
+			$video_markup .= '</button>';
 		}
 
 		return $image_markup . $video_markup;


### PR DESCRIPTION
As noted by @swissspidy in #2642:

> In the non-AMP version, `wp-includes/js/wp-custom-header.js` adds a button with the ID `wp-custom-header-video-button` that allows to pause/play the video header, to make custom video headers more accessible.
>
> It would be nice if we could keep this accessibility level. Perhaps in a separate PR?

This PR looks to add that button.

There is one issue, however: `amp-bind` is not set up to allow toggling the `paused` state of an `amp-video`. Neither is there a `togglePlay` action exposed on `amp-video`. There are only `play` and `pause` actions. This means that the singular `wp-custom-header-video-button` will not work as-is in how it toggles pause/play. There will need to be two separate buttons, one for `pause` and another for `play` and only one can be shown at a time. For accessibility, we'll need to ensure that `focus` is put on the alternate button when toggling.

We should also consider adding the play/pause button for the YouTube videos.