### PR TITLE
Update amphtml validator spec to v1907301630320

### DIFF
--- a/includes/embeds/class-amp-soundcloud-embed.php
+++ b/includes/embeds/class-amp-soundcloud-embed.php
@@ -189,9 +189,13 @@ class AMP_SoundCloud_Embed_Handler extends AMP_Base_Embed_Handler {
 			$attributes['data-visual'] = rest_sanitize_boolean( $args['visual'] ) ? 'true' : 'false';
 		}
 
-		// @todo Set width to $args['width'] and layout to responsive once amp-soundcloud supports it: <https://github.com/ampproject/amphtml/issues/23144>.
 		$attributes['height'] = $args['height'] ?: $this->args['height'];
-		$attributes['layout'] = 'fixed-height';
+		if ( $args['width'] ) {
+			$attributes['width']  = $args['width'];
+			$attributes['layout'] = 'responsive';
+		} else {
+			$attributes['layout'] = 'fixed-height';
+		}
 
 		return AMP_HTML_Utils::build_tag(
 			'amp-soundcloud',

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 896;
+	private static $spec_file_revision = 920;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -739,6 +739,57 @@ class AMP_Allowed_Tags_Generated {
 						'amp-ad',
 					),
 					'spec_url' => 'https://amp.dev/documentation/components/amp-ad',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'data-url' => array(
+						'mandatory' => true,
+						'value_url' => array(
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'template' => array(),
+					'type' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'custom',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'also_requires_tag_warning' => array(
+						'amp-ad extension .js script',
+					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							8,
+							9,
+							1,
+							4,
+						),
+					),
+					'disallowed_ancestor' => array(
+						'amp-app-banner',
+					),
+					'requires_extension' => array(
+						'amp-ad',
+					),
+					'spec_name' => 'amp-ad with type=custom',
+					'spec_url' => 'https://github.com/ampproject/amphtml/blob/master/ads/custom.md',
 				),
 			),
 			array(
@@ -1863,7 +1914,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'type' => array(
-						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => array(
 							'carousel',
@@ -2303,6 +2353,11 @@ class AMP_Allowed_Tags_Generated {
 					'[max]' => array(),
 					'[min]' => array(),
 					'[src]' => array(),
+					'allow-blocked-end-date' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -2391,6 +2446,11 @@ class AMP_Allowed_Tags_Generated {
 					'[max]' => array(),
 					'[min]' => array(),
 					'[src]' => array(),
+					'allow-blocked-end-date' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -2475,6 +2535,11 @@ class AMP_Allowed_Tags_Generated {
 					'[max]' => array(),
 					'[min]' => array(),
 					'[src]' => array(),
+					'allow-blocked-end-date' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -2572,6 +2637,11 @@ class AMP_Allowed_Tags_Generated {
 					'[max]' => array(),
 					'[min]' => array(),
 					'[src]' => array(),
+					'allow-blocked-end-date' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'allow-blocked-ranges' => array(
 						'value' => array(
 							'',
@@ -2717,7 +2787,6 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'template' => array(),
 					'type' => array(
 						'mandatory' => true,
 					),
@@ -3309,6 +3378,9 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'srcdoc' => array(),
+					'tabindex' => array(
+						'value_regex' => '-?\\d+',
+					),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -4603,9 +4675,10 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'sandbox' => array(),
+					'script' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'mandatory' => true,
 						'value_url' => array(
 							'allow_relative' => false,
 							'protocol' => array(
@@ -4632,7 +4705,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-script',
 					),
-					'unique' => true,
 				),
 			),
 		),
@@ -4911,7 +4983,13 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'amp_layout' => array(
 						'supported_layouts' => array(
+							6,
+							2,
 							3,
+							7,
+							9,
+							1,
+							4,
 						),
 					),
 					'requires_extension' => array(
@@ -5237,6 +5315,12 @@ class AMP_Allowed_Tags_Generated {
 		'amp-story-grid-layer' => array(
 			array(
 				'attr_spec_list' => array(
+					'position' => array(
+						'value' => array(
+							'landscape-half-left',
+							'landscape-half-right',
+						),
+					),
 					'template' => array(
 						'mandatory' => true,
 						'value' => array(
@@ -5397,11 +5481,9 @@ class AMP_Allowed_Tags_Generated {
 					'data-cards' => array(),
 					'data-conversation' => array(),
 					'data-limit' => array(),
-					'data-link-color' => array(),
 					'data-momentid' => array(
 						'value_regex' => '\\d+',
 					),
-					'data-theme' => array(),
 					'data-timeline-id' => array(
 						'value_regex' => '\\d+',
 					),
@@ -14651,7 +14733,18 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'section' => array(
 			array(
-				'attr_spec_list' => array(),
+				'attr_spec_list' => array(
+					'poool-access-content' => array(
+						'requires_extension' => array(
+							'amp-access-poool',
+						),
+					),
+					'poool-access-preview' => array(
+						'requires_extension' => array(
+							'amp-access-poool',
+						),
+					),
+				),
 				'tag_spec' => array(
 					'disallowed_ancestor' => array(
 						'amp-accordion',

--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -56,6 +56,7 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 					function ( $matches ) use ( &$responsive_width, &$responsive_height ) {
 						$responsive_width  = $matches['width'];
 						$responsive_height = $matches['height'];
+						return '';
 					},
 					$class
 				)

--- a/includes/sanitizers/class-amp-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-block-sanitizer.php
@@ -33,6 +33,11 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			/**
+			 * Element.
+			 *
+			 * @var DOMElement $node
+			 */
 			$node = $nodes->item( $i );
 
 			// We are only looking for <figure> elements which have wp-block-embed as class.
@@ -42,11 +47,35 @@ class AMP_Block_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// Remove classes like wp-embed-aspect-16-9 since responsive layout is handled by AMP's layout system.
-			$node->setAttribute( 'class', preg_replace( '/(?<=^|\s)wp-embed-aspect-\d+-\d+(?=\s|$)/', '', $class ) );
+			$responsive_width  = null;
+			$responsive_height = null;
+			$node->setAttribute(
+				'class',
+				preg_replace_callback(
+					'/(?<=^|\s)wp-embed-aspect-(?P<width>\d+)-(?P<height>\d+)(?=\s|$)/',
+					function ( $matches ) use ( &$responsive_width, &$responsive_height ) {
+						$responsive_width  = $matches['width'];
+						$responsive_height = $matches['height'];
+					},
+					$class
+				)
+			);
 
 			// We're looking for <figure> elements that have one child node only.
 			if ( 1 !== count( $node->childNodes ) ) {
 				continue;
+			}
+
+			// @todo Should this only be done if the body has a .wp-embed-responsive class (i.e. current_theme_supports( 'responsive-embeds' ))?
+			// @todo Should we consider just eliminating the .wp-block-embed__wrapper element since unnecessary?
+			// For visual parity with blocks in non-AMP pages, override the oEmbed's natural responsive dimensions with the aspect ratio specified in the wp-embed-aspect-* class name.
+			if ( $responsive_width && $responsive_height ) {
+				$xpath       = new DOMXPath( $this->dom );
+				$amp_element = $xpath->query( './div[ contains( @class, "wp-block-embed__wrapper" ) ]/*[ @layout = "responsive" ]', $node )->item( 0 );
+				if ( $amp_element instanceof DOMElement ) {
+					$amp_element->setAttribute( 'width', $responsive_width );
+					$amp_element->setAttribute( 'height', $responsive_height );
+				}
 			}
 
 			$attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $node );

--- a/tests/php/test-amp-soundcloud-embed.php
+++ b/tests/php/test-amp-soundcloud-embed.php
@@ -123,12 +123,12 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 
 			'track_simple'    => [
 				$this->track_url . PHP_EOL,
-				'<p><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart &#8211; Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
+				'<p><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart &#8211; Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
 			],
 
 			'playlist_simple' => [
 				$this->playlist_url . PHP_EOL,
-				'<p><amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music &#8211; The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
+				'<p><amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music &#8211; The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud></p>' . PHP_EOL,
 			],
 		];
 
@@ -141,34 +141,34 @@ class AMP_SoundCloud_Embed_Test extends WP_UnitTestCase {
 				$data,
 				[
 					'shortcode_with_bare_track_api_url'   => [
-						'[soundcloud https://api.soundcloud.com/tracks/89299804]' . PHP_EOL,
-						'<amp-soundcloud data-trackid="89299804" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
+						'[soundcloud https://api.soundcloud.com/tracks/90097394]' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
 					],
 
 					'shortcode_with_track_api_url'        => [
-						'[soundcloud url=https://api.soundcloud.com/tracks/89299804]' . PHP_EOL,
-						'<amp-soundcloud data-trackid="89299804" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
+						'[soundcloud url=https://api.soundcloud.com/tracks/90097394]' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
 					],
 
 					'shortcode_with_track_permalink'      => [
 						"[soundcloud url=$this->track_url]",
-						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
 					],
 
 					'shortcode_with_bare_track_permalink' => [
 						"[soundcloud $this->track_url]",
-						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="true" height="400" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/jack-villano-villano/mozart-requiem-in-d-minor">Mozart - Requiem in D minor Complete Full by Jack Villano Villano</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
 					],
 
 					'shortcode_with_playlist_permalink'   => [
 						"[soundcloud url=$this->playlist_url]",
-						'<amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" layout="fixed-height">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music - The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
+						'<amp-soundcloud data-playlistid="40936190" data-visual="true" height="450" width="500" layout="responsive">' . ( function_exists( 'wp_filter_oembed_iframe_title_attribute' ) ? '<a fallback href="https://soundcloud.com/classical-music-playlist/sets/classical-music-essential-collection">Classical Music - The Essential Collection by Classical Music</a>' : '' ) . '</amp-soundcloud>' . PHP_EOL,
 					],
 
 					// This apparently only works on WordPress.com.
 					'shortcode_with_id'                   => [
-						'[soundcloud id=89299804]' . PHP_EOL,
-						'<amp-soundcloud data-trackid="89299804" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
+						'[soundcloud id=90097394]' . PHP_EOL,
+						'<amp-soundcloud data-trackid="90097394" data-visual="false" height="166" layout="fixed-height"></amp-soundcloud>' . PHP_EOL,
 					],
 				]
 			);

--- a/tests/php/test-class-amp-block-sanitizer.php
+++ b/tests/php/test-class-amp-block-sanitizer.php
@@ -41,6 +41,11 @@ class AMP_Block_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure class="wp-block-embed" data-amp-layout="fill"><amp-facebook width="100"></amp-facebook></figure>',
 				'<figure class="wp-block-embed" data-amp-layout="fill" style="position:relative; width: 100%; height: 400px;"><amp-facebook layout="fill"></amp-facebook></figure>',
 			],
+
+			'responsive_layout'    => [
+				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud wp-embed-aspect-4-3 wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="400" width="640" layout="responsive"></amp-soundcloud></div></figure>',
+				'<figure class="wp-block-embed-soundcloud wp-block-embed is-type-rich is-provider-soundcloud  wp-has-aspect-ratio"><div class="wp-block-embed__wrapper"><amp-soundcloud data-trackid="90097394" data-visual="true" height="3" width="4" layout="responsive"></amp-soundcloud></div></figure>',
+			],
 		];
 	}
 


### PR DESCRIPTION
Previously: #2816.

- [x] Run `./bin/amphtml-update.sh`
- [x] Examine diff for changelog
- [x] ~Update spec generator as needed based on spec format changes~ (see #938)
- [x] ~Modify validating sanitizer based on changes to spec, if needed~ (see #938)
- [x] Add tests for key changes

Todos specific to this update:

- [x] Use `responsive` layout for `amp-soundcloud`.
- [x] When `AMP_Block_Sanitizer` removes classes like `wp-embed-aspect-16-9`, have it push the width and height onto the child element if it has `layout=responsive`.

# Changelog

* Add `amp-ad` with `type=custom`
* Add `allow-blocked-end-date` attribute to `amp-date-picker`.
* Remove `template` attribute from `amp-embed`.
* Add `tabindex` attribute regex constraint (as integer) for `amp-iframe`.
* Add supported layouts to `amp-soundcloud`. See https://github.com/ampproject/amp-wp/pull/2722 which now needs revisiting to implement `responsive` layout. See below.
* Update `amp-script`:
  * Add `sandbox` attribute.
  * Remove `unique` constraint for `amp-script`, so you can now use multiple scripts on a page.
  * Add a `script` attribute which contains the ID for a `script[type=text/plain]` on the page containing the JS to run, except this is temporarily disabled: https://github.com/ampproject/amphtml/blob/1907301630320/extensions/amp-script/validator-amp-script.protoascii#L27-L56
  * Remove `mandatory` constraint for `src` attribute, since the `script` can soon be defined inline via the `script` attribute.
* Add `position` attribute (value being either `landscape-half-left` or `landscape-half-right`) to `amp-story-grid-layer`. See https://github.com/ampproject/amp-wp/issues/2409.
* Add `poool-access-content` and `poool-access-preview` attributes to the `section` element.

## SoundCloud Embed Layout

This is revisiting #2722 since `amp-soundcloud` now supports `layout=responsive` per https://github.com/ampproject/amphtml/issues/23144.

### Before

Only `layout=fixed-height` was supported, resulting in squished-looking embeds:

<img width="1051" alt="Screen Shot 2019-08-09 at 15 41 26" src="https://user-images.githubusercontent.com/134745/62812815-407c0b80-babc-11e9-9f13-b47edd1de979.png">

### After

Now with `layout=responsive`, the embed looks identical to the non-AMP version, including the preservation of the aspect ratio defined by the block class name:

<img width="1042" alt="Screen Shot 2019-08-09 at 15 41 08" src="https://user-images.githubusercontent.com/134745/62812871-981a7700-babc-11e9-8f26-def3954f56ce.png">

# Details


```bash
(
    PREV_VERSION=1907022322580;
    THIS_VERSION=1907301630320; 
    git diff $PREV_VERSION...$THIS_VERSION -- $( git ls-files $THIS_VERSION -- . | grep '.protoascii' )
)
```

<details>
<summary>Compare 1907022322580...1907301630320</summary>

```diff
diff --git a/extensions/amp-ad/validator-amp-ad.protoascii b/extensions/amp-ad/validator-amp-ad.protoascii
index cfc0e8018..67cce32bb 100644
--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -77,6 +77,42 @@ tags: {  # <amp-ad>
     supported_layouts: RESPONSIVE
   }
 }
+tags: {  # <amp-ad type="custom">
+  html_format: AMP  # Ads are not allowed inside ads
+  tag_name: "AMP-AD"
+  spec_name: "amp-ad with type=custom"
+  requires_extension: "amp-ad"  # See note at top of file
+  also_requires_tag_warning: "amp-ad extension .js script"
+  # If modifying disallowed_ancestors, then please also edit
+  # extensions/amp-auto-ads/*/placement.js
+  disallowed_ancestor: "AMP-APP-BANNER"
+  attrs: {
+    name: "data-url"
+    mandatory: true
+    value_url: {
+      protocol: "https"
+    }
+  }
+  attrs: { name: "template" }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value: "custom"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://github.com/ampproject/amphtml/blob/master/ads/custom.md"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: FLUID
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
 tags: {  # <amp-ad data-multi-size>
   html_format: AMP  # Ads are not allowed inside ads
   tag_name: "AMP-AD"
@@ -185,7 +221,6 @@ tags: {  # <amp-embed>
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  attrs: { name: "template" }
   attrs: { name: "type" mandatory: true }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-ad"
diff --git a/extensions/amp-carousel/validator-amp-carousel.protoascii b/extensions/amp-carousel/validator-amp-carousel.protoascii
index b40dab8a3..1b1f31e9c 100644
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -37,13 +37,11 @@ attr_lists: {
     value: ""
   }
   attrs: {
-    disabled_by: "amp4email"
     name: "autoplay"
     value_regex: "(|[0-9]+)"
   }
   attrs: { name: "controls" }
   attrs: {
-    disabled_by: "amp4email"
     name: "delay"
     value_regex: "[0-9]+"
   }
@@ -59,6 +57,23 @@ attr_lists: {
   # <amp-bind>
   attrs: { name: "[slide]" }
 }
+# There are 4 variants here, due to two independent axis of differences:
+#  1) type=slides vs. type=carousel
+#     - type=slides is the implied default if type is unspecified. This is
+#       encoded in the rules by making type=carousel mandatory, and
+#       type=slides optional.
+#     - slides vs. carousel implies different sets up supported layouts.
+#  2) presence of `lightbox` attribute.
+#     - lightbox is only allowed in AMP html format.
+#     - lightbox implies additional reference_point requirements of the
+#       amp-lightbox children.
+# The attribute implied rules (different layouts or different children) is not
+# a feature of the validator rules engine. Thus the only supportable ruleset is
+# to implement 1 tagspec for each combination. This produces the desired rules
+# but has undesirable results for some of the error messages, as seen in some
+# of the test cases. The main issue is that since there are two tagspecs with
+# each combination, we cannot use the usual dispatch_key trick for either
+# attribute.
 tags: {  # <amp-carousel type=slides>
   html_format: AMP
   html_format: AMP4ADS
@@ -96,7 +111,6 @@ tags: {  # <amp-carousel type=carousel>
     name: "type"
     value: "carousel"
     mandatory: true
-    dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "amp-carousel-common"
   attr_lists: "extended-amp-global"
diff --git a/extensions/amp-date-picker/validator-amp-date-picker.protoascii b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
index 8beca0716..0e96a1eba 100644
--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -133,6 +133,10 @@ tags: {
 
 attr_lists: {
   name: "amp-date-picker-common-attributes"
+  attrs: {
+    name: "allow-blocked-end-date"
+    value: ""
+  }
   attrs: {
     name: "allow-blocked-ranges"
     value: ""
diff --git a/extensions/amp-iframe/validator-amp-iframe.protoascii b/extensions/amp-iframe/validator-amp-iframe.protoascii
index bb9475837..5b4c88fba 100644
--- a/extensions/amp-iframe/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/validator-amp-iframe.protoascii
@@ -60,6 +60,10 @@ tags: {  # <amp-iframe>
     value: "no"
     value: "yes"
   }
+  attrs: {
+    name: "tabindex"
+    value_regex: "-?\\d+"
+  }
   attrs: {
     name: "src"
     mandatory_oneof: "['src', 'srcdoc']"
diff --git a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
index 25ca279e1..238852928 100644
--- a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
+++ b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
@@ -36,6 +36,8 @@ tags: {  # amp-image-lightbox
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
+  deprecation: "amp-image-lightbox cannot be properly positioned in emails and will soon be invalid in AMP4EMAIL."
+  deprecation_url: "https://github.com/ampproject/amphtml/issues/23170"
 }
 tags: {  # <amp-image-lightbox>
   html_format: AMP
diff --git a/extensions/amp-lightbox/validator-amp-lightbox.protoascii b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
index d433afe29..afb77bd7d 100644
--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -29,15 +29,27 @@ tags: {  # amp-lightbox
 }
 tags: {  # amp-lightbox
   html_format: AMP4ADS
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4ADS)"
+  extension_spec: {
+    name: "amp-lightbox"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-lightbox
   html_format: AMP4EMAIL
   tag_name: "SCRIPT"
-  spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4EMAIL/AMP4ADS)"
+  spec_name: "SCRIPT[custom-element=amp-lightbox] (AMP4EMAIL)"
   extension_spec: {
     name: "amp-lightbox"
     version: "0.1"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
+  deprecation: "amp-lightbox cannot be properly positioned in emails and will soon be invalid in AMP4EMAIL."
+  deprecation_url: "https://github.com/ampproject/amphtml/issues/23170"
 }
 tags: {  # <amp-lightbox>
   html_format: AMP
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index 93781374c..59205f343 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -24,17 +24,50 @@ tags: {
   }
   attr_lists: "common-extension-attrs"
 }
-
+# Temporarily disable until interaction of amp-script and signed exchanges has
+# been security reviewed.
+#tags: {  # <amp-script> (local script)
+#  html_format: AMP
+#  tag_name: "SCRIPT"
+#  spec_name: "amp-script extension local script"
+#  requires_extension: "amp-script"
+#  attrs: {
+#    name: "target"
+#    mandatory: true
+#    value: "amp-script"
+#    dispatch_key: NAME_VALUE_DISPATCH
+#  }
+#  attrs: {
+#    name: "type"
+#    mandatory: true
+#    value_casei: "text/plain"
+#  }
+#  attr_lists: "mandatory-id-attr"
+#  attr_lists: "nonce-attr"
+#  cdata: {
+#    max_bytes: 10000
+#    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script#faq"
+#    blacklisted_cdata_regex: {
+#      regex: "<!--"
+#      error_message: "html comments"
+#    }
+#  }
+#  spec_url: "https://amp.dev/documentation/components/amp-script"
+#}
 tags: {  # <amp-script>
   html_format: AMP
   tag_name: "AMP-SCRIPT"
   disallowed_ancestor: "AMP-SCRIPT"
   requires_extension: "amp-script"
   requires: "amp-experiment-token"
-  unique: true # TODO(choumx): Remove when global size limit is implemented.
+  attrs: { name: "sandbox" }
+  attrs: {
+    name: "script"
+    mandatory_anyof: "['script', 'src']"
+  }
   attrs: {
     name: "src"
-    mandatory: true
+    mandatory_anyof: "['script', 'src']"
     value_url: {
       protocol: "https"
       allow_relative: false
diff --git a/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii b/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
index 953ca77c4..84081d8c0 100644
--- a/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
+++ b/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
@@ -55,6 +55,12 @@ tags: {  # <amp-soundcloud>
   }
   attr_lists: "extended-amp-global"
   amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
   }
 }
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index 4ff1f1e5f..afc738f2f 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -146,6 +146,11 @@ tags: {  # <amp-story-grid-layer>
     value: "thirds"
     value: "vertical"
   }
+  attrs: {
+    name: "position"
+    value: "landscape-half-left"
+    value: "landscape-half-right"
+  }
   descendant_tag_list: "amp-story-grid-layer-allowed-descendants"
   reference_points: {
     tag_spec_name: "AMP-STORY-GRID-LAYER default"
diff --git a/extensions/amp-twitter/validator-amp-twitter.protoascii b/extensions/amp-twitter/validator-amp-twitter.protoascii
index e1f218e46..02ec95854 100644
--- a/extensions/amp-twitter/validator-amp-twitter.protoascii
+++ b/extensions/amp-twitter/validator-amp-twitter.protoascii
@@ -48,23 +48,11 @@ tags: {  # <amp-twitter>
       also_requires_attr: "data-momentid"
     }
   }
-  attrs: {
-    name: "data-link-color"
-    trigger: {
-      also_requires_attr: "data-tweetid"
-    }
-  }
   attrs: {
     name: "data-momentid"
     mandatory_oneof: "['data-momentid', 'data-timeline-source-type', 'data-tweetid']"
     value_regex: "\\d+"
   }
-  attrs: {
-    name: "data-theme"
-    trigger: {
-      also_requires_attr: "data-tweetid"
-    }
-  }
   attrs: {
     name: "data-timeline-id"
     trigger: {
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index 79ad56a11..cec9e6b2b 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 896
+spec_file_revision: 920
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -993,6 +993,24 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
 }
+# AMP metadata, name=amp4ads-vars-*
+# Allows advertisers to pass information from creatives
+# to be included in amp-ad-metadata.
+tags: {
+  html_format: AMP4ADS
+  tag_name: "META"
+  spec_name: "meta name=amp4ads-vars-*"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "content"
+    mandatory: true
+  }
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_regex: "amp4ads-vars-.+"
+  }
+}
 # 4.2.6 The style
 # Text contents of the style tag will be validated seperately.
 tags: {  # Special custom 'author' spreadsheet for AMP
@@ -1537,6 +1555,17 @@ tags: {
   tag_name: "ARTICLE"
 }
 # 4.3.3 The section element
+attr_lists: {
+  name: "poool-access-attrs"
+  attrs: {
+    name: "poool-access-preview"
+    requires_extension: "amp-access-poool"
+  }
+  attrs: {
+    name: "poool-access-content"
+    requires_extension: "amp-access-poool"
+  }
+}
 tags: {
   html_format: AMP
   html_format: AMP4ADS
@@ -1544,6 +1573,7 @@ tags: {
   html_format: ACTIONS
   tag_name: "SECTION"
   disallowed_ancestor: "AMP-ACCORDION"
+  attr_lists: "poool-access-attrs"
 }
 # 4.3.4 The nav element
 tags: {
@@ -4123,6 +4153,7 @@ tags {  # <form method=GET ...>
     name: "action-xhr"
     value_url: {
       protocol: "https"
+      allow_relative: false
     }
     blacklisted_value_regex: "__amp_source_origin|"
         "{{|}}"    # Mustache is disallowed in action-xhr.
@@ -6303,6 +6334,8 @@ attr_lists: {
   attrs: { name: "accesskey" }
   attrs: {
     # attribute "class" for transformed is handled within the Validator engine.
+    # If this changes, please be sure to also update:
+    # amp-experiment 1.0 implementation.
     disabled_by: "transformed"
     name: "class"
     blacklisted_value_regex: "(^|\\W)i-amphtml-"
@@ -6810,6 +6843,10 @@ error_specificity {
   code: CSS_EXCESSIVELY_NESTED
   specificity: 119
 }
+error_specificity {
+  code: DOCUMENT_SIZE_LIMIT_EXCEEDED
+  specificity: 120
+}
 # Error formats
 error_formats {
   code: UNKNOWN_CODE
@@ -7270,3 +7307,7 @@ error_formats {
   code: CSS_EXCESSIVELY_NESTED
   format: "CSS excessively nested in tag '%1'."
 }
+error_formats {
+  code: DOCUMENT_SIZE_LIMIT_EXCEEDED
+  format: "Document exceeded %1 bytes limit. Actual size %2 bytes."
+}
```

</details>