### PR TITLE
Add comment website URL sanitization

### DIFF
--- a/includes/sanitizers/class-amp-comments-sanitizer.php
+++ b/includes/sanitizers/class-amp-comments-sanitizer.php
@@ -47,7 +47,7 @@ class AMP_Comments_Sanitizer extends AMP_Base_Sanitizer {
 
 		$xpath = new DOMXPath( $this->dom );
 
-		$comments = $xpath->query( '//*[ contains( @class, "comment-list" ) ]/*[ starts-with( @id, "comment-" ) ]' );
+		$comments = $xpath->query( '//*[ starts-with( @id, "comment-" ) ]' );
 		foreach ( $comments as $comment ) {
 			$this->sanitize_comment_fields( $comment, $xpath );
 		}

--- a/tests/php/test-class-amp-comments-sanitizer.php
+++ b/tests/php/test-class-amp-comments-sanitizer.php
@@ -158,6 +158,30 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 		}
 	}
 
+	public function test_comment_website_url_sanitization() {
+		$instance = new AMP_Comments_Sanitizer( $this->dom );
+
+		$valid_comment = self::factory()->comment->create_and_get(
+			[ 'comment_author_url' => 'http://example.com/' ]
+		);
+
+		$invalid_comment = self::factory()->comment->create_and_get(
+			[ 'comment_author_url' => 'http://foo@' ]
+		);
+
+		$html = wp_list_comments(
+			[ 'echo' => false ],
+			[ $valid_comment, $invalid_comment ]
+		);
+
+		$this->dom->loadHTML( $html );
+
+		$instance->sanitize();
+		$sanitized_html = $this->dom->saveHTML();
+		$this->assertNotFalse( strpos( $sanitized_html, 'href="http://example.com/"' ) );
+		$this->assertFalse( strpos( $sanitized_html, 'href="http://foo@"' ) );
+	}
+
 	/**
 	 * Creates a form for testing.
 	 *


### PR DESCRIPTION
This is the second attempt at fixing #2671, after I had to find out that it couldn't possibly be done at the attribute sanitization level.

This now introduces an additional step that iterates over comment entries and checks their (final) website URL targets.

If an invalid URL is detected, the `href` attribute of that link is removed. This should keep the visual output intact, while getting rid of the validation error.

Fixes #2671