### PR TITLE
Update e2e test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ jobs:
       install:
         - nvm install
         - composer install
-        - npm run install
+        - npm install
       script:
         - npm run build:js
         - npm run build:css

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,11 +92,11 @@ jobs:
       install:
         - nvm install
         - composer install
-        # npm is handled by `npm run env:start`
+        - npm run install
       script:
-        - npm run env:start # also install npm dependencies
         - npm run build:js
         - npm run build:css
+        - npm run env:start
         - npm run env:reset-site
         - npm run test:e2e:ci
         - npm run env:stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,21 +101,6 @@ jobs:
         - npm run test:e2e:ci
         - npm run env:stop
 
-    - name: E2E tests (Author)
-      php: "7.3"
-      env: WP_VERSION=latest DEV_LIB_SKIP=phpcs,eslint,xmllint,phpsyntax,phpunit PUPPETEER_SKIP_CHROMIUM_DOWNLOAD= E2E_ROLE=author
-      install:
-        - nvm install
-        - composer install
-        # npm is handled by `npm run env:start`
-      script:
-        - npm run env:start # also install npm dependencies
-        - npm run build:js
-        - npm run build:css
-        - npm run env:reset-site
-        - npm run test:e2e:ci
-        - npm run env:stop
-
     - name: PHP unit tests w/ external-http (7.3, WordPress latest)
       php: "7.3"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1 PHPUNIT_EXTRA_GROUP=external-http

--- a/bin/local-env/docker-compose.yml
+++ b/bin/local-env/docker-compose.yml
@@ -29,6 +29,7 @@ services:
     depends_on:
       - mysql
       - wordpress
+    command: tail -f /dev/null
 
   mysql:
     image: mysql:5.7

--- a/bin/local-env/includes.sh
+++ b/bin/local-env/includes.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Common variables.
+DOCKER_COMPOSE_FILE_OPTIONS="-f $(dirname "$0")/docker-compose.yml"
+# These are the containers and values for the development site.
+CLI='cli'
+CONTAINER='wordpress'
+SITE_TITLE='AMP Dev'
+
 ##
 # Ask a Yes/No question, and way for a reply.
 #
@@ -131,4 +138,31 @@ action_format() {
 ##
 command_exists() {
 	type -t "$1" >/dev/null 2>&1
+}
+
+##
+# Docker Compose helper
+#
+# Calls docker-compose with common options.
+##
+dc() {
+	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS "$@"
+}
+
+##
+# WP CLI
+#
+# Executes a WP CLI request in the CLI container.
+##
+wp() {
+	dc exec -u xfs $CLI wp "$@"
+}
+
+##
+# WordPress Container helper.
+#
+# Executes the given command in the wordpress container.
+##
+container() {
+	dc exec $CONTAINER "$@"
 }

--- a/bin/local-env/install-node-nvm.sh
+++ b/bin/local-env/install-node-nvm.sh
@@ -65,12 +65,14 @@ if [ "$TRAVIS" != "true" ] && [ "$(nvm current)" != "$(nvm version-remote --lts)
 	exit 1
 fi
 
-# Install/update packages
-echo -e $(status_message "Installing and updating NPM packages..." )
-npm install
+if [ "$TRAVIS" != "true" ]; then
+  # Install/update packages
+  echo -e $(status_message "Installing and updating NPM packages..." )
+  npm install
 
-# Make sure npm is up-to-date
-npm install npm -g
+  # Make sure npm is up-to-date
+  npm install npm -g
+fi
 
 # There was a bug in NPM that caused changes in package-lock.json. Handle that.
 if [ "$TRAVIS" != "true" ] && ! git diff --no-ext-diff --exit-code package-lock.json >/dev/null; then

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -43,8 +43,8 @@ fi
 echo -e $(status_message "Installing WordPress...")
 wp core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:$HOST_PORT  --quiet
 
-# Install additional Users.
-echo -e $(status_message "Installing additional users...")
+# Create additional users.
+echo -e $(status_message "Creating additional users...")
 wp user create editor editor@example.com --role=editor --user_pass=password --quiet
 echo -e $(status_message "Editor created! Username: editor Password: password")
 wp user create author author@example.com --role=author --user_pass=password --quiet

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -4,20 +4,18 @@
 set -e
 
 # Common variables.
-DOCKER_COMPOSE_FILE_OPTIONS="-f $(dirname "$0")/docker-compose.yml"
 WP_DEBUG=${WP_DEBUG-true}
 SCRIPT_DEBUG=${SCRIPT_DEBUG-true}
+WP_VERSION=${WP_VERSION-"latest"}
 
 # Include useful functions
 . "$(dirname "$0")/includes.sh"
 
-# These are the containers and values for the development site.
-CLI='cli'
-CONTAINER='wordpress'
-SITE_TITLE='AMP Dev'
+# Make sure Docker containers are running
+dc up -d >/dev/null 2>&1
 
 # Get the host port for the WordPress container.
-HOST_PORT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS port $CONTAINER 80 | awk -F : '{printf $2}')
+HOST_PORT=$(dc port $CONTAINER 80 | awk -F : '{printf $2}')
 
 # Wait until the Docker containers are running and the WordPress site is
 # responding to requests.
@@ -32,72 +30,92 @@ echo ''
 # dirty up the tests.
 if [ "$1" == '--reset-site' ]; then
 	echo -e $(status_message "Resetting test database...")
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI db reset --yes --quiet
+	wp db reset --yes --quiet
+fi
+
+if [ ! -z "$WP_VERSION" ] && [ "$WP_VERSION" != "latest" ]; then
+	# Potentially downgrade WordPress
+	echo -e $(status_message "Downloading WordPress version $WP_VERSION...")
+	wp core download --version=${WP_VERSION} --force --quiet
 fi
 
 # Install WordPress.
 echo -e $(status_message "Installing WordPress...")
-# The `-u 33` flag tells Docker to run the command as a particular user and
-# prevents permissions errors. See: https://github.com/WordPress/gutenberg/pull/8427#issuecomment-410232369
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:$HOST_PORT --quiet
+wp core install --title="$SITE_TITLE" --admin_user=admin --admin_password=password --admin_email=test@test.com --skip-email --url=http://localhost:$HOST_PORT  --quiet
 
-if [ "$E2E_ROLE" = "author" ]; then
-	echo -e $(status_message "Creating an additional author user for testing...")
-	# Create an additional author user for testing.
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI user create author author@example.com --role=author --user_pass=authpass --quiet
-	# Assign the existing Hello World post to the author.
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI post update 1 --post_author=2 --quiet
-fi
+# Install additional Users.
+echo -e $(status_message "Installing additional users...")
+wp user create editor editor@example.com --role=editor --user_pass=password --quiet
+echo -e $(status_message "Editor created! Username: editor Password: password")
+wp user create author author@example.com --role=author --user_pass=password --quiet
+echo -e $(status_message "Author created! Username: author Password: password")
+wp user create contributor contributor@example.com --role=contributor --user_pass=password --quiet
+echo -e $(status_message "Contributor created! Username: contributor Password: password")
+wp user create subscriber subscriber@example.com --role=subscriber --user_pass=password --quiet
+echo -e $(status_message "Subscriber created! Username: subscriber Password: password")
 
 # Make sure the uploads and upgrade folders exist and we have permissions to add files.
 echo -e $(status_message "Ensuring that files can be uploaded...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER mkdir -p /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER chmod 767 /var/www/html/wp-content/plugins /var/www/html/wp-config.php /var/www/html/wp-settings.php /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
+container mkdir -p \
+	/var/www/html/wp-content/uploads \
+	/var/www/html/wp-content/upgrade
+container chmod 767 \
+	/var/www/html/wp-content \
+	/var/www/html/wp-content/plugins \
+	/var/www/html/wp-config.php \
+	/var/www/html/wp-settings.php \
+	/var/www/html/wp-content/uploads \
+	/var/www/html/wp-content/upgrade
 
-CURRENT_WP_VERSION=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm $CLI core version)
+CURRENT_WP_VERSION=$(wp core version | tr -d '\r')
 echo -e $(status_message "Current WordPress version: $CURRENT_WP_VERSION...")
 
 if [ "$WP_VERSION" == "latest" ]; then
 	# Check for WordPress updates, to make sure we're running the very latest version.
 	echo -e $(status_message "Updating WordPress to the latest version...")
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core update --quiet
+	wp core update --quiet
 	echo -e $(status_message "Updating The WordPress Database...")
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI core update-db --quiet
+	wp core update-db --quiet
 fi
 
 # If the 'wordpress' volume wasn't during the down/up earlier, but the post port has changed, we need to update it.
 echo -e $(status_message "Checking the site's url...")
-CURRENT_URL=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm $CLI option get siteurl)
+CURRENT_URL=$(wp option get siteurl)
 if [ "$CURRENT_URL" != "http://localhost:$HOST_PORT" ]; then
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI option update home "http://localhost:$HOST_PORT" --quiet
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI option update siteurl "http://localhost:$HOST_PORT" --quiet
+	wp option update home "http://localhost:$HOST_PORT" --quiet
+	wp option update siteurl "http://localhost:$HOST_PORT" --quiet
 fi
 
 # Install a dummy favicon to avoid 404 errors.
 echo -e $(status_message "Installing a dummy favicon...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm $CONTAINER touch /var/www/html/favicon.ico
+container touch /var/www/html/favicon.ico
+container chmod 767 /var/www/html/favicon.ico
 
 # Activate AMP plugin.
 echo -e $(status_message "Activating AMP plugin...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin activate amp --quiet
+wp plugin activate amp --quiet
 
 # Install & activate Gutenberg plugin.
 echo -e $(status_message "Installing and activating Gutenberg plugin...")
-# todo: Use `wp plugin install --activate` once WP-CLI is updated, see https://github.com/wp-cli/extension-command/issues/176.
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin install gutenberg --activate --quiet
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI plugin activate gutenberg --quiet
+wp plugin install gutenberg --activate --force --quiet
+
+# Set pretty permalinks.
+echo -e $(status_message "Setting permalink structure...")
+wp rewrite structure '%postname%' --hard --quiet
 
 # Configure site constants.
 echo -e $(status_message "Configuring site constants...")
-WP_DEBUG_CURRENT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json WP_DEBUG)
+WP_DEBUG_CURRENT=$(wp config get --type=constant --format=json WP_DEBUG | tr -d '\r')
+
 if [ "$WP_DEBUG" != $WP_DEBUG_CURRENT ]; then
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI config set WP_DEBUG $WP_DEBUG --raw --type=constant --quiet
-	WP_DEBUG_RESULT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json WP_DEBUG)
+	wp config set WP_DEBUG $WP_DEBUG --raw --type=constant --quiet
+	WP_DEBUG_RESULT=$(wp config get --type=constant --format=json WP_DEBUG | tr -d '\r')
 	echo -e $(status_message "WP_DEBUG: $WP_DEBUG_RESULT...")
 fi
-SCRIPT_DEBUG_CURRENT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json SCRIPT_DEBUG)
+
+SCRIPT_DEBUG_CURRENT=$(wp config get --type=constant --format=json SCRIPT_DEBUG | tr -d '\r')
 if [ "$SCRIPT_DEBUG" != $SCRIPT_DEBUG_CURRENT ]; then
-	docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run --rm -u 33 $CLI config set SCRIPT_DEBUG $SCRIPT_DEBUG --raw --type=constant --quiet
-	SCRIPT_DEBUG_RESULT=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm -u 33 $CLI config get --type=constant --format=json SCRIPT_DEBUG)
+	wp config set SCRIPT_DEBUG $SCRIPT_DEBUG --raw --type=constant --quiet
+	SCRIPT_DEBUG_RESULT=$(wp config get --type=constant --format=json SCRIPT_DEBUG | tr -d '\r')
 	echo -e $(status_message "SCRIPT_DEBUG: $SCRIPT_DEBUG_RESULT...")
 fi

--- a/bin/local-env/launch-containers.sh
+++ b/bin/local-env/launch-containers.sh
@@ -3,9 +3,6 @@
 # Exit if any command fails.
 set -e
 
-# Common variables.
-DOCKER_COMPOSE_FILE_OPTIONS="-f $(dirname "$0")/docker-compose.yml"
-
 # Include useful functions.
 . "$(dirname "$0")/includes.sh"
 
@@ -23,12 +20,12 @@ fi
 
 # Stop existing containers.
 echo -e $(status_message "Stopping Docker containers...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS down --remove-orphans >/dev/null 2>&1
+dc down --remove-orphans >/dev/null 2>&1
 
 # Download image updates.
 echo -e $(status_message "Downloading Docker image updates...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS pull
+dc pull
 
 # Launch the containers.
 echo -e $(status_message "Starting Docker containers...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS up -d >/dev/null
+dc up -d >/dev/null

--- a/bin/local-env/start.sh
+++ b/bin/local-env/start.sh
@@ -52,7 +52,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 
 EOT
 
-CURRENT_URL=$(docker-compose $DOCKER_COMPOSE_FILE_OPTIONS run -T --rm cli option get siteurl)
+CURRENT_URL=$(wp option get siteurl | tr -d '\r')
 
 echo -e "\nWelcome to...\n"
 echo -e "\033[95m$AMP\033[0m"

--- a/bin/local-env/stop.sh
+++ b/bin/local-env/stop.sh
@@ -3,9 +3,6 @@
 # Exit if any command fails.
 set -e
 
-# Common variables.
-DOCKER_COMPOSE_FILE_OPTIONS="-f $(dirname "$0")/docker-compose.yml"
-
 # Include useful functions.
 . "$(dirname "$0")/includes.sh"
 
@@ -23,4 +20,4 @@ fi
 
 # Stop existing containers.
 echo -e $(status_message "Stopping Docker containers...")
-docker-compose $DOCKER_COMPOSE_FILE_OPTIONS down --remove-orphans >/dev/null 2>&1
+dc down --remove-orphans >/dev/null 2>&1

--- a/tests/e2e/specs/stories-editor/code-editor.test.js
+++ b/tests/e2e/specs/stories-editor/code-editor.test.js
@@ -24,6 +24,8 @@ describe( 'Code Editor', () => {
 
 		await expect( page ).not.toMatchElement( '.block-editor-writing-flow__click-redirect' );
 
+		// Ensure the menu is available before switching mode.
+		await page.waitForSelector( '.edit-post-more-menu [aria-label="More tools & options"]' );
 		await switchEditorModeTo( 'Code' );
 		await page.click( '.edit-post-more-menu [aria-label="More tools & options"]' );
 


### PR DESCRIPTION
Over at the [Site Kit repository](https://github.com/google/site-kit-wp) there was a really nice addition to the e2e setup. See https://github.com/google/site-kit-wp/pull/400 for details.

With this PR I am trying to port these over almost 1:1.

The biggest changes:

* Makes all the Bash scripts more DRY und thus easier to read.
* Creates new users out of the box, not relying on a `E2E_ROLE` env var or similar.
* Makes it easier to use a specific WordPress version other than `latest` in the future.

Contrary to Gutenberg, where we got the inspiration for this setup from, we don't need to run all the tests as a separate user. Instead, we only need to run a certain amount of tests as non-admins. It doesn't make sense to use a second build job for this on Travis.