### PR TITLE
Fix issue with column block

### DIFF
--- a/assets/src/block-validation/components/higher-order/with-validation-error-notice.js
+++ b/assets/src/block-validation/components/higher-order/with-validation-error-notice.js
@@ -14,8 +14,10 @@ import { ValidationErrorMessage } from '../';
 const applyWithSelect = withSelect( ( select, { clientId } ) => {
 	const { getBlockValidationErrors } = select( 'amp/block-validation' );
 
+	const blockValidationErrors = getBlockValidationErrors( clientId );
+
 	return {
-		blockValidationErrors: getBlockValidationErrors( clientId ),
+		blockValidationErrors: blockValidationErrors.length ? blockValidationErrors : undefined,
 	};
 } );
 
@@ -30,11 +32,11 @@ export default createHigherOrderComponent(
 		return applyWithSelect( ( props ) => {
 			const { blockValidationErrors, onReplace } = props;
 
-			const errorCount = blockValidationErrors.length;
-
-			if ( errorCount === 0 ) {
+			if ( ! blockValidationErrors ) {
 				return <BlockEdit { ...props } />;
 			}
+
+			const errorCount = blockValidationErrors.length;
 
 			const actions = [
 				{


### PR DESCRIPTION
This changes the `withSelect` call in the `withValidationErrorNotice` HOC to not return empty arrays.

Since it seems to generate a new array (reference) every time, strict equal fails, triggering a new component update.

To avoid this, return `undefined` when there are no block validation errors anyway.

Kind of related: https://github.com/WordPress/gutenberg/issues/16612

Fixes #2870.