### PR TITLE
Manually update eslint-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8467,10 +8467,13 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-      "dev": true
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "22.15.2",
     "eslint-plugin-react": "7.14.3",
+    "eslint-utils": "1.4.2",
     "grunt": "1.0.4",
     "grunt-contrib-clean": "2.0.0",
     "grunt-contrib-copy": "1.0.0",


### PR DESCRIPTION
Addresses a potential security vulnerability in this dependency of `@wordpress/scripts` / `eslint`

The new entry in `package.json` can probably be removed once a new version of `@wordpress/scripts` is out.