### PR TITLE
Add missing amp_story_head actions present on wp_head

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -218,8 +218,20 @@ class AMP_Story_Post_Type {
 			},
 			8
 		);
-		add_action( 'amp_story_head', 'rel_canonical' );
 		add_action( 'amp_story_head', 'amp_add_generator_metadata' );
+		add_action( 'amp_story_head', 'rest_output_link_wp_head', 10, 0 );
+		add_action( 'amp_story_head', 'wp_resource_hints', 2 );
+		add_action( 'amp_story_head', 'feed_links', 2 );
+		add_action( 'amp_story_head', 'feed_links_extra', 3 );
+		add_action( 'amp_story_head', 'rsd_link' );
+		add_action( 'amp_story_head', 'wlwmanifest_link' );
+		add_action( 'amp_story_head', 'adjacent_posts_rel_link_wp_head', 10, 0 );
+		add_action( 'amp_story_head', 'noindex', 1 );
+		add_action( 'amp_story_head', 'wp_generator' );
+		add_action( 'amp_story_head', 'rel_canonical' );
+		add_action( 'amp_story_head', 'wp_shortlink_wp_head', 10, 0 );
+		add_action( 'amp_story_head', 'wp_site_icon', 99 );
+		add_action( 'amp_story_head', 'wp_oembed_add_discovery_links' );
 
 		// Remove unnecessary settings.
 		add_filter( 'block_editor_settings', [ __CLASS__, 'filter_block_editor_settings' ], 10, 2 );


### PR DESCRIPTION
This is a follow-up to #3039 for #2968. In particular, there are more functions being output at `wp_head` which also need to be output at `amp_story_head`.

Here's the difference in the output of a single story post with the changes in this PR:

```diff
@@ -5,7 +5,11 @@
 	<meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 	<meta name="amp-experiments-opt-in" content="amp-img-auto-sizes">
 	<meta name="generator" content="AMP Plugin v1.2.3-alpha; mode=transitional; experiences=website,stories">
+	<meta name="generator" content="WordPress 5.3-alpha-45282-src">
+	<meta name="msapplication-TileImage" content="https://wordpressdev.lndo.site/content/uploads/2019/02/cropped-Security-Photo-4-270x270.png">
 	<title>Bison2 – WordPressDevs</title>
+	<link rel="dns-prefetch" href="//wordpressdev.lndo.site">
+	<link rel="dns-prefetch" href="//s.w.org">
 	<link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
 	<link rel="preload" as="script" href="https://cdn.ampproject.org/v0/amp-story-1.0.js">
 	<script async="" src="https://cdn.ampproject.org/v0.js"></script>
@@ -80,7 +84,19 @@ Total included size: 948 bytes (6% of 14,729 total after tree shaking)
 	}
 
 	/*# sourceURL=amp-custom.css */</style>
+	<link rel="alternate" type="application/rss+xml" title="WordPressDevs » Feed" href="https://wordpressdev.lndo.site/feed/">
+	<link rel="alternate" type="application/rss+xml" title="WordPressDevs » Comments Feed" href="https://wordpressdev.lndo.site/comments/feed/">
+	<link rel="https://api.w.org/" href="https://wordpressdev.lndo.site/wp-json/">
+	<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://wordpressdev.lndo.site/core-dev/src/xmlrpc.php?rsd">
+	<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://wordpressdev.lndo.site/core-dev/src/wp-includes/wlwmanifest.xml">
+	<link rel="prev" title="Test" href="https://wordpressdev.lndo.site/stories/test-5/">
 	<link rel="canonical" href="https://wordpressdev.lndo.site/stories/bison-2/">
+	<link rel="shortlink" href="https://wordpressdev.lndo.site/?p=3056">
+	<link rel="alternate" type="application/json+oembed" href="https://wordpressdev.lndo.site/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwordpressdev.lndo.site%2Fstories%2Fbison-2%2F">
+	<link rel="alternate" type="text/xml+oembed" href="https://wordpressdev.lndo.site/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fwordpressdev.lndo.site%2Fstories%2Fbison-2%2F&amp;format=xml">
+	<link rel="icon" href="https://wordpressdev.lndo.site/content/uploads/2019/02/cropped-Security-Photo-4-32x32.png" sizes="32x32">
+	<link rel="icon" href="https://wordpressdev.lndo.site/content/uploads/2019/02/cropped-Security-Photo-4-192x192.png" sizes="192x192">
+	<link rel="apple-touch-icon-precomposed" href="https://wordpressdev.lndo.site/content/uploads/2019/02/cropped-Security-Photo-4-180x180.png">
 	<script type="application/ld+json">{
 		"@context": "http:\/\/schema.org",
 		"publisher": {
```