### PR TITLE
Update eslint-plugin-jest to 22.16.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7894,9 +7894,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "22.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.15.2.tgz",
-      "integrity": "sha512-p4NME9TgXIt+KgpxcXyNBvO30ZKxwFAO1dJZBc2OGfDnXVEtPwEyNs95GSr6RIE3xLHdjd8ngDdE2icRRXrbxg==",
+      "version": "22.16.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-22.16.0.tgz",
+      "integrity": "sha512-eBtSCDhO1k7g3sULX/fuRK+upFQ7s548rrBtxDyM1fSoY7dTWp/wICjrJcDZKVsW7tsFfH22SG+ZaxG5BZodIg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "^1.13.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint": "6.2.2",
     "eslint-plugin-eslint-comments": "3.1.2",
     "eslint-plugin-import": "2.18.2",
-    "eslint-plugin-jest": "22.15.2",
+    "eslint-plugin-jest": "22.16.0",
     "eslint-plugin-react": "7.14.3",
     "eslint-utils": "1.4.2",
     "grunt": "1.0.4",

--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -122,9 +122,12 @@ function observeConsoleLogging() {
 	} );
 }
 
-// Before every test suite run, delete all content created by the test. This ensures
-// other posts/comments/etc. aren't dirtying tests and tests don't depend on
-// each other's side-effects.
+/*
+ Before every test suite run, delete all content created by the test. This ensures
+ other posts/comments/etc. aren't dirtying tests and tests don't depend on
+ each other's side-effects.
+*/
+// eslint-disable-next-line jest/require-top-level-describe
 beforeAll( async () => {
 	capturePageEventsForTearDown();
 	enablePageDialogAccept();
@@ -132,11 +135,13 @@ beforeAll( async () => {
 	await setBrowserViewport( 'large' );
 } );
 
+// eslint-disable-next-line jest/require-top-level-describe
 afterEach( async () => {
 	await clearLocalStorage();
 	await setBrowserViewport( 'large' );
 } );
 
+// eslint-disable-next-line jest/require-top-level-describe
 afterAll( () => {
 	removePageEvents();
 } );


### PR DESCRIPTION
Disables the new `jest/require-top-level-describe` rule where necessary

Supersedes #3144.