### PR TITLE
Fix Text blocks: Revert multiline

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-text/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.js
@@ -153,7 +153,6 @@ class TextBlockEdit extends Component {
 						// Ensure line breaks are normalised to HTML.
 						value={ content }
 						onChange={ ( nextContent ) => setAttributes( { content: nextContent } ) }
-						multiline={ true }
 						// The 2 following lines are necessary for pasting to work.
 						onReplace={ this.onReplace }
 						onSplit={ () => {} }


### PR DESCRIPTION
Fixes #2997.

This reverts adding the `multiline` attribute to Text block since that seems to cause regressions (see #2979)

It's possible that for accommodating the `multiline` we'd need to add deprecation logic + modify the templates.

Meanwhile, we can fix it by just reverting the change and continue looking into `multiline` within another PR.