### PR TITLE
Fix handling of child_tag_name_oneof constraint in tag spec

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1850,7 +1850,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Loop through node's children and remove the ones that are not whitelisted.
+	 * Check whether the node validates the constraints for children.
 	 *
 	 * @param DOMNode $node Node.
 	 * @param array   $child_tags {
@@ -1878,24 +1878,22 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Verify that all of the child are among the set of allowed elements.
-		$removed_count = 0;
 		if ( isset( $child_tags['child_tag_name_oneof'] ) ) {
 			foreach ( $child_elements as $child_element ) {
 				if ( ! in_array( $child_element->nodeName, $child_tags['child_tag_name_oneof'], true ) ) {
-					$removed_count++;
-					$this->remove_invalid_child( $child_element );
+					return false;
 				}
 			}
 		}
 
 		// If there aren't the exact number of elements, then mark this $node as being invalid.
 		if ( isset( $child_tags['mandatory_num_child_tags'] ) ) {
-			return ( count( $child_elements ) - $removed_count ) === $child_tags['mandatory_num_child_tags'];
+			return count( $child_elements ) === $child_tags['mandatory_num_child_tags'];
 		}
 
 		// If there aren't enough elements, then mark this $node as being invalid.
 		if ( isset( $child_tags['mandatory_min_num_child_tags'] ) ) {
-			return ( count( $child_elements ) - $removed_count ) >= $child_tags['mandatory_min_num_child_tags'];
+			return count( $child_elements ) >= $child_tags['mandatory_min_num_child_tags'];
 		}
 
 		return true;


### PR DESCRIPTION
In reviewing the Newspack theme (https://github.com/Automattic/newspack-theme/pull/120/files#r309371902), I was seeing something very strange in regards to markup like:

```html
<amp-sidebar id="mobile-sidebar" layout="nodisplay" side="right">
	<nav>
		<ul>
			<li><a href="https://example.com/"></a></li>
		</ul>
		<div class="some-div">
			...
		</div>
	</nav>
</amp-sidebar>
```

The AMP plugin was marking it as invalid  as if it was matching the [`amp-sidebar > nav` tag spec](https://github.com/ampproject/amphtml/blob/e9f3857405939612d3a84a7afd10f59acd504b85/extensions/amp-sidebar/validator-amp-sidebar.protoascii#L75-L97), specifically due to the `child_tags` constraint:

```
  child_tags: {
    mandatory_num_child_tags: 1
    child_tag_name_oneof: "OL"
    child_tag_name_oneof: "UL"
  }
```

But this made no sense because this tag spec should not be considered at all because the `nav` does not have the `toolbar` or `toolbar-target` attributes which are also part of that tag spec:

```
  attrs: {
    name: "toolbar"
    mandatory: true
    # This tagspec sometimes produces errors for non-sidebar NAVs. This
    # dispatch key helps with this somewhat.
    dispatch_key: NAME_DISPATCH
  }
  attrs: {
    name: "toolbar-target"
    mandatory: true
  }
```

The reason turns out to be that the DOM was being mutated while checking for candidate tag specs to validate against a given node.

When beginning to `process_node`, we have to gather up a list of candidate tag specs to validate the node against:

https://github.com/ampproject/amp-wp/blob/1a3646e859daef3b3c5c4bf998d1644820b3996f/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L402-L415

This loop is only checking for candidate tag specs; it should not be doing any sanitization. Nevertheless, the `validate_tag_spec_for_node()` method call there was doing this in its last line:

https://github.com/ampproject/amp-wp/blob/1a3646e859daef3b3c5c4bf998d1644820b3996f/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L713

The `check_valid_children()` method call here was erroneously mutating the document, while checking to see if the `nav` is a match for that tag spec. The actual tag spec that should only be considered here is the [`nav` spec](https://github.com/ampproject/amphtml/blob/e9f3857405939612d3a84a7afd10f59acd504b85/validator/validator-main.protoascii#L1578-L1585) which has no constraints on the children:

```
# 4.3.4 The nav element
tags: {
  html_format: AMP
  html_format: AMP4ADS
  html_format: AMP4EMAIL
  html_format: ACTIONS
  tag_name: "NAV"
}
```

This is a bug that was introduced in v1.1 via #1860.

👉 A side-effect of the change here is the sanitization of AMP components with invalid children will be more draconian. For example, if an `amp-story` has an invalid child element, then the entire `amp-story` element will be removed, as opposed to the invalid child alone being removed. Nevertheless, since only AMP components have such validation constraints for children, it should not so common for this to occur in WordPress sites that are just outputting normal HTML. It only will become an issue when starting to use AMP components, and this makes https://github.com/ampproject/amp-wp/issues/1420 much more important as it will be needed to explain _why_ the element was removed.