### PR TITLE
Add missing waitForSelector call to flaky story templates e2e test

### DIFF
--- a/tests/e2e/specs/stories-editor/story-templates.js
+++ b/tests/e2e/specs/stories-editor/story-templates.js
@@ -73,11 +73,14 @@ describe( 'Story Templates', () => {
 			} );
 
 			it( 'should display non-template reusable blocks in the reusable blocks management screen', async () => {
+				const titleSelector = '.page-title .row-title';
+
 				await visitAdminPage( 'edit.php', 'post_type=wp_block' );
+				await page.waitForSelector( titleSelector );
 
 				// Check that it is untitled
 				const title = await page.$eval(
-					'.page-title .row-title',
+					titleSelector,
 					( element ) => element.innerText
 				);
 				expect( title ).toBe( 'Untitled Reusable Block' );


### PR DESCRIPTION
In the #3117 PR this test was constantly failing, for no obvious reason.

This should address the flakiness of that test.

Props @kienstra.