### PR TITLE
Improve handling of unlisted Vimeo videos

### DIFF
--- a/includes/embeds/class-amp-vimeo-embed.php
+++ b/includes/embeds/class-amp-vimeo-embed.php
@@ -156,16 +156,15 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Determine the video ID from the URL.
 	 *
 	 * @param string $url URL.
-	 * @return integer Video ID.
+	 * @return int Video ID.
 	 */
 	private function get_video_id_from_url( $url ) {
-		$parsed_url = wp_parse_url( $url );
-		parse_str( $parsed_url['path'], $path );
+		$path = wp_parse_url( $url, PHP_URL_PATH );
 
+		// @todo This will not get the private key for unlisted videos (which look like https://vimeo.com/123456789/abcdef0123), but amp-vimeo doesn't support them currently anyway.
 		$video_id = '';
-		if ( $path ) {
-			$tok      = explode( '/', $parsed_url['path'] );
-			$video_id = end( $tok );
+		if ( $path && preg_match( ':^/(\d+):', $path, $matches ) ) {
+			$video_id = $matches[1];
 		}
 
 		return $video_id;

--- a/tests/php/test-amp-vimeo-embed.php
+++ b/tests/php/test-amp-vimeo-embed.php
@@ -8,7 +8,7 @@
 /**
  * Class AMP_Vimeo_Embed_Test
  *
- * @covers AMP_SoundCloud_Embed_Handler
+ * @covers AMP_Vimeo_Embed_Handler
  */
 class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 

--- a/tests/php/test-amp-vimeo-embed.php
+++ b/tests/php/test-amp-vimeo-embed.php
@@ -1,6 +1,22 @@
 <?php
+/**
+ * Class AMP_Vimeo_Embed_Test
+ *
+ * @package AMP
+ */
 
+/**
+ * Class AMP_Vimeo_Embed_Test
+ *
+ * @covers AMP_SoundCloud_Embed_Handler
+ */
 class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
+
+	/**
+	 * Get conversion data.
+	 *
+	 * @return array
+	 */
 	public function get_conversion_data() {
 		return [
 			'no_embed'                      => [
@@ -10,6 +26,11 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 
 			'url_simple'                    => [
 				'https://vimeo.com/172355597' . PHP_EOL,
+				'<p><amp-vimeo data-videoid="172355597" layout="responsive" width="600" height="338"></amp-vimeo></p>' . PHP_EOL,
+			],
+
+			'url_unlisted'                  => [
+				'https://vimeo.com/172355597/abcdef0123' . PHP_EOL,
 				'<p><amp-vimeo data-videoid="172355597" layout="responsive" width="600" height="338"></amp-vimeo></p>' . PHP_EOL,
 			],
 
@@ -32,7 +53,12 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test conversion.
+	 *
 	 * @dataProvider get_conversion_data
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 */
 	public function test__conversion( $source, $expected ) {
 		$embed = new AMP_Vimeo_Embed_Handler();
@@ -42,6 +68,11 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $filtered_content );
 	}
 
+	/**
+	 * Get scripts data.
+	 *
+	 * @return array Scripts data.
+	 */
 	public function get_scripts_data() {
 		return [
 			'not_converted' => [
@@ -56,7 +87,12 @@ class AMP_Vimeo_Embed_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_scripts().
+	 *
 	 * @dataProvider get_scripts_data
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 */
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Vimeo_Embed_Handler();


### PR DESCRIPTION
Vimeo has the ability to create unlisted videos: https://vimeo.com/blog/post/share-unlisted-videos-with-private-links/

Such videos have URLs like: `https://vimeo.com/172355597/abcdef0123`

The AMP plugin was erroneously turning this into the following:

```html
<p><amp-vimeo data-videoid="abcdef0123" layout="responsive" width="600" height="338"></amp-vimeo></p>
```

And this was causing an AMP validation error, because the video ID has to consist of digits only. But here the secret video key was erroneously being provided as the ID.

Now, it's likely that this will still result in the Vimeo unlisted video being unviewable, since the unlisted key is just dropped. Nevertheless, it's somewhat better than having an AMP validation error. 