### PR TITLE
Fix handling of polyfill dependencies

### DIFF
--- a/assets/src/polyfills/wp-server-side-render.js
+++ b/assets/src/polyfills/wp-server-side-render.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import * as serverSideRender from '@wordpress/server-side-render';
+
+window.wp = window.wp || {};
+
+window.wp.serverSideRender = serverSideRender;

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -400,10 +400,20 @@ function amp_register_default_scripts( $wp_scripts ) {
 	 * Polyfill dependencies that are registered in Gutenberg and WordPress 5.0.
 	 * Note that Gutenberg will override these at wp_enqueue_scripts if it is active.
 	 */
-	$handles = [ 'wp-i18n', 'wp-dom-ready' ];
+	$handles = [ 'wp-i18n', 'wp-dom-ready', 'wp-server-side-render' ];
 	foreach ( $handles as $handle ) {
 		if ( ! isset( $wp_scripts->registered[ $handle ] ) ) {
-			$wp_scripts->add( $handle, amp_get_asset_url( sprintf( 'js/%s.js', $handle ) ) );
+			$script_deps_path    = AMP__DIR__ . '/assets/js/' . $handle . '.deps.json';
+			$script_dependencies = file_exists( $script_deps_path )
+				? json_decode( file_get_contents( $script_deps_path ), false ) // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+				: [];
+
+			$wp_scripts->add(
+				$handle,
+				amp_get_asset_url( sprintf( 'js/%s.js', $handle ) ),
+				$script_dependencies,
+				AMP__VERSION
+			);
 		}
 	}
 

--- a/tests/e2e/specs/block-editor/amp-toggle.test.js
+++ b/tests/e2e/specs/block-editor/amp-toggle.test.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { createNewPost } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { activatePlugin, deactivatePlugin } from '../../utils';
+
+describe( 'Enable AMP Toggle', () => {
+	it( 'is enabled by default', async () => {
+		await createNewPost();
+
+		await expect( page ).toMatchElement( 'label[for="amp-enabled"]', { text: 'Enable AMP' } );
+		await expect( page ).toMatchElement( 'label[for="amp-enabled"] + .components-form-toggle.is-checked' );
+	} );
+
+	it( 'should display even when Gutenberg is not active', async () => {
+		await deactivatePlugin( 'gutenberg' );
+		await createNewPost();
+
+		await expect( page ).toMatchElement( 'label[for="amp-enabled"]', { text: 'Enable AMP' } );
+
+		await activatePlugin( 'gutenberg' );
+	} );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,8 @@ const WebpackBar = require( 'webpackbar' );
  * WordPress dependencies
  */
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
+const { defaultRequestToExternal, defaultRequestToHandle } = require( '@wordpress/dependency-extraction-webpack-plugin/util' );
 
 const sharedConfig = {
 	output: {
@@ -204,8 +206,32 @@ const wpPolyfills = {
 	...defaultConfig,
 	...sharedConfig,
 	externals: {},
-	// Disable BundleAnalyzerPlugin for polyfills.
 	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			useDefaults: false,
+			requestToHandle: ( request ) => {
+				switch ( request ) {
+					case '@wordpress/dom-ready':
+					case '@wordpress/i18n':
+					case '@wordpress/server-side-render':
+						return undefined;
+
+					default:
+						return defaultRequestToHandle( request );
+				}
+			},
+			requestToExternal: ( request ) => {
+				switch ( request ) {
+					case '@wordpress/dom-ready':
+					case '@wordpress/i18n':
+					case '@wordpress/server-side-render':
+						return undefined;
+
+					default:
+						return defaultRequestToExternal( request );
+				}
+			},
+		} ),
 		new WebpackBar( {
 			name: 'WordPress Polyfills',
 			color: '#21a0d0',
@@ -214,6 +240,7 @@ const wpPolyfills = {
 	entry: {
 		'wp-i18n': './assets/src/polyfills/wp-i18n.js',
 		'wp-dom-ready': './assets/src/polyfills/wp-dom-ready.js',
+		'wp-server-side-render': './assets/src/polyfills/wp-server-side-render.js',
 	},
 };
 


### PR DESCRIPTION
This aims to fix the issue discovered in #2977 by:

* Adding a polyfill for the new `wp.serverSideRender` global  
  The old `wp.components.serverSideRender` has been deprecated and [will throw notices](https://github.com/WordPress/gutenberg/pull/16133).
* Adjusted the `DependencyExtractionWebpackPlugin` config so that polyfills will not bundle their dependencies, but instead will reference the existing `wp.*` globals - except for themselves.  
  This way the polyfills are only as small as they need to be. Actually only affects the `server-side-render` polyfill and not the others.
* Adds a missing version param to the polyfills.

For testing:

* Verify that the "Enable AMP" toggle in the block editor is shown even when not using the Gutenberg plugin.