### PR TITLE
Add warning notice to AMP settings screen when not using HTTPS

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -637,9 +637,9 @@ class AMP_Options_Manager {
 		$uses_ssl = (
 			is_ssl()
 			&&
-			( strpos( get_bloginfo( 'wpurl' ), 'https' ) !== 0 )
+			( strpos( get_bloginfo( 'wpurl' ), 'https' ) === 0 )
 			&&
-			( strpos( get_bloginfo( 'url' ), 'https' ) !== 0 )
+			( strpos( get_bloginfo( 'url' ), 'https' ) === 0 )
 		);
 
 		if ( ! $uses_ssl && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -645,15 +645,16 @@ class AMP_Options_Manager {
 		if ( ! $uses_ssl && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
 				'<div class="notice notice-warning"><p>%s</p></div>',
-				sprintf(
-					/* translators: %s: "Why should I use HTTPS" support URL */
-					wp_kses(
-						__( 'Your site is not being fully served over a secure connection (using HTTPS).<br>' .
-						    'As some AMP functionality requires a secure connection, you might experience degraded performance or broken components.<br>' .
-						    '<a href="%s">More details</a>', 'amp' ),
-						[ 'br' => [], 'a' => [ 'href' => true ] ]
+				wp_kses(
+					sprintf(
+						/* translators: %s: "Why should I use HTTPS" support URL */
+						__( 'Your site is not being fully served over a secure connection (using HTTPS).<br>As some AMP functionality requires a secure connection, you might experience degraded performance or broken components.<br><a href="%s">More details</a>', 'amp' ),
+						esc_url( __( 'https://wordpress.org/support/article/why-should-i-use-https/', 'amp' ) )
 					),
-					esc_url( __( 'https://wordpress.org/support/article/why-should-i-use-https/', 'amp' ) )
+					[
+						'br' => [],
+						'a'  => [ 'href' => true ],
+					]
 				)
 			);
 		}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -66,6 +66,7 @@ class AMP_Options_Manager {
 		add_action( 'admin_notices', [ __CLASS__, 'persistent_object_caching_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'render_cache_miss_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'render_php_css_parser_conflict_notice' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'insecure_connection_notice' ] );
 	}
 
 	/**
@@ -621,6 +622,41 @@ class AMP_Options_Manager {
 			&&
 			AMP_Theme_Support::exceeded_cache_miss_threshold()
 		);
+	}
+
+
+	/**
+	 * Outputs an admin notice if the site is not served over HTTPS.
+	 *
+	 * @since 1.3
+	 *
+	 * @return void
+	 */
+	public static function insecure_connection_notice() {
+		// is_ssl() only tells us whether the admin backend uses HTTPS here, so we add a few more sanity checks.
+		$uses_ssl = (
+			is_ssl()
+			&&
+			( strpos( get_bloginfo( 'wpurl' ), 'https' ) !== 0 )
+			&&
+			( strpos( get_bloginfo( 'url' ), 'https' ) !== 0 )
+		);
+
+		if ( ! $uses_ssl && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
+			printf(
+				'<div class="notice notice-warning"><p>%s</p></div>',
+				sprintf(
+					/* translators: %s: "Why should I use HTTPS" support URL */
+					wp_kses(
+						__( 'Your site is not being fully served over a secure connection (using HTTPS).<br>' .
+						    'As some AMP functionality requires a secure connection, you might experience degraded performance or broken components.<br>' .
+						    '<a href="%s">More details</a>', 'amp' ),
+						[ 'br' => [], 'a' => [ 'href' => true ] ]
+					),
+					esc_url( __( 'https://wordpress.org/support/article/why-should-i-use-https/', 'amp' ) )
+				)
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This PR adds a notice to the AMP Settings screen to warn users when their site is not being served over HTTPS.

To check this, it doesn't solely rely on `is_ssl()` but also checks the `url` and `wpurl` options, similar to what Site Health does, to make sure we get a value for the frontend as well.

The warning links to the official HTTPS support page from WP: [https://wordpress.org/support/article/why-should-i-use-https/](https://wordpress.org/support/article/why-should-i-use-https/)

![Image 2019-09-10 at 12 01 53 PM](https://user-images.githubusercontent.com/83631/64606476-9fd48080-d3c6-11e9-99b4-67994374385d.png)

Fixes #2006 