### PR TITLE
Fix accidental omission of selector when no modifications made

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1313,7 +1313,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private function process_stylesheet( $stylesheet, $options = [] ) {
 		$parsed      = null;
 		$cache_key   = null;
-		$cache_group = 'amp-parsed-stylesheet-v18'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group = 'amp-parsed-stylesheet-v19'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(
@@ -2795,8 +2795,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$before_type_selector_pattern = '(?<=^|\(|\s|>|\+|~|,|})';
 			$after_type_selector_pattern  = '(?=$|[^a-zA-Z0-9_-])';
 
-			$did_edit_selector = false;
-
 			/*
 			 * Loop over each selector mappings. A single HTML tag can map to multiple AMP tags (e.g. img could be amp-img or amp-anim).
 			 * The $selector_mappings array contains ~6 items, so rest easy your O(n^3) eyes when seeing triple nested loops!
@@ -2837,14 +2835,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 					// Replace the current edited selector with all the new edited selectors resulting from the mapping replacement.
 					array_splice( $edited_selectors, $i, 1, $edited_selectors_from_selector );
-					$did_edit_selector = true;
+					$has_changed_selectors = true;
 				}
 			}
 
-			if ( $did_edit_selector ) {
-				$has_changed_selectors = true;
-				$selectors             = array_merge( $selectors, $edited_selectors );
-			}
+			$selectors = array_merge( $selectors, $edited_selectors );
 		}
 
 		if ( $has_changed_selectors ) {

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -616,6 +616,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img,amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img{object-fit:contain}',
 				'amp-img.amp-wp-enforced-sizes[layout="intrinsic"] > img,amp-anim.amp-wp-enforced-sizes[layout="intrinsic"] > img{object-fit:contain}',
 			],
+			'admin-bar-style-selectors' => [
+				'<div id="wpadminbar"><a href="https://example.com/"><amp-img src="https://example.com/foo.png" width="100" height="100"></amp-img><amp-anim src="https://example.com/foo.gif" width="100" height="100"></amp-anim></a></div>',
+				'#wpadminbar a, #wpadminbar a:hover, #wpadminbar a img, #wpadminbar a img:hover { border: none; text-decoration: none; background: none;}',
+				'#wpadminbar a,#wpadminbar a:hover,#wpadminbar a amp-img,#wpadminbar a amp-anim,#wpadminbar a amp-img:hover,#wpadminbar a amp-anim:hover{border:none;text-decoration:none;background:none}',
+			],
 			'img_with_amp_img' => [
 				'<amp-img></amp-img>',
 				'amp-img img{background-color:red}',


### PR DESCRIPTION
This fixes a regression introduced in #2793. Given a CSS rule like:

```css
#wpadminbar a,
#wpadminbar a:hover,
#wpadminbar a img,
#wpadminbar a img:hover {...}
```

This should be converted to AMP as:

```css
#wpadminbar a,
#wpadminbar a:hover,
#wpadminbar a amp-img,
#wpadminbar a amp-img:hover,
#wpadminbar a amp-anim,
#wpadminbar a amp-anim:hover {...}
```

Nevertheless, it is actually being converted as:

```css
#wpadminbar a amp-img,
#wpadminbar a amp-img:hover,
#wpadminbar a amp-anim,
#wpadminbar a amp-anim:hover {...}
```

It's omitting the `#wpadminbar a` and `#wpadminbar a:hover` selectors here. This is due to a bug in the `\AMP_Style_Sanitizer::ampify_ruleset_selectors()` logic which resulted in a selector not needing transformation would get omitted if there were other selectors in the same rule that did need transformation.

This turned up when looking a site with the Genesis Sample theme active, where the links in the admin bar got underlined erroneously due to the selector not being present to target them to apply `text-decoration:none`:

# Before

<img width="786" alt="Screen Shot 2019-08-06 at 14 23 30" src="https://user-images.githubusercontent.com/134745/62578495-217c4000-b856-11e9-9680-7362ff9fe978.png">

# After

<img width="785" alt="Screen Shot 2019-08-06 at 14 24 24" src="https://user-images.githubusercontent.com/134745/62578496-217c4000-b856-11e9-9c16-bbc069c5f388.png">
