### PR TITLE
Add RTL admin-bar.css and update fork to WP 5.3-alpha@160fc055da

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,3 +1,4 @@
 assets/css/admin-bar.css
+assets/css/admin-bar-rtl.css
 assets/css/*-compiled.css
 assets/css/*-compiled-rtl.css

--- a/assets/css/admin-bar-rtl.css
+++ b/assets/css/admin-bar-rtl.css
@@ -87,7 +87,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar {
-	direction: ltr;
+	direction: rtl;
 	color: #ccc;
 	font-size: 13px;
 	font-weight: 400;
@@ -96,7 +96,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	height: 32px;
 	position: fixed;
 	top: 0;
-	left: 0;
+	right: 0;
 	width: 100%;
 	min-width: 600px; /* match the min-width of the body in wp-admin/css/common.css */
 	z-index: 99999;
@@ -117,15 +117,15 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar ul#wp-admin-bar-root-default>li {
-	margin-right: 0;
+	margin-left: 0;
 }
 
 #wpadminbar .quicklinks ul {
-	text-align: left;
+	text-align: right;
 }
 
 #wpadminbar li {
-	float: left;
+	float: right;
 }
 
 #wpadminbar .ab-empty-item {
@@ -133,7 +133,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .quicklinks .ab-top-secondary > li {
-	float: right;
+	float: left;
 }
 
 #wpadminbar .quicklinks a,
@@ -146,7 +146,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .quicklinks > ul > li > a {
-	padding: 0 8px 0 7px;
+	padding: 0 7px 0 8px;
 }
 
 #wpadminbar .menupop .ab-sub-wrapper,
@@ -163,7 +163,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar.ie7 .menupop .ab-sub-wrapper,
 #wpadminbar.ie7 .shortlink-input {
 	top: 32px;
-	left: 0;
+	right: 0;
 }
 
 #wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
@@ -171,8 +171,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .ab-top-secondary .menupop .ab-sub-wrapper {
-	right: 0;
-	left: auto;
+	left: 0;
+	right: auto;
 }
 
 #wpadminbar .ab-submenu {
@@ -213,15 +213,15 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar .menupop li:hover > .ab-sub-wrapper,
 #wpadminbar .menupop li:focus-within > .ab-sub-wrapper {
-	margin-left: 100%;
+	margin-right: 100%;
 	margin-top: -32px;
 }
 
 #wpadminbar .ab-top-secondary .menupop li:hover > .ab-sub-wrapper,
 #wpadminbar .ab-top-secondary .menupop li:focus-within > .ab-sub-wrapper {
-	margin-left: 0;
-	left: inherit;
-	right: 100%;
+	margin-right: 0;
+	right: inherit;
+	left: 100%;
 }
 
 #wpadminbar:not(.mobile) .ab-top-menu > li > .ab-item:focus,
@@ -231,6 +231,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	background: #32373c;
 	color: #00b9eb;
 }
+
 #wpadminbar .ab-top-menu > li:focus-within > .ab-item {
 	background: #32373c;
 	color: #00b9eb;
@@ -247,14 +248,14 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .ab-item:before,
 .wp-admin-bar-arrow {
 	position: relative;
-	float: left;
+	float: right;
 	font: normal 20px/1 dashicons;
 	speak: none;
 	padding: 4px 0;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 	background-image: none !important;
-	margin-right: 6px;
+	margin-left: 6px;
 }
 
 #wpadminbar .ab-icon:before,
@@ -333,32 +334,32 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar .menupop .menupop > .ab-item {
 	display: block;
-	padding-right: 2em;
+	padding-left: 2em;
 }
 
 #wpadminbar .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 	top: 1px;
-	right: 10px;
+	left: 10px;
 	padding: 4px 0;
-	content: "\f139";
+	content: "\f141";
 	color: inherit;
 }
 
 #wpadminbar .ab-top-secondary .menupop .menupop > .ab-item {
-	padding-left: 2em;
-	padding-right: 1em;
+	padding-right: 2em;
+	padding-left: 1em;
 }
 
 #wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 	top: 1px;
-	left: 6px;
-	content: "\f141";
+	right: 6px;
+	content: "\f139";
 }
 
 #wpadminbar .quicklinks .menupop ul.ab-sub-secondary {
 	display: block;
 	position: relative;
-	right: auto;
+	left: auto;
 	margin: 0;
 	box-shadow: none;
 }
@@ -389,7 +390,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .ab-top-secondary {
-	float: right;
+	float: left;
 }
 
 #wpadminbar ul li:last-child,
@@ -423,9 +424,9 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wp-admin-bar-my-account > .ab-item:before {
 	content: "\f110";
 	top: 2px;
-	float: right;
-	margin-left: 6px;
-	margin-right: 0;
+	float: left;
+	margin-right: 6px;
+	margin-left: 0;
 }
 
 #wp-admin-bar-my-account.with-avatar > .ab-item:before {
@@ -442,8 +443,8 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar #wp-admin-bar-user-actions > li {
-	margin-left: 16px;
 	margin-right: 16px;
+	margin-left: 16px;
 }
 
 #wpadminbar #wp-admin-bar-user-actions.ab-submenu {
@@ -451,7 +452,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar #wp-admin-bar-my-account.with-avatar #wp-admin-bar-user-actions > li {
-	margin-left: 88px;
+	margin-right: 88px;
 }
 
 #wpadminbar #wp-admin-bar-user-info {
@@ -463,7 +464,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wp-admin-bar-user-info .avatar {
 	position: absolute;
-	left: -72px;
+	right: -72px;
 	top: 4px;
 	width: 64px;
 	height: 64px;
@@ -499,7 +500,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	background: #eee;
 	line-height: 1.84615384;
 	vertical-align: middle;
-	margin: -4px 0 0 6px;
+	margin: -4px 6px 0 0;
 	float: none;
 	display: inline-block; /* Was inline. */
 }
@@ -515,7 +516,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #wp-admin-bar-wp-logo > .ab-item .ab-icon {
 	width: 15px;
 	height: 20px;
-	margin-right: 0;
+	margin-left: 0;
 	padding: 6px 0 5px;
 }
 
@@ -532,7 +533,7 @@ html:lang(he-il) .rtl #wpadminbar * {
  * My Sites & Site Title
  */
 #wpadminbar .quicklinks li .blavatar {
-	float: left;
+	float: right;
 	font: normal 16px/1 dashicons !important;
 	speak: none;
 	-webkit-font-smoothing: antialiased;
@@ -551,7 +552,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	height: 16px;
 	width: 16px;
 	display: inline-block;
-	margin: 6px 8px 0 -2px;
+	margin: 6px -2px 0 8px;
 }
 
 #wpadminbar #wp-admin-bar-appearance {
@@ -589,7 +590,7 @@ html:lang(he-il) .rtl #wpadminbar * {
  * Comments
  */
 #wpadminbar #wp-admin-bar-comments .ab-icon {
-	margin-right: 6px;
+	margin-left: 6px;
 }
 
 #wpadminbar #wp-admin-bar-comments .ab-icon:before {
@@ -639,7 +640,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar #adminbarsearch:before {
 	position: absolute;
 	top: 6px;
-	left: 5px;
+	right: 5px;
 	z-index: 20;
 	font: normal 20px/1 dashicons !important;
 	content: "\f179";
@@ -661,7 +662,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	height: 24px;
 	width: 24px;
 	max-width: none;
-	padding: 0 3px 0 24px;
+	padding: 0 24px 0 3px;
 	margin: 0;
 	color: #ccc;
 	background-color: rgba(255, 255, 255, 0);
@@ -691,7 +692,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 #wpadminbar.ie8 > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input {
 	/* IE8 z-index bug with transparent / empty elements - fill in with an encoded transparent GIF */
-	background: transparent 0 0 repeat scroll url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+	background: transparent 100% 0 repeat scroll url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
 }
 
 /* IE8 doesn't redraw the pseudo elements unless you make a change to the content */
@@ -744,7 +745,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 #wpadminbar .screen-reader-shortcut:focus {
-	left: 6px;
+	right: 6px;
 	top: 7px;
 	height: auto;
 	width: auto;
@@ -769,7 +770,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 }
 
 * html #wpadminbar .quicklinks ul li a {
-	float: left;
+	float: right;
 }
 
 * html #wpadminbar .menupop a span {
@@ -868,7 +869,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .quicklinks .menupop:focus-within ul li .ab-item,
 	#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item,
 	#wpadminbar .shortlink-input {
-		line-height: 1.6;
+	    line-height: 1.6;
 	}
 
 	#wpadminbar .ab-label {
@@ -881,12 +882,12 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	#wpadminbar .ab-top-menu .menupop .ab-sub-wrapper .menupop > .ab-item {
-		padding-right: 30px;
+		padding-left: 30px;
 	}
 
 	#wpadminbar .menupop .menupop > .ab-item:before {
 		top: 10px;
-		right: 6px;
+		left: 6px;
 	}
 
 	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper .ab-item {
@@ -940,7 +941,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .ab-icon,
 	#wpadminbar .ab-item:before {
 		padding: 0;
-		margin-right: 0;
+		margin-left: 0;
 	}
 
 	#wpadminbar #wp-admin-bar-edit > .ab-item:before,
@@ -1017,7 +1018,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wpadminbar .quicklinks li#wp-admin-bar-my-account.with-avatar > a img {
 		position: absolute;
 		top: 13px;
-		right: 10px;
+		left: 10px;
 		width: 26px;
 		height: 26px;
 	}
@@ -1084,7 +1085,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	#wpadminbar ul#wp-admin-bar-root-default > li {
-		margin-right: 0;
+		margin-left: 0;
 	}
 
 	/* Experimental fix for touch toolbar dropdown positioning */
@@ -1102,18 +1103,18 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	#wpadminbar #wp-admin-bar-my-account {
-		float: right;
+		float: left;
 	}
 
 	.network-admin #wpadminbar ul#wp-admin-bar-top-secondary > li#wp-admin-bar-my-account {
-		margin-right: 0;
+		margin-left: 0;
 	}
 
 	/* Realign arrows on taller responsive submenus */
 
 	#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before {
 		top: 10px;
-		left: 0;
+		right: 0;
 	}
 }
 
@@ -1124,7 +1125,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	#wp-responsive-overlay {
 		position: fixed;
 		top: 0;
-		left: 0;
+		right: 0;
 		width: 100%;
 		height: 100%;
 		z-index: 400;
@@ -1132,7 +1133,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 
 	#wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
 		width: 100%;
-		left: 0;
+		right: 0;
 	}
 
 	#wpadminbar .menupop .menupop > .ab-item:before {
@@ -1140,20 +1141,20 @@ html:lang(he-il) .rtl #wpadminbar * {
 	}
 
 	#wpadminbar #wp-admin-bar-wp-logo.menupop .ab-sub-wrapper {
-		margin-left: 0;
+		margin-right: 0;
 	}
 
 	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper {
 		margin: 0;
 		width: 100%;
 		top: auto;
-		left: auto;
+		right: auto;
 		position: relative;
 	}
 
 	#wpadminbar .ab-top-menu > .menupop li > .ab-sub-wrapper .ab-item {
 		font-size: 16px;
-		padding: 6px 15px 19px 30px;
+		padding: 6px 30px 19px 15px;
 	}
 
 	#wpadminbar li:hover ul li ul li {

--- a/assets/css/admin-bar-rtl.css
+++ b/assets/css/admin-bar-rtl.css
@@ -341,7 +341,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 	top: 1px;
 	left: 10px;
 	padding: 4px 0;
-	content: "\f141";
+	content: "\f139";
 	color: inherit;
 }
 
@@ -353,7 +353,7 @@ html:lang(he-il) .rtl #wpadminbar * {
 #wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 	top: 1px;
 	right: 6px;
-	content: "\f139";
+	content: "\f141";
 }
 
 #wpadminbar .quicklinks .menupop ul.ab-sub-secondary {

--- a/assets/css/admin-bar.css
+++ b/assets/css/admin-bar.css
@@ -1,8 +1,10 @@
 /*
-This is forked from core's admin-bar.css from WP 4.9.6
-- Rules for IE<9 have been removed.
+This is forked from core's admin-bar.css from WP 5.3-alpha at 160fc055da156248277513dd5256fbcc66faa5a7.
+
+https://github.com/WordPress/wordpress-develop/blob/160fc055da156248277513dd5256fbcc66faa5a7/src/wp-includes/css/admin-bar.css
+
 - References to .hover have been replaced with :focus-within (which is not supported in IE11).
-- A universal selector properties have been removed which interferes with AMP shadow elements.
+- Universal selector properties have been removed which interferes with AMP shadow elements.
 */
 
 
@@ -18,7 +20,7 @@ This is forked from core's admin-bar.css from WP 4.9.6
 	font-size: 13px;
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	line-height: 32px;
+	line-height: 2.46153846;
 	border-radius: 0;
 	box-sizing: content-box;
 	transition: none;
@@ -30,7 +32,7 @@ This is forked from core's admin-bar.css from WP 4.9.6
 	font-family: Tahoma, sans-serif;
 }
 
-html:lang(he-il) .rtl #wpadminbar *  {
+html:lang(he-il) .rtl #wpadminbar * {
 	font-family: Arial, sans-serif;
 }
 
@@ -61,7 +63,6 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar a:hover,
 #wpadminbar a img,
 #wpadminbar a img:hover {
-	outline: none;
 	border: none;
 	text-decoration: none;
 	background: none;
@@ -79,7 +80,11 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar textarea,
 #wpadminbar div {
 	box-shadow: none;
-	outline: none;
+}
+
+#wpadminbar a:focus {
+	/* Inherits transparent outline only visible in Windows High Contrast mode */
+	outline-offset: -1px;
 }
 
 #wpadminbar {
@@ -88,13 +93,13 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	font-size: 13px;
 	font-weight: 400;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	line-height: 32px;
+	line-height: 2.46153846;
 	height: 32px;
 	position: fixed;
 	top: 0;
 	left: 0;
 	width: 100%;
-	min-width: 600px; /* match the min-width of the body in wp-admin.css */
+	min-width: 600px; /* match the min-width of the body in wp-admin/css/common.css */
 	z-index: 99999;
 	background: #23282d;
 }
@@ -149,11 +154,17 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar .shortlink-input {
 	margin: 0;
 	padding: 0;
-	box-shadow: 0 3px 5px rgba(0,0,0,0.2);
+	box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2);
 	background: #32373c;
 	display: none;
 	position: absolute;
 	float: none;
+}
+
+#wpadminbar.ie7 .menupop .ab-sub-wrapper,
+#wpadminbar.ie7 .shortlink-input {
+	top: 32px;
+	left: 0;
 }
 
 #wpadminbar .ab-top-menu > .menupop > .ab-sub-wrapper {
@@ -186,7 +197,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar .quicklinks .menupop:focus-within ul li .ab-item,
 #wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item,
 #wpadminbar .shortlink-input {
-	line-height: 26px;
+	line-height: 2;
 	height: 26px;
 	white-space: nowrap;
 	min-width: 140px;
@@ -234,7 +245,8 @@ html:lang(he-il) .rtl #wpadminbar *  {
 
 #wpadminbar > #wp-toolbar > #wp-admin-bar-root-default .ab-icon,
 #wpadminbar .ab-icon,
-#wpadminbar .ab-item:before {
+#wpadminbar .ab-item:before,
+.wp-admin-bar-arrow {
 	position: relative;
 	float: left;
 	font: normal 20px/1 dashicons;
@@ -250,7 +262,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar .ab-item:before,
 #wpadminbar #adminbarsearch:before {
 	color: #a0a5aa;
-	color: rgba(240,245,250,0.6);
+	color: rgba(240, 245, 250, 0.6);
 }
 
 #wpadminbar .ab-icon:before,
@@ -267,7 +279,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 
 #wpadminbar .ab-submenu .ab-item {
 	color: #b4b9be;
-	color: rgba(240,245,250,0.7);
+	color: rgba(240, 245, 250, 0.7);
 }
 
 #wpadminbar .quicklinks .menupop ul li a,
@@ -275,7 +287,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar .quicklinks .menupop:focus-within ul li a,
 #wpadminbar.nojs .quicklinks .menupop:hover ul li a {
 	color: #b4b9be;
-	color: rgba(240,245,250,0.7);
+	color: rgba(240, 245, 250, 0.7);
 }
 
 #wpadminbar .quicklinks .menupop ul li a:hover,
@@ -306,7 +318,12 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	color: #b4b9be;
 }
 
-#wpadminbar .menupop .menupop > .ab-item:before,
+#wpadminbar.mobile .quicklinks :focus-within .ab-icon:before,
+#wpadminbar.mobile .quicklinks :focus-within .ab-item:before {
+	color: #00b9eb;
+}
+
+#wpadminbar .menupop .menupop > .ab-item .wp-admin-bar-arrow:before,
 #wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before {
 	position: absolute;
 	font: normal 17px/1 dashicons;
@@ -320,9 +337,10 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	padding-right: 2em;
 }
 
-#wpadminbar .menupop .menupop > .ab-item:before {
+#wpadminbar .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 	top: 1px;
-	right: 4px;
+	right: 10px;
+	padding: 4px 0;
 	content: "\f139";
 	color: inherit;
 }
@@ -332,7 +350,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	padding-right: 1em;
 }
 
-#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item:before {
+#wpadminbar .ab-top-secondary .menupop .menupop > .ab-item .wp-admin-bar-arrow:before {
 	top: 1px;
 	left: 6px;
 	content: "\f141";
@@ -366,7 +384,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	border-radius: 10px;
 }
 
-#wpadminbar .quicklinks a:hover span#ab-updates  {
+#wpadminbar .quicklinks a:hover span#ab-updates {
 	background: #fff;
 	color: #000;
 }
@@ -378,6 +396,22 @@ html:lang(he-il) .rtl #wpadminbar *  {
 #wpadminbar ul li:last-child,
 #wpadminbar ul li:last-child .ab-item {
 	box-shadow: none;
+}
+
+/**
+ * Recovery Mode
+ */
+#wpadminbar #wp-admin-bar-recovery-mode {
+	color: #fff;
+	background-color: #ca4a1f;
+}
+
+#wpadminbar .ab-top-menu > #wp-admin-bar-recovery-mode:focus-within >.ab-item,
+#wpadminbar.nojq .quicklinks .ab-top-menu > #wp-admin-bar-recovery-mode > .ab-item:focus,
+#wpadminbar:not(.mobile) .ab-top-menu > #wp-admin-bar-recovery-mode:hover > .ab-item,
+#wpadminbar:not(.mobile) .ab-top-menu > #wp-admin-bar-recovery-mode > .ab-item:focus {
+	color: #fff;
+	background-color: #c0461e;
 }
 
 /**
@@ -404,6 +438,10 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	min-width: 270px;
 }
 
+#wpadminbar.ie8 #wp-admin-bar-my-account.with-avatar .ab-item {
+	white-space: nowrap;
+}
+
 #wpadminbar #wp-admin-bar-user-actions > li {
 	margin-left: 16px;
 	margin-right: 16px;
@@ -425,7 +463,6 @@ html:lang(he-il) .rtl #wpadminbar *  {
 }
 
 #wp-admin-bar-user-info .avatar {
-	/* TODO: The amp-img>img does not get loaded since the container is initially hidden, and :hover does not trigger a re-calc. Resizing the window does, however. */
 	position: absolute;
 	left: -72px;
 	top: 4px;
@@ -461,11 +498,16 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	padding: 0;
 	border: 1px solid #82878c;
 	background: #eee;
-	line-height: 24px;
+	line-height: 1.84615384;
 	vertical-align: middle;
 	margin: -4px 0 0 6px;
 	float: none;
 	display: inline-block; /* Was inline. */
+}
+
+#wpadminbar.ie8 #wp-admin-bar-my-account.with-avatar > .ab-empty-item img,
+#wpadminbar.ie8 #wp-admin-bar-my-account.with-avatar > a img {
+	width: 16px; /* Was auto. */
 }
 
 /**
@@ -579,6 +621,10 @@ html:lang(he-il) .rtl #wpadminbar *  {
 /**
  * Search
  */
+#wpadminbar.ie8 #wp-admin-bar-search {
+	display: block;
+	min-width: 32px;
+}
 #wpadminbar #wp-admin-bar-search .ab-item {
 	padding: 0;
 	background: transparent;
@@ -611,7 +657,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	z-index: 30;
 	font-size: 13px;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	line-height: 24px;
+	line-height: 1.84615384;
 	text-indent: 0;
 	height: 24px;
 	width: 24px;
@@ -619,7 +665,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	padding: 0 3px 0 24px;
 	margin: 0;
 	color: #ccc;
-	background-color: rgba( 255, 255, 255, 0 );
+	background-color: rgba(255, 255, 255, 0);
 	border: none;
 	outline: none;
 	cursor: pointer;
@@ -634,12 +680,30 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	z-index: 10;
 	color: #000;
 	width: 200px;
-	background-color: rgba( 255, 255, 255, 0.9 );
+	background-color: rgba(255, 255, 255, 0.9);
 	cursor: text;
 	border: 0;
 }
 
-/* Removed IE hacks. */
+#wpadminbar.ie7 > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input {
+	margin-top: 3px;
+	width: 120px;
+}
+
+#wpadminbar.ie8 > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input {
+	/* IE8 z-index bug with transparent / empty elements - fill in with an encoded transparent GIF */
+	background: transparent 0 0 repeat scroll url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
+}
+
+/* IE8 doesn't redraw the pseudo elements unless you make a change to the content */
+#wpadminbar.ie8 #adminbarsearch.adminbar-focused:before {
+	content: "\f179 "; /* extra space */
+}
+
+#wpadminbar.ie8 > #wp-toolbar > #wp-admin-bar-top-secondary > #wp-admin-bar-search #adminbarsearch input.adminbar-input:focus {
+	background: #fff;
+	z-index: -1;
+}
 
 #wpadminbar #adminbarsearch .adminbar-button {
 	display: none;
@@ -694,34 +758,86 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	z-index: 100000;
 	line-height: normal;
 	text-decoration: none;
-	box-shadow: 0 0 2px 2px rgba(0,0,0,.6);
+	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
 }
 
 /**
- * Removed IE 6-targeted rules
+ * IE 6-targeted rules
  */
+* html #wpadminbar {
+	overflow: hidden;
+	position: absolute;
+}
 
-/* Removed No @font-face support */
+* html #wpadminbar .quicklinks ul li a {
+	float: left;
+}
 
-@media screen and ( max-width: 782px ) {
+* html #wpadminbar .menupop a span {
+	background-image: none;
+}
+
+/* No @font-face support */
+.no-font-face #wpadminbar ul.ab-top-menu > li > a.ab-item {
+	display: block;
+	width: 45px;
+	text-align: center;
+	overflow: hidden;
+	margin: 0 3px;
+}
+
+.no-font-face #wpadminbar #wp-admin-bar-my-sites > .ab-item,
+.no-font-face #wpadminbar #wp-admin-bar-site-name > .ab-item,
+.no-font-face #wpadminbar #wp-admin-bar-edit > .ab-item {
+	text-indent: 0;
+}
+
+.no-font-face #wpadminbar .ab-icon,
+.no-font-face #wpadminbar .ab-icon:before,
+.no-font-face #wpadminbar a.ab-item:before,
+.no-font-face #wpadminbar #wp-admin-bar-wp-logo > .ab-item {
+	display: none !important;
+}
+
+.no-font-face #wpadminbar ul.ab-top-menu > li > a > span.ab-label {
+	display: inline;
+}
+
+.no-font-face #wpadminbar #wp-admin-bar-menu-toggle span.ab-icon {
+	display: inline !important;
+}
+
+.no-font-face #wpadminbar #wp-admin-bar-menu-toggle span.ab-icon:before {
+	content: "Menu";
+	font: 14px/45px sans-serif !important;
+	display: inline-block !important;
+	color: #fff;
+}
+
+.no-font-face #wpadminbar #wp-admin-bar-site-name a.ab-item {
+	color: #fff;
+}
+/* End no @font-face */
+
+@media screen and (max-width: 782px) {
 	/* Toolbar Touchification*/
 	html #wpadminbar {
 		height: 46px;
-		min-width: 300px;
+		min-width: 240px; /* match the min-width of the body in wp-admin/css/common.css */
 	}
 
 	#wpadminbar * {
 		font-size: 14px;
 		font-weight: 400;
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		line-height: 32px;
+		line-height: 2.28571428;
 	}
 
 	#wpadminbar .quicklinks > ul > li > a,
 	#wpadminbar .quicklinks .ab-empty-item {
 		padding: 0;
 		height: 46px;
-		line-height: 46px;
+		line-height: 3.28571428;
 		width: auto;
 	}
 
@@ -746,6 +862,14 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	#wpadminbar #wp-admin-bar-my-sites a.ab-item,
 	#wpadminbar #wp-admin-bar-my-account a.ab-item {
 		text-overflow: clip;
+	}
+
+	#wpadminbar .quicklinks .menupop ul li .ab-item,
+	#wpadminbar .quicklinks .menupop ul li a strong,
+	#wpadminbar .quicklinks .menupop:focus-within ul li .ab-item,
+	#wpadminbar.nojs .quicklinks .menupop:hover ul li .ab-item,
+	#wpadminbar .shortlink-input {
+		line-height: 1.6;
 	}
 
 	#wpadminbar .ab-label {
@@ -852,7 +976,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	/* New Content */
 	#wpadminbar #wp-admin-bar-new-content .ab-icon:before {
 		top: 0;
-		line-height: 53px;
+		line-height: 1.33333333;
 		height: 46px !important;
 		text-align: center;
 		width: 52px;
@@ -877,7 +1001,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 		display: block;
 		font-size: 34px;
 		height: 46px;
-		line-height: 47px;
+		line-height: 1.38235294;
 		top: 0;
 	}
 
@@ -914,7 +1038,7 @@ html:lang(he-il) .rtl #wpadminbar *  {
 	#wpadminbar #wp-admin-bar-user-info .display-name {
 		height: auto;
 		font-size: 16px;
-		line-height: 24px;
+		line-height: 1.5;
 		color: #eee;
 	}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1382,6 +1382,9 @@ class AMP_Theme_Support {
 		wp_styles()->registered['admin-bar']->src = amp_get_asset_url( 'css/admin-bar.css' );
 		wp_styles()->registered['admin-bar']->ver = AMP__VERSION;
 
+		// Remove any possible '.min' to avoid RTL failing to generate the href for admin-bar-rtl.css, which does not currently have a minified version in the AMP plugin.
+		wp_styles()->registered['admin-bar']->extra['suffix'] = '';
+
 		// Remove script which is almost entirely made obsolete by :focus-inside in the forked admin-bar.css.
 		wp_dequeue_script( 'admin-bar' );
 


### PR DESCRIPTION
# Add RTL admin-bar

This PR includes an `admin-bar-rtl.css` and ensures it gets loaded when `is_rtl()`.

## Before

<img width="806" alt="Screen Shot 2019-08-06 at 13 58 57" src="https://user-images.githubusercontent.com/134745/62578175-5f2c9900-b855-11e9-9dd0-ee48dc5a1196.png">

## After

<img width="804" alt="Screen Shot 2019-08-06 at 14 15 01" src="https://user-images.githubusercontent.com/134745/62578191-6784d400-b855-11e9-8609-faf788cd185c.png">

# Update Forks

The `admin-bar.css` in core has been updated since we forked it from WP 4.9. This updates it to the latest: https://github.com/WordPress/wordpress-develop/blob/160fc055da156248277513dd5256fbcc66faa5a7/src/wp-includes/css/admin-bar.css

Changes applied to fork:

```diff
0a1,10
> /*
> This is forked from core's admin-bar.css from WP 5.3-alpha at 160fc055da156248277513dd5256fbcc66faa5a7.
> 
> https://github.com/WordPress/wordpress-develop/blob/160fc055da156248277513dd5256fbcc66faa5a7/src/wp-includes/css/admin-bar.css
> 
> - References to .hover have been replaced with :focus-within (which is not supported in IE11).
> - Universal selector properties have been removed which interferes with AMP shadow elements.
> */
> 
> 
6c16
< 	position: static;
---
> 	/* Removed because interferes with amp-img>img: position: static; */
187c197
< #wpadminbar .quicklinks .menupop.hover ul li .ab-item,
---
> #wpadminbar .quicklinks .menupop:focus-within ul li .ab-item,
201c211
< #wpadminbar li.hover > .ab-sub-wrapper {
---
> #wpadminbar li:focus-within > .ab-sub-wrapper {
206c216
< #wpadminbar .menupop li.hover > .ab-sub-wrapper {
---
> #wpadminbar .menupop li:focus-within > .ab-sub-wrapper {
212c222
< #wpadminbar .ab-top-secondary .menupop li.hover > .ab-sub-wrapper {
---
> #wpadminbar .ab-top-secondary .menupop li:focus-within > .ab-sub-wrapper {
221c231,235
< #wpadminbar .ab-top-menu > li.hover > .ab-item {
---
> #wpadminbar .ab-top-menu > li:focus-within > .ab-item {
> 	background: #32373c;
> 	color: #00b9eb;
> }
> #wpadminbar .ab-top-menu > li:focus-within > .ab-item {
227c241
< #wpadminbar > #wp-toolbar li.hover span.ab-label,
---
> #wpadminbar > #wp-toolbar li:focus-within span.ab-label,
273c287
< #wpadminbar .quicklinks .menupop.hover ul li a,
---
> #wpadminbar .quicklinks .menupop:focus-within ul li a,
283,287c297,301
< #wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a,
< #wpadminbar .quicklinks .menupop.hover ul li a:hover,
< #wpadminbar .quicklinks .menupop.hover ul li a:focus,
< #wpadminbar .quicklinks .menupop.hover ul li div[tabindex]:hover,
< #wpadminbar .quicklinks .menupop.hover ul li div[tabindex]:focus,
---
> #wpadminbar .quicklinks .ab-sub-wrapper .menupop:focus-within > a,
> #wpadminbar .quicklinks .menupop:focus-within ul li a:hover,
> #wpadminbar .quicklinks .menupop:focus-within ul li a:focus,
> #wpadminbar .quicklinks .menupop:focus-within ul li div[tabindex]:hover,
> #wpadminbar .quicklinks .menupop:focus-within ul li div[tabindex]:focus,
295,296c309,310
< #wpadminbar li.hover .ab-icon:before,
< #wpadminbar li.hover .ab-item:before,
---
> #wpadminbar li:focus-within .ab-icon:before,
> #wpadminbar li:focus-within .ab-item:before,
307,308c321,322
< #wpadminbar.mobile .quicklinks .hover .ab-icon:before,
< #wpadminbar.mobile .quicklinks .hover .ab-item:before {
---
> #wpadminbar.mobile .quicklinks :focus-within .ab-icon:before,
> #wpadminbar.mobile .quicklinks :focus-within .ab-item:before {
395c409
< #wpadminbar .ab-top-menu > #wp-admin-bar-recovery-mode.hover >.ab-item,
---
> #wpadminbar .ab-top-menu > #wp-admin-bar-recovery-mode:focus-within >.ab-item,
482c496
< 	width: auto;
---
> 	width: 16px; /* Was auto. */
491c505
< 	display: inline;
---
> 	display: inline-block; /* Was inline. */
496c510
< 	width: auto;
---
> 	width: 16px; /* Was auto. */
532c546
< #wpadminbar .quicklinks .ab-sub-wrapper .menupop.hover > a .blavatar {
---
> #wpadminbar .quicklinks .ab-sub-wrapper .menupop:focus-within > a .blavatar {
855c869
< 	#wpadminbar .quicklinks .menupop.hover ul li .ab-item,
---
> 	#wpadminbar .quicklinks .menupop:focus-within ul li .ab-item,
866c880
< 	#wpadminbar .menupop li.hover > .ab-sub-wrapper {
---
> 	#wpadminbar .menupop li:focus-within > .ab-sub-wrapper {
1060c1074
< 	#wpadminbar li.hover ul li,
---
> 	#wpadminbar li:focus-within ul li,
1109,1111c1123
< 	#wpadminbar {
< 		position: absolute;
< 	}
---
> 	/* Removed: #wpadminbar { position: absolute; } */
```