### PR TITLE
Discard invalid hosts in URL attributes

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1329,8 +1329,19 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					$url = substr( $url, strlen( $protocol ) + 1 );
 				}
 
+				$parts = wp_parse_url( $url );
+
+				// Use host if found, and fall back to path if not.
+				$host = isset( $parts['host'] )
+					? $parts['host']
+					: ( isset( $parts['path'] ) ? $parts['path'] : null );
+
+				// Check if a host was found.
+				if ( null === $host ) {
+					return AMP_Rule_Spec::FAIL;
+				}
+
 				// Check if the host contains invalid chars (hostCharIsValid: https://github.com/ampproject/amphtml/blob/af1e3a550feeafd732226202b8d1f26dcefefa18/validator/engine/parse-url.js#L62-L103).
-				$host = wp_parse_url( $url, PHP_URL_HOST );
 				if ( $host && preg_match( '/[!"#$%&\'()*+,\/:;<=>?@[\]^`{|}~\s]/i', $host ) ) {
 					return AMP_Rule_Spec::FAIL;
 				}

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1693,6 +1693,58 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
+	public function get_check_attr_spec_rule_valid_url() {
+		return [
+			'valid_without_protocol' => [
+				[
+					'source'         => '<div url="example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'url',
+					'attr_spec_rule' => [
+						'value_url' => [],
+					],
+				],
+				AMP_Rule_Spec::PASS,
+			],
+			'valid_with_protocol' => [
+				[
+					'source'         => '<div url="http://example.com"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'url',
+					'attr_spec_rule' => [
+						'value_url' => [],
+					],
+				],
+				AMP_Rule_Spec::PASS,
+			],
+			'invalid_char' => [
+				[
+					'source'         => '<div url="foo@"></div>',
+					'node_tag_name'  => 'div',
+					'attr_name'      => 'url',
+					'attr_spec_rule' => [
+						'value_url' => [],
+					],
+				],
+				AMP_Rule_Spec::FAIL,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider get_check_attr_spec_rule_valid_url
+	 * @group allowed-tags-private-methods
+	 */
+	public function test_check_attr_spec_rule_valid_url( $data, $expected ) {
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $data['source'] );
+		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
+		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+
+		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_valid_url', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
+
+		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
+	}
+
 	/**
 	 * Use this to call private methods.
 	 *


### PR DESCRIPTION
The reason why the bogus value of `@foo` could even pass in the first place is that `wp_parse_url()` does not return a `$host` for that value, and this inadvertently bypasses the check for invalid characters in the host name.

I fixed it by falling back to `$path` when `$host` is not detected, and checking `$path` for invalid characters in that case.

I am not 100% sure though whether that might not discard another case where `$path` might contain valid characters that are turned into invalid characters when interpreted as a host name. However, as this is for the `value_url` type of attributes only, I couldn't immediately think of such a case.

Fixes #2671