### PR TITLE
Adjust CTA style considering potential image & fix spacings.

### DIFF
--- a/assets/css/amp-stories-frontend.css
+++ b/assets/css/amp-stories-frontend.css
@@ -16,6 +16,10 @@ amp-story-grid-layer {
 	align-content: unset;
 }
 
+.amp-block-story-cta__link amp-img {
+	max-height: 100%;
+}
+
 .amp-block-story-cta__link amp-img * {
 	object-fit: contain;
 }

--- a/assets/css/amp-stories-frontend.css
+++ b/assets/css/amp-stories-frontend.css
@@ -18,6 +18,9 @@ amp-story-grid-layer {
 
 .amp-block-story-cta__link amp-img {
 	max-height: 100%;
+
+	/* Counteract the height increase caused by the inline-block. */
+	margin-bottom: -.2em;
 }
 
 .amp-block-story-cta__link amp-img * {

--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -43,6 +43,7 @@ amp-story-grid-layer[template="fill"] .wp-block-image {
 	display: inline-block;
 	font-size: 18px;
 	margin: 0;
+	height: calc(100% - 24px);
 	padding: 12px 24px;
 	text-align: center;
 	text-decoration: none;

--- a/assets/css/amp-stories.css
+++ b/assets/css/amp-stories.css
@@ -43,7 +43,7 @@ amp-story-grid-layer[template="fill"] .wp-block-image {
 	display: inline-block;
 	font-size: 18px;
 	margin: 0;
-	height: calc(100% - 24px);
+	max-height: calc(100% - 24px);
 	padding: 12px 24px;
 	text-align: center;
 	text-decoration: none;

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.css
@@ -13,9 +13,6 @@
 
 	/* Remove the top/bottom padding from the available space. */
 	max-height: calc(110px - 24px);
-
-	/* Counteract the height increase caused by the inline-block. */
-	margin-bottom: -9px;
 }
 
 .amp-block-story-cta__link img {

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.css
@@ -5,10 +5,17 @@
 	height: 20%;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-cta"] * {
+.block-editor-block-list__layout div[data-type="amp/amp-story-cta"]:not(#id) {
+	margin-top: 0;
+}
 
-	/* 20% of the full height of a page in the editor */
-	max-height: 110px;
+.editor-block-list__layout div[data-type="amp/amp-story-cta"] img {
+
+	/* Remove the top/bottom padding from the available space. */
+	max-height: calc(110px - 24px);
+
+	/* Counteract the height increase caused by the inline-block. */
+	margin-bottom: -9px;
 }
 
 .amp-block-story-cta__link img {


### PR DESCRIPTION
Fixes QA feedback received in #2706

The issue which was present on https://story-test-wordpress-amp.pantheonsite.io/stories/title-here/ and highlighted by Claudio was happening because there was no height applied on the wrapper. 
As I dived deeper into this I noticed some paddings were not respected when an image was added inside, so I fixed that too. 
Another glitch was happening when the CTA was the only block inside of the story and aligning it to the left or right inherited some 34px top margin from the Gutenberg core styles which I had to overwrite to keep the CTA in place and not move up/down depending on the alignment.
Screen recording of how this looks: https://dsh.re/8d464