### PR TITLE
Always hide AMP admin menu item and compatibility tool menu items for non-admins role

### DIFF
--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -52,19 +52,16 @@ class AMP_Options_Menu {
 	 */
 	public function add_menu_items() {
 
-		$user_can_manage_options = current_user_can( 'manage_options' );
-
-		// Abort if the user doesn't have the capability to see anything.
-		if ( ! $user_can_manage_options && ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-			return;
-		}
-
+		/*
+		 * Note that the admin items for Validated URLs and Validation Errors will also be placed under this admin menu
+		 * page when the current user can manage_options.
+		 */
 		add_menu_page(
 			__( 'AMP Options', 'amp' ),
 			__( 'AMP', 'amp' ),
-			$user_can_manage_options ? 'manage_options' : 'edit_posts',
-			$user_can_manage_options ? AMP_Options_Manager::OPTION_NAME : esc_attr( 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ),
-			$user_can_manage_options ? [ $this, 'render_screen' ] : '',
+			'manage_options',
+			AMP_Options_Manager::OPTION_NAME,
+			[ $this, 'render_screen' ],
 			self::ICON_BASE64_SVG
 		);
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -52,12 +52,19 @@ class AMP_Options_Menu {
 	 */
 	public function add_menu_items() {
 
+		$user_can_manage_options = current_user_can( 'manage_options' );
+
+		// Abort if the user doesn't have the capability to see anything.
+		if ( ! $user_can_manage_options && ! current_theme_supports( AMP_Theme_Support::SLUG ) ) {
+			return;
+		}
+
 		add_menu_page(
 			__( 'AMP Options', 'amp' ),
 			__( 'AMP', 'amp' ),
-			'edit_posts',
-			AMP_Options_Manager::OPTION_NAME,
-			[ $this, 'render_screen' ],
+			$user_can_manage_options ? 'manage_options' : 'edit_posts',
+			$user_can_manage_options ? AMP_Options_Manager::OPTION_NAME : esc_attr( 'edit.php?post_type=' . AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ),
+			$user_can_manage_options ? [ $this, 'render_screen' ] : '',
 			self::ICON_BASE64_SVG
 		);
 
@@ -65,7 +72,7 @@ class AMP_Options_Menu {
 			AMP_Options_Manager::OPTION_NAME,
 			__( 'AMP Settings', 'amp' ),
 			__( 'General', 'amp' ),
-			'edit_posts',
+			'manage_options',
 			AMP_Options_Manager::OPTION_NAME
 		);
 

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -199,7 +199,7 @@ class AMP_Options_Menu {
 				line-height: 1;
 			}
 		</style>
-		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+		<fieldset>
 			<dl>
 				<dt>
 					<input type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[experiences][]' ); ?>" id="website_experience" value="<?php echo esc_attr( AMP_Options_Manager::WEBSITE_EXPERIENCE ); ?>" <?php checked( in_array( AMP_Options_Manager::WEBSITE_EXPERIENCE, $experiences, true ) ); ?>>
@@ -307,7 +307,7 @@ class AMP_Options_Menu {
 		$builtin_support = in_array( get_template(), AMP_Core_Theme_Sanitizer::get_supported_themes(), true );
 		?>
 
-		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+		<fieldset>
 			<?php if ( AMP_Theme_Support::READER_MODE_SLUG === AMP_Theme_Support::get_support_mode() ) : ?>
 				<?php if ( AMP_Theme_Support::STANDARD_MODE_SLUG === AMP_Theme_Support::get_support_mode_added_via_theme() ) : ?>
 					<div class="notice notice-success notice-alt inline">
@@ -407,7 +407,7 @@ class AMP_Options_Menu {
 	 */
 	public function render_validation_handling() {
 		?>
-		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+		<fieldset>
 			<?php
 			$auto_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization(
 				[
@@ -497,7 +497,7 @@ class AMP_Options_Menu {
 		?>
 
 		<?php if ( ! isset( $theme_support_args['available_callback'] ) ) : ?>
-			<fieldset id="all_templates_supported_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+			<fieldset id="all_templates_supported_fieldset">
 				<?php if ( isset( $theme_support_args['templates_supported'] ) && 'all' === $theme_support_args['templates_supported'] ) : ?>
 					<div class="notice notice-info notice-alt inline">
 						<p>
@@ -530,7 +530,7 @@ class AMP_Options_Menu {
 			</div>
 		<?php endif; ?>
 
-		<fieldset id="supported_post_types_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+		<fieldset id="supported_post_types_fieldset">
 			<?php
 			$element_name         = AMP_Options_Manager::OPTION_NAME . '[supported_post_types][]';
 			$supported_post_types = AMP_Options_Manager::get_option( 'supported_post_types' );
@@ -566,7 +566,7 @@ class AMP_Options_Menu {
 		</fieldset>
 
 		<?php if ( ! isset( $theme_support_args['available_callback'] ) ) : ?>
-			<fieldset id="supported_templates_fieldset" <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+			<fieldset id="supported_templates_fieldset">
 				<style>
 					#supported_templates_fieldset ul ul {
 						margin-left: 40px;
@@ -631,7 +631,7 @@ class AMP_Options_Menu {
 	 */
 	public function render_caching() {
 		?>
-		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
+		<fieldset>
 			<?php if ( AMP_Options_Manager::show_response_cache_disabled_notice() ) : ?>
 				<div class="notice notice-info notice-alt inline">
 					<p><?php esc_html_e( 'The post-processor cache was disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, '' ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
@@ -740,11 +740,6 @@ class AMP_Options_Menu {
 			AMP_Options_Manager::check_supported_post_type_update_errors();
 		}
 		?>
-		<?php if ( ! current_user_can( 'manage_options' ) ) : ?>
-			<div class="notice notice-info">
-				<p><?php esc_html_e( 'You do not have permission to modify these settings. They are shown here for your reference. Please contact your administrator to make changes.', 'amp' ); ?></p>
-			</div>
-		<?php endif; ?>
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 			<?php settings_errors(); ?>

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -51,7 +51,6 @@ class AMP_Options_Menu {
 	 * Add menu.
 	 */
 	public function add_menu_items() {
-
 		/*
 		 * Note that the admin items for Validated URLs and Validation Errors will also be placed under this admin menu
 		 * page when the current user can manage_options.

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -196,7 +196,7 @@ class AMP_Options_Menu {
 				line-height: 1;
 			}
 		</style>
-		<fieldset>
+		<fieldset <?php disabled( ! current_user_can( 'manage_options' ) ); ?>>
 			<dl>
 				<dt>
 					<input type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[experiences][]' ); ?>" id="website_experience" value="<?php echo esc_attr( AMP_Options_Manager::WEBSITE_EXPERIENCE ); ?>" <?php checked( in_array( AMP_Options_Manager::WEBSITE_EXPERIENCE, $experiences, true ) ); ?>>

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -112,7 +112,7 @@ class AMP_Validated_URL_Post_Type {
 				'supports'     => false,
 				'public'       => false,
 				'show_ui'      => true,
-				'show_in_menu' => ( self::should_show_in_menu() || AMP_Validation_Error_Taxonomy::should_show_in_menu() ) ? AMP_Options_Manager::OPTION_NAME : false,
+				'show_in_menu' => current_user_can( 'manage_options' ) ? AMP_Options_Manager::OPTION_NAME : false,
 				// @todo Show in rest.
 			]
 		);
@@ -151,19 +151,6 @@ class AMP_Validated_URL_Post_Type {
 				clean_post_cache( $post_id );
 			}
 		}
-	}
-
-	/**
-	 * Determine whether the admin menu item should be included.
-	 *
-	 * @return bool Whether to show in menu.
-	 */
-	public static function should_show_in_menu() {
-		global $pagenow;
-		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-			return true;
-		}
-		return ( 'edit.php' === $pagenow && ( isset( $_GET['post_type'] ) && self::POST_TYPE_SLUG === $_GET['post_type'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -172,7 +172,7 @@ class AMP_Validated_URL_Post_Type {
 	public static function add_admin_hooks() {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_post_list_screen_scripts' ] );
 
-		if ( AMP_Options_Manager::is_website_experience_enabled() ) {
+		if ( AMP_Options_Manager::is_website_experience_enabled() && current_user_can( 'manage_options' ) ) {
 			add_filter( 'dashboard_glance_items', [ __CLASS__, 'filter_dashboard_glance_items' ] );
 			add_action( 'rightnow_end', [ __CLASS__, 'print_dashboard_glance_styles' ] );
 		}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -112,7 +112,7 @@ class AMP_Validated_URL_Post_Type {
 				'supports'     => false,
 				'public'       => false,
 				'show_ui'      => true,
-				'show_in_menu' => current_user_can( 'manage_options' ) ? AMP_Options_Manager::OPTION_NAME : false,
+				'show_in_menu' => current_theme_supports( 'amp' ) && current_user_can( 'manage_options' ) ? AMP_Options_Manager::OPTION_NAME : false,
 				// @todo Show in rest.
 			]
 		);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -259,7 +259,7 @@ class AMP_Validation_Error_Taxonomy {
 				'show_tagcloud'      => false,
 				'show_in_quick_edit' => false,
 				'hierarchical'       => false, // Or true? Code could be the parent term?
-				'show_in_menu'       => self::should_show_in_menu() || AMP_Validated_URL_Post_Type::should_show_in_menu(),
+				'show_in_menu'       => current_user_can( 'manage_options' ),
 				'meta_box_cb'        => false,
 				'capabilities'       => [
 					// Note that delete_terms is needed so the checkbox (cb) table column will work.
@@ -274,19 +274,6 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		self::accept_validation_errors( AMP_Core_Theme_Sanitizer::get_acceptable_errors( get_template() ) );
-	}
-
-	/**
-	 * Determine whether the admin menu item should be included.
-	 *
-	 * @return bool Whether to show in menu.
-	 */
-	public static function should_show_in_menu() {
-		global $pagenow;
-		if ( AMP_Options_Manager::is_website_experience_enabled() && current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-			return true;
-		}
-		return ( 'edit-tags.php' === $pagenow && ( isset( $_GET['taxonomy'] ) && self::TAXONOMY_SLUG === $_GET['taxonomy'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -259,7 +259,7 @@ class AMP_Validation_Error_Taxonomy {
 				'show_tagcloud'      => false,
 				'show_in_quick_edit' => false,
 				'hierarchical'       => false, // Or true? Code could be the parent term?
-				'show_in_menu'       => current_user_can( 'manage_options' ),
+				'show_in_menu'       => current_theme_supports( 'amp' ) && current_user_can( 'manage_options' ),
 				'meta_box_cb'        => false,
 				'capabilities'       => [
 					// Note that delete_terms is needed so the checkbox (cb) table column will work.

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -34,6 +34,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	public function test_register() {
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertFalse( is_admin() );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		AMP_Validated_URL_Post_Type::register();
 		$amp_post_type = get_post_type_object( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG );
@@ -60,6 +61,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::add_admin_hooks()
 	 */
 	public function test_add_admin_hooks() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validated_URL_Post_Type::add_admin_hooks();
 
 		$this->assertEquals( 10, has_filter( 'dashboard_glance_items', [ self::TESTED_CLASS, 'filter_dashboard_glance_items' ] ) );

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -55,27 +55,6 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test should_show_in_menu.
-	 *
-	 * @covers AMP_Validated_URL_Post_Type::should_show_in_menu()
-	 */
-	public function test_should_show_in_menu() {
-		global $pagenow;
-		add_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertTrue( AMP_Validated_URL_Post_Type::should_show_in_menu() );
-
-		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertFalse( AMP_Validated_URL_Post_Type::should_show_in_menu() );
-
-		$pagenow           = 'edit.php';
-		$_GET['post_type'] = 'post';
-		$this->assertFalse( AMP_Validated_URL_Post_Type::should_show_in_menu() );
-
-		$_GET['post_type'] = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
-		$this->assertTrue( AMP_Validated_URL_Post_Type::should_show_in_menu() );
-	}
-
-	/**
 	 * Test add_admin_hooks.
 	 *
 	 * @covers \AMP_Validated_URL_Post_Type::add_admin_hooks()

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -84,27 +84,6 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test should_show_in_menu.
-	 *
-	 * @covers AMP_Validation_Error_Taxonomy::should_show_in_menu()
-	 */
-	public function test_should_show_in_menu() {
-		global $pagenow;
-		add_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertTrue( AMP_Validation_Error_Taxonomy::should_show_in_menu() );
-
-		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertFalse( AMP_Validation_Error_Taxonomy::should_show_in_menu() );
-
-		$pagenow          = 'edit-tags.php';
-		$_GET['taxonomy'] = 'post_tag';
-		$this->assertFalse( AMP_Validation_Error_Taxonomy::should_show_in_menu() );
-
-		$_GET['taxonomy'] = AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG;
-		$this->assertTrue( AMP_Validation_Error_Taxonomy::should_show_in_menu() );
-	}
-
-	/**
 	 * Test get_term.
 	 *
 	 * @covers AMP_Validation_Error_Taxonomy::get_term()

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -48,6 +48,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_register() {
 		global $wp_taxonomies;
 		add_theme_support( AMP_Theme_Support::SLUG );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 
 		AMP_Validation_Error_Taxonomy::register();
 		$taxonomy_object = $wp_taxonomies[ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ];
@@ -544,6 +545,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 */
 	public function test_add_admin_hooks() {
 		add_theme_support( AMP_Theme_Support::SLUG );
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Error_Taxonomy::register();
 
 		// add_group_terms_clauses_filter() needs the screen to be set.
@@ -973,6 +975,9 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::filter_tag_row_actions()
 	 */
 	public function test_filter_tag_row_actions() {
+		wp_set_current_user( $this->factory()->user->create( [ 'role' => 'administrator' ] ) );
+		global $pagenow;
+		$pagenow = 'edit-tags.php';
 
 		// Prevent an error in add_query_arg().
 		$_SERVER['REQUEST_URI'] = 'https://example.com';


### PR DESCRIPTION
See  https://wordpress.org/support/topic/hide-amp-in-side-bar-for-specific-roles-authors/

When a user is not an administrator, they still have access to the AMP settings screen but all of the fields on the screen are disabled and they can't modify anything. This was allowed because the Validated URLs and Validation Error screens are are admin submenu items under the top-level AMP menu page. Thus the top-level  page was given `edit_posts` capability, though all of the settings required `manage_options` to change.

The thinking here was to allow the users to access the admin screens the compatibility tool even if they cannot `manage_options`. In reality, this is just noise and non-admins should not be concerned with site-level validation errors. See https://github.com/ampproject/amp-wp/issues/2316#issuecomment-517482714 and https://github.com/ampproject/amp-wp/issues/2673. 

Nevertheless, a case can be made to continue allowing a user to access the Validated URL screen individually for posts that they can edit. This is what this PR does. Non-admin users never see the top-level AMP admin menu item, and they never see the admin menu items for Validated URLs and Validation Errors. The only way they can get to these screens is by causing a validation error, at which point they will see the warning notice in Gutenberg, allowing them to access the screen via the “Review Issues” link.

This PR also hides the Validated URLs from the “At a Glance” dashboard widget, if the user is not an administrator.

# Before

<img width="669" alt="Screen Shot 2019-08-09 at 13 21 14" src="https://user-images.githubusercontent.com/134745/62806771-96df4f00-baa8-11e9-89ef-8b715aee5534.png">

# After

<img width="669" alt="Screen Shot 2019-08-09 at 13 20 08" src="https://user-images.githubusercontent.com/134745/62806794-9cd53000-baa8-11e9-8935-1962ee81e7ad.png">

----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3488014/amp.zip) - 1.2.1-beta1-20190809T205628Z-303e81ea

Fixes #2702.