### PR TITLE
Improve gallery sizing

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -125,6 +125,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			$urls[] = [
 				'href'   => $href,
 				'url'    => $url,
+				'srcset' => wp_get_attachment_image_srcset( $attachment_id, $atts['size'] ),
 				'width'  => $width,
 				'height' => $height,
 				'alt'    => trim( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ) ), // Logic from wp_get_attachment_image().
@@ -215,6 +216,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		foreach ( $args['images'] as $props ) {
 			$image_atts = [
 				'src'    => $props['url'],
+				'srcset' => $props['srcset'],
 				'width'  => $props['width'],
 				'height' => $props['height'],
 				'layout' => 'responsive',

--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -209,8 +209,9 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			return '';
 		}
 
-		$max_width  = 0;
-		$max_height = 0;
+		$max_aspect_ratio = 0;
+		$carousel_width   = 0;
+		$carousel_height  = 0;
 
 		$images = [];
 		foreach ( $args['images'] as $props ) {
@@ -222,8 +223,14 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 				'layout' => 'responsive',
 				'alt'    => $props['alt'],
 			];
-			$max_width  = max( $max_width, $props['width'] );
-			$max_height = max( $max_height, $props['height'] );
+
+			$this_aspect_ratio = $props['width'] / $props['height'];
+			if ( $this_aspect_ratio > $max_aspect_ratio ) {
+				$max_aspect_ratio = $this_aspect_ratio;
+				$carousel_width   = $props['width'];
+				$carousel_height  = $props['height'];
+			}
+
 			if ( ! empty( $args['lightbox'] ) ) {
 				$image_atts['lightbox'] = '';
 				$image_atts['on']       = 'tap:' . AMP_Img_Sanitizer::AMP_IMAGE_LIGHTBOX_ID;
@@ -251,8 +258,8 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		return AMP_HTML_Utils::build_tag(
 			'amp-carousel',
 			[
-				'width'  => $max_width,
-				'height' => $max_height,
+				'width'  => $carousel_width,
+				'height' => $carousel_height,
 				'type'   => 'slides',
 				'layout' => 'responsive',
 			],

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -161,30 +161,37 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 	 * }
 	 */
 	protected function get_carousel_dimensions( $element ) {
+		/**
+		 * Elements.
+		 *
+		 * @var DOMElement $image
+		 */
 		$images     = $element->getElementsByTagName( 'amp-img' );
 		$num_images = $images->length;
-		$max_height = 0;
-		$max_width  = 0;
+
+		$max_aspect_ratio = 0;
+		$carousel_width   = 0;
+		$carousel_height  = 0;
+
 		if ( 0 === $num_images ) {
 			return [ self::FALLBACK_WIDTH, self::FALLBACK_HEIGHT ];
 		}
 		foreach ( $images as $image ) {
-			/**
-			 * Image.
-			 *
-			 * @var DOMElement $image
-			 */
-			$image_height = $image->getAttribute( 'height' );
-			if ( is_numeric( $image_height ) ) {
-				$max_height = max( $max_height, $image_height );
+			if ( ! is_numeric( $image->getAttribute( 'width' ) ) || ! is_numeric( $image->getAttribute( 'height' ) ) ) {
+				continue;
 			}
-			$image_width = $image->getAttribute( 'width' );
-			if ( is_numeric( $image_width ) ) {
-				$max_width = max( $max_width, $image_width );
+			$width  = (float) $image->getAttribute( 'width' );
+			$height = (float) $image->getAttribute( 'height' );
+
+			$this_aspect_ratio = $width / $height;
+			if ( $this_aspect_ratio > $max_aspect_ratio ) {
+				$max_aspect_ratio = $this_aspect_ratio;
+				$carousel_width   = $width;
+				$carousel_height  = $height;
 			}
 		}
 
-		return [ $max_width, $max_height ];
+		return [ $carousel_width, $carousel_height ];
 	}
 
 	/**


### PR DESCRIPTION
This is intended to resolve issues reported with galleries in https://wordpress.org/support/topic/classic-block-galleries-amp-issues/

The appearance of galleries became unpredictable when images in landscape and portrait appear in the same gallery. The `amp-carousel` dimensions were being obtained from the max height of all images and the max width of all the images. Since the `amp-carousel` had a `responsive` layout, the width/height resulted in unexpected letterboxing above or to the side of the images. So this PR seeks to make the galleries more consistent by always opting for showing the carousel so that there will be no letterboxing above/below the image. Landscape images will fill the carousel, and portrait images will be constrained to fit inside the landscape box.

This PR also supplies missing `srcset` for images in shortcode galleries.

# Testing

Create a gallery with two images, one portrait and one landscape:

* https://via.placeholder.com/1367x2048
* https://via.placeholder.com/2048x1367

Supply the attachment IDs in `post_content` such as the following (taking the place of `2715,2714`):

```html
<!-- wp:heading -->
<h2>Gallery Block</h2>
<!-- /wp:heading -->

<!-- wp:gallery {"ids":[2715,2714],"ampCarousel":true} -->
<ul class="wp-block-gallery columns-2 is-cropped" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><img src="https://wordpressdev.lndo.site/content/uploads/2019/07/1367x2048-684x1024.png" alt="" data-id="2715" data-link="https://wordpressdev.lndo.site/?attachment_id=2715" class="wp-image-2715"/><figcaption>First slide</figcaption></figure></li><li class="blocks-gallery-item"><figure><img src="https://wordpressdev.lndo.site/content/uploads/2019/07/2048x1367-1024x684.png" alt="" data-id="2714" data-link="https://wordpressdev.lndo.site/?attachment_id=2714" class="wp-image-2714"/><figcaption>Second slide</figcaption></figure></li></ul>
<!-- /wp:gallery -->

<!-- wp:heading -->
<h2>Gallery Shortcode</h2>
<!-- /wp:heading -->

<!-- wp:shortcode {"ampCarousel":true} -->
[gallery ids="2715,2714"  link="none" size="large"]
<!-- /wp:shortcode -->

<!-- wp:heading -->
<h2>Gallery in Classic Block</h2>
<!-- /wp:heading -->

<p>[gallery link="none" size="large" ids="2715,2714"]</p>
```

## Before

### Before Portrait
> ![before-portrait](https://user-images.githubusercontent.com/134745/61662929-12619380-ac95-11e9-9884-7ac77a3cc2c1.png) 

### Before Landscape
> ![before-landscape](https://user-images.githubusercontent.com/134745/61662940-1ab9ce80-ac95-11e9-861f-68ed1b5b0634.png)

## After

### After Portrait
> ![after-portrait](https://user-images.githubusercontent.com/134745/61663003-40df6e80-ac95-11e9-8414-872714df742a.png)

### After Landscape
> ![after-landscape](https://user-images.githubusercontent.com/134745/61663034-518fe480-ac95-11e9-837f-23e49b32abec.png)

----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3419069/amp.zip) (v1.2.1-beta1-20190722T201452Z-11d51844)