### PR TITLE
Add amp_print_analytics action triggering before printing entries as amp-analytics

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -673,7 +673,21 @@ function amp_print_analytics( $analytics ) {
 	if ( '' === $analytics ) {
 		$analytics = [];
 	}
+
 	$analytics_entries = amp_get_analytics( $analytics );
+
+	/**
+	 * Triggers before analytics entries are printed as amp-analytics tags.
+	 *
+	 * This is useful for printing additional `amp-analytics` tags to the page without having to refactor any existing
+	 * markup generation logic to use the data structure mutated by the `amp_analytics_entries` filter. For such cases,
+	 * this action should be used for printing `amp-analytics` tags as opposed to using the `wp_footer` and
+	 * `amp_post_template_footer` actions; this will ensure analytics will also be included on AMP Stories.
+	 *
+	 * @since 1.3
+	 * @param array $analytics_entries Analytics entries, already potentially modified by the amp_analytics_entries filter.
+	 */
+	do_action( 'amp_print_analytics', $analytics_entries );
 
 	if ( empty( $analytics_entries ) ) {
 		return;

--- a/tests/php/test-amp-analytics-options.php
+++ b/tests/php/test-amp-analytics-options.php
@@ -261,7 +261,18 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 
 		$analytics = amp_get_analytics();
 
+		$trigger_count = 0;
+		add_action(
+			'amp_print_analytics',
+			function ( $entries ) use ( $analytics, &$trigger_count ) {
+				$this->assertEquals( $analytics, $entries );
+				$trigger_count++;
+			}
+		);
+
 		$output = get_echo( 'amp_print_analytics', [ $analytics ] );
+
+		$this->assertEquals( 1, $trigger_count );
 
 		$this->assertStringStartsWith( '<amp-analytics', $output );
 		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );


### PR DESCRIPTION
This is useful for printing additional `amp-analytics` tags to the page without having to refactor any existing markup generation logic to use the data structure mutated by the `amp_analytics_entries` filter. For such cases, this action should be used for printing `amp-analytics` tags as opposed to using the `wp_footer` and `amp_post_template_footer` actions; this will ensure analytics will also be included on AMP Stories.

See:

* https://github.com/ampproject/amp-wp/pull/3095#issuecomment-525402333
* https://github.com/google/site-kit-wp/issues/435
* https://github.com/ampproject/amp-wp/issues/1949