### PR TITLE
Add missing $this to callback isset check

### DIFF
--- a/includes/validation/class-amp-validation-callback-wrapper.php
+++ b/includes/validation/class-amp-validation-callback-wrapper.php
@@ -55,7 +55,7 @@ class AMP_Validation_Callback_Wrapper implements ArrayAccess {
 			$before_scripts_enqueued = $wp_scripts->queue;
 		}
 
-		$is_filter = isset( $callback['source']['hook'] ) && ! did_action( $this->callback['source']['hook'] );
+		$is_filter = isset( $this->callback['source']['hook'] ) && ! did_action( $this->callback['source']['hook'] );
 
 		// Wrap the markup output of (action) hooks in source comments.
 		AMP_Validation_Manager::$hook_source_stack[] = $this->callback['source'];


### PR DESCRIPTION
Because of a missing `$this->` reference, the `$is_filter` check could never be true in `AMP_Validation_Callback_Wrapper::__invoke()`.