### PR TITLE
Add missing lightbox attributes & node on aligned image blocks

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -386,8 +386,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		// to div.wp-block-image > figure > img and the amp-lightbox attribute
 		// can be found on the wrapping div instead of the figure element.
 		$grand_parent = $parent_node->parentNode;
-		if ( $grand_parent instanceof DOMElement
-			&& ! empty ( $grand_parent->getAttribute( 'class' ) ) ) {
+		if ( $grand_parent instanceof DOMElement ) {
 			$classes = explode( ' ', $grand_parent->getAttribute( 'class' ) );
 			if ( in_array( 'wp-block-image', $classes, true ) ) {
 				$parent_node = $grand_parent;

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -384,7 +384,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		// Account for blocks that include alignment.
 		// In that case, the structure changes from figure.wp-block-image > img
 		// to div.wp-block-image > figure > img and the amp-lightbox attribute
-		// can be found on thr wrapping div instead of the figure element.
+		// can be found on the wrapping div instead of the figure element.
 		$grand_parent = $parent_node->parentNode;
 		if ( $grand_parent instanceof DOMElement
 			&& ! empty ( $grand_parent->getAttribute( 'class' ) ) ) {

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -387,7 +387,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 		// can be found on the wrapping div instead of the figure element.
 		$grand_parent = $parent_node->parentNode;
 		if ( $grand_parent instanceof DOMElement ) {
-			$classes = explode( ' ', $grand_parent->getAttribute( 'class' ) );
+			$classes = preg_split( '/\s+/', $grand_parent->getAttribute( 'class' ) );
 			if ( in_array( 'wp-block-image', $classes, true ) ) {
 				$parent_node = $grand_parent;
 			}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -381,6 +381,19 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			return $attributes;
 		}
 
+		// Account for blocks that include alignment.
+		// In that case, the structure changes from figure.wp-block-image > img
+		// to div.wp-block-image > figure > img and the amp-lightbox attribute
+		// can be found on thr wrapping div instead of the figure element.
+		$grand_parent = $parent_node->parentNode;
+		if ( $grand_parent instanceof DOMElement
+			&& ! empty ( $grand_parent->getAttribute( 'class' ) ) ) {
+			$classes = explode( ' ', $grand_parent->getAttribute( 'class' ) );
+			if ( in_array( 'wp-block-image', $classes, true ) ) {
+				$parent_node = $grand_parent;
+			}
+		}
+
 		$parent_attributes = AMP_DOM_Utils::get_node_attributes_as_assoc_array( $parent_node );
 
 		if ( isset( $parent_attributes['data-amp-lightbox'] ) && true === filter_var( $parent_attributes['data-amp-lightbox'], FILTER_VALIDATE_BOOLEAN ) ) {

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -325,6 +325,16 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				array_fill( 0, 51, 'invalid_attribute' ),
 			],
+
+			'image_block_with_lightbox'                => [
+				'<figure class="wp-block-image" data-amp-lightbox="true"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
+				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+			],
+
+			'aligned_image_block_with_lightbox'        => [
+				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure></div>',
+				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+			],
 		];
 	}
 

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -333,7 +333,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'aligned_image_block_with_lightbox'        => [
 				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure></div>',
-				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			],
 		];
 	}


### PR DESCRIPTION
The problem seems to be limited to the image block in the block editor, not images in general.

I solved this by looking for a grand-parent element that has a `wp-block-image` class and then check for the AMP lightbox setting on that grand-parent element.

I also added two test cases for this scenario.

Fixes #2936