### PR TITLE
Fix encoding error when HTML5 meta charset does not appear at beginning of head

### DIFF
--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -118,21 +118,22 @@ class AMP_DOM_Utils {
 				},
 				$document
 			);
+		}
 
-			/*
-			 * Add a pre-HTML5-style declaration of the encoding since libxml<2.8 doesn't recognize
-			 * HTML5's meta charset. See <https://bugzilla.gnome.org/show_bug.cgi?id=655218>.
-			 */
-			$document = preg_replace(
-				'#(?=<meta\s+charset=["\']?([a-z0-9_-]+))#i',
-				'<meta http-equiv="Content-Type" content="text/html; charset=$1" id="meta-http-equiv-content-type">',
-				$document,
-				1,
-				$count
-			);
-			if ( 1 === $count ) {
-				$added_back_compat_meta_content_type = true;
-			}
+		/*
+		 * Add a pre-HTML5-style declaration of the encoding since libxml doesn't always recognize
+		 * HTML5's meta charset. In libxml<2.8 it never does, see <https://bugzilla.gnome.org/show_bug.cgi?id=655218>.
+		 * In libxml>=2.8, if the meta charset does not appear at the beginning of the head then it fails to be understood.
+		 */
+		$document = preg_replace(
+			'#(?=<meta\s+charset=["\']?([a-z0-9_-]+))#i',
+			'<meta http-equiv="Content-Type" content="text/html; charset=$1" id="meta-http-equiv-content-type">',
+			$document,
+			1,
+			$count
+		);
+		if ( 1 === $count ) {
+			$added_back_compat_meta_content_type = true;
 		}
 
 		/*

--- a/tests/php/test-class-amp-dom-utils.php
+++ b/tests/php/test-class-amp-dom-utils.php
@@ -303,18 +303,20 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 	 * @covers \AMP_DOM_Utils::get_dom()
 	 */
 	public function test_get_dom_encoding() {
-		$html  = '<!DOCTYPE html><html><head><meta charset="utf-8"></head><body>';
-		$html .= '<p>Check out ‘this’ and “that” and—other things.</p>';
-		$html .= '<p>Check out &#8216;this&#8217; and &#8220;that&#8221; and&#8212;other things.</p>';
-		$html .= '<p>Check out &lsquo;this&rsquo; and &ldquo;that&rdquo; and&mdash;other things.</p>';
+		$html  = '<!DOCTYPE html><html><head><title>مرحبا بالعالم! Check out ‘this’ and “that” and—other things.</title><meta charset="UTF-8"></head><body>';
+		$html .= '<p>مرحبا بالعالم! Check out ‘this’ and “that” and—other things.</p>';
+		$html .= '<p>&#x645;&#x631;&#x62D;&#x628;&#x627; &#x628;&#x627;&#x644;&#x639;&#x627;&#x644;&#x645;! Check out &#8216;this&#8217; and &#8220;that&#8221; and&#8212;other things.</p>';
+		$html .= '<p>&#x645;&#x631;&#x62D;&#x628;&#x627; &#x628;&#x627;&#x644;&#x639;&#x627;&#x644;&#x645;! Check out &lsquo;this&rsquo; and &ldquo;that&rdquo; and&mdash;other things.</p>';
 		$html .= '</body></html>';
 
-		$document = AMP_DOM_Utils::get_dom_from_content( $html );
+		$document = AMP_DOM_Utils::get_dom( $html );
+
 		$this->assertEquals( 'UTF-8', $document->encoding );
 		$paragraphs = $document->getElementsByTagName( 'p' );
 		$this->assertSame( 3, $paragraphs->length );
 		$this->assertSame( $paragraphs->item( 0 )->textContent, $paragraphs->item( 1 )->textContent );
 		$this->assertSame( $paragraphs->item( 1 )->textContent, $paragraphs->item( 2 )->textContent );
+		$this->assertSame( $document->getElementsByTagName( 'title' )->item( 0 )->textContent, $paragraphs->item( 2 )->textContent );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/big-problem-in-my-persian-site/

It turns out that libxml>=2.6 fails to read the `<meta charset=…>` if it is not the first child of the `head`. So this PR adds the old-school HTML4 `<meta http-equiv=Content-Type>` tag which was required always prior to libxml 2.6 so that it will be added unconditionally.

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3469562/amp.zip) - v1.2.1-beta1-20190805T220646Z-680afba9
