### PR TITLE
Remove launched experiment amp-img-auto-sizes

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -148,21 +148,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		$this->determine_dimensions( $need_dimensions );
 		$this->adjust_and_replace_nodes_in_array_map( $need_dimensions );
-
-		/*
-		 * Opt-in to amp-img-auto-sizes experiment.
-		 * This is needed because the sizes attribute is removed from all img elements converted to amp-img
-		 * in order to prevent the undesirable setting of the width. This $meta tag can be removed once the
-		 * experiment ends (and the feature has been fully launched).
-		 * See <https://github.com/ampproject/amphtml/issues/21371> and <https://github.com/ampproject/amp-wp/pull/2036>.
-		 */
-		$head = $this->dom->getElementsByTagName( 'head' )->item( 0 );
-		if ( $head ) {
-			$meta = $this->dom->createElement( 'meta' );
-			$meta->setAttribute( 'name', 'amp-experiments-opt-in' );
-			$meta->setAttribute( 'content', 'amp-img-auto-sizes' );
-			$head->insertBefore( $meta, $head->firstChild );
-		}
 	}
 
 	/**

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -385,9 +385,6 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$this->assertEquals( $expected, $content );
-
-		$xpath = new DOMXPath( $dom );
-		$this->assertEquals( $img_count ? 1 : 0, $xpath->query( '/html/head/meta[ @name = "amp-experiments-opt-in" ][ @content = "amp-img-auto-sizes" ]' )->length );
 	}
 
 	/**


### PR DESCRIPTION
The `amp-img-auto-sizes` experiment has graduated since May: https://github.com/ampproject/amphtml/pull/22053 (https://github.com/ampproject/amphtml/issues/20517, https://github.com/ampproject/amphtml/issues/19513). Therefore, we can now remove this extra `meta` tag from being added to AMP pages (originally added in https://github.com/ampproject/amp-wp/pull/2036).