### PR TITLE
Add missing vendor files to build artifact

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -98,6 +98,8 @@ module.exports = function( grunt ) {
 			paths.push( 'vendor/sabberworm/php-css-parser/lib/**' );
 			paths.push( 'vendor/fasterimage/fasterimage/src/**' );
 			paths.push( 'vendor/willwashburn/stream/src/**' );
+			paths.push( 'vendor/wp-cli/mustangostang-spyc/includes/*' );
+			paths.push( 'vendor/wp-cli/php-cli-tools/lib/**' );
 
 			grunt.config.set( 'copy', {
 				build: {


### PR DESCRIPTION
I noticed that after #3056 doing a build artifact from `develop` results in an `amp.zip` that lacks certain required files. This ensures those files are included which allow (as far as I can tell) the plugin to not fatal-error. It results in these files being included in a build artifact:

```
vendor/wp-cli/mustangostang-spyc/includes/functions.php
vendor/wp-cli/php-cli-tools/lib/cli/Arguments.php
vendor/wp-cli/php-cli-tools/lib/cli/Colors.php
vendor/wp-cli/php-cli-tools/lib/cli/Memoize.php
vendor/wp-cli/php-cli-tools/lib/cli/Notify.php
vendor/wp-cli/php-cli-tools/lib/cli/Progress.php
vendor/wp-cli/php-cli-tools/lib/cli/Shell.php
vendor/wp-cli/php-cli-tools/lib/cli/Streams.php
vendor/wp-cli/php-cli-tools/lib/cli/Table.php
vendor/wp-cli/php-cli-tools/lib/cli/Tree.php
vendor/wp-cli/php-cli-tools/lib/cli/arguments/Argument.php
vendor/wp-cli/php-cli-tools/lib/cli/arguments/HelpScreen.php
vendor/wp-cli/php-cli-tools/lib/cli/arguments/InvalidArguments.php
vendor/wp-cli/php-cli-tools/lib/cli/arguments/Lexer.php
vendor/wp-cli/php-cli-tools/lib/cli/cli.php
vendor/wp-cli/php-cli-tools/lib/cli/notify/Dots.php
vendor/wp-cli/php-cli-tools/lib/cli/notify/Spinner.php
vendor/wp-cli/php-cli-tools/lib/cli/progress/Bar.php
vendor/wp-cli/php-cli-tools/lib/cli/table/Ascii.php
vendor/wp-cli/php-cli-tools/lib/cli/table/Renderer.php
vendor/wp-cli/php-cli-tools/lib/cli/table/Tabular.php
vendor/wp-cli/php-cli-tools/lib/cli/tree/Ascii.php
vendor/wp-cli/php-cli-tools/lib/cli/tree/Markdown.php
vendor/wp-cli/php-cli-tools/lib/cli/tree/Renderer.php
vendor/wp-cli/php-cli-tools/lib/cli/unicode/regex.php
```

There may be other files required! But I couldn't cause a fatal error after these files are included.

Relates to #1840.