### PR TITLE
Revert "Avoid undefined variable warning for $path_args which is populated by wp_parse_str()"

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -461,7 +461,6 @@ function amp_maybe_add_actions() {
 
 		// Prevent infinite URL space under /amp/ endpoint.
 		global $wp;
-		$path_args = [];
 		wp_parse_str( $wp->matched_query, $path_args );
 		if ( isset( $path_args[ amp_get_slug() ] ) && '' !== $path_args[ amp_get_slug() ] ) {
 			wp_safe_redirect( amp_get_permalink( $post->ID ), 301 );


### PR DESCRIPTION
Reverts ampproject/amp-wp#2693 from `master`, which was accidentally targeting the wrong branch.