### PR TITLE
Harden logic for normalizing image metadata before adding story images

### DIFF
--- a/includes/class-amp-story-media.php
+++ b/includes/class-amp-story-media.php
@@ -141,7 +141,9 @@ class AMP_Story_Media {
 			return $data;
 		}
 
-		if ( is_string( $data['image'] ) ) {
+		if ( empty( $data['image'] ) ) {
+			$data['image'] = [];
+		} elseif ( is_string( $data['image'] ) ) {
 			$data['image'] = [ $data['image'] ];
 		} elseif ( is_array( $data['image'] ) && isset( $data['image']['@type'] ) ) {
 			$data['image'] = [ $data['image'] ];

--- a/includes/class-amp-story-media.php
+++ b/includes/class-amp-story-media.php
@@ -141,12 +141,12 @@ class AMP_Story_Media {
 			return $data;
 		}
 
-		if ( ! isset( $data['image'] ) ) {
+		if ( is_string( $data['image'] ) ) {
+			$data['image'] = [ $data['image'] ];
+		} elseif ( is_array( $data['image'] ) && isset( $data['image']['@type'] ) ) {
+			$data['image'] = [ $data['image'] ];
+		} elseif ( ! is_array( $data['image'] ) ) {
 			$data['image'] = [];
-		} elseif ( is_string( $data['image'] ) ) {
-			$data['image'] = [ $data['image'] ];
-		} elseif ( isset( $data['image']['@type'] ) ) {
-			$data['image'] = [ $data['image'] ];
 		}
 
 		$data['image'] = array_merge(


### PR DESCRIPTION
Fixes #3041.

The Yoast AMP Glue plugin has a bug (to be fixed in https://github.com/Yoast/yoastseo-amp/pull/123) which can result in `false` being set to the `image` metadata. This results in a PHP warning:

> Warning: array_merge(): Argument #2 is not an array in /app/public/wp-content/plugins/amp/includes/class-amp-story-media.php on line 154

This PR prevents that from happening by ensuring an array value is always used when merging.