### PR TITLE
Fix specification of text_domain for WordPress.WP.I18n sniff

### DIFF
--- a/includes/class-amp-story-media.php
+++ b/includes/class-amp-story-media.php
@@ -319,7 +319,7 @@ class AMP_Story_Media {
 			'featured_media',
 			[
 				'schema' => [
-					'description' => __( 'The ID of the featured media for the object.' ),
+					'description' => __( 'The ID of the featured media for the object.', 'amp' ),
 					'type'        => 'integer',
 					'context'     => [ 'view', 'edit', 'embed' ],
 				],

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -299,7 +299,7 @@ class AMP_Options_Menu {
 		$transitional_description = sprintf( __( 'The active theme’s templates are used to generate non-AMP and AMP versions of your content, allowing for each canonical URL to have a corresponding (paired) AMP URL. This mode is useful to progressively transition towards a fully AMP-first site. Depending on your theme/plugins, a varying level of <a href="%s">development work</a> may be required.', 'amp' ), esc_url( 'https://amp-wp.org/documentation/developing-wordpress-amp-sites/' ) );
 		$reader_description       = __( 'Formerly called the <b>classic mode</b>, this mode generates paired AMP content using simplified templates which may not match the look-and-feel of your site. Only posts/pages can be served as AMP in Reader mode. No redirection is performed for mobile visitors; AMP pages are served by AMP consumption platforms.', 'amp' );
 		/* translators: %s: URL to the ecosystem page. */
-		$ecosystem_description = sprintf( __( 'For a list of themes and plugins that are known to be AMP compatible, please see the <a href="%s">ecosystem page</a>.' ), esc_url( 'https://amp-wp.org/ecosystem/' ) );
+		$ecosystem_description = sprintf( __( 'For a list of themes and plugins that are known to be AMP compatible, please see the <a href="%s">ecosystem page</a>.', 'amp' ), esc_url( 'https://amp-wp.org/ecosystem/' ) );
 
 		$builtin_support = in_array( get_template(), AMP_Core_Theme_Sanitizer::get_supported_themes(), true );
 		?>

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -175,7 +175,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 					$reason = sprintf( __( 'The server responded with %1$s (code %2$s).', 'amp' ), '{{status_text}}', '{{status_code}}' );
 				} else {
 					$p->appendChild( $this->dom->createTextNode( __( 'It appears your submission was successful.', 'amp' ) ) );
-					$reason = __( 'Even though the server responded OK, it is possible the submission was not processed.' );
+					$reason = __( 'Even though the server responded OK, it is possible the submission was not processed.', 'amp' );
 				}
 				$reason .= ' ' . __( 'Please contact the developer of this form processor to improve this message.', 'amp' );
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2099,7 +2099,7 @@ class AMP_Validated_URL_Post_Type {
 
 		if ( $page_title ) {
 			/* translators: Admin screen title. %s: Admin screen name */
-			return sprintf( __( '%s &#8212; WordPress' ), $page_title );
+			return sprintf( __( '%s &#8212; WordPress', 'default' ), $page_title );
 		}
 
 		return $title;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,7 +9,10 @@
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" value="amp,default" />
+			<property name="text_domain" type="array">
+				<element value="amp"/>
+				<element value="default"/>
+			</property>
 		</properties>
 	</rule>
 


### PR DESCRIPTION
I found that the `WordPress.WP.I18n` sniff was failing to catch a missing text domain. This resulted in a support forum report: https://wordpress.org/support/topic/two-l10n-issues/

I found the format needs to be as specified on https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#internationalization-setting-your-text-domain

So this fixes the text_domain property and adds missing text domains for translation functions.