### PR TITLE
Remove deprecated formattingControls.

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.css
@@ -65,6 +65,11 @@
 	max-width: 100%;
 }
 
+.wp-block-amp-amp-story-cta .block-editor-rich-text__editable code {
+	background: inherit;
+	color: inherit;
+}
+
 .wp-block-amp-amp-story-cta .block-editor-rich-text__editable[data-is-placeholder-visible="true"] {
 	height: auto;
 }

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -73,7 +73,7 @@ class CallToActionEdit extends Component {
 						placeholder={ __( 'Add text…', 'amp' ) }
 						value={ text }
 						onChange={ ( value ) => setAttributes( { text: value } ) }
-						allowedFormats={ [ 'bold', 'italic', 'strikethrough' ] }
+						allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
 						className={ classnames(
 							'amp-block-story-cta__link', {
 								'has-background': backgroundColor.color,

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -73,7 +73,6 @@ class CallToActionEdit extends Component {
 						placeholder={ __( 'Add text…', 'amp' ) }
 						value={ text }
 						onChange={ ( value ) => setAttributes( { text: value } ) }
-						allowedFormats={ [ 'core/bold', 'core/italic', 'core/strikethrough' ] }
 						className={ classnames(
 							'amp-block-story-cta__link', {
 								'has-background': backgroundColor.color,

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -73,7 +73,7 @@ class CallToActionEdit extends Component {
 						placeholder={ __( 'Add text…', 'amp' ) }
 						value={ text }
 						onChange={ ( value ) => setAttributes( { text: value } ) }
-						formattingControls={ [ 'bold', 'italic', 'strikethrough' ] }
+						allowedFormats={ [ 'bold', 'italic', 'strikethrough' ] }
 						className={ classnames(
 							'amp-block-story-cta__link', {
 								'has-background': backgroundColor.color,

--- a/assets/src/stories-editor/helpers/test/addAMPExtraProps.js
+++ b/assets/src/stories-editor/helpers/test/addAMPExtraProps.js
@@ -10,18 +10,6 @@ describe( 'addAMPExtraProps', () => {
 		expect( props ).toStrictEqual( {} );
 	} );
 
-	it( 'generates a unique ID', () => {
-		const props = addAMPExtraProps( {}, { name: 'amp/amp-story-text' }, {} );
-
-		expect( props ).toHaveProperty( 'id' );
-	} );
-
-	it( 'uses the existing anchor attribute as the ID', () => {
-		const props = addAMPExtraProps( {}, { name: 'amp/amp-story-text' }, { anchor: 'foo' } );
-
-		expect( props ).toStrictEqual( { id: 'foo' } );
-	} );
-
 	it( 'adds a font family attribute', () => {
 		const props = addAMPExtraProps( {}, { name: 'amp/amp-story-text' }, { ampFontFamily: 'Roboto' } );
 


### PR DESCRIPTION
`formattingControls` will be deprecated with https://github.com/WordPress/gutenberg/pull/14542.

This PR updates the code in CTA block to match that.

Updates style for `Inline Code` and removes the deprecated param.