### PR TITLE
Remove value_url attributes with an invalid URL

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -433,6 +433,7 @@ abstract class AMP_Base_Sanitizer {
 		$should_remove = $this->should_sanitize_validation_error( $validation_error, compact( 'node' ) );
 		if ( $should_remove ) {
 			$element->removeAttributeNode( $node );
+			$this->clean_up_after_attribute_removal( $element, $node, $validation_error );
 		}
 		return $should_remove;
 	}
@@ -528,6 +529,33 @@ abstract class AMP_Base_Sanitizer {
 		}
 
 		return $error;
+	}
+
+	/**
+	 * Cleans up artifacts after the removal of an attribute node.
+	 *
+	 * @since 1.3
+	 *
+	 * @param DOMElement $element          The node for which he attribute was
+	 *                                     removed.
+	 * @param DOMAttr    $attribute        The attribute that was removed.
+	 * @param array      $validation_error Validation error details.
+	 */
+	protected function clean_up_after_attribute_removal( $element, $attribute, $validation_error ) {
+		static $attributes_tied_to_href = [ 'target', 'download', 'rel', 'rev', 'hreflang', 'type' ];
+
+		if ( 'href' === $attribute->nodeName ) {
+			/*
+			 * "The target, download, rel, rev, hreflang, and type attributes must be omitted
+			 * if the href attribute is not present."
+			 * See: https://www.w3.org/TR/2016/REC-html51-20161101/textlevel-semantics.html#the-a-element
+			 */
+			foreach ( $attributes_tied_to_href as $attribute_to_remove ) {
+				if ( $element->hasAttribute( $attribute_to_remove ) ) {
+					$element->removeAttribute( $attribute_to_remove );
+				}
+			}
+		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1072,7 +1072,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 		// Remove the disallowed values.
 		foreach ( $attrs_to_remove as $attr_node ) {
-			if ( isset( $attr_spec_list[ $attr_node->nodeName ][ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
+			if ( isset( $attr_spec_list[ $attr_node->nodeName ][ AMP_Rule_Spec::VALUE_URL ] ) &&
+				'href' === $attr_node->nodeName ) {
+				$attributes_pending_removal[] = $attr_node;
+			} elseif ( isset( $attr_spec_list[ $attr_node->nodeName ][ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) &&
 				( true === $attr_spec_list[ $attr_node->nodeName ][ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOW_EMPTY ] ) ) {
 				$attr_node->nodeValue = '';
 			} else {
@@ -1323,6 +1326,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
 				$url = urldecode( $url );
 
+				// Check whether the URL is parseable.
+				$parts = wp_parse_url( $url );
+				if ( false === $parts ) {
+					return AMP_Rule_Spec::FAIL;
+				}
+
 				// Check if the protocol contains invalid chars (protocolCharIsValid: https://github.com/ampproject/amphtml/blob/af1e3a550feeafd732226202b8d1f26dcefefa18/validator/engine/parse-url.js#L31-L39).
 				$protocol = $this->parse_protocol( $url );
 				if ( isset( $protocol ) ) {
@@ -1332,9 +1341,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					$url = substr( $url, strlen( $protocol ) + 1 );
 				}
 
+
 				// Check if the host contains invalid chars (hostCharIsValid: https://github.com/ampproject/amphtml/blob/af1e3a550feeafd732226202b8d1f26dcefefa18/validator/engine/parse-url.js#L62-L103).
 				$host = wp_parse_url( $url, PHP_URL_HOST );
-				if ( $host && preg_match( '/[!"#$%&\'()*+,\/:;<=>?@[\]^`{|}~\s]/i', $host ) ) {
+				if ( $host && preg_match( '/[!"#$%&\'()*+,\/:;<=>?@[\]^`{|}~\s]/', $host ) ) {
 					return AMP_Rule_Spec::FAIL;
 				}
 			}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1341,7 +1341,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					$url = substr( $url, strlen( $protocol ) + 1 );
 				}
 
-
 				// Check if the host contains invalid chars (hostCharIsValid: https://github.com/ampproject/amphtml/blob/af1e3a550feeafd732226202b8d1f26dcefefa18/validator/engine/parse-url.js#L62-L103).
 				$host = wp_parse_url( $url, PHP_URL_HOST );
 				if ( $host && preg_match( '/[!"#$%&\'()*+,\/:;<=>?@[\]^`{|}~\s]/', $host ) ) {

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -517,7 +517,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'attribute_value_blacklisted_by_regex_removed' => [
 				'<a href="__amp_source_origin">Click me.</a>',
-				'<a href="">Click me.</a>',
+				'<a>Click me.</a>',
 			],
 
 			'host_relative_url_allowed'                    => [
@@ -528,15 +528,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<a href="//example.com/path/to/content">Click me.</a>',
 			],
 
-			'node_with_whiteilsted_protocol_http_allowed'  => [
+			'node_with_whitelisted_protocol_http_allowed'  => [
 				'<a href="http://example.com/path/to/content">Click me.</a>',
 			],
 
-			'node_with_whiteilsted_protocol_https_allowed' => [
+			'node_with_whitelisted_protocol_https_allowed' => [
 				'<a href="https://example.com/path/to/content">Click me.</a>',
 			],
 
-			'node_with_whiteilsted_protocol_other_allowed' => [
+			'node_with_whitelisted_protocol_other_allowed' => [
 				implode(
 					'',
 					[
@@ -546,6 +546,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						'<a href="web+mastodon:follow/@handle@instance">Click me.</a>',
 					]
 				),
+			],
+
+			'node_with_non_parseable_url_removed'          => [
+				'<a href="http://foo@">Invalid Link</a>',
+				'<a>Invalid Link</a>',
+			],
+
+			'node_with_non_parseable_url_leftovers_cleaned_up' => [
+				'<a id="this-is-kept" href="http://foo@" target="_blank" download rel="nofollow" rev="nofollow" hreflang="en" type="text/html" class="this-stays">Invalid Link</a>',
+				'<a id="this-is-kept" class="this-stays">Invalid Link</a>',
 			],
 
 			'attribute_value_valid'                        => [
@@ -959,12 +969,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'a_with_custom_protocol'                       => [
 				'<a class="foo" href="custom:bad">value</a>',
-				'<a class="foo" href="">value</a>',
+				'<a class="foo">value</a>',
 			],
 
 			'a_with_wrong_host'                            => [
 				'<a class="foo" href="http://foo bar">value</a>',
-				'<a class="foo" href="">value</a>',
+				'<a class="foo">value</a>',
 			],
 			'a_with_encoded_host'                          => [
 				'<a class="foo" href="http://%65%78%61%6d%70%6c%65%2e%63%6f%6d/foo/">value</a>',
@@ -972,11 +982,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 			'a_with_wrong_schemeless_host'                 => [
 				'<a class="foo" href="//bad domain with a space.com/foo">value</a>',
-				'<a class="foo" href="">value</a>',
+				'<a class="foo">value</a>',
 			],
 			'a_with_mail_host'                             => [
 				'<a class="foo" href="mail to:foo@bar.com">value</a>',
-				'<a class="foo" href="">value</a>',
+				'<a class="foo">value</a>',
 			],
 
 			// font is removed so we should check that other elements are checked as well.
@@ -1888,7 +1898,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'code'            => 'invalid_element',
 			'node_attributes' => [ 'class' => 'baz-invalid' ],
 		];
-		$content[]         = '<amp-story-grid-layer class="a-invalid"><a href="">Invalid a tag.</a></amp-story-grid-layer>';
+		$content[]         = '<amp-story-grid-layer class="a-invalid"><a>Invalid a tag.</a></amp-story-grid-layer>';
 		$expected_errors[] = [
 			'node_name'       => 'amp-story-grid-layer',
 			'parent_name'     => 'body',

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1761,6 +1761,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<html amp><head><meta charset="utf-8"><meta name="amp-script-src" content="sha384-abc123 sha384-def456"></head><body></body></html>',
 				null, // No change.
 			],
+			'link_without_valid_mandatory_href'       => [
+				'<html amp><head><meta charset="utf-8"><link rel="manifest" href="https://bad@"></head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"></head><body></body></html>',
+			],
 		];
 
 		$bad_dev_mode_document = sprintf(


### PR DESCRIPTION
Adds logic to the `value_url` checks to invalidate URLs that cannot be properly parsed by `wp_parse_url()`, like `http://foo@`.

Also adds logic to remove left-over attributes after the removal of an invalid attribute. This is used to check specifically for the `href` attribute being removed, and apply the following HTML5 spec detail:

> The target, download, rel, rev, hreflang, and type attributes must be omitted if the href attribute is not present.

## Before

The invalid link successfully passes sanitization and causes validation errors on the frontend.

![Image 2019-08-30 at 6 02 41 PM](https://user-images.githubusercontent.com/83631/64035208-7ad34880-cb50-11e9-874c-81b010f0f0bf.png)

![Image 2019-08-30 at 4 49 44 PM](https://user-images.githubusercontent.com/83631/64030589-2f686c80-cb47-11e9-8920-33fea70ed1a3.png)

## After

The invalid link is caught. As a result, the `href` attribute is removed, as well as all attributes that directly relate to it.

Other attributes not directly related to the `href` attribute stay intact, in order to preserve styling.

![Image 2019-08-30 at 4 49 12 PM](https://user-images.githubusercontent.com/83631/64030614-35f6e400-cb47-11e9-9ae4-d1aaab9e3968.png)

Fixes #2671
Previous attempts at fixing this: #3103 & #3117