### PR TITLE
Add notice if Xdebug extension is loaded

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -251,8 +251,9 @@ function _amp_xdebug_admin_notice() {
 	<div class="notice notice-warning">
 		<p>
 			<?php
-			echo wp_kses_post(
-				__( 'Your server currently has the Xdebug PHP extension loaded. This can cause some of the AMP plugin\'s processes to timeout depending on your system resources and configuration. Please deactivate Xdebug for the best experience.', 'amp' )
+			echo esc_html_e(
+				'Your server currently has the Xdebug PHP extension loaded. This can cause some of the AMP plugin\'s processes to timeout depending on your system resources and configuration. Please deactivate Xdebug for the best experience.',
+				'amp'
 			);
 			?>
 		</p>

--- a/amp.php
+++ b/amp.php
@@ -252,7 +252,7 @@ function _amp_xdebug_admin_notice() {
 		<p>
 			<?php
 			echo wp_kses_post(
-				__( 'We\'ve detected that your server currently has the Xdebug PHP extension loaded. This can cause some of the AMP plugin\'s processes to timeout depending on your system resources and configuration. We recommend deactivating Xdebug for the best experience.', 'amp' )
+				__( 'Your server currently has the Xdebug PHP extension loaded. This can cause some of the AMP plugin\'s processes to timeout depending on your system resources and configuration. Please deactivate Xdebug for the best experience.', 'amp' )
 			);
 			?>
 		</p>

--- a/amp.php
+++ b/amp.php
@@ -241,6 +241,28 @@ if ( 'amp' !== basename( AMP__DIR__ ) ) {
 	add_action( 'admin_notices', '_amp_incorrect_plugin_slug_admin_notice' );
 }
 
+/**
+ * Print admin notice if the xdebug extension is loaded.
+ *
+ * @since T.B.D
+ */
+function _amp_xdebug_admin_notice() {
+	?>
+	<div class="notice notice-warning">
+		<p>
+			<?php
+			echo wp_kses_post(
+				__( 'We\'ve detected that your server currently has the Xdebug PHP extension loaded. This can cause some of the AMP plugin\'s processes to timeout depending on your system resources and configuration. We recommend deactivating Xdebug for the best experience.', 'amp' )
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+if ( extension_loaded( 'xdebug' ) ) {
+	add_action( 'admin_notices', '_amp_xdebug_admin_notice' );
+}
+
 require_once AMP__DIR__ . '/includes/class-amp-autoloader.php';
 AMP_Autoloader::register();
 

--- a/amp.php
+++ b/amp.php
@@ -242,7 +242,7 @@ if ( 'amp' !== basename( AMP__DIR__ ) ) {
 }
 
 /**
- * Print admin notice if the xdebug extension is loaded.
+ * Print admin notice if the Xdebug extension is loaded.
  *
  * @since T.B.D
  */

--- a/amp.php
+++ b/amp.php
@@ -251,7 +251,7 @@ function _amp_xdebug_admin_notice() {
 	<div class="notice notice-warning">
 		<p>
 			<?php
-			echo esc_html_e(
+			esc_html_e(
 				'Your server currently has the Xdebug PHP extension loaded. This can cause some of the AMP plugin\'s processes to timeout depending on your system resources and configuration. Please deactivate Xdebug for the best experience.',
 				'amp'
 			);

--- a/amp.php
+++ b/amp.php
@@ -244,7 +244,7 @@ if ( 'amp' !== basename( AMP__DIR__ ) ) {
 /**
  * Print admin notice if the Xdebug extension is loaded.
  *
- * @since T.B.D
+ * @since 1.3
  */
 function _amp_xdebug_admin_notice() {
 	?>


### PR DESCRIPTION
As discovered in https://github.com/ampproject/amp-wp/issues/1915#issuecomment-528117914, xdebug can cause AMP stylesheet parsing to take much longer than normal and potentially crash the site due to maximum execution limit timeout.

This PR adds a notice to inform the user of the potential risk.

I would expect perhaps the wording should maybe change, if so, just let me know!