### PR TITLE
Update the AMP_Twitter_Embed_Handler class to support all of the custom data attributes supported by the amp-twitter tag

### DIFF
--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Class AMP_Twitter_Embed_Handler
  *
@@ -11,8 +10,7 @@
  *
  *  Much of this class is borrowed from Jetpack embeds
  */
-class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
-{
+class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	/**
 	 * URL pattern for a Tweet URL.
@@ -57,27 +55,25 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 		'width',
 		'align',
 		'lang',
-		'dnt'
+		'dnt',
 	];
 
 	/**
 	 * Registers embed.
 	 */
-	public function register_embed()
-	{
-		add_shortcode('tweet', [$this, 'shortcode']); // Note: This is a Jetpack shortcode.
-		wp_embed_register_handler('amp-twitter', self::URL_PATTERN, [$this, 'oembed'], -1);
-		wp_embed_register_handler('amp-twitter-timeline', self::URL_PATTERN_TIMELINE, [$this, 'oembed_timeline'], -1);
+	public function register_embed() {
+		add_shortcode( 'tweet', [ $this, 'shortcode' ] ); // Note: This is a Jetpack shortcode.
+		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		wp_embed_register_handler( 'amp-twitter-timeline', self::URL_PATTERN_TIMELINE, [ $this, 'oembed_timeline' ], -1 );
 	}
 
 	/**
 	 * Unregisters embed.
 	 */
-	public function unregister_embed()
-	{
-		remove_shortcode('tweet'); // Note: This is a Jetpack shortcode.
-		wp_embed_unregister_handler('amp-twitter', -1);
-		wp_embed_unregister_handler('amp-twitter-timeline', -1);
+	public function unregister_embed() {
+		remove_shortcode( 'tweet' ); // Note: This is a Jetpack shortcode.
+		wp_embed_unregister_handler( 'amp-twitter', -1 );
+		wp_embed_unregister_handler( 'amp-twitter-timeline', -1 );
 	}
 
 	/**
@@ -88,8 +84,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 * @param array $attr The Twitter attributes.
 	 * @return string Twitter shortcode markup.
 	 */
-	public function shortcode($attr)
-	{
+	public function shortcode( $attr ) {
 		$attr = wp_parse_args(
 			$attr,
 			[
@@ -97,20 +92,20 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 			]
 		);
 
-		if (empty($attr['tweet']) && !empty($attr[0])) {
+		if ( empty( $attr['tweet'] ) && ! empty( $attr[0] ) ) {
 			$attr['tweet'] = $attr[0];
 		}
 
 		$id = false;
-		if (is_numeric($attr['tweet'])) {
+		if ( is_numeric( $attr['tweet'] ) ) {
 			$id = $attr['tweet'];
 		} else {
-			preg_match(self::URL_PATTERN, $attr['tweet'], $matches);
-			if (isset($matches['tweet']) && is_numeric($matches['tweet'])) {
+			preg_match( self::URL_PATTERN, $attr['tweet'], $matches );
+			if ( isset( $matches['tweet'] ) && is_numeric( $matches['tweet'] ) ) {
 				$id = $matches['tweet'];
 			}
 
-			if (empty($id)) {
+			if ( empty( $id ) ) {
 				return '';
 			}
 		}
@@ -136,19 +131,18 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 * @param array $matches URL pattern matches.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed($matches)
-	{
+	public function oembed( $matches ) {
 		$id = false;
 
-		if (isset($matches['tweet']) && is_numeric($matches['tweet'])) {
+		if ( isset( $matches['tweet'] ) && is_numeric( $matches['tweet'] ) ) {
 			$id = $matches['tweet'];
 		}
 
-		if (!$id) {
+		if ( ! $id ) {
 			return '';
 		}
 
-		return $this->shortcode(['tweet' => $id]);
+		return $this->shortcode( [ 'tweet' => $id ] );
 	}
 
 	/**
@@ -159,9 +153,8 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 * @param array $matches URL pattern matches.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed_timeline($matches)
-	{
-		if (!isset($matches['username'])) {
+	public function oembed_timeline( $matches ) {
+		if ( ! isset( $matches['username'] ) ) {
 			return '';
 		}
 
@@ -170,19 +163,19 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 			'data-timeline-screen-name' => $matches['username'],
 		];
 
-		if (isset($matches['type'])) {
-			switch ($matches['type']) {
+		if ( isset( $matches['type'] ) ) {
+			switch ( $matches['type'] ) {
 				case 'likes':
 					$attributes['data-timeline-source-type'] = 'likes';
 					break;
 				case 'lists':
-					if (!isset($matches['id'])) {
+					if ( ! isset( $matches['id'] ) ) {
 						return '';
 					}
 					$attributes['data-timeline-source-type']       = 'list';
 					$attributes['data-timeline-slug']              = $matches['id'];
 					$attributes['data-timeline-owner-screen-name'] = $attributes['data-timeline-screen-name'];
-					unset($attributes['data-timeline-screen-name']);
+					unset( $attributes['data-timeline-screen-name'] );
 					break;
 				default:
 					return '';
@@ -195,7 +188,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 
 		$this->did_convert_elements = true;
 
-		return AMP_HTML_Utils::build_tag($this->amp_tag, $attributes);
+		return AMP_HTML_Utils::build_tag( $this->amp_tag, $attributes );
 	}
 
 	/**
@@ -203,28 +196,27 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 *
 	 * @param DOMDocument $dom DOM.
 	 */
-	public function sanitize_raw_embeds($dom)
-	{
+	public function sanitize_raw_embeds( $dom ) {
 		/**
 		 * Node list.
 		 *
 		 * @var DOMNodeList $node
 		 */
-		$nodes     = $dom->getElementsByTagName($this->sanitize_tag);
+		$nodes     = $dom->getElementsByTagName( $this->sanitize_tag );
 		$num_nodes = $nodes->length;
 
-		if (0 === $num_nodes) {
+		if ( 0 === $num_nodes ) {
 			return;
 		}
 
-		for ($i = $num_nodes - 1; $i >= 0; $i--) {
-			$node = $nodes->item($i);
-			if (!$node instanceof DOMElement) {
+		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
+			$node = $nodes->item( $i );
+			if ( ! $node instanceof DOMElement ) {
 				continue;
 			}
 
-			if ($this->is_tweet_raw_embed($node)) {
-				$this->create_amp_twitter_and_replace_node($dom, $node);
+			if ( $this->is_tweet_raw_embed( $node ) ) {
+				$this->create_amp_twitter_and_replace_node( $dom, $node );
 			}
 		}
 	}
@@ -235,11 +227,10 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 * @param DOMElement $node The DOMNode to adjust and replace.
 	 * @return bool Whether node is for raw embed.
 	 */
-	private function is_tweet_raw_embed($node)
-	{
-		$class_attr = $node->getAttribute('class');
+	private function is_tweet_raw_embed( $node ) {
+		$class_attr = $node->getAttribute( 'class' );
 
-		return null !== $class_attr && false !== strpos($class_attr, 'twitter-tweet');
+		return null !== $class_attr && false !== strpos( $class_attr, 'twitter-tweet' );
 	}
 
 	/**
@@ -248,18 +239,18 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 * @param DOMDocument $dom The HTML Document.
 	 * @param DOMElement  $node The DOMNode to adjust and replace.
 	 */
-	private function create_amp_twitter_and_replace_node($dom, $node)
-	{
-		$tweet_id = $this->get_tweet_id($node);
-		if (!$tweet_id) {
+	private function create_amp_twitter_and_replace_node( $dom, $node ) {
+		$tweet_id = $this->get_tweet_id( $node );
+		if ( ! $tweet_id ) {
 			return;
 		}
 
 		$additional_attributes = [];
 
-		foreach ($this->supported_data_attributes as $attr) {
-			if ($value = $node->getAttribute('data-' . $attr)) {
-				$additional_attributes['data-' . $attr] = $value;
+		foreach ( $this->supported_data_attributes as $attr ) {
+			$value = $node->getAttribute( 'data-' . $attr );
+			if ( $value ) {
+				$additional_attributes[ 'data-' . $attr ] = $value;
 			}
 		}
 
@@ -269,17 +260,17 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 			array_merge(
 				$additional_attributes,
 				[
-					'width'             => $this->DEFAULT_WIDTH,
-					'height'            => $this->DEFAULT_HEIGHT,
-					'layout'            => 'responsive',
-					'data-tweetid'      => $tweet_id,
+					'width'        => $this->DEFAULT_WIDTH,
+					'height'       => $this->DEFAULT_HEIGHT,
+					'layout'       => 'responsive',
+					'data-tweetid' => $tweet_id,
 				]
 			)
 		);
 
-		$this->sanitize_embed_script($node);
+		$this->sanitize_embed_script( $node );
 
-		$node->parentNode->replaceChild($new_node, $node);
+		$node->parentNode->replaceChild( $new_node, $node );
 
 		$this->did_convert_elements = true;
 	}
@@ -290,23 +281,22 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 * @param DOMElement $node The DOMNode to adjust and replace.
 	 * @return string Tweet ID.
 	 */
-	private function get_tweet_id($node)
-	{
+	private function get_tweet_id( $node ) {
 		/**
 		 * DOMNode
 		 *
 		 * @var DOMNodeList $anchors
 		 */
-		$anchors = $node->getElementsByTagName('a');
+		$anchors = $node->getElementsByTagName( 'a' );
 
 		/**
 		 * Anchor.
 		 *
 		 * @type DOMElement $anchor
 		 */
-		foreach ($anchors as $anchor) {
-			$found = preg_match(self::URL_PATTERN, $anchor->getAttribute('href'), $matches);
-			if ($found) {
+		foreach ( $anchors as $anchor ) {
+			$found = preg_match( self::URL_PATTERN, $anchor->getAttribute( 'href' ), $matches );
+			if ( $found ) {
 				return $matches['tweet'];
 			}
 		}
@@ -319,32 +309,31 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
 	 *
 	 * @param DOMElement $node The DOMNode to whose sibling is the instagram script.
 	 */
-	private function sanitize_embed_script($node)
-	{
+	private function sanitize_embed_script( $node ) {
 		$next_element_sibling = $node->nextSibling;
-		while ($next_element_sibling && !($next_element_sibling instanceof DOMElement)) {
+		while ( $next_element_sibling && ! ( $next_element_sibling instanceof DOMElement ) ) {
 			$next_element_sibling = $next_element_sibling->nextSibling;
 		}
 
 		$script_src = 'platform.twitter.com/widgets.js';
 
 		// Handle case where script is wrapped in paragraph by wpautop.
-		if ($next_element_sibling instanceof DOMElement && 'p' === $next_element_sibling->nodeName) {
-			$children = $next_element_sibling->getElementsByTagName('*');
-			if (1 === $children->length && 'script' === $children->item(0)->nodeName && false !== strpos($children->item(0)->getAttribute('src'), $script_src)) {
-				$next_element_sibling->parentNode->removeChild($next_element_sibling);
+		if ( $next_element_sibling instanceof DOMElement && 'p' === $next_element_sibling->nodeName ) {
+			$children = $next_element_sibling->getElementsByTagName( '*' );
+			if ( 1 === $children->length && 'script' === $children->item( 0 )->nodeName && false !== strpos( $children->item( 0 )->getAttribute( 'src' ), $script_src ) ) {
+				$next_element_sibling->parentNode->removeChild( $next_element_sibling );
 				return;
 			}
 		}
 
 		// Handle case where script is immediately following.
-		$is_embed_script = ($next_element_sibling
+		$is_embed_script = ( $next_element_sibling
 			&&
-			'script' === strtolower($next_element_sibling->nodeName)
+			'script' === strtolower( $next_element_sibling->nodeName )
 			&&
-			false !== strpos($next_element_sibling->getAttribute('src'), $script_src));
-		if ($is_embed_script) {
-			$next_element_sibling->parentNode->removeChild($next_element_sibling);
+			false !== strpos( $next_element_sibling->getAttribute( 'src' ), $script_src ) );
+		if ( $is_embed_script ) {
+			$next_element_sibling->parentNode->removeChild( $next_element_sibling );
 		}
 	}
 }

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -315,7 +315,8 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		}
 
 		// Handle case where script is immediately following.
-		$is_embed_script = ( $next_element_sibling
+		$is_embed_script = (
+			$next_element_sibling
 			&&
 			'script' === strtolower( $next_element_sibling->nodeName )
 			&&

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -228,6 +228,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( ! $tweet_id ) {
 			return;
 		}
+		
 
 		$attributes = [
 			'width'        => $this->DEFAULT_WIDTH,

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -229,31 +229,23 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			return;
 		}
 
-		$additional_attributes = [];
+		$attributes = [
+			'width'        => $this->DEFAULT_WIDTH,
+			'height'       => $this->DEFAULT_HEIGHT,
+			'layout'       => 'responsive',
+			'data-tweetid' => $tweet_id,
+		];
 
 		if ( $node->hasAttributes() ) {
 			foreach ( $node->attributes as $attr ) {
-				$name  = $attr->nodeName;
-				$value = $attr->nodeValue;
-
-				if ( substr( $name, 0, 5 ) === 'data-' ) {
-					$additional_attributes[ $name ] = $value;
-				}
+				$attributes[ $attr->nodeName ] = $attr->nodeValue;
 			}
 		}
 
 		$new_node = AMP_DOM_Utils::create_node(
 			$dom,
 			$this->amp_tag,
-			array_merge(
-				[
-					'width'        => $this->DEFAULT_WIDTH,
-					'height'       => $this->DEFAULT_HEIGHT,
-					'layout'       => 'responsive',
-					'data-tweetid' => $tweet_id,
-				],
-				$additional_attributes
-			)
+			$attributes
 		);
 
 		$this->sanitize_embed_script( $node );

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Class AMP_Twitter_Embed_Handler
  *
@@ -10,7 +11,8 @@
  *
  *  Much of this class is borrowed from Jetpack embeds
  */
-class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
+class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler
+{
 
 	/**
 	 * URL pattern for a Tweet URL.
@@ -43,21 +45,39 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	private $amp_tag = 'amp-twitter';
 
 	/**
+	 * Attributes.
+	 *
+	 * @var array supported attributes of the amp-twitter tag.
+	 */
+	private $supported_data_attributes = [
+		'cards',
+		'conversation',
+		'theme',
+		'link-color',
+		'width',
+		'align',
+		'lang',
+		'dnt'
+	];
+
+	/**
 	 * Registers embed.
 	 */
-	public function register_embed() {
-		add_shortcode( 'tweet', [ $this, 'shortcode' ] ); // Note: This is a Jetpack shortcode.
-		wp_embed_register_handler( 'amp-twitter', self::URL_PATTERN, [ $this, 'oembed' ], -1 );
-		wp_embed_register_handler( 'amp-twitter-timeline', self::URL_PATTERN_TIMELINE, [ $this, 'oembed_timeline' ], -1 );
+	public function register_embed()
+	{
+		add_shortcode('tweet', [$this, 'shortcode']); // Note: This is a Jetpack shortcode.
+		wp_embed_register_handler('amp-twitter', self::URL_PATTERN, [$this, 'oembed'], -1);
+		wp_embed_register_handler('amp-twitter-timeline', self::URL_PATTERN_TIMELINE, [$this, 'oembed_timeline'], -1);
 	}
 
 	/**
 	 * Unregisters embed.
 	 */
-	public function unregister_embed() {
-		remove_shortcode( 'tweet' ); // Note: This is a Jetpack shortcode.
-		wp_embed_unregister_handler( 'amp-twitter', -1 );
-		wp_embed_unregister_handler( 'amp-twitter-timeline', -1 );
+	public function unregister_embed()
+	{
+		remove_shortcode('tweet'); // Note: This is a Jetpack shortcode.
+		wp_embed_unregister_handler('amp-twitter', -1);
+		wp_embed_unregister_handler('amp-twitter-timeline', -1);
 	}
 
 	/**
@@ -68,7 +88,8 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param array $attr The Twitter attributes.
 	 * @return string Twitter shortcode markup.
 	 */
-	public function shortcode( $attr ) {
+	public function shortcode($attr)
+	{
 		$attr = wp_parse_args(
 			$attr,
 			[
@@ -76,20 +97,20 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			]
 		);
 
-		if ( empty( $attr['tweet'] ) && ! empty( $attr[0] ) ) {
+		if (empty($attr['tweet']) && !empty($attr[0])) {
 			$attr['tweet'] = $attr[0];
 		}
 
 		$id = false;
-		if ( is_numeric( $attr['tweet'] ) ) {
+		if (is_numeric($attr['tweet'])) {
 			$id = $attr['tweet'];
 		} else {
-			preg_match( self::URL_PATTERN, $attr['tweet'], $matches );
-			if ( isset( $matches['tweet'] ) && is_numeric( $matches['tweet'] ) ) {
+			preg_match(self::URL_PATTERN, $attr['tweet'], $matches);
+			if (isset($matches['tweet']) && is_numeric($matches['tweet'])) {
 				$id = $matches['tweet'];
 			}
 
-			if ( empty( $id ) ) {
+			if (empty($id)) {
 				return '';
 			}
 		}
@@ -115,18 +136,19 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param array $matches URL pattern matches.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed( $matches ) {
+	public function oembed($matches)
+	{
 		$id = false;
 
-		if ( isset( $matches['tweet'] ) && is_numeric( $matches['tweet'] ) ) {
+		if (isset($matches['tweet']) && is_numeric($matches['tweet'])) {
 			$id = $matches['tweet'];
 		}
 
-		if ( ! $id ) {
+		if (!$id) {
 			return '';
 		}
 
-		return $this->shortcode( [ 'tweet' => $id ] );
+		return $this->shortcode(['tweet' => $id]);
 	}
 
 	/**
@@ -137,8 +159,9 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param array $matches URL pattern matches.
 	 * @return string Rendered oEmbed.
 	 */
-	public function oembed_timeline( $matches ) {
-		if ( ! isset( $matches['username'] ) ) {
+	public function oembed_timeline($matches)
+	{
+		if (!isset($matches['username'])) {
 			return '';
 		}
 
@@ -147,19 +170,19 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			'data-timeline-screen-name' => $matches['username'],
 		];
 
-		if ( isset( $matches['type'] ) ) {
-			switch ( $matches['type'] ) {
+		if (isset($matches['type'])) {
+			switch ($matches['type']) {
 				case 'likes':
 					$attributes['data-timeline-source-type'] = 'likes';
 					break;
 				case 'lists':
-					if ( ! isset( $matches['id'] ) ) {
+					if (!isset($matches['id'])) {
 						return '';
 					}
 					$attributes['data-timeline-source-type']       = 'list';
 					$attributes['data-timeline-slug']              = $matches['id'];
 					$attributes['data-timeline-owner-screen-name'] = $attributes['data-timeline-screen-name'];
-					unset( $attributes['data-timeline-screen-name'] );
+					unset($attributes['data-timeline-screen-name']);
 					break;
 				default:
 					return '';
@@ -172,7 +195,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		$this->did_convert_elements = true;
 
-		return AMP_HTML_Utils::build_tag( $this->amp_tag, $attributes );
+		return AMP_HTML_Utils::build_tag($this->amp_tag, $attributes);
 	}
 
 	/**
@@ -180,27 +203,28 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @param DOMDocument $dom DOM.
 	 */
-	public function sanitize_raw_embeds( $dom ) {
+	public function sanitize_raw_embeds($dom)
+	{
 		/**
 		 * Node list.
 		 *
 		 * @var DOMNodeList $node
 		 */
-		$nodes     = $dom->getElementsByTagName( $this->sanitize_tag );
+		$nodes     = $dom->getElementsByTagName($this->sanitize_tag);
 		$num_nodes = $nodes->length;
 
-		if ( 0 === $num_nodes ) {
+		if (0 === $num_nodes) {
 			return;
 		}
 
-		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
-			$node = $nodes->item( $i );
-			if ( ! $node instanceof DOMElement ) {
+		for ($i = $num_nodes - 1; $i >= 0; $i--) {
+			$node = $nodes->item($i);
+			if (!$node instanceof DOMElement) {
 				continue;
 			}
 
-			if ( $this->is_tweet_raw_embed( $node ) ) {
-				$this->create_amp_twitter_and_replace_node( $dom, $node );
+			if ($this->is_tweet_raw_embed($node)) {
+				$this->create_amp_twitter_and_replace_node($dom, $node);
 			}
 		}
 	}
@@ -211,10 +235,11 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param DOMElement $node The DOMNode to adjust and replace.
 	 * @return bool Whether node is for raw embed.
 	 */
-	private function is_tweet_raw_embed( $node ) {
-		$class_attr = $node->getAttribute( 'class' );
+	private function is_tweet_raw_embed($node)
+	{
+		$class_attr = $node->getAttribute('class');
 
-		return null !== $class_attr && false !== strpos( $class_attr, 'twitter-tweet' );
+		return null !== $class_attr && false !== strpos($class_attr, 'twitter-tweet');
 	}
 
 	/**
@@ -223,26 +248,38 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param DOMDocument $dom The HTML Document.
 	 * @param DOMElement  $node The DOMNode to adjust and replace.
 	 */
-	private function create_amp_twitter_and_replace_node( $dom, $node ) {
-		$tweet_id = $this->get_tweet_id( $node );
-		if ( ! $tweet_id ) {
+	private function create_amp_twitter_and_replace_node($dom, $node)
+	{
+		$tweet_id = $this->get_tweet_id($node);
+		if (!$tweet_id) {
 			return;
+		}
+
+		$additional_attributes = [];
+
+		foreach ($this->supported_data_attributes as $attr) {
+			if ($value = $node->getAttribute('data-' . $attr)) {
+				$additional_attributes['data-' . $attr] = $value;
+			}
 		}
 
 		$new_node = AMP_DOM_Utils::create_node(
 			$dom,
 			$this->amp_tag,
-			[
-				'width'        => $this->DEFAULT_WIDTH,
-				'height'       => $this->DEFAULT_HEIGHT,
-				'layout'       => 'responsive',
-				'data-tweetid' => $tweet_id,
-			]
+			array_merge(
+				$additional_attributes,
+				[
+					'width'             => $this->DEFAULT_WIDTH,
+					'height'            => $this->DEFAULT_HEIGHT,
+					'layout'            => 'responsive',
+					'data-tweetid'      => $tweet_id,
+				]
+			)
 		);
 
-		$this->sanitize_embed_script( $node );
+		$this->sanitize_embed_script($node);
 
-		$node->parentNode->replaceChild( $new_node, $node );
+		$node->parentNode->replaceChild($new_node, $node);
 
 		$this->did_convert_elements = true;
 	}
@@ -253,22 +290,23 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @param DOMElement $node The DOMNode to adjust and replace.
 	 * @return string Tweet ID.
 	 */
-	private function get_tweet_id( $node ) {
+	private function get_tweet_id($node)
+	{
 		/**
 		 * DOMNode
 		 *
 		 * @var DOMNodeList $anchors
 		 */
-		$anchors = $node->getElementsByTagName( 'a' );
+		$anchors = $node->getElementsByTagName('a');
 
 		/**
 		 * Anchor.
 		 *
 		 * @type DOMElement $anchor
 		 */
-		foreach ( $anchors as $anchor ) {
-			$found = preg_match( self::URL_PATTERN, $anchor->getAttribute( 'href' ), $matches );
-			if ( $found ) {
+		foreach ($anchors as $anchor) {
+			$found = preg_match(self::URL_PATTERN, $anchor->getAttribute('href'), $matches);
+			if ($found) {
 				return $matches['tweet'];
 			}
 		}
@@ -281,33 +319,32 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 *
 	 * @param DOMElement $node The DOMNode to whose sibling is the instagram script.
 	 */
-	private function sanitize_embed_script( $node ) {
+	private function sanitize_embed_script($node)
+	{
 		$next_element_sibling = $node->nextSibling;
-		while ( $next_element_sibling && ! ( $next_element_sibling instanceof DOMElement ) ) {
+		while ($next_element_sibling && !($next_element_sibling instanceof DOMElement)) {
 			$next_element_sibling = $next_element_sibling->nextSibling;
 		}
 
 		$script_src = 'platform.twitter.com/widgets.js';
 
 		// Handle case where script is wrapped in paragraph by wpautop.
-		if ( $next_element_sibling instanceof DOMElement && 'p' === $next_element_sibling->nodeName ) {
-			$children = $next_element_sibling->getElementsByTagName( '*' );
-			if ( 1 === $children->length && 'script' === $children->item( 0 )->nodeName && false !== strpos( $children->item( 0 )->getAttribute( 'src' ), $script_src ) ) {
-				$next_element_sibling->parentNode->removeChild( $next_element_sibling );
+		if ($next_element_sibling instanceof DOMElement && 'p' === $next_element_sibling->nodeName) {
+			$children = $next_element_sibling->getElementsByTagName('*');
+			if (1 === $children->length && 'script' === $children->item(0)->nodeName && false !== strpos($children->item(0)->getAttribute('src'), $script_src)) {
+				$next_element_sibling->parentNode->removeChild($next_element_sibling);
 				return;
 			}
 		}
 
 		// Handle case where script is immediately following.
-		$is_embed_script = (
-			$next_element_sibling
+		$is_embed_script = ($next_element_sibling
 			&&
-			'script' === strtolower( $next_element_sibling->nodeName )
+			'script' === strtolower($next_element_sibling->nodeName)
 			&&
-			false !== strpos( $next_element_sibling->getAttribute( 'src' ), $script_src )
-		);
-		if ( $is_embed_script ) {
-			$next_element_sibling->parentNode->removeChild( $next_element_sibling );
+			false !== strpos($next_element_sibling->getAttribute('src'), $script_src));
+		if ($is_embed_script) {
+			$next_element_sibling->parentNode->removeChild($next_element_sibling);
 		}
 	}
 }

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -43,22 +43,6 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	private $amp_tag = 'amp-twitter';
 
 	/**
-	 * Attributes.
-	 *
-	 * @var array supported attributes of the amp-twitter tag.
-	 */
-	private $supported_data_attributes = [
-		'cards',
-		'conversation',
-		'theme',
-		'link-color',
-		'width',
-		'align',
-		'lang',
-		'dnt',
-	];
-
-	/**
 	 * Registers embed.
 	 */
 	public function register_embed() {
@@ -247,10 +231,14 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		$additional_attributes = [];
 
-		foreach ( $this->supported_data_attributes as $attr ) {
-			$value = $node->getAttribute( 'data-' . $attr );
-			if ( $value ) {
-				$additional_attributes[ 'data-' . $attr ] = $value;
+		if ( $node->hasAttributes() ) {
+			foreach ( $node->attributes as $attr ) {
+				$name  = $attr->nodeName;
+				$value = $attr->nodeValue;
+
+				if ( substr ( $name, 0, 5 ) === 'data-' ) {
+					$additional_attributes[ $name ] = $value;
+				}
 			}
 		}
 
@@ -258,13 +246,13 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			$dom,
 			$this->amp_tag,
 			array_merge(
-				$additional_attributes,
 				[
 					'width'        => $this->DEFAULT_WIDTH,
 					'height'       => $this->DEFAULT_HEIGHT,
 					'layout'       => 'responsive',
 					'data-tweetid' => $tweet_id,
-				]
+				],
+				$additional_attributes
 			)
 		);
 

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -331,7 +331,8 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			&&
 			'script' === strtolower( $next_element_sibling->nodeName )
 			&&
-			false !== strpos( $next_element_sibling->getAttribute( 'src' ), $script_src ) );
+			false !== strpos( $next_element_sibling->getAttribute( 'src' ), $script_src )
+		);
 		if ( $is_embed_script ) {
 			$next_element_sibling->parentNode->removeChild( $next_element_sibling );
 		}

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -228,7 +228,6 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( ! $tweet_id ) {
 			return;
 		}
-		
 
 		$attributes = [
 			'width'        => $this->DEFAULT_WIDTH,

--- a/includes/embeds/class-amp-twitter-embed.php
+++ b/includes/embeds/class-amp-twitter-embed.php
@@ -236,7 +236,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 				$name  = $attr->nodeName;
 				$value = $attr->nodeValue;
 
-				if ( substr ( $name, 0, 5 ) === 'data-' ) {
+				if ( substr( $name, 0, 5 ) === 'data-' ) {
 					$additional_attributes[ $name ] = $value;
 				}
 			}

--- a/tests/php/test-amp-twitter-embed.php
+++ b/tests/php/test-amp-twitter-embed.php
@@ -125,22 +125,22 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                        => [
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-lang="en"></amp-twitter>' . "\n\n",
+				'<amp-twitter data-lang="en" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_with_data_conversation' => [
 				wpautop( '<blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-conversation="none"></amp-twitter>' . "\n\n",
+				'<amp-twitter data-conversation="none" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_with_data_theme'        => [
 				wpautop( '<blockquote class="twitter-tweet" data-theme="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-theme="en"></amp-twitter>' . "\n\n",
+				'<amp-twitter data-theme="en" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_not_autop'              => [
 				'<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-lang="en"></amp-twitter> ',
+				'<amp-twitter data-lang="en" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter> ',
 			],
 		];
 	}

--- a/tests/php/test-amp-twitter-embed.php
+++ b/tests/php/test-amp-twitter-embed.php
@@ -125,7 +125,7 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                        => [
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en"></amp-twitter>'. "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en"></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_with_data_conversation' => [

--- a/tests/php/test-amp-twitter-embed.php
+++ b/tests/php/test-amp-twitter-embed.php
@@ -114,23 +114,33 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	 */
 	public function get_raw_embed_dataset() {
 		return [
-			'no_embed'                         => [
+			'no_embed'                                => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>',
 			],
-			'embed_blockquote_without_twitter' => [
+			'embed_blockquote_without_twitter'        => [
 				'<blockquote>lorem ipsum</blockquote>',
 				'<blockquote>lorem ipsum</blockquote>',
 			],
 
-			'blockquote_embed'                 => [
+			'blockquote_embed'                        => [
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-lang="en"></amp-twitter>' . "\n\n",
 			],
 
-			'blockquote_embed_not_autop'       => [
+			'blockquote_embed_with_data_conversation' => [
+				wpautop( '<blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-conversation="none"></amp-twitter>' . "\n\n",
+			],
+
+			'blockquote_embed_with_data_theme'        => [
+				wpautop( '<blockquote class="twitter-tweet" data-theme="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-theme="en"></amp-twitter>' . "\n\n",
+			],
+
+			'blockquote_embed_not_autop'              => [
 				'<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter> ',
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" data-lang="en"></amp-twitter> ',
 			],
 		];
 	}

--- a/tests/php/test-amp-twitter-embed.php
+++ b/tests/php/test-amp-twitter-embed.php
@@ -125,22 +125,22 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 
 			'blockquote_embed'                        => [
 				wpautop( '<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter data-lang="en" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en"></amp-twitter>'. "\n\n",
 			],
 
 			'blockquote_embed_with_data_conversation' => [
 				wpautop( '<blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter data-conversation="none" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-conversation="none"></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_with_data_theme'        => [
 				wpautop( '<blockquote class="twitter-tweet" data-theme="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>' ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter data-theme="en" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter>' . "\n\n",
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-theme="en"></amp-twitter>' . "\n\n",
 			],
 
 			'blockquote_embed_not_autop'              => [
 				'<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">Celebrate the WordPress 15th Anniversary on May 27 <a href="https://t.co/jv62WkI9lr">https://t.co/jv62WkI9lr</a> <a href="https://t.co/4ZECodSK78">pic.twitter.com/4ZECodSK78</a></p>&mdash; WordPress (@WordPress) <a href="https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw">April 20, 2018</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript, WordPress.Arrays.ArrayDeclarationSpacing.ArrayItemNoNewLine
-				'<amp-twitter data-lang="en" width="600" height="480" layout="responsive" data-tweetid="987437752164737025"></amp-twitter> ',
+				'<amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025" class="twitter-tweet" data-lang="en"></amp-twitter> ',
 			],
 		];
 	}


### PR DESCRIPTION
Re: issue #3050 I did some research and the Jetpack `tweet` shortcode supports the same attributes that the [amp-twitter](https://amp.dev/documentation/components/amp-twitter/) tag does.

I've updated the `AMP_Twitter_Embed_Handler` class to track an array of `$supported_data_attributes` which is based on [Twitter's current embed documentation](https://developer.twitter.com/en/docs/twitter-for-websites/embedded-tweets/guides/embedded-tweet-parameter-reference). This prevents arbitrary access to data attributes on the elements while allowing an easy method for adding new ones if the API is updated in future.

Those attributes are then passed to `AMP_DOM_Utils::create_node`.

Any questions let me know. I've been testing with these tweets on a WP page:

```html
<blockquote class="twitter-tweet" data-lang="en">
<p dir="ltr">Miss you, can’t wait to see back in the starting 11</p>
<p>— Kurt Kufuor (@Kurt_Kufour) <a href="https://twitter.com/Kurt_Kufour/status/1115992642632941568?ref_src=twsrc%5Etfw">April 10, 2019</a></p>
</blockquote>
<p><script charset="utf-8" type="text/javascript" src="https://platform.twitter.com/widgets.js" async=""></script></p>
<blockquote class="twitter-tweet" data-lang="en" data-theme="dark" data-conversation="none">
<p dir="ltr">WELCOME BACK! it was great seeing u even if on the bench &lt;3</p>
<p>— Catlady Dee (@PsycheDALIAc) <a href="https://twitter.com/PsycheDALIAc/status/1115993152115105792?ref_src=twsrc%5Etfw">April 10, 2019</a></p>
</blockquote>
<p><script charset="utf-8" type="text/javascript" src="https://platform.twitter.com/widgets.js" async=""></script></p>
<blockquote class="twitter-tweet" data-lang="en" data-conversation="none">
<p dir="ltr">Good for you Joe. What a great time to be back! YNWA</p>
<p>— Yang Bertweet (YB) (@AbdFauzi) <a href="https://twitter.com/AbdFauzi/status/1116003307162689537?ref_src=twsrc%5Etfw">April 10, 2019</a></p>
</blockquote>
<p><script charset="utf-8" type="text/javascript" src="https://platform.twitter.com/widgets.js" async=""></script></p>
```

Fixes #3050.