### PR TITLE
Hide tooltips that should be hidden

### DIFF
--- a/assets/css/admin-tables.css
+++ b/assets/css/admin-tables.css
@@ -69,3 +69,7 @@ td.column-found_elements_and_attributes div {
 .wrap .wp-heading-inline + .page-title-action {
 	margin-left: 1rem;
 }
+
+.tooltip[hidden] {
+	visibility: hidden;
+}

--- a/assets/css/amp-validation-tooltips.css
+++ b/assets/css/amp-validation-tooltips.css
@@ -5,3 +5,7 @@
 	cursor: pointer;
 	color: #767676;
 }
+
+.tooltip[hidden] {
+	visibility: hidden;
+}


### PR DESCRIPTION
Hides tooltip containers that don't seem to be actually used themselves. Only their content is extracted in `amp-validation-tooltips.js`.

Before:

![Screenshot 2019-08-08 at 16 17 55](https://user-images.githubusercontent.com/841956/62711519-7a380e00-b9f9-11e9-8ec3-6b134401ed1e.png)

After:

![Screenshot 2019-08-08 at 16 26 45](https://user-images.githubusercontent.com/841956/62711526-7d32fe80-b9f9-11e9-9f95-06ffae618198.png)

