### PR TITLE
Automatically set poster images for videos

### DIFF
--- a/assets/src/common/helpers/index.js
+++ b/assets/src/common/helpers/index.js
@@ -392,3 +392,27 @@ export const getContentLengthFromUrl = async ( url ) => {
 	} );
 	return Number( response.headers.get( 'content-length' ) );
 };
+
+/**
+ * On selecting a video, ensure that there is a poster image.
+ *
+ * Not an arrow function so that it can be called like maybeSupplyPoster.call( this, media ).
+ * @todo: if the image matches the defaultImagePattern or it doesn't exist,
+ * get an image using canvas, like Weston suggested.
+ * Then POST the image to an endpoint, and use that image if it succeeds.
+ *
+ * @param {Object} media The selected media.
+ */
+export const maybeSupplyPoster = function( media ) {
+	if ( ! media || ! media.image ) {
+		return;
+	}
+
+	// Videos often have a 'default' image from WP core as media.image, which isn't useful as a poster.
+	const defaultImagePattern = /wp-includes\/images\/media\/video\.png$/;
+	const { image } = media;
+	if ( ! image.src.match( defaultImagePattern ) ) {
+		const { setAttributes } = this.props;
+		setAttributes( { poster: image.src } );
+	}
+};

--- a/assets/src/common/helpers/test/maybeSupplyPoster.js
+++ b/assets/src/common/helpers/test/maybeSupplyPoster.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { Component } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { maybeSupplyPoster } from '../';
+import { Mock } from './fixtures/mockClasses';
+
+/**
+ * Sets the component's attributes.
+ *
+ * @param {Object} attributes The attributes to set.
+ */
+const setAttributes = function( attributes ) {
+	for ( const attributeName in attributes ) {
+		if ( attributes.hasOwnProperty( attributeName ) ) {
+			this.props.attributes[ attributeName ] = attributes[ attributeName ];
+		}
+	}
+};
+
+describe( 'maybeSupplyPoster', () => {
+	it( 'it should not attempt to set the poster if the media argument is falsey', () => {
+		const mockThis = new Component();
+		const media = null;
+		maybeSupplyPoster.call( mockThis, media );
+
+		expect( mockThis.props ).toBe( undefined );
+	} );
+
+	it( 'should not attempt to set the poster if the media only has the default video image', () => {
+		const mockThis = new Component();
+		const media = new Mock();
+		const src = 'https://example.com/wp-includes/images/media/video.png';
+		media.set( {
+			image: { src },
+		} );
+		maybeSupplyPoster.call( mockThis, media );
+
+		expect( mockThis.props ).toBe( undefined );
+	} );
+
+	it( 'should set the poster if the media has an image that is not the default', () => {
+		const mockThis = new Component();
+		mockThis.props = {
+			attributes: {},
+			setAttributes: setAttributes.bind( mockThis ),
+		};
+
+		const media = new Mock();
+		const src = 'https://example.com/wp-content/uploads/2019/10/baz-video-poster.png';
+		media.set( {
+			image: { src },
+		} );
+		maybeSupplyPoster.call( mockThis, media );
+
+		expect( mockThis.props.attributes.poster ).toBe( src );
+	} );
+} );

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.js
@@ -45,6 +45,7 @@ import {
 } from '../../helpers';
 import {
 	getVideoBytesPerSecond,
+	maybeSupplyPoster,
 	isVideoSizeExcessive,
 } from '../../../common/helpers';
 
@@ -134,6 +135,7 @@ class PageEdit extends Component {
 			mediaType,
 			poster: VIDEO_BACKGROUND_TYPE === mediaType && media.image && media.image.src !== media.icon ? media.image.src : undefined,
 		} );
+		maybeSupplyPoster.call( this, media );
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -37,7 +37,7 @@ import { withSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getContentLengthFromUrl, isVideoSizeExcessive } from '../../common/helpers';
+import { getContentLengthFromUrl, isVideoSizeExcessive, maybeSupplyPoster } from '../../common/helpers';
 import { MEGABYTE_IN_BYTES, VIDEO_ALLOWED_MEGABYTES_PER_SECOND } from '../../common/constants';
 
 const ALLOWED_MEDIA_TYPES = [ 'video' ];
@@ -188,6 +188,7 @@ class CustomVideoBlockEdit extends Component {
 			// selected media, then switches off the editing UI
 			setAttributes( { src: media.url, id: media.id } );
 			this.setState( { src: media.url, editing: false, duration: null, videoSize: null } );
+			maybeSupplyPoster.call( this, media );
 		};
 
 		if ( editing ) {


### PR DESCRIPTION
* So far, on selecting a video, this looks to see if it has an image in the `media` object.
* If so, it uses that image as the poster.
* This applies to the Video block and the AMP Story block 'Background Media'.
* So far, this only implements the beginning of the [requirements](https://github.com/ampproject/amp-wp/issues/903#issuecomment-498914903).
* Even this might need refinement, like seeing if that image is the proper size. There's a lot more work needed on this PR.

Closes #903

