### PR TITLE
Stop pinning amp-carousel at v0.1 so that v0.2 can be used

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -479,15 +479,6 @@ function amp_register_default_scripts( $wp_scripts ) {
 			null
 		);
 	}
-
-	if ( $wp_scripts->query( 'amp-carousel', 'registered' ) ) {
-		/*
-		 * The 0.2 version of amp-carousel depends on the amp-base-carousel component, but this is still experimental.
-		 * Also, the validator spec does not currently specify what base dependencies a given component has.
-		 * @todo Revisit once amp-base-carousel is no longer experimental. Add support for obtaining a list of extensions that depend on other extensions to include in the script dependencies when registering below.
-		 */
-		$wp_scripts->registered['amp-carousel']->src = 'https://cdn.ampproject.org/v0/amp-carousel-0.1.js';
-	}
 }
 
 /**


### PR DESCRIPTION
This is a follow-up to #3084.

It turns out that `amp-carousel` 0.2 wasn't broken due to a dependence on `amp-base-carousel`, but there was some other issue: https://github.com/ampproject/amphtml/issues/23966. So we can allow `amp-carousel` to update from 0.1 to 0.2 once the AMP fix is live.

Fixes #3700.