### PR TITLE
Fix cut handler by shortcut

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-page/copy-paste-handler.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/copy-paste-handler.js
@@ -138,9 +138,12 @@ export default withDispatch( ( dispatch, ownProps, { select } ) => {
 		// Reuse code in onCode.
 		onCopy();
 		// Remove selected Blocks.
-		for ( const clientId of selectedBlockClientIds ) {
-			removeBlock( clientId );
-		}
+		// But wait 1 render cycle to do it to allow the browser to correctly pick up the cut content.
+		setTimeout( () => {
+			for ( const clientId of selectedBlockClientIds ) {
+				removeBlock( clientId );
+			}
+		} );
 	};
 
 	return {


### PR DESCRIPTION
_Fixes https://github.com/ampproject/amp-wp/issues/2989#issuecomment-531245896_

In order to allow the browser to correctly pick up what content is being cut, we need to keep it on-stage for another cycle before visually removing it from the page.

This is done by wrapping the block removal in a `setTimeout()`.

### TODO

- [ ] Add e2e tests for copy-pasting with keyboard shortcuts.