### PR TITLE
Add special-case handling for layout=fill interpretation

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1240,3 +1240,120 @@ function amp_print_story_auto_ads() {
 
 	echo AMP_HTML_Utils::build_tag( 'amp-story-auto-ads', [], $script_element ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
+
+/*
+ * The function below is copied from the ramsey/array_column package.
+ *
+ * Changes were made to code style to pass PHPCS requirements, but logic is unchanged.
+ *
+ * This can be removed once the required PHP version moves to PHP 5.5+.
+ *
+ * @link https://github.com/ramsey/array_column
+ *
+ * @copyright Copyright (c) Ben Ramsey (http://benramsey.com)
+ * @license   http://opensource.org/licenses/MIT MIT
+ */
+if ( ! function_exists( 'array_column' ) ) {
+	/**
+	 * Returns the values from a single column of the input array, identified by
+	 * the $columnKey.
+	 *
+	 * Optionally, you may provide an $indexKey to index the values in the returned
+	 * array by the values from the $indexKey column in the input array.
+	 *
+	 * @param array $input      A multi-dimensional array (record set) from which to pull
+	 *                          a column of values.
+	 * @param mixed $column_key The column of values to return. This value may be the
+	 *                          integer key of the column you wish to retrieve, or it
+	 *                          may be the string key name for an associative array.
+	 * @param mixed $index_key  (Optional.) The column to use as the index/keys for
+	 *                          the returned array. This value may be the integer key
+	 *                          of the column, or it may be the string key name.
+	 * @return array|bool
+	 */
+	function array_column( $input = null, $column_key = null, $index_key = null ) {
+		// Using func_get_args() in order to check for proper number of
+		// parameters and trigger errors exactly as the built-in array_column()
+		// does in PHP 5.5.
+		$argc   = func_num_args();
+		$params = func_get_args();
+
+		if ( $argc < 2 ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.Security.EscapeOutput.OutputNotEscaped
+			trigger_error( "array_column() expects at least 2 parameters, {$argc} given", E_USER_WARNING );
+			return null;
+		}
+
+		if ( ! is_array( $params[0] ) ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error,WordPress.Security.EscapeOutput.OutputNotEscaped
+			trigger_error( 'array_column() expects parameter 1 to be array, ' . gettype( $params[0] ) . ' given', E_USER_WARNING );
+			return null;
+		}
+
+		if ( ! is_int( $params[1] )
+			&& ! is_float( $params[1] )
+			&& ! is_string( $params[1] )
+			&& null !== $params[1]
+			&& ! ( is_object( $params[1] ) && method_exists( $params[1], '__toString' ) )
+		) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( 'array_column(): The column key should be either a string or an integer', E_USER_WARNING );
+			return false;
+		}
+
+		if ( isset( $params[2] )
+			&& ! is_int( $params[2] )
+			&& ! is_float( $params[2] )
+			&& ! is_string( $params[2] )
+			&& ! ( is_object( $params[2] ) && method_exists( $params[2], '__toString' ) )
+		) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error( 'array_column(): The index key should be either a string or an integer', E_USER_WARNING );
+			return false;
+		}
+
+		$params_input      = $params[0];
+		$params_column_key = ( null !== $params[1] ) ? (string) $params[1] : null;
+
+		$params_index_key = null;
+		if ( isset( $params[2] ) ) {
+			if ( is_float( $params[2] ) || is_int( $params[2] ) ) {
+				$params_index_key = (int) $params[2];
+			} else {
+				$params_index_key = (string) $params[2];
+			}
+		}
+
+		$result_array = [];
+
+		foreach ( $params_input as $row ) {
+			$key       = null;
+			$value     = null;
+			$key_set   = false;
+			$value_set = false;
+
+			if ( null !== $params_index_key && array_key_exists( $params_index_key, $row ) ) {
+				$key_set = true;
+				$key     = (string) $row[ $params_index_key ];
+			}
+
+			if ( null === $params_column_key ) {
+				$value_set = true;
+				$value     = $row;
+			} elseif ( is_array( $row ) && array_key_exists( $params_column_key, $row ) ) {
+				$value_set = true;
+				$value     = $row[ $params_column_key ];
+			}
+
+			if ( $value_set ) {
+				if ( $key_set ) {
+					$result_array[ $key ] = $value;
+				} else {
+					$result_array[] = $value;
+				}
+			}
+		}
+
+		return $result_array;
+	}
+}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -280,10 +280,10 @@ abstract class AMP_Base_Sanitizer {
 			// top, left, bottom, right are used.
 			if ( isset( $styles['position'], $styles['top'], $styles['left'], $styles['bottom'], $styles['right'] )
 				&& 'absolute' === $styles['position']
-				&& '0' === (string) $styles['top']
-				&& '0' === (string) $styles['left']
-				&& '0' === (string) $styles['bottom']
-				&& '0' === (string) $styles['right']
+				&& 0 === (int) $styles['top']
+				&& 0 === (int) $styles['left']
+				&& 0 === (int) $styles['bottom']
+				&& 0 === (int) $styles['right']
 			) {
 				unset( $attributes['style'], $styles['position'], $styles['top'], $styles['left'], $styles['bottom'], $styles['right'] );
 				if ( ! empty( $styles ) ) {
@@ -296,8 +296,8 @@ abstract class AMP_Base_Sanitizer {
 			// top, left, width, height are used.
 			if ( isset( $styles['position'], $styles['top'], $styles['left'], $styles['width'], $styles['height'] )
 				&& 'absolute' === $styles['position']
-				&& '0' === (string) $styles['top']
-				&& '0' === (string) $styles['left']
+				&& 0 === (int) $styles['top']
+				&& 0 === (int) $styles['left']
 				&& '100%' === (string) $styles['width']
 				&& '100%' === (string) $styles['height']
 			) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -704,7 +704,7 @@ abstract class AMP_Base_Sanitizer {
 	 * Parse a style string into an associative array of style attributes.
 	 *
 	 * @param string $style_string Style string to parse.
-	 * @return array Associative array of style attributes.
+	 * @return string[] Associative array of style attributes.
 	 */
 	protected function parse_style_string( $style_string ) {
 		// We need to turn the style string into an associative array of styles first.

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -277,7 +277,7 @@ abstract class AMP_Base_Sanitizer {
 		if ( ! empty( $attributes['style'] ) ) {
 			$styles = $this->parse_style_string( $attributes['style'] );
 
-			// top, left, bottom, right are used.
+			// Apply fill layout if top, left, bottom, right are used.
 			if ( isset( $styles['position'], $styles['top'], $styles['left'], $styles['bottom'], $styles['right'] )
 				&& 'absolute' === $styles['position']
 				&& 0 === (int) $styles['top']
@@ -293,7 +293,7 @@ abstract class AMP_Base_Sanitizer {
 				return $attributes;
 			}
 
-			// top, left, width, height are used.
+			// Apply fill layout if top, left, width, height are used.
 			if ( isset( $styles['position'], $styles['top'], $styles['left'], $styles['width'], $styles['height'] )
 				&& 'absolute' === $styles['position']
 				&& 0 === (int) $styles['top']

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -717,6 +717,8 @@ abstract class AMP_Base_Sanitizer {
 		}
 
 		$chunks = array_chunk( $elements, 2 );
+
+		// phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_columnFound -- WP Core provides a polyfill.
 		return array_combine( array_column( $chunks, 0 ), array_column( $chunks, 1 ) );
 	}
 
@@ -734,12 +736,16 @@ abstract class AMP_Base_Sanitizer {
 		// Discard empty values first.
 		$styles = array_filter( $styles );
 
-		return array_reduce( array_keys( $styles ), static function ( $style_string, $style_name ) use ( $styles ) {
-			if ( ! empty( $style_string ) ) {
-				$style_string .= ';';
-			}
+		return array_reduce(
+			array_keys( $styles ),
+			static function ( $style_string, $style_name ) use ( $styles ) {
+				if ( ! empty( $style_string ) ) {
+					$style_string .= ';';
+				}
 
-			return $style_string . "{$style_name}:{$styles[ $style_name ]}";
-		}, '' );
+				return $style_string . "{$style_name}:{$styles[ $style_name ]}";
+			},
+			''
+		);
 	}
 }

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -257,14 +257,14 @@ abstract class AMP_Base_Sanitizer {
 	/**
 	 * Sets the layout, and possibly the 'height' and 'width' attributes.
 	 *
-	 * @param string[] $attributes {
+	 * @param array $attributes {
 	 *      Attributes.
 	 *
-	 *      @type int $height
-	 *      @type int $width
-	 *      @type string $sizes
-	 *      @type string $class
-	 *      @type string $layout
+	 *      @type int|string $height
+	 *      @type int|string $width
+	 *      @type string     $sizes
+	 *      @type string     $class
+	 *      @type string     $layout
 	 * }
 	 * @return array Attributes.
 	 */
@@ -272,6 +272,44 @@ abstract class AMP_Base_Sanitizer {
 		if ( isset( $attributes['layout'] ) && ( 'fill' === $attributes['layout'] || 'flex-item' !== $attributes['layout'] ) ) {
 			return $attributes;
 		}
+
+		// Special-case handling for inline style that should be transformed into layout=fill.
+		if ( ! empty( $attributes['style'] ) ) {
+			$styles = $this->parse_style_string( $attributes['style'] );
+
+			// top, left, bottom, right are used.
+			if ( isset( $styles['position'], $styles['top'], $styles['left'], $styles['bottom'], $styles['right'] )
+				&& 'absolute' === $styles['position']
+				&& '0' === (string) $styles['top']
+				&& '0' === (string) $styles['left']
+				&& '0' === (string) $styles['bottom']
+				&& '0' === (string) $styles['right']
+			) {
+				unset( $attributes['style'], $styles['position'], $styles['top'], $styles['left'], $styles['bottom'], $styles['right'] );
+				if ( ! empty( $styles ) ) {
+					$attributes['style'] = $this->reassemble_style_string( $styles );
+				}
+				$attributes['layout'] = 'fill';
+				return $attributes;
+			}
+
+			// top, left, width, height are used.
+			if ( isset( $styles['position'], $styles['top'], $styles['left'], $styles['width'], $styles['height'] )
+				&& 'absolute' === $styles['position']
+				&& '0' === (string) $styles['top']
+				&& '0' === (string) $styles['left']
+				&& '100%' === (string) $styles['width']
+				&& '100%' === (string) $styles['height']
+			) {
+				unset( $attributes['style'], $styles['position'], $styles['top'], $styles['left'], $styles['width'], $styles['height'] );
+				if ( ! empty( $styles ) ) {
+					$attributes['style'] = $this->reassemble_style_string( $styles );
+				}
+				$attributes['layout'] = 'fill';
+				return $attributes;
+			}
+		}
+
 		if ( empty( $attributes['height'] ) ) {
 			unset( $attributes['width'] );
 			$attributes['height'] = self::FALLBACK_HEIGHT;
@@ -660,5 +698,48 @@ abstract class AMP_Base_Sanitizer {
 			]
 		);
 		$body_node->appendChild( $amp_image_lightbox );
+	}
+
+	/**
+	 * Parse a style string into an associative array of style attributes.
+	 *
+	 * @param string $style_string Style string to parse.
+	 * @return array Associative array of style attributes.
+	 */
+	protected function parse_style_string( $style_string ) {
+		// We need to turn the style string into an associative array of styles first.
+		$style_string = trim( $style_string, " \t\n\r\0\x0B;" );
+		$elements     = preg_split( '/(\s*:\s*|\s*;\s*)/', $style_string );
+
+		if ( 0 !== count( $elements ) % 2 ) {
+			// Style string was malformed, try to process as good as possible by stripping the last element.
+			array_pop( $elements );
+		}
+
+		$chunks = array_chunk( $elements, 2 );
+		return array_combine( array_column( $chunks, 0 ), array_column( $chunks, 1 ) );
+	}
+
+	/**
+	 * Reassemble a style string that can be used in a 'style' attribute.
+	 *
+	 * @param array $styles Associative array of styles to reassemble into a string.
+	 * @return string Reassembled style string.
+	 */
+	protected function reassemble_style_string( $styles ) {
+		if ( ! is_array( $styles ) ) {
+			return '';
+		}
+
+		// Discard empty values first.
+		$styles = array_filter( $styles );
+
+		return array_reduce( array_keys( $styles ), static function ( $style_string, $style_name ) use ( $styles ) {
+			if ( ! empty( $style_string ) ) {
+				$style_string .= ';';
+			}
+
+			return $style_string . "{$style_name}:{$styles[ $style_name ]}";
+		}, '' );
 	}
 }

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -102,6 +102,54 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 					'height' => 100,
 				],
 			],
+
+			'fill_with_bottom_right_removes_empty_style'   => [
+				[
+					'style' => 'position:absolute;top:0;left:0;right:0;bottom:0',
+				],
+				[
+					'layout' => 'fill',
+				],
+			],
+
+			'fill_with_bottom_right_keeps_unrelated_styles'   => [
+				[
+					'style' => 'position:absolute;background-color:white;top:0;left:0;right:0;bottom:0;color:red;',
+				],
+				[
+					'layout' => 'fill',
+					'style'  => 'background-color:white;color:red'
+				],
+			],
+
+			'fill_with_width_height_removes_empty_style'   => [
+				[
+					'style' => 'position:absolute;top:0;left:0;width:100%;height:100%',
+				],
+				[
+					'layout' => 'fill',
+				],
+			],
+
+			'fill_with_width_height_keeps_unrelated_styles'   => [
+				[
+					'style' => 'position:absolute;background-color:white;top:0;left:0;width:100%;height:100%;color:red;',
+				],
+				[
+					'layout' => 'fill',
+					'style'  => 'background-color:white;color:red'
+				],
+			],
+
+			'fill_can_handle_whitespace_noise'   => [
+				[
+					'style' => '; position  :  absolute ;   top : 0; color:  red; left:0;   right:0;;;  bottom:0;; ',
+				],
+				[
+					'layout' => 'fill',
+					'style'  => 'color:red'
+				],
+			],
 		];
 	}
 

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -36,7 +36,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 	 */
 	public function get_data() {
 		return [
-			'both_dimensions_included' => [
+			'both_dimensions_included'                   => [
 				[
 					'width'  => 100,
 					'height' => 100,
@@ -49,7 +49,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'both_dimensions_missing'  => [
+			'both_dimensions_missing'                    => [
 				[],
 				[
 					'height' => 400,
@@ -58,7 +58,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'both_dimensions_empty'    => [
+			'both_dimensions_empty'                      => [
 				[
 					'width'  => '',
 					'height' => '',
@@ -70,7 +70,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'no_width'                 => [
+			'no_width'                                   => [
 				[
 					'height' => 100,
 				],
@@ -81,7 +81,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'no_height'                => [
+			'no_height'                                  => [
 				[
 					'width' => 200,
 				],
@@ -92,7 +92,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'no_layout_specified'      => [
+			'no_layout_specified'                        => [
 				[
 					'width'  => 100,
 					'height' => 100,
@@ -103,7 +103,7 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'fill_with_bottom_right_removes_empty_style'   => [
+			'fill_with_bottom_right_removes_empty_style' => [
 				[
 					'style' => 'position:absolute;top:0;left:0;right:0;bottom:0',
 				],
@@ -112,17 +112,17 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'fill_with_bottom_right_keeps_unrelated_styles'   => [
+			'fill_with_bottom_right_keeps_unrelated_styles' => [
 				[
 					'style' => 'position:absolute;background-color:white;top:0;left:0;right:0;bottom:0;color:red;',
 				],
 				[
 					'layout' => 'fill',
-					'style'  => 'background-color:white;color:red'
+					'style'  => 'background-color:white;color:red',
 				],
 			],
 
-			'fill_with_width_height_removes_empty_style'   => [
+			'fill_with_width_height_removes_empty_style' => [
 				[
 					'style' => 'position:absolute;top:0;left:0;width:100%;height:100%',
 				],
@@ -131,23 +131,23 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			'fill_with_width_height_keeps_unrelated_styles'   => [
+			'fill_with_width_height_keeps_unrelated_styles' => [
 				[
 					'style' => 'position:absolute;background-color:white;top:0;left:0;width:100%;height:100%;color:red;',
 				],
 				[
 					'layout' => 'fill',
-					'style'  => 'background-color:white;color:red'
+					'style'  => 'background-color:white;color:red',
 				],
 			],
 
-			'fill_can_handle_whitespace_noise'   => [
+			'fill_can_handle_whitespace_noise'           => [
 				[
 					'style' => '; position  :  absolute ;   top : 0; color:  red; left:0;   right:0;;;  bottom:0;; ',
 				],
 				[
 					'layout' => 'fill',
-					'style'  => 'color:red'
+					'style'  => 'color:red',
 				],
 			],
 		];


### PR DESCRIPTION
## Changes
This PR adds the following to the `AMP_Base_Sanitizer` class:
* `protected function parse_style_string( $style_string )` to parse the value of a `style` attribute into an associative array of `property => value` entries.
* `protected function reassemble_style_string( $styles )` to reassemble an associative array of `property => value` entries into a string that can be used as a `style` attribute.
* Special-case handling in `set_layout()` method to cover the following cases:
	* `position:absolute;top:0;left:0;bottom:0;right:0` => `layout=fill`
	* `position:absolute;top:0;left:0;width:100%;height:100%` => `layout=fill`
* Tests for the above.

## Before

<img width="855" alt="Image 2019-09-09 at 11 18 01 AM" src="https://user-images.githubusercontent.com/83631/64519502-86fb9a80-d2f4-11e9-8384-2b5dcbfdbfb6.png">

## After

<img width="863" alt="Image 2019-09-09 at 11 17 23 AM" src="https://user-images.githubusercontent.com/83631/64519491-83681380-d2f4-11e9-91c2-df35997d4ae2.png">

Fixes #3142