### PR TITLE
Hide the Block Manager and add an e2e test for it

### DIFF
--- a/assets/css/amp-stories-editor.css
+++ b/assets/css/amp-stories-editor.css
@@ -181,7 +181,7 @@
 /**
  * Hide Block Manager option
  */
-.edit-post-more-menu__content .components-menu-group:nth-last-of-type(2) div[role="menu"] > .components-button:first-child {
+.edit-post-more-menu__content .components-menu-group:nth-last-of-type(2) div[role="group"] > .components-button:first-child {
 	display: none;
 }
 

--- a/tests/e2e/specs/stories-editor/block-manager-disabled.test.js
+++ b/tests/e2e/specs/stories-editor/block-manager-disabled.test.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { createNewPost, getAllBlocks, selectBlockByClientId } from '@wordpress/e2e-test-utils';
+import { createNewPost } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -20,14 +20,11 @@ describe( 'Block Manager', () => {
 	it( 'the button should not appear, due to styling of display: none', async () => {
 		await createNewPost( { postType: 'amp_story' } );
 
-		// Select the page block.
-		await selectBlockByClientId(
-			( await getAllBlocks() )[ 0 ].clientId
-		);
-
 		// Click the 'More tools & options' button to expand the popover.
-		await page.click( '.components-button.components-icon-button.components-dropdown-menu__toggle' );
+		await page.click( '.edit-post-more-menu .components-dropdown-menu__toggle' );
 
-		await expect( page ).not.toMatch( 'Block Manager' );
+		// The text 'Block Manager' should not be present.
+		const blockManagerButton = await page.waitForXPath( '//button[contains(text(), "Block Manager")]' );
+		expect( await blockManagerButton.isIntersectingViewport() ).toStrictEqual( false );
 	} );
 } );

--- a/tests/e2e/specs/stories-editor/block-manager-disabled.test.js
+++ b/tests/e2e/specs/stories-editor/block-manager-disabled.test.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost, getAllBlocks, selectBlockByClientId } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { activateExperience, deactivateExperience } from '../../utils';
+
+describe( 'Block Manager', () => {
+	beforeAll( async () => {
+		await activateExperience( 'stories' );
+	} );
+
+	afterAll( async () => {
+		await deactivateExperience( 'stories' );
+	} );
+
+	it( 'the button should not appear due to styling of display: none', async () => {
+		await createNewPost( { postType: 'amp_story' } );
+
+		// Select the page block.
+		await selectBlockByClientId(
+			( await getAllBlocks() )[ 0 ].clientId
+		);
+
+		// Click the 'More tools & options' button to expand the popover.
+		const buttonSelector = '.components-button.components-icon-button.components-dropdown-menu__toggle';
+		await page.waitForSelector( buttonSelector );
+		await page.click( buttonSelector );
+
+		await expect( page ).not.toMatch( 'Block Manager' );
+	} );
+} );

--- a/tests/e2e/specs/stories-editor/block-manager-disabled.test.js
+++ b/tests/e2e/specs/stories-editor/block-manager-disabled.test.js
@@ -17,7 +17,7 @@ describe( 'Block Manager', () => {
 		await deactivateExperience( 'stories' );
 	} );
 
-	it( 'the button should not appear due to styling of display: none', async () => {
+	it( 'the button should not appear, due to styling of display: none', async () => {
 		await createNewPost( { postType: 'amp_story' } );
 
 		// Select the page block.
@@ -26,9 +26,7 @@ describe( 'Block Manager', () => {
 		);
 
 		// Click the 'More tools & options' button to expand the popover.
-		const buttonSelector = '.components-button.components-icon-button.components-dropdown-menu__toggle';
-		await page.waitForSelector( buttonSelector );
-		await page.click( buttonSelector );
+		await page.click( '.components-button.components-icon-button.components-dropdown-menu__toggle' );
 
 		await expect( page ).not.toMatch( 'Block Manager' );
 	} );


### PR DESCRIPTION
# Before
<img width="537" alt="block-manager-appears" src="https://user-images.githubusercontent.com/4063887/62448811-3fe71c00-b72e-11e9-9fbb-92eec88f629d.png">


# After
<img width="574" alt="block-manager" src="https://user-images.githubusercontent.com/4063887/62448817-483f5700-b72e-11e9-9375-0797c38cd2d7.png">


Closes #2904 