### PR TITLE
Bump requried Gutenberg version by one

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -22,7 +22,7 @@ class AMP_Story_Post_Type {
 	 *
 	 * @var string
 	 */
-	const REQUIRED_GUTENBERG_VERSION = '5.8';
+	const REQUIRED_GUTENBERG_VERSION = '5.9';
 
 	/**
 	 * The slug of the story card CSS file.


### PR DESCRIPTION
In some current PRs we're using the `useSelect` and `useDispatch` hooks, which have first been introduced in Gutenberg 5.9.

Eventually the Gutenberg requirement should be removed, but for now this is the minimum change we need to make in order to be able to use these hooks.

See #2538.