### PR TITLE
Normalize frameborder=no|yes to frameborder=0|1 in iframe sanitizer

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -255,6 +255,34 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Sanitizes a boolean character (or string) into a '0' or '1' character.
+	 *
+	 * @param string $value A boolean character to sanitize. If a string containing more than a single
+	 *                      character is provided, only the first character is taken into account.
+	 *
+	 * @return string Returns either '0' or '1'.
+	 */
+	public function sanitize_boolean_digit( $value ) {
+
+		if ( empty( $value ) ) {
+			return '0';
+		}
+
+		if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+			return '0';
+		}
+
+		switch ( substr( (string) $value, 0, 1 ) ) {
+			case '1':
+			case 'y':
+			case 'Y':
+				return '1';
+		}
+
+		return '0';
+	}
+
+	/**
 	 * Sets the layout, and possibly the 'height' and 'width' attributes.
 	 *
 	 * @param string[] $attributes {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -264,14 +264,17 @@ abstract class AMP_Base_Sanitizer {
 	 */
 	public function sanitize_boolean_digit( $value ) {
 
+		// Default to false if the value was forgotten.
 		if ( empty( $value ) ) {
 			return '0';
 		}
 
+		// Default to false if the value has an unexpected type.
 		if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
 			return '0';
 		}
 
+		// See: https://github.com/ampproject/amp-wp/issues/2335#issuecomment-493209861
 		switch ( substr( (string) $value, 0, 1 ) ) {
 			case '1':
 			case 'y':

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -255,37 +255,6 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Sanitizes a boolean character (or string) into a '0' or '1' character.
-	 *
-	 * @param string $value A boolean character to sanitize. If a string containing more than a single
-	 *                      character is provided, only the first character is taken into account.
-	 *
-	 * @return string Returns either '0' or '1'.
-	 */
-	public function sanitize_boolean_digit( $value ) {
-
-		// Default to false if the value was forgotten.
-		if ( empty( $value ) ) {
-			return '0';
-		}
-
-		// Default to false if the value has an unexpected type.
-		if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
-			return '0';
-		}
-
-		// See: https://github.com/ampproject/amp-wp/issues/2335#issuecomment-493209861
-		switch ( substr( (string) $value, 0, 1 ) ) {
-			case '1':
-			case 'y':
-			case 'Y':
-				return '1';
-		}
-
-		return '0';
-	}
-
-	/**
 	 * Sets the layout, and possibly the 'height' and 'width' attributes.
 	 *
 	 * @param string[] $attributes {

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -131,7 +131,9 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 			if ( $this->args['add_noscript_fallback'] ) {
 				$node->setAttribute( 'src', $normalized_attributes['src'] );
-
+				if ( $node->hasAttribute( 'frameborder' ) ) {
+					$node->setAttribute( 'frameborder', $normalized_attributes['frameborder'] );
+				}
 				// Preserve original node in noscript for no-JS environments.
 				$this->append_old_node_noscript( $new_node, $node, $this->dom );
 			}
@@ -155,7 +157,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type bool $allowfullscreen <iframe> `allowfullscreen` attribute - Convert 'false' to empty string ''
 	 *      @type bool $allowtransparency <iframe> `allowtransparency` attribute - Convert 'false' to empty string ''
 	 * }
-	 * @return array Returns HTML attributes; normalizes src, dimensions, frameborder, sandox, allowtransparency and allowfullscreen
+	 * @return array Returns HTML attributes; normalizes src, dimensions, frameborder, sandbox, allowtransparency and allowfullscreen
 	 */
 	private function normalize_attributes( $attributes ) {
 		$out = [];
@@ -189,10 +191,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					break;
 
 				case 'frameborder':
-					if ( '0' !== $value && '1' !== $value ) {
-						$value = '0';
-					}
-					$out[ $name ] = $value;
+					$out[ $name ] = $this->sanitize_boolean_digit( $value );
 					break;
 
 				case 'allowfullscreen':

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -273,4 +273,34 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 		return $placeholder_node;
 	}
 
+	/**
+	 * Sanitizes a boolean character (or string) into a '0' or '1' character.
+	 *
+	 * @param string $value A boolean character to sanitize. If a string containing more than a single
+	 *                      character is provided, only the first character is taken into account.
+	 *
+	 * @return string Returns either '0' or '1'.
+	 */
+	private function sanitize_boolean_digit( $value ) {
+
+		// Default to false if the value was forgotten.
+		if ( empty( $value ) ) {
+			return '0';
+		}
+
+		// Default to false if the value has an unexpected type.
+		if ( ! is_string( $value ) && ! is_numeric( $value ) ) {
+			return '0';
+		}
+
+		// See: https://github.com/ampproject/amp-wp/issues/2335#issuecomment-493209861.
+		switch ( substr( (string) $value, 0, 1 ) ) {
+			case '1':
+			case 'y':
+			case 'Y':
+				return '1';
+		}
+
+		return '0';
+	}
 }

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -131,9 +131,12 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 
 			if ( $this->args['add_noscript_fallback'] ) {
 				$node->setAttribute( 'src', $normalized_attributes['src'] );
+
+				// AMP is stricter than HTML5 for this attribute, so make sure we use a normalized value.
 				if ( $node->hasAttribute( 'frameborder' ) ) {
 					$node->setAttribute( 'frameborder', $normalized_attributes['frameborder'] );
 				}
+
 				// Preserve original node in noscript for no-JS environments.
 				$this->append_old_node_noscript( $new_node, $node, $this->dom );
 			}

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -111,7 +111,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				'
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
 						<noscript>
-							<iframe src="https://example.com/embed/132886713" width="500" height="281"></iframe>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0"></iframe>
 						</noscript>					
 					</amp-iframe>
 				',
@@ -340,6 +340,38 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					'add_placeholder'       => false,
 					'current_origin'        => 'https://example.com',
 					'alias_origin'          => 'https://alt.example.org',
+				],
+			],
+
+			'iframe_with_frameborder_no'                => [
+				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="no" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" class="iframe-class"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				[
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
+				],
+			],
+
+			'iframe_with_frameborder_yes'               => [
+				'<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="yes" class="iframe-class" allowtransparency="false" allowfullscreen></iframe>',
+				'
+					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1" class="iframe-class amp-wp-enforced-sizes" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+						<noscript>
+							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1" class="iframe-class"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				[
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
 				],
 			],
 		];


### PR DESCRIPTION
Fixes #2335

The logic to normalize the frameborder attribute is based on the text from [https://html.spec.whatwg.org/#frames-and-framesets](https://html.spec.whatwg.org/#frames-and-framesets):

> A frameset or frame element has a border if the following algorithm returns true:
> 
> If the element has a frameborder attribute whose value is not the empty string and whose first character is either a U+0031 DIGIT ONE (1) character, a U+0079 LATIN SMALL LETTER Y character (y), or a U+0059 LATIN CAPITAL LETTER Y character (Y), then return true.

Open questions:

- [x] The actual normalization logic is a method called `sanitize_boolean_digit()` in the `AMP_Base_Sanitizer` parent class, to mirror the behavior of `sanitize_dimension()` which is in there, too. Should the base class regroup such logic that might be needed across sanitizer? Or would it make sense to extract them into either separate helper objects or traits?
- [x] The name of the method is `sanitize_boolean_digit()`... is there a name that is clearer here? Maybe an official HTML "attribute type" name I don't know about?