### PR TITLE
Sort the list of active plugins

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -797,9 +797,14 @@ class AMP_Validated_URL_Post_Type {
 	 * @return array Environment.
 	 */
 	public static function get_validated_environment() {
+		// We want to sort the list of plugins to avoid fluctuations due to plugins fighting for first spot
+		// to constantly invalidate our cache.
+		$plugins = get_option( 'active_plugins', [] );
+		sort( $plugins );
+
 		return [
 			'theme'   => get_stylesheet(),
-			'plugins' => get_option( 'active_plugins', [] ),
+			'plugins' => $plugins,
 		];
 	}
 


### PR DESCRIPTION
As there are plugins that actively manipulate the ordering of this option to put themselves in first place, and as this might lead to situations where multiple plugins go back-and-forth and constantly alternate in positions, we normalize the array of 'active_plugins' by sorting it, to avoid unnecessary cache invalidations and make the mechanism less brittle.

Fixes #3172