### PR TITLE
Fix notice thrown for checking nonexistent is_block_editor property

### DIFF
--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -133,7 +133,7 @@ class AMP_Post_Meta_Box {
 		$validate = (
 			isset( $screen->base ) &&
 			'post' === $screen->base &&
-			! $screen->is_block_editor &&
+			( ! isset( $screen->is_block_editor ) || ! $screen->is_block_editor ) &&
 			is_post_type_viewable( $post->post_type ) &&
 			AMP_Story_Post_Type::POST_TYPE_SLUG !== $post->post_type
 		);


### PR DESCRIPTION
We need to check first whether the `$screen->is_block_editor` property actually exists.

Otherwise, we get a notice on WP < 5.0.
<img width="1152" alt="Image 2019-08-30 at 9 20 32 PM" src="https://user-images.githubusercontent.com/83631/64046973-b4667c80-cb6d-11e9-9276-0036edfe4430.png">

Fixes #3154