### PR TITLE
Use a transient to cache the potentially slow "Pending URLs Count" query

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -83,11 +83,11 @@ class AMP_Validated_URL_Post_Type {
 	const VALIDATION_ERRORS_META_BOX = 'amp_validation_errors';
 
 	/**
-	 * The transient key to use for caching the pending URLs count.
+	 * The transient key to use for caching the number of URLs with new validation errors.
 	 *
 	 * @var string
 	 */
-	const PENDING_URLS_COUNT_TRANSIENT = 'amp_pending_urls_count';
+	const NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT = 'amp_new_validation_error_urls_count';
 
 	/**
 	 * The total number of errors associated with a URL, regardless of the maximum that can display.
@@ -367,33 +367,33 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
-		$pending_count = get_transient( static::PENDING_URLS_COUNT_TRANSIENT );
+		$new_validation_error_urls = get_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
 
-		if ( false === $pending_count ) {
-			$pending_count = static::get_pending_urls_count();
-			set_transient( static::PENDING_URLS_COUNT_TRANSIENT, $pending_count, DAY_IN_SECONDS );
+		if ( false === $new_validation_error_urls ) {
+			$new_validation_error_urls = static::get_validation_error_urls_count();
+			set_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT, $new_validation_error_urls, DAY_IN_SECONDS );
 		}
 
-		if ( 0 === $pending_count ) {
+		if ( 0 === $new_validation_error_urls ) {
 			return;
 		}
 
 		foreach ( $submenu[ AMP_Options_Manager::OPTION_NAME ] as &$submenu_item ) {
 			if ( 'edit.php?post_type=' . self::POST_TYPE_SLUG === $submenu_item[2] ) {
-				$submenu_item[0] .= ' <span class="awaiting-mod"><span class="pending-count">' . esc_html( number_format_i18n( $pending_count ) ) . '</span></span>';
+				$submenu_item[0] .= ' <span class="awaiting-mod"><span class="new-validation-error-urls-count">' . esc_html( number_format_i18n( $new_validation_error_urls ) ) . '</span></span>';
 				break;
 			}
 		}
 	}
 
 	/**
-	 * Get the count of pending URLs that have validation errors.
+	 * Get the count of URLs that have new validation errors.
 	 *
 	 * @since 1.3
 	 *
-	 * @return int Count of pending URLs.
+	 * @return int Count of new validation error URLs.
 	 */
-	protected static function get_pending_urls_count() {
+	protected static function get_validation_error_urls_count() {
 		$query = new WP_Query(
 			[
 				'post_type'              => self::POST_TYPE_SLUG,
@@ -814,7 +814,7 @@ class AMP_Validated_URL_Post_Type {
 			update_post_meta( $post_id, '_amp_queried_object', $args['queried_object'] );
 		}
 
-		delete_transient( static::PENDING_URLS_COUNT_TRANSIENT );
+		delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
 
 		return $post_id;
 	}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -83,6 +83,13 @@ class AMP_Validated_URL_Post_Type {
 	const VALIDATION_ERRORS_META_BOX = 'amp_validation_errors';
 
 	/**
+	 * The transient key to use for caching the pending URLs count.
+	 *
+	 * @var string
+	 */
+	const PENDING_URLS_COUNT_TRANSIENT = 'amp_pending_urls_count';
+
+	/**
 	 * The total number of errors associated with a URL, regardless of the maximum that can display.
 	 *
 	 * @var int
@@ -360,7 +367,12 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
-		$pending_count = static::get_pending_urls_count();
+		$pending_count = get_transient( static::PENDING_URLS_COUNT_TRANSIENT );
+
+		if ( false === $pending_count ) {
+			$pending_count = static::get_pending_urls_count();
+			set_transient( static::PENDING_URLS_COUNT_TRANSIENT, $pending_count, DAY_IN_SECONDS );
+		}
 
 		if ( 0 === $pending_count ) {
 			return;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -814,6 +814,8 @@ class AMP_Validated_URL_Post_Type {
 			update_post_meta( $post_id, '_amp_queried_object', $args['queried_object'] );
 		}
 
+		delete_transient( static::PENDING_URLS_COUNT_TRANSIENT );
+
 		return $post_id;
 	}
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -360,6 +360,28 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
+		$pending_count = static::get_pending_urls_count();
+
+		if ( 0 === $pending_count ) {
+			return;
+		}
+
+		foreach ( $submenu[ AMP_Options_Manager::OPTION_NAME ] as &$submenu_item ) {
+			if ( 'edit.php?post_type=' . self::POST_TYPE_SLUG === $submenu_item[2] ) {
+				$submenu_item[0] .= ' <span class="awaiting-mod"><span class="pending-count">' . esc_html( number_format_i18n( $pending_count ) ) . '</span></span>';
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Get the count of pending URLs that have validation errors.
+	 *
+	 * @since 1.3
+	 *
+	 * @return int Count of pending URLs.
+	 */
+	protected static function get_pending_urls_count() {
 		$query = new WP_Query(
 			[
 				'post_type'              => self::POST_TYPE_SLUG,
@@ -372,15 +394,7 @@ class AMP_Validated_URL_Post_Type {
 			]
 		);
 
-		if ( 0 === $query->found_posts ) {
-			return;
-		}
-		foreach ( $submenu[ AMP_Options_Manager::OPTION_NAME ] as &$submenu_item ) {
-			if ( 'edit.php?post_type=' . self::POST_TYPE_SLUG === $submenu_item[2] ) {
-				$submenu_item[0] .= ' <span class="awaiting-mod"><span class="pending-count">' . esc_html( number_format_i18n( $query->found_posts ) ) . '</span></span>';
-				break;
-			}
-		}
+		return $query->found_posts;
 	}
 
 	/**

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1623,6 +1623,8 @@ class AMP_Validated_URL_Post_Type {
 					)
 				);
 			}
+
+			delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
 		}
 
 		$redirect = wp_get_referer();

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2220,6 +2220,8 @@ class AMP_Validation_Error_Taxonomy {
 			);
 		}
 
+		delete_transient( AMP_Validated_URL_Post_Type::PENDING_URLS_COUNT_TRANSIENT );
+
 		return $redirect_to;
 	}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2220,7 +2220,7 @@ class AMP_Validation_Error_Taxonomy {
 			);
 		}
 
-		delete_transient( AMP_Validated_URL_Post_Type::PENDING_URLS_COUNT_TRANSIENT );
+		delete_transient( AMP_Validated_URL_Post_Type::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
 
 		return $redirect_to;
 	}

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -141,7 +141,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
 
-		$this->assertContains( '<span class="awaiting-mod"><span class="pending-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+		$this->assertContains( '<span class="awaiting-mod"><span class="new-validation-error-urls-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 	}
 
 	/**


### PR DESCRIPTION
Extracts the pending URL count query into a separate method and then wraps usage of that method into a transient.

The key name is `amp_pending_urls_count` and the expiry time is set to 24h.

Fixes #2736