### PR TITLE
Omit file_exists() checks (for vendor and built files) from plugin builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -119,6 +119,9 @@ module.exports = function( grunt ) {
 									content = content.replace( versionRegex, '$1' + version );
 									content = content.replace( /(define\(\s*'AMP__VERSION',\s*')(.+?)(?=')/, '$1' + version );
 								}
+
+								// Remove dev mode code blocks.
+								content = content.replace( /\n\/\/\s*DEV_CODE.+?\n}\n/s, '' );
 							}
 							return content;
 						},

--- a/amp.php
+++ b/amp.php
@@ -149,6 +149,7 @@ if ( count( $_amp_missing_functions ) > 0 ) {
 
 unset( $_amp_required_extensions, $_amp_missing_extensions, $_amp_required_constructs, $_amp_missing_classes, $_amp_missing_functions, $_amp_required_extension, $_amp_construct_type, $_amp_construct, $_amp_constructs );
 
+// DEV_CODE. This block of code is removed during the build process.
 if ( ! file_exists( AMP__DIR__ . '/vendor/autoload.php' ) || ! file_exists( AMP__DIR__ . '/vendor/sabberworm/php-css-parser' ) || ! file_exists( AMP__DIR__ . '/assets/js/amp-block-editor.js' ) ) {
 	$_amp_load_errors->add(
 		'build_required',


### PR DESCRIPTION
Fixes #2670

Diff of running build before/after change:

```diff
8c8
<  * Version: 1.2.3-alpha-20190903T165926Z-7ba548d8
---
>  * Version: 1.2.3-alpha-20190903T170002Z-05645f60
18c18
< define( 'AMP__VERSION', '1.2.3-alpha-20190903T165926Z-7ba548d8' );
---
> define( 'AMP__VERSION', '1.2.3-alpha-20190903T170002Z-05645f60' );
152,162d151
< if ( ! file_exists( AMP__DIR__ . '/vendor/autoload.php' ) || ! file_exists( AMP__DIR__ . '/vendor/sabberworm/php-css-parser' ) || ! file_exists( AMP__DIR__ . '/assets/js/amp-block-editor.js' ) ) {
< 	$_amp_load_errors->add(
< 		'build_required',
< 		sprintf(
< 			/* translators: %s: composer install && npm install && npm run build */
< 			__( 'You appear to be running the AMP plugin from source. Please do %s to finish installation.', 'amp' ), // phpcs:ignore WordPress.Security.EscapeOutput
< 			'<code>composer install &amp;&amp; npm install &amp;&amp; npm run build</code>'
< 		)
< 	);
< }
< 
```