### PR TITLE
Update allowed tags/attributes from spec in amphtml 1908162134430

### DIFF
--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 920;
+	private static $spec_file_revision = 935;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -492,7 +492,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'referrerpolicy' => array(),
 					'rel' => array(
-						'blacklisted_value_regex' => '(^|\\s)(components|dns-prefetch|import|manifest|preconnect|prefetch|preload|prerender|serviceworker|stylesheet|subresource|)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(components|dns-prefetch|import|manifest|preconnect|prefetch|preload|prerender|serviceworker|stylesheet|subresource)(\\s|$)',
 					),
 					'role' => array(),
 					'tabindex' => array(),
@@ -1356,7 +1356,6 @@ class AMP_Allowed_Tags_Generated {
 							5,
 						),
 					),
-					'mandatory_ancestor' => 'form',
 					'requires_extension' => array(
 						'amp-autocomplete',
 					),
@@ -1857,6 +1856,9 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'slide' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'type' => array(
 						'value' => array(
 							'slides',
@@ -1913,7 +1915,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'slide' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'type' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => array(
 							'carousel',
@@ -1968,6 +1974,9 @@ class AMP_Allowed_Tags_Generated {
 						'value' => array(
 							'',
 						),
+					),
+					'slide' => array(
+						'value_regex' => '[0-9]+',
 					),
 					'type' => array(
 						'value' => array(
@@ -2039,7 +2048,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'slide' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'type' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value' => array(
 							'carousel',
@@ -2323,6 +2336,7 @@ class AMP_Allowed_Tags_Generated {
 					'offset-seconds' => array(
 						'value_regex' => '-?\\d+',
 					),
+					'template' => array(),
 					'timestamp-ms' => array(
 						'value_regex' => '\\d+',
 					),
@@ -2472,6 +2486,7 @@ class AMP_Allowed_Tags_Generated {
 					'media' => array(),
 					'min' => array(),
 					'mode' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => array(
 							'overlay',
@@ -2669,6 +2684,7 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-9]+',
 					),
 					'mode' => array(
+						'dispatch_key' => 2,
 						'mandatory' => true,
 						'value_casei' => array(
 							'overlay',
@@ -4796,7 +4812,6 @@ class AMP_Allowed_Tags_Generated {
 					'disallowed_ancestor' => array(
 						'amp-story',
 					),
-					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
@@ -5731,6 +5746,118 @@ class AMP_Allowed_Tags_Generated {
 					'artwork' => array(),
 					'attribution' => array(),
 					'autoplay' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'controls' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'controlslist' => array(),
+					'crossorigin' => array(),
+					'data-amp-bind-album' => array(),
+					'data-amp-bind-alt' => array(),
+					'data-amp-bind-artist' => array(),
+					'data-amp-bind-artwork' => array(),
+					'data-amp-bind-attribution' => array(),
+					'data-amp-bind-controls' => array(),
+					'data-amp-bind-controlslist' => array(),
+					'data-amp-bind-loop' => array(),
+					'data-amp-bind-poster' => array(),
+					'data-amp-bind-preload' => array(),
+					'data-amp-bind-src' => array(),
+					'data-amp-bind-title' => array(),
+					'disableremoteplayback' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
+					'lightbox' => array(),
+					'lightbox-thumbnail-id' => array(
+						'value_regex_casei' => '^[a-z][a-z\\d_-]*',
+					),
+					'loop' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'media' => array(),
+					'muted' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'noaudio' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'object-fit' => array(),
+					'object-position' => array(),
+					'placeholder' => array(),
+					'poster' => array(),
+					'preload' => array(
+						'value' => array(
+							'auto',
+							'metadata',
+							'none',
+							'',
+						),
+					),
+					'rotate-to-fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'blacklisted_value_regex' => '__amp_source_origin',
+						'value_url' => array(
+							'allow_relative' => true,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
+				'tag_spec' => array(
+					'also_requires_tag_warning' => array(
+						'amp-video extension .js script',
+					),
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							1,
+							4,
+						),
+					),
+					'mandatory_ancestor' => 'amp-story-page-attachment',
+					'spec_name' => 'amp-story >> amp-story-page-attachment >> amp-video',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-video',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'album' => array(),
+					'alt' => array(),
+					'artist' => array(),
+					'artwork' => array(),
+					'attribution' => array(),
+					'autoplay' => array(
 						'mandatory' => true,
 						'value' => array(
 							'',
@@ -6525,6 +6652,21 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'canvas' => array(
+			array(
+				'attr_spec_list' => array(
+					'height' => array(),
+					'width' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-script',
+					'requires_extension' => array(
+						'amp-script',
+					),
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags',
+				),
+			),
+		),
 		'caption' => array(
 			array(
 				'attr_spec_list' => array(),
@@ -7036,6 +7178,18 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-image-slider',
 					'spec_name' => 'AMP-IMAGE-SLIDER > DIV [second]',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-image-slider',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'align' => array(),
+					'fetch-error' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-list',
+					'spec_name' => 'AMP-LIST DIV [fetch-error]',
 				),
 			),
 		),
@@ -8495,7 +8649,10 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'height' => array(),
+					'importance' => array(),
+					'intrinsicsize' => array(),
 					'ismap' => array(),
+					'loading' => array(),
 					'longdesc' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'value_url' => array(
@@ -8623,6 +8780,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-amp-bind-size' => array(),
 					'data-amp-bind-spellcheck' => array(),
 					'data-amp-bind-step' => array(),
+					'data-amp-bind-type' => array(),
 					'data-amp-bind-value' => array(),
 					'data-amp-bind-width' => array(),
 					'disabled' => array(),
@@ -8694,6 +8852,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-amp-bind-size' => array(),
 					'data-amp-bind-spellcheck' => array(),
 					'data-amp-bind-step' => array(),
+					'data-amp-bind-type' => array(),
 					'data-amp-bind-value' => array(),
 					'data-amp-bind-width' => array(),
 					'disabled' => array(),
@@ -9472,7 +9631,7 @@ class AMP_Allowed_Tags_Generated {
 					'hreflang' => array(),
 					'media' => array(),
 					'rel' => array(
-						'blacklisted_value_regex' => '(^|\\s)(canonical|components|import|manifest|preload|serviceworker|stylesheet|subresource|)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(canonical|components|import|manifest|preload|serviceworker|stylesheet|subresource)(\\s|$)',
 						'mandatory' => true,
 					),
 					'sizes' => array(),
@@ -10166,6 +10325,24 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_parent' => 'head',
 					'spec_name' => 'meta name=amp-recaptcha-input',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'content' => array(
+						'mandatory' => true,
+					),
+					'name' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value_casei' => array(
+							'amp-script-src',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'head',
+					'spec_name' => 'meta name=amp-script-src',
 				),
 			),
 			array(
@@ -12197,6 +12374,7 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => 2,
 						'version' => array(
 							'0.1',
+							'0.2',
 							'latest',
 						),
 					),
@@ -15470,6 +15648,7 @@ class AMP_Allowed_Tags_Generated {
 					'font-weight' => array(),
 					'glyph-orientation-horizontal' => array(),
 					'glyph-orientation-vertical' => array(),
+					'height' => array(),
 					'image-rendering' => array(),
 					'kerning' => array(),
 					'letter-spacing' => array(),
@@ -15503,6 +15682,7 @@ class AMP_Allowed_Tags_Generated {
 					'vector-effect' => array(),
 					'viewbox' => array(),
 					'visibility' => array(),
+					'width' => array(),
 					'word-spacing' => array(),
 					'writing-mode' => array(),
 					'xml:lang' => array(),


### PR DESCRIPTION
Previously: #3003.

- [x] Run `./bin/amphtml-update.sh`
- [ ] Examine diff for changelog
- [ ] Update spec generator as needed based on spec format changes.
- [ ] Modify validating sanitizer based on changes to spec, if needed.
- [ ] Add tests for key changes

# Changelog

..

# Details


```bash
(
    PREV_VERSION=1907301630320;
    THIS_VERSION=1908162134430; 
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files $THIS_VERSION -- . | grep '.protoascii' )
)
```

<details>
<summary>Compare 1907301630320...1908162134430</summary>

```diff
diff --git a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
index 6c0485078..03ec7cfb0 100644
--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -29,7 +29,6 @@ tags: {  # <amp-autocomplete>
   tag_name: "AMP-AUTOCOMPLETE"
   spec_name: "amp-autocomplete"
   requires_extension: "amp-autocomplete"
-  mandatory_ancestor: "FORM"
   attrs: {
     name: "filter"
     value_casei: "custom"
diff --git a/extensions/amp-carousel/validator-amp-carousel.protoascii b/extensions/amp-carousel/validator-amp-carousel.protoascii
index 1b1f31e9c..1984908e9 100644
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -23,6 +23,7 @@ tags: {  # amp-carousel
   extension_spec: {
     name: "amp-carousel"
     version: "0.1"
+    version: "0.2"
     version: "latest"
     requires_usage: GRANDFATHERED
     deprecated_allow_duplicates: true
@@ -53,6 +54,10 @@ attr_lists: {
   attrs: {
     name: "loop"
     value: ""
+  }
+    attrs: {
+    name: "slide"
+    value_regex: "[0-9]+"
   }
   # <amp-bind>
   attrs: { name: "[slide]" }
@@ -111,6 +116,7 @@ tags: {  # <amp-carousel type=carousel>
     name: "type"
     value: "carousel"
     mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "amp-carousel-common"
   attr_lists: "extended-amp-global"
@@ -169,6 +175,7 @@ tags: {  # <amp-carousel lightbox type=carousel>
     name: "type"
     value: "carousel"
     mandatory: true
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attr_lists: "amp-carousel-common"
   attr_lists: "extended-amp-global"
diff --git a/extensions/amp-date-display/validator-amp-date-display.protoascii b/extensions/amp-date-display/validator-amp-date-display.protoascii
index 2391ad711..e7e1550bb 100644
--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-date-display/validator-amp-date-display.protoascii
@@ -42,6 +42,7 @@ tags: {  # <amp-date-display>
     value_regex: "-?\\d+"
   }
   attrs: { name: "locale" }
+  attrs: { name: "template" }
   attrs: {
     name: "timestamp-ms"
     mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"
diff --git a/extensions/amp-date-picker/validator-amp-date-picker.protoascii b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
index 0e96a1eba..07633ddae 100644
--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -62,6 +62,7 @@ tags: {
     name: "mode"
     mandatory: true
     value_casei: "overlay"
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "type"
@@ -115,6 +116,7 @@ tags: {
     name: "mode"
     mandatory: true
     value_casei: "overlay"
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   attrs: {
     name: "type"
diff --git a/extensions/amp-list/validator-amp-list.protoascii b/extensions/amp-list/validator-amp-list.protoascii
index f27d16bcb..b5f35a026 100644
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -118,10 +118,24 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     supported_layouts: RESPONSIVE
   }
 }
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: ACTIONS
+  tag_name: "DIV"
+  spec_name: "AMP-LIST DIV [fetch-error]"
+  mandatory_ancestor: "AMP-LIST"
+  attrs: { name: "align" }
+  attrs: {
+    name: "fetch-error"
+    mandatory: true
+  }
+}
 
 tags: { # amp-list-load-more
   html_format: AMP
-  html_format: EXPERIMENTAL
+  html_format: ACTIONS
   tag_name: "AMP-LIST-LOAD-MORE"
   requires_extension: "amp-list"
   mandatory_parent: "AMP-LIST"
@@ -150,7 +164,7 @@ tags: { # amp-list-load-more
 # The button element variant allowed in amp-list-load-more.
 tags: {
   html_format: AMP
-  html_format: EXPERIMENTAL
+  html_format: ACTIONS
   requires_extension: "amp-list"
   tag_name: "BUTTON"
   spec_name: "amp-list-load-more button[load-more-clickable]"
@@ -187,6 +201,12 @@ tags: {  # <amp-list>
   disallowed_ancestor: "AMP-LIST"
   disallowed_ancestor: "AMP-STATE"
   disallowed_ancestor: "TEMPLATE"
+  attrs: {
+    name: "binding"
+    value: "always"
+    value: "no"
+    value: "refresh"
+  }
   attrs: { name: "items" }
   attrs: { name: "max-items" }
   attrs: { name: "single-item" }
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index 59205f343..7e7c62f01 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -59,7 +59,6 @@ tags: {  # <amp-script>
   tag_name: "AMP-SCRIPT"
   disallowed_ancestor: "AMP-SCRIPT"
   requires_extension: "amp-script"
-  requires: "amp-experiment-token"
   attrs: { name: "sandbox" }
   attrs: {
     name: "script"
@@ -85,3 +84,13 @@ tags: {  # <amp-script>
     supported_layouts: RESPONSIVE
   }
 }
+# HTML5, 4.8.11 The canvas element.
+tags: {
+  html_format: AMP
+  tag_name: "CANVAS"
+  attrs: { name: "height" }
+  attrs: { name: "width" }
+  mandatory_ancestor: "AMP-SCRIPT"
+  requires_extension: "amp-script"
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/#html-tags"
+}
diff --git a/extensions/amp-sidebar/validator-amp-sidebar.protoascii b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
index eb8d6bec6..c2f39dc37 100644
--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -44,7 +44,6 @@ tags: {  # <amp-sidebar> not in amp-story
   tag_name: "AMP-SIDEBAR"
   # There is an alternate spec for amp-sidebar in amp-story.
   disallowed_ancestor: "AMP-STORY"
-  mandatory_parent: "BODY"
   requires_extension: "amp-sidebar"
   attrs: {
     name: "side"
diff --git a/extensions/amp-video/validator-amp-video.protoascii b/extensions/amp-video/validator-amp-video.protoascii
index e16cf5242..9c41b799c 100644
--- a/extensions/amp-video/validator-amp-video.protoascii
+++ b/extensions/amp-video/validator-amp-video.protoascii
@@ -132,6 +132,29 @@ tags: {  # <amp-video> not in amp-story.
   }
 }
 
+tags: {  # <amp-video> in amp-story-page-attachment (same rules as regular AMPHTML).
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: ACTIONS
+  tag_name: "AMP-VIDEO"
+  spec_name: "amp-story >> amp-story-page-attachment >> amp-video"
+  mandatory_ancestor: "AMP-STORY-PAGE-ATTACHMENT"
+  also_requires_tag_warning: "amp-video extension .js script"
+  attrs: { name: "poster" }
+  attr_lists: "extended-amp-global"
+  attr_lists: "amp-video-common"
+  attr_lists: "lightboxable-elements"
+  spec_url: "https://amp.dev/documentation/components/amp-video"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+
 tags: {  # <amp-video> in amp-story
   html_format: AMP
   html_format: AMP4ADS
@@ -144,6 +167,17 @@ tags: {  # <amp-video> in amp-story
     value: ""
     mandatory: true
   }
+  attrs: {
+    name: "controls"
+    value: ""
+    deprecation: "- no replacement"
+    deprecation_url: "https://github.com/ampproject/amphtml/issues/23798"
+  }
+  attrs: {
+    name: "[controls]"
+    deprecation: "- no replacement"
+    deprecation_url: "https://github.com/ampproject/amphtml/issues/23798"
+  }
   attrs: {
     name: "poster"
     mandatory: true
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index cec9e6b2b..aa86c144e 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 920
+spec_file_revision: 935
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -222,7 +222,7 @@ tags: {
         "preload|"  # Handled separately below, has specific requirements.
         "serviceworker|"
         "stylesheet|"  # Handled separately below, has specific requirements.
-        "subresource|"
+        "subresource"
         ")(\\s|$)"
     # It is worth noting that user-authored tags for dns-prefectch, preconnect,
     # prefetch, and prerender will be disabled by the transformations applied
@@ -574,7 +574,9 @@ tags: {
     value_casei: "amp-experiment-token"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  satisfies: "amp-experiment-token"
+  # Disabled because there are no active origin experiments; uncomment when
+  # there is at least one corresponding `requires` clause.
+  # satisfies: "amp-experiment-token"
 }
 # AMP metadata, name=amp-link-variable-allowed-origin
 # https://github.com/ampproject/amphtml/issues/8132
@@ -659,6 +661,23 @@ tags: {
     dispatch_key: NAME_VALUE_DISPATCH
   }
 }
+# AMP metadata, name=amp-script-src
+tags: {
+  html_format: AMP
+  tag_name: "META"
+  spec_name: "meta name=amp-script-src"
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "content"
+    mandatory: true
+  }
+  attrs: {
+    name: "name"
+    mandatory: true
+    value_casei: "amp-script-src"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+}
 # AMP4ADS metadata, name=amp4ads-id
 # https://github.com/ampproject/amphtml/issues/7730
 tags: {
@@ -1888,7 +1907,7 @@ tags: {
         "prerender|"
         "serviceworker|"
         "stylesheet|"  # Only allowed for link tags, specific req's for AMP.
-        "subresource|"
+        "subresource"
         ")(\\s|$)"
   }
   attrs: {
@@ -2270,6 +2289,9 @@ tags: {
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
+  attrs: { name: "importance" }  # Not yet part of the html spec
+  attrs: { name: "intrinsicsize" }  # Not yet part of the html spec
+  attrs: { name: "loading" }  # Not yet part of the html spec
   attrs: {
     name: "src"
     alternative_names: "srcset"
@@ -3068,12 +3090,16 @@ attr_lists: {
     css_declaration: { name: "text-decoration-color" }
     css_declaration: { name: "text-decoration-line" }
     css_declaration: { name: "text-decoration-style" }
+    css_declaration: { name: "text-fill-color" }
     css_declaration: { name: "text-indent" }
     css_declaration: { name: "text-justify" }
     css_declaration: { name: "text-orientation" }
     css_declaration: { name: "text-overflow" }
     css_declaration: { name: "text-rendering" } # SVG
     css_declaration: { name: "text-shadow" }
+    css_declaration: { name: "text-stroke" }
+    css_declaration: { name: "text-stroke-color" }
+    css_declaration: { name: "text-stroke-width" }
     css_declaration: { name: "text-transform" }
     css_declaration: { name: "text-underline-position" }
     css_declaration: { name: "top" }
@@ -3687,8 +3713,10 @@ tags: {
   tag_name: "SYMBOL"
   mandatory_ancestor: "SVG"
   attrs: { name: "externalresourcesrequired" }
+  attrs: { name: "height" }
   attrs: { name: "preserveaspectratio" }
   attrs: { name: "viewbox" }
+  attrs: { name: "width" }
   attr_lists: "svg-core-attributes"
   attr_lists: "svg-presentation-attributes"
   attr_lists: "svg-style-attr"
@@ -3839,6 +3867,9 @@ tags: {
 # 4.8 Links
 # Links are a concept, rather than a tag. See tagspecs for "LINK", "A", etc.
 
+# 4.8.11 The canvas element
+# See extensions/amp-mustache/validator-amp-script.protoascii
+
 # 4.9 Tabular data
 # 4.9.1 The table element
 tags: {
@@ -4426,6 +4457,7 @@ tags: {
 tags: {
   html_format: AMP
   html_format: AMP4ADS
+  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "INPUT"
   attrs: {
@@ -4442,11 +4474,12 @@ tags: {
         "password|"
         ")(\\s|$)"
   }
+  attrs: {
+    disabled_by: "amp4email"
+    name: "[type]"
+  }
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
-  # Note that this amp-bind attribute is not available for the AMP4Email format
-  # thus we add this manually for the formats that should.
-  attrs: { name: "[type]" }
   spec_url: "https://amp.dev/documentation/components/amp-form"
 }
 tags: {
@@ -4464,6 +4497,10 @@ tags: {
     mandatory: true
     dispatch_key: NAME_VALUE_DISPATCH
   }
+  attrs: {
+    disabled_by: "amp4email"
+    name: "[type]"
+  }
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
   mandatory_ancestor: "FORM [method=POST]"
@@ -4479,27 +4516,13 @@ tags: {
     mandatory: true
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  attr_lists: "input-common-attr"
-  attr_lists: "name-attr"
-  mandatory_ancestor: "FORM [method=POST]"
-  spec_url: "https://amp.dev/documentation/components/amp-form"
-}
-# amp-bind usage of [type] is not allowed in AMP4EMAIL
-tags: {
-  html_format: AMP4EMAIL
-  tag_name: "INPUT"
-  spec_name: "INPUT (AMP4EMAIL)"
   attrs: {
-    name: "type"
-    blacklisted_value_regex: "(^|\\s)("  # Values are space separated.
-        "button|"
-        "file|"
-        "image|"
-        "password|"
-        ")(\\s|$)"
+    disabled_by: "amp4email"
+    name: "[type]"
   }
   attr_lists: "input-common-attr"
   attr_lists: "name-attr"
+  mandatory_ancestor: "FORM [method=POST]"
   spec_url: "https://amp.dev/documentation/components/amp-form"
 }
 # 4.10.6 The button element
@@ -6299,11 +6322,15 @@ attr_lists: {
     css_declaration: { name: "text-decoration-color" }
     css_declaration: { name: "text-decoration-line" }
     css_declaration: { name: "text-decoration-style" }
+    css_declaration: { name: "text-fill-color" }
     css_declaration: { name: "text-indent" }
     css_declaration: { name: "text-justify" }
     css_declaration: { name: "text-orientation" }
     css_declaration: { name: "text-overflow" }
     css_declaration: { name: "text-shadow" }
+    css_declaration: { name: "text-stroke" }
+    css_declaration: { name: "text-stroke-color" }
+    css_declaration: { name: "text-stroke-width" }
     css_declaration: { name: "text-transform" }
     css_declaration: { name: "text-underline-position" }
     css_declaration: { name: "top" }
@@ -6847,6 +6874,14 @@ error_specificity {
   code: DOCUMENT_SIZE_LIMIT_EXCEEDED
   specificity: 120
 }
+error_specificity {
+  code: DEV_MODE_ONLY
+  # This should always trump any other error. It is asserting
+  # that the developer intends for this tag to be an error but
+  # that no additional errors should be reported for this tag.
+  specificity: 1000
+}
+
 # Error formats
 error_formats {
   code: UNKNOWN_CODE
@@ -7311,3 +7346,8 @@ error_formats {
   code: DOCUMENT_SIZE_LIMIT_EXCEEDED
   format: "Document exceeded %1 bytes limit. Actual size %2 bytes."
 }
+error_formats {
+  code: DEV_MODE_ONLY
+  format: "Tag 'html' marked with attribute 'ampdevmode'. Validator "
+          "will suppress errors regarding any other tag with this attribute."
+}
```

</details>