### PR TITLE
Prevent empty srcset for images in galleries

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -217,12 +217,14 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		foreach ( $args['images'] as $props ) {
 			$image_atts = [
 				'src'    => $props['url'],
-				'srcset' => $props['srcset'],
 				'width'  => $props['width'],
 				'height' => $props['height'],
 				'layout' => 'responsive',
 				'alt'    => $props['alt'],
 			];
+			if ( ! empty( $props['srcset'] ) ) {
+				$image_atts['srcset'] = $props['srcset'];
+			}
 
 			$this_aspect_ratio = $props['width'] / $props['height'];
 			if ( $this_aspect_ratio > $max_aspect_ratio ) {


### PR DESCRIPTION
It turns out that `wp_get_attachment_image_srcset()` does not always return a value. It can return `false` when there is no image size available. This is something that `wp_make_content_images_responsive()` accounts for, since `wp_image_add_srcset_and_sizes()` will only add the `srcset` and `sizes` attributes if `wp_calculate_image_srcset()` actually returns value. This was missing from the logic to add `srcset` to gallery images introduced in #2864.

Fixes #3087.