### PR TITLE
Text block: create new paragraph on enter

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -153,6 +153,7 @@ class TextBlockEdit extends Component {
 						// Ensure line breaks are normalised to HTML.
 						value={ content }
 						onChange={ ( nextContent ) => setAttributes( { content: nextContent } ) }
+						multiline={ true }
 						// The 2 following lines are necessary for pasting to work.
 						onReplace={ this.onReplace }
 						onSplit={ () => {} }


### PR DESCRIPTION
See #2732.

This has come up a few times in user testing, as it's rather annoying that nothing happens when pressing enter.