### PR TITLE
Prevent tree-shaking CSS selectors for dynamic attributes

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -188,6 +188,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * This is initially populated with boolean attributes which can be mutated by AMP at runtime,
 	 * since they can by dynamically added at any time.
 	 *
+	 * @todo With the exception of 'hidden' (which can be on any element), the values here could be removed in favor of
+	 *       checking to see if any of the related elements exist in the page in `\AMP_Style_Sanitizer::has_used_attributes()`.
+	 *       Nevertheless, selectors mentioning these attributes are very numerous, so tree-shaking improvements will be marginal.
+	 *
+	 * @see \AMP_Style_Sanitizer::has_used_attributes()
+	 *
 	 * @since 1.1
 	 * @var array
 	 */
@@ -199,7 +205,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'hidden'    => true,
 		'loop'      => true,
 		'multiple'  => true,
-		'open'      => true,
 		'readonly'  => true,
 		'required'  => true,
 		'selected'  => true,
@@ -667,6 +672,32 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 				$this->used_attributes[ $attribute_name ] = ( 0 !== $this->xpath->query( $expression )->length );
 			}
+
+			// Attributes for amp-accordion, see <https://amp.dev/documentation/components/amp-accordion/#styling>.
+			if ( 'expanded' === $attribute_name ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-accordion' ] ) ) {
+					return false;
+				}
+				continue;
+			}
+
+			// Attributes for amp-sidebar, see <https://amp.dev/documentation/components/amp-sidebar/#styling>.
+			if ( 'open' === $attribute_name ) {
+				// The 'open' attribute is also used by the HTML5 <details> attribute.
+				if ( ! $this->has_used_tag_names( [ 'amp-sidebar' ] ) && ! $this->has_used_tag_names( [ 'details' ] ) ) {
+					return false;
+				}
+				continue;
+			}
+
+			// Attributes for amp-live-list, see <https://amp.dev/documentation/components/amp-live-list/#styling>.
+			if ( 'data-tombstone' === $attribute_name ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) ) {
+					return false;
+				}
+				continue;
+			}
+
 			if ( ! $this->used_attributes[ $attribute_name ] ) {
 				return false;
 			}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -461,7 +461,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				[],
 			],
-			'dynamic_classes_preserved_conditionally' => [
+			'dynamic_classes_and_attributes_preserved_conditionally' => [
 				'
 					<html amp><head>
 					<style> .amp-viewer { color: blue; } </style>
@@ -472,8 +472,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .amp-form-submit-success { color: green; } </style>
 					<style> .amp-access-laterpay-container { color: purple} </style>
 					<style> .amp-image-lightbox-caption { color: brown} </style>
-					<style> .amp-live-list-item-new { color: lime} </style>
-					<style> .amp-sidebar-toolbar-target-hidden { color: lavender} </style>
+					<style> .amp-live-list-item-new { color: lime} #my-live-list [data-tombstone] { display: block; }</style>
+					<style> .amp-sidebar-toolbar-target-hidden { color: lavender} #sidebar1[open] { outline: solid 1px red; }</style>
 					<style> .amp-sticky-ad-close-button { color: aliceblue} </style>
 					<style> .amp-docked-video-shadow { color: azure} </style>
 					<style> .amp-geo-pending { color: saddlebrown; } </style>
@@ -481,6 +481,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					<style> .amp-geo-group-foo { color: peru; } </style>
 					<style> .amp-iso-country-us { color: oldlace; } </style>
 					<style> .amp-video-eq { display: none; } </style>
+					<style> #accord section[expanded] { outline: solid 1px blue; } </style>
 					<style> .non-existent { color: black; } </style>
 					</head>
 					<body>
@@ -495,6 +496,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						<amp-sticky-ad layout="nodisplay"><amp-ad width="320" height="50" type="doubleclick" data-slot="/35096353/amptesting/formats/sticky"></amp-ad></amp-sticky-ad>
 						<amp-video dock width="720" height="305" layout="responsive" src="https://yourhost.com/videos/myvideo.mp4" poster="https://yourhost.com/posters/poster.png" artwork="https://yourhost.com/artworks/artwork.png" title="Awesome video" artist="Awesome artist" album="Amazing album"></amp-video>
 						<amp-geo layout="nodisplay"><script type="application/json">{"ISOCountryGroups": {"foo":["us"]}}</script></amp-geo>
+						<amp-accordion id="accord" disable-session-states><section><h2>Section 1</h2><p>Content in section 1.</p></section><section><h2>Section 2</h2><div>Content in section 2.</div></section></amp-accordion>
 					</body>
 					</html>
 				',
@@ -507,8 +509,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.amp-form-submit-success{color:green}',
 					'.amp-access-laterpay-container{color:purple}',
 					'.amp-image-lightbox-caption{color:brown}',
-					'.amp-live-list-item-new{color:lime}',
-					'.amp-sidebar-toolbar-target-hidden{color:lavender}',
+					'.amp-live-list-item-new{color:lime}#my-live-list [data-tombstone]{display:block}',
+					'.amp-sidebar-toolbar-target-hidden{color:lavender}#sidebar1[open]{outline:solid 1px red}',
 					'.amp-sticky-ad-close-button{color:aliceblue}',
 					'.amp-docked-video-shadow{color:azure}',
 					'.amp-geo-pending{color:saddlebrown}',
@@ -516,6 +518,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'.amp-geo-group-foo{color:peru}',
 					'.amp-iso-country-us{color:oldlace}',
 					'.amp-video-eq{display:none}',
+					'#accord section[expanded]{outline:solid 1px blue}',
 					'', // Because no non-existent.
 				],
 				[],


### PR DESCRIPTION
This fixes an issue [reported](https://wordpress.org/support/topic/plugin-is-stripping-css-attribute-selector/) on the support forum:

> I’m only trying to style an expanded menu inside of a sidebar. I’m using standard AMP elements, including amp-accordion. The inline style that gets added by the plugin is automatically removing the styles that would allow this, for example:
> 
> ```css
> section.menu-section[expanded] {
> background: green;
> }
> ```
>
> The plugin isn’t stripping out any other content. 

In #1959 (and #2017, #2642, #2710) tree shaking for CSS selectors was made aware of the class names for AMP components which can be dynamically added/removed from a page. Even though the selector with such a class name may not exist at the initial time of rendering the page, the selector may very well apply later. The same logic needed to be extended to attributes which are added/removed to AMP components. In particular:

* `amp-sidebar`: The `open` attribute is dynamically added when the sidebar is opened.
* `amp-accordion`: The `expanded` attribute is added when a section  is opened by the user.
* `amp-live-list`: The `data-tombstone` attribute can appear in an `amp-live-list`'s contents during the life of a page.
