### PR TITLE
Fix lightbox on file-linked galleries

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -166,11 +166,18 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		$is_lightbox = isset( $attributes['amp-lightbox'] ) && true === filter_var( $attributes['amp-lightbox'], FILTER_VALIDATE_BOOLEAN );
 		if ( isset( $attributes['amp-carousel'] ) && false === filter_var( $attributes['amp-carousel'], FILTER_VALIDATE_BOOLEAN ) ) {
 			if ( true === $is_lightbox ) {
+				$add_lightbox_attribute = static function ( $attr ) {
+					$attr['lightbox'] = '';
+					return $attr;
+				};
+
 				remove_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10 );
-				add_filter( 'wp_get_attachment_image_attributes', [ $this, 'add_lightbox_attribute' ], 10, 3 );
+				add_filter( 'wp_get_attachment_image_attributes', $add_lightbox_attribute );
+
 				$attributes['link'] = 'none';
 				$html               = gallery_shortcode( $attributes );
-				remove_filter( 'wp_get_attachment_image_attributes', [ $this, 'add_lightbox_attribute' ], 10 );
+
+				remove_filter( 'wp_get_attachment_image_attributes', $add_lightbox_attribute );
 				add_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10, 2 );
 			}
 
@@ -290,20 +297,5 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			}
 		</style>
 		<?php
-	}
-
-	/**
-	 * Add lightbox attribute to a provided attachment.
-	 *
-	 * @param array        $attr       Attributes for the image markup.
-	 * @param WP_Post      $attachment Image attachment post.
-	 * @param string|array $size       Requested size. Image size or array of
-	 *                                 width and height values (in that order).
-	 *                                 Default 'thumbnail'.
-	 * @return array Modified attributes for the image markup.
-	 */
-	public function add_lightbox_attribute( $attr, $attachment, $size ) {
-		$attr['lightbox'] = '';
-		return $attr;
 	}
 }

--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -167,8 +167,10 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( isset( $attributes['amp-carousel'] ) && false === filter_var( $attributes['amp-carousel'], FILTER_VALIDATE_BOOLEAN ) ) {
 			if ( true === $is_lightbox ) {
 				remove_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10 );
+				add_filter( 'wp_get_attachment_image_attributes', [ $this, 'add_lightbox_attribute' ], 10, 3 );
 				$attributes['link'] = 'none';
-				$html               = '<ul class="amp-lightbox">' . gallery_shortcode( $attributes ) . '</ul>';
+				$html               = gallery_shortcode( $attributes );
+				remove_filter( 'wp_get_attachment_image_attributes', [ $this, 'add_lightbox_attribute' ], 10 );
 				add_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10, 2 );
 			}
 
@@ -288,5 +290,10 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			}
 		</style>
 		<?php
+	}
+
+	public function add_lightbox_attribute( $attr, $attachment, $size ) {
+		$attr['lightbox'] = '';
+		return $attr;
 	}
 }

--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -292,6 +292,16 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 		<?php
 	}
 
+	/**
+	 * Add lightbox attribute to a provided attachment.
+	 *
+	 * @param array        $attr       Attributes for the image markup.
+	 * @param WP_Post      $attachment Image attachment post.
+	 * @param string|array $size       Requested size. Image size or array of
+	 *                                 width and height values (in that order).
+	 *                                 Default 'thumbnail'.
+	 * @return array Modified attributes for the image markup.
+	 */
 	public function add_lightbox_attribute( $attr, $attachment, $size ) {
 		$attr['lightbox'] = '';
 		return $attr;

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -9,15 +9,15 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 
 	public function get_conversion_data() {
 		return [
-			'shortcode_with_invalid_id'                            => [
+			'shortcode_with_invalid_id'               => [
 				'[gallery ids=1]',
 				'',
 			],
-			'shortcode_with_valid_id'                              => [
+			'shortcode_with_valid_id'                 => [
 				'[gallery ids={{id1}}]',
 				'<amp-carousel width="50" height="50" type="slides" layout="responsive"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></amp-carousel>',
 			],
-			'shortcode_with_multiple_ids'                          => [
+			'shortcode_with_multiple_ids'             => [
 				'[gallery ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
@@ -25,7 +25,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
 				'</amp-carousel>',
 			],
-			'shortcode_linking_to_file'                            => [
+			'shortcode_linking_to_file'               => [
 				'[gallery link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
@@ -33,7 +33,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
 				'</amp-carousel>',
 			],
-			'shortcode_with_carousel'                              => [
+			'shortcode_with_carousel'                 => [
 				'[gallery amp-lightbox=false amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
@@ -41,7 +41,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
 				'</amp-carousel>',
 			],
-			'shortcode_with_carousel_linking_to_file'              => [
+			'shortcode_with_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=false amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
@@ -49,7 +49,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
 				'</amp-carousel>',
 			],
-			'shortcode_with_lightbox'                              => [
+			'shortcode_with_lightbox'                 => [
 				'[gallery amp-lightbox=true amp-carousel=false ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
@@ -57,7 +57,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
 				'</amp-carousel>',
 			],
-			'shortcode_with_lightbox_linking_to_file'              => [
+			'shortcode_with_lightbox_linking_to_file' => [
 				'[gallery amp-lightbox=true amp-carousel=false link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
@@ -65,7 +65,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
 				'</amp-carousel>',
 			],
-			'shortcode_with_lightbox_and_carousel'                 => [
+			'shortcode_with_lightbox_and_carousel'    => [
 				'[gallery amp-lightbox=true amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
 					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -1,0 +1,170 @@
+<?php
+
+class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var array Associative array of string replacements to process.
+	 */
+	private $replacements = [];
+
+	public function get_conversion_data() {
+		return [
+			'shortcode_with_invalid_id'                            => [
+				'[gallery ids=1]',
+				'',
+			],
+			'shortcode_with_valid_id'                              => [
+				'[gallery ids={{id1}}]',
+				'<amp-carousel width="50" height="50" type="slides" layout="responsive"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></amp-carousel>',
+			],
+			'shortcode_with_multiple_ids'                          => [
+				'[gallery ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
+					'<amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img>' .
+					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
+				'</amp-carousel>',
+			],
+			'shortcode_linking_to_file'                            => [
+				'[gallery link="file" ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
+					'<a href="{{file2}}.jpg"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img></a>' .
+					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
+				'</amp-carousel>',
+			],
+			'shortcode_with_carousel'                              => [
+				'[gallery amp-lightbox=false amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
+					'<amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img>' .
+					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
+				'</amp-carousel>',
+			],
+			'shortcode_with_carousel_linking_to_file'              => [
+				'[gallery amp-lightbox=false amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
+					'<a href="{{file2}}.jpg"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img></a>' .
+					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
+				'</amp-carousel>',
+			],
+			'shortcode_with_lightbox'                              => [
+				'[gallery amp-lightbox=true amp-carousel=false ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
+					'<amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img>' .
+					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
+				'</amp-carousel>',
+			],
+			'shortcode_with_lightbox_linking_to_file'              => [
+				'[gallery amp-lightbox=true amp-carousel=false link="file" ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
+					'<a href="{{file2}}.jpg"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img></a>' .
+					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
+				'</amp-carousel>',
+			],
+			'shortcode_with_lightbox_and_carousel'                 => [
+				'[gallery amp-lightbox=true amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .
+					'<amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .
+					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .
+				'</amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+			],
+			'shortcode_with_lightbox_and_carousel_linking_to_file' => [
+				'[gallery amp-lightbox=true amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
+				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
+					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .
+					'<amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .
+					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text" lightbox on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img>' .
+				'</amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_conversion_data
+	 */
+	public function test__conversion( $source, $expected ) {
+		$source_files = [
+			DIR_TESTDATA . '/images/test-image.jpg',
+			DIR_TESTDATA . '/images/canola.jpg',
+			DIR_TESTDATA . '/images/gradient-square.jpg',
+		];
+
+		// When we generate new attachments, we neither control the IDs being
+		// generated, which we need for the gallery shortcode, nor the actual
+		// filenames, which will have an index appended because of filename
+		// collisions. So we write the tests in a way that they don't rely on
+		// this, and str-replace the dynamic portions into the expected and
+		// actual output after the fact.
+
+		$ids = $files = [];
+
+		foreach ( $source_files as $index => $source_file ) {
+			$ids[ $index ] = self::factory()->attachment
+				->create_upload_object( $source_file, 0 );
+
+			$files[ $index ] = rtrim(
+				wp_get_attachment_url( $ids[ $index ] ),
+				'.jpg'
+			);
+
+			update_post_meta(
+				$ids[ $index ],
+				'_wp_attachment_image_alt',
+				'Alt text'
+			);
+		}
+
+		$this->initialize_replacements( $ids, $files );
+
+		$embed = new AMP_Gallery_Embed_Handler();
+		$embed->register_embed();
+
+		$filtered_content = apply_filters(
+			'the_content',
+			$this->normalize( $source )
+		);
+
+		$this->assertEquals(
+			$this->normalize( $expected ),
+			$this->normalize( $filtered_content )
+		);
+	}
+
+	/**
+	 * Initialize the associative array of replacements to perform.
+	 *
+	 * @param array<int>    $ids   Array of attachment post IDs.
+	 * @param array<string> $files Array of file URLs.
+	 */
+	private function initialize_replacements( $ids, $files ) {
+		$this->replacements = [
+			'{{id1}}'   => $ids[0],
+			'{{id2}}'   => $ids[1],
+			'{{id3}}'   => $ids[2],
+			'{{file1}}' => $files[0],
+			'{{file2}}' => $files[1],
+			'{{file3}}' => $files[2],
+			"\n"        => '', // Make tests ignore new lines.
+		];
+	}
+
+	/**
+	 * Normalize a piece of content by replacing placeholders with the related
+	 * dynamic parts.
+	 *
+	 * @param string|array $content Content to normalize.
+	 * @return string|array Normalized content.
+	 */
+	private function normalize( $content ) {
+		return str_replace(
+			array_keys( $this->replacements ),
+			$this->replacements,
+			$content
+		);
+	}
+}

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -101,7 +101,8 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 		// this, and str-replace the dynamic portions into the expected and
 		// actual output after the fact.
 
-		$ids = $files = [];
+		$ids   = [];
+		$files = [];
 
 		foreach ( $source_files as $index => $source_file ) {
 			$ids[ $index ] = self::factory()->attachment

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -51,19 +51,35 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 			],
 			'shortcode_with_lightbox'                 => [
 				'[gallery amp-lightbox=true amp-carousel=false ids={{id1}},{{id2}},{{id3}}]',
-				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img>' .
-					'<amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img>' .
-					'<amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img>' .
-				'</amp-carousel>',
+				'<style type=\'text/css\'> #gallery-8 { margin: auto; } #gallery-8 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-8 img { border: 2px solid #cfcfcf; } #gallery-8 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				<div id=\'gallery-8\' class=\'gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail\'>
+					<dl class=\'gallery-item\'><dt class=\'gallery-icon landscape\'>
+						<img width="50" height="50" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" lightbox="" />
+					</dt></dl>
+					<dl class=\'gallery-item\'><dt class=\'gallery-icon landscape\'>
+						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" lightbox="" />
+					</dt></dl>
+					<dl class=\'gallery-item\'><dt class=\'gallery-icon landscape\'>
+						<img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" lightbox="" />
+					</dt></dl>
+					<br style="clear: both" />
+				</div>',
 			],
 			'shortcode_with_lightbox_linking_to_file' => [
 				'[gallery amp-lightbox=true amp-carousel=false link="file" ids={{id1}},{{id2}},{{id3}}]',
-				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="responsive" alt="Alt text"></amp-img></a>' .
-					'<a href="{{file2}}.jpg"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="responsive" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w"></amp-img></a>' .
-					'<a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="responsive" alt="Alt text"></amp-img></a>' .
-				'</amp-carousel>',
+				'<style type=\'text/css\'> #gallery-10 { margin: auto; } #gallery-10 .gallery-item { float: left; margin-top: 10px; text-align: center; width: 33%; } #gallery-10 img { border: 2px solid #cfcfcf; } #gallery-10 .gallery-caption { margin-left: 0; } /* see gallery_shortcode() in wp-includes/media.php */ </style>
+				<div id=\'gallery-10\' class=\'gallery galleryid-0 gallery-columns-3 gallery-size-thumbnail\'>
+					<dl class=\'gallery-item\'><dt class=\'gallery-icon landscape\'>
+						<img width="50" height="50" src="{{file1}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" lightbox="" />
+					</dt></dl>
+					<dl class=\'gallery-item\'><dt class=\'gallery-icon landscape\'>
+						<img width="150" height="150" src="{{file2}}-150x150.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" lightbox="" />
+					</dt></dl>
+					<dl class=\'gallery-item\'><dt class=\'gallery-icon landscape\'>
+						<img width="100" height="100" src="{{file3}}.jpg" class="attachment-thumbnail size-thumbnail" alt="Alt text" lightbox="" />
+					</dt></dl>
+					<br style="clear: both" />
+				</div>',
 			],
 			'shortcode_with_lightbox_and_carousel'    => [
 				'[gallery amp-lightbox=true amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
@@ -151,6 +167,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 			'{{file2}}' => $files[1],
 			'{{file3}}' => $files[2],
 			"\n"        => '', // Make tests ignore new lines.
+			'> <'       => '><', // Remove left-over space between elements.
 		];
 	}
 
@@ -162,6 +179,11 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 	 * @return string|array Normalized content.
 	 */
 	private function normalize( $content ) {
+		// We start by turning multiple whitespaces into one space, as the default WP gallery code
+		// creates a mess with lots of spaces.
+		$content = trim( preg_replace( '/\s+/', ' ', $content ) );
+
+		// Then we go through all previously defined replacements.
 		return str_replace(
 			array_keys( $this->replacements ),
 			$this->replacements,


### PR DESCRIPTION
Add the `lightbox` attribute to gallery shortcode images when they are being linked to by file and the AMP lightobx setting is enabled.

There was no test suite yet for the gallery embed handler, so I added a test suite to make sure this works as expected.

Fixes #2850