### PR TITLE
Try to prevent editor crash

### DIFF
--- a/assets/src/block-validation/index.js
+++ b/assets/src/block-validation/index.js
@@ -23,13 +23,15 @@ import '../block-editor/store';
 const { isEditedPostDirty } = select( 'core/editor' );
 
 subscribe( () => {
-	if ( ! isEditedPostDirty() ) {
-		if ( ! isAMPEnabled() ) {
-			maybeResetValidationErrors();
-		} else {
-			updateValidationErrors();
+	try {
+		if ( ! isEditedPostDirty() ) {
+			if ( ! isAMPEnabled() ) {
+				maybeResetValidationErrors();
+			} else {
+				updateValidationErrors();
+			}
 		}
-	}
+	} catch ( err ) {}
 } );
 
 addFilter( 'editor.BlockEdit', 'amp/add-notice', withValidationErrorNotice, 99 );


### PR DESCRIPTION
When running current Gutenberg master and the AMP plugin together, I get the following error:

```
Uncaught TypeError: Cannot read property 'transientEdits' of undefined
    at index.js:1
    at f (index.js:1)
    at xe (index.js:1)
    at index.js:1
    at Object.r [as hasEditsForEntityRecord] (index.js:1)
    at index.js:17
    at e (index.js:1)
    at index.js:1
    at r (index.js:1)
    at amp-block-validation.js:1742
```

Adding a `try catch` block around the code causing this seems to fix it.

But perhaps this just happens on my machine, so some validation would be nice.