### PR TITLE
Update allowed tags/attributes from spec in amphtml 1910071803120

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -504,6 +504,10 @@ def GetTagRules(tag_spec):
 	if tag_spec.enabled_by and 'transformed' in tag_spec.enabled_by:
 		return None
 
+	# Ignore amp-custom-length-check because the AMP plugin will indicate how close they are to the limit.
+	if tag_spec.HasField('spec_name') and str(tag_spec.spec_name) == 'style amp-custom-length-check':
+		return None
+
 	if tag_spec.HasField('extension_spec'):
 		extension_spec = {}
 		for field in tag_spec.extension_spec.ListFields():

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 935;
+	private static $spec_file_revision = 950;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -1861,6 +1861,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'type' => array(
 						'value' => array(
+							'carousel',
 							'slides',
 						),
 					),
@@ -1880,64 +1881,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-carousel',
 					),
-					'spec_name' => 'AMP-CAROUSEL [type=slides]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'arrows' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'autoplay' => array(
-						'value_regex' => '(|[0-9]+)',
-					),
-					'controls' => array(),
-					'data-amp-bind-slide' => array(),
-					'delay' => array(
-						'value_regex' => '[0-9]+',
-					),
-					'dots' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'loop' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'slide' => array(
-						'value_regex' => '[0-9]+',
-					),
-					'type' => array(
-						'dispatch_key' => 2,
-						'mandatory' => true,
-						'value' => array(
-							'carousel',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							2,
-							3,
-							1,
-						),
-					),
-					'requires_extension' => array(
-						'amp-carousel',
-					),
-					'spec_name' => 'AMP-CAROUSEL [type=carousel]',
+					'spec_name' => 'AMP-CAROUSEL',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
 				),
 			),
@@ -1980,6 +1924,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'type' => array(
 						'value' => array(
+							'carousel',
 							'slides',
 						),
 					),
@@ -2010,78 +1955,7 @@ class AMP_Allowed_Tags_Generated {
 						'amp-carousel',
 						'amp-lightbox-gallery',
 					),
-					'spec_name' => 'AMP-CAROUSEL [lightbox] [type=slides]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'arrows' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'autoplay' => array(
-						'value_regex' => '(|[0-9]+)',
-					),
-					'controls' => array(),
-					'data-amp-bind-slide' => array(),
-					'delay' => array(
-						'value_regex' => '[0-9]+',
-					),
-					'dots' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'lightbox' => array(
-						'mandatory' => true,
-					),
-					'loop' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'slide' => array(
-						'value_regex' => '[0-9]+',
-					),
-					'type' => array(
-						'dispatch_key' => 2,
-						'mandatory' => true,
-						'value' => array(
-							'carousel',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							2,
-							3,
-							1,
-						),
-					),
-					'reference_points' => array(
-						'AMP-CAROUSEL lightbox [child]' => array(
-							'mandatory' => false,
-							'unique' => false,
-						),
-						'AMP-CAROUSEL lightbox [lightbox-exclude]' => array(
-							'mandatory' => false,
-							'unique' => false,
-						),
-					),
-					'requires_extension' => array(
-						'amp-carousel',
-						'amp-lightbox-gallery',
-					),
-					'spec_name' => 'AMP-CAROUSEL [lightbox] [type=carousel]',
+					'spec_name' => 'AMP-CAROUSEL lightbox',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-carousel',
 				),
 			),
@@ -8673,6 +8547,7 @@ class AMP_Allowed_Tags_Generated {
 							'allow_relative' => true,
 							'protocol' => array(
 								'data',
+								'http',
 								'https',
 							),
 						),
@@ -9765,6 +9640,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'integrity' => array(),
 					'media' => array(),
+					'nonce' => array(),
 					'rel' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
@@ -15330,6 +15206,31 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'head',
 					'spec_name' => 'style amp-custom',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-custom-length-check' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/css',
+						),
+					),
+				),
+				'cdata' => array(
+					'max_bytes' => -1,
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'head',
+					'spec_name' => 'style amp-custom-length-check',
 					'unique' => true,
 				),
 			),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 950;
+	private static $spec_file_revision = 957;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -307,6 +307,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-live-list',
 			'amp-live-list',
 			'amp-mathml',
+			'amp-megaphone',
 			'amp-mowplayer',
 			'amp-nexxtv-player',
 			'amp-o2-player',
@@ -1330,6 +1331,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'filter-value' => array(),
 					'highlight-user-entry' => array(),
+					'items' => array(),
 					'max-entries' => array(),
 					'media' => array(),
 					'min-characters' => array(),
@@ -3754,6 +3756,11 @@ class AMP_Allowed_Tags_Generated {
 					'data-amp-bind-is-layout-container' => array(),
 					'data-amp-bind-src' => array(),
 					'data-amp-bind-state' => array(),
+					'diffable' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'items' => array(),
 					'load-more' => array(
 						'value' => array(
@@ -3912,6 +3919,146 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-mathml',
 					),
+				),
+			),
+		),
+		'amp-megaphone' => array(
+			array(
+				'attr_spec_list' => array(
+					'data-episodes' => array(
+						'value_regex' => '[0-9]+',
+					),
+					'data-light' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'data-playlist' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+						'value_regex' => '[A-Za-z0-9]+',
+					),
+					'data-sharing' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+						),
+					),
+					'requires_extension' => array(
+						'amp-megaphone',
+					),
+					'spec_name' => 'amp-megaphone [data-playlist]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'data-episode' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+						'value_regex' => '[A-Za-z0-9]+',
+					),
+					'data-light' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'data-sharing' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'data-start' => array(
+						'value_regex' => '\\d+(\\.\\d+)?',
+					),
+					'data-tile' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+						),
+					),
+					'requires_extension' => array(
+						'amp-megaphone',
+					),
+					'spec_name' => 'amp-megaphone [data-episode]',
+				),
+			),
+		),
+		'amp-minute-media-player' => array(
+			array(
+				'attr_spec_list' => array(
+					'autoplay' => array(),
+					'data-content-id' => array(),
+					'data-content-type' => array(
+						'mandatory' => true,
+						'value' => array(
+							'curated',
+							'specific',
+							'semantic',
+						),
+					),
+					'data-minimum-date-factor' => array(),
+					'data-scanned-element' => array(),
+					'data-scanned-element-type' => array(
+						'value' => array(
+							'className',
+							'id',
+							'tag',
+						),
+					),
+					'data-scoped-keywords' => array(),
+					'data-tags' => array(),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							4,
+							6,
+							2,
+							3,
+							7,
+						),
+					),
+					'requires_extension' => array(
+						'amp-minute-media-player',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-minute-media-player',
 				),
 			),
 		),
@@ -13442,6 +13589,56 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'name' => 'amp-megaphone',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-minute-media-player',
+						'version' => array(
+							'0.1',
+							'latest',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
 						'name' => 'amp-mowplayer',
 						'version' => array(
 							'0.1',
@@ -15687,6 +15884,9 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'id' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
 					'type' => array(
 						'mandatory' => true,
 						'value' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -15408,31 +15408,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'amp-custom-length-check' => array(
-						'dispatch_key' => 1,
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/css',
-						),
-					),
-				),
-				'cdata' => array(
-					'max_bytes' => -1,
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'head',
-					'spec_name' => 'style amp-custom-length-check',
-					'unique' => true,
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'amp-boilerplate' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -346,14 +346,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			);
 		}
 
-		$can_include_noscript = (
-			$this->args['add_noscript_fallback']
-			&&
-			( $node->hasAttribute( 'src' ) && ! preg_match( '/^http:/', $node->getAttribute( 'src' ) ) )
-			&&
-			( ! $node->hasAttribute( 'srcset' ) || ! preg_match( '/http:/', $node->getAttribute( 'srcset' ) ) )
-		);
-		if ( $can_include_noscript ) {
+		if ( $this->args['add_noscript_fallback'] ) {
 			// Preserve original node in noscript for no-JS environments.
 			$this->append_old_node_noscript( $img_node, $node, $this->dom );
 		}

--- a/includes/sanitizers/trait-amp-noscript-fallback.php
+++ b/includes/sanitizers/trait-amp-noscript-fallback.php
@@ -34,12 +34,21 @@ trait AMP_Noscript_Fallback {
 	 */
 	protected function initialize_noscript_allowed_attributes( $tag ) {
 		$this->noscript_fallback_allowed_attributes = array_fill_keys(
-			array_merge(
-				array_keys( current( AMP_Allowed_Tags_Generated::get_allowed_tag( $tag ) )['attr_spec_list'] ),
-				array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() )
-			),
+			array_keys( AMP_Allowed_Tags_Generated::get_allowed_attributes() ),
 			true
 		);
+
+		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( $tag ) as $tag_spec ) { // Normally 1 iteration.
+			foreach ( $tag_spec['attr_spec_list'] as $attr_name => $attr_spec ) {
+				$this->noscript_fallback_allowed_attributes[ $attr_name ] = true;
+				if ( isset( $attr_spec['alternative_names'] ) ) {
+					$this->noscript_fallback_allowed_attributes = array_merge(
+						$this->noscript_fallback_allowed_attributes,
+						array_fill_keys( $attr_spec['alternative_names'], true )
+					);
+				}
+			}
+		}
 	}
 
 	/**

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -261,12 +261,12 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'img_with_http_protocol_src'               => [
 				'<img src="http://placehold.it/350x150" width="350" height="150">',
-				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<amp-img src="http://placehold.it/350x150" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" width="350" height="150"></noscript></amp-img>',
 			],
 
 			'img_with_http_protocol_srcset'            => [
-				'<img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150">',
-				'<amp-img src="https://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img>',
+				'<img src="http://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150">',
+				'<amp-img src="http://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="http://placehold.it/350x150" srcset="http://placehold.it/1024x768 1024w" width="350" height="150"></noscript></amp-img>',
 			],
 
 			'img_with_fill_layout_inline_style'        => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1660,6 +1660,18 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-user-location' ],
 			],
 
+			'amp-megaphone'                                => [
+				'<amp-megaphone height="166" layout="fixed-height" data-episode="OSC7749686951" data-light></amp-megaphone>',
+				null,
+				[ 'amp-megaphone' ],
+			],
+
+			'amp-minute-media-player'                      => [
+				'<amp-minute-media-player dock data-content-type="semantic" data-minimum-date-factor="10" data-scanned-element-type="tag" data-scanned-element="post-body" data-scoped-keywords="football" layout="responsive" width="160" height="96"></amp-minute-media-player>',
+				null,
+				[ 'amp-minute-media-player', 'amp-video-docking' ],
+			],
+
 			'deeply_nested_elements_200'                   => [
 				// If a DOM tree is too deep, libxml itself will issue an error: Excessive depth in document: 256 use XML_PARSE_HUGE option.
 				// Also, if XDebug is enabled, then max_nesting_level error is reached if call stack is >256. A nesting level of 200 is safe,


### PR DESCRIPTION
Previously #3084.

- [x] Run `./bin/amphtml-update.sh`
- [x] Examine diff for changelog
- [x] Update spec generator as needed based on spec format changes.
- [x] Modify validating sanitizer based on changes to spec, if needed.
- [x] Add tests for key changes

# Changelog

* Allow `http` protocol for `amp-img > noscript > img` fallbacks.
* Add `amp-megaphone` component.
* Add `amp-minute-media-player` component.
* Add `diffable` attribute to `amp-list` component.

# Details

```bash
(
    PREV_VERSION=1908162134430;
    THIS_VERSION=1910071803120; 
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

<details>
<summary>Compare 1908162134430..1910071803120</summary>

```diff
diff --git a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
index 03ec7cfb0..803ec9a2c 100644
--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -65,6 +65,7 @@ tags: {  # <amp-autocomplete>
   }
   attrs: { name: "highlight-user-entry" }
   attrs: { name: "template" }
+  attrs: { name: "items" }
   # amp-bind
   attrs: {
     name: "[src]"
diff --git a/extensions/amp-carousel/validator-amp-carousel.protoascii b/extensions/amp-carousel/validator-amp-carousel.protoascii
index 821c34fdb..b29a9b5e5 100644
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -17,7 +17,6 @@
 tags: {  # amp-carousel
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
@@ -30,6 +29,16 @@ tags: {  # amp-carousel
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-carousel for AMP4EMAIL
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-carousel] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-carousel"
+    version: "0.1"
+  }
+  attr_lists: "common-extension-attrs"
+}
 attr_lists: {
   name: "amp-carousel-common"
   attrs: {
diff --git a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
index 4ab0cde35..32e59aff9 100644
--- a/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
+++ b/extensions/amp-date-countdown/validator-amp-date-countdown.protoascii
@@ -64,9 +64,10 @@ tags: {  # <amp-date-countdown>
     name: "offset-seconds"
     value_regex: "-?\\d+"
   }
-  # TODO(gregable): Implement validation that requires the template attr value
-  # to reference the id of an existing template element.
-  attrs: { name: "template" }
+  attrs: {
+    name: "template"
+    value_oneof_set: TEMPLATE_IDS
+  }
   attrs: {
     name: "timeleft-ms"
     mandatory_oneof: "['end-date', 'timeleft-ms', 'timestamp-ms', 'timestamp-seconds']"
diff --git a/extensions/amp-date-display/validator-amp-date-display.protoascii b/extensions/amp-date-display/validator-amp-date-display.protoascii
index e7e1550bb..94db81ff2 100644
--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-date-display/validator-amp-date-display.protoascii
@@ -42,7 +42,10 @@ tags: {  # <amp-date-display>
     value_regex: "-?\\d+"
   }
   attrs: { name: "locale" }
-  attrs: { name: "template" }
+  attrs: {
+    name: "template"
+    value_oneof_set: TEMPLATE_IDS
+  }
   attrs: {
     name: "timestamp-ms"
     mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"
diff --git a/extensions/amp-list/validator-amp-list.protoascii b/extensions/amp-list/validator-amp-list.protoascii
index b5f35a026..f41c4446b 100644
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -64,6 +64,10 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     value: "refresh"
   }
   attrs: { name: "credentials" }
+  attrs: {
+    name: "diffable"
+    value: ""
+  }
   attrs: { name: "items" }
   attrs: {
     name: "load-more"
@@ -93,9 +97,10 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
-  # TODO(gregable): Implement validation that requires the template attr value
-  # to reference the id of an existing template element.
-  attrs: { name: "template" }
+  attrs: {
+    name: "template"
+    value_oneof_set: TEMPLATE_IDS
+  }
   # <amp-bind>
   attrs: {
     name: "[is-layout-container]"
@@ -220,9 +225,10 @@ tags: {  # <amp-list>
     blacklisted_value_regex: "__amp_source_origin|"
         "{{|}}"    # Mustache is disallowed in src.
   }
-  # TODO(gregable): Implement validation that requires the template attr value
-  # to reference the id of an existing template element.
-  attrs: { name: "template" }
+  attrs: {
+    name: "template"
+    value_oneof_set: TEMPLATE_IDS
+  }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL
diff --git a/extensions/amp-megaphone/validator-amp-megaphone.protoascii b/extensions/amp-megaphone/validator-amp-megaphone.protoascii
new file mode 100644
index 000000000..7f885a70c
--- /dev/null
+++ b/extensions/amp-megaphone/validator-amp-megaphone.protoascii
@@ -0,0 +1,92 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-megaphone
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-megaphone"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+
+attr_lists: {
+  name: "amp-megaphone-common"
+  attrs: {
+    name: "data-light"
+    value: ""
+  }
+  attrs: {
+    name: "data-sharing"
+    value: ""
+  }
+}
+
+tags: {  # <amp-megaphone> for playlists
+  html_format: AMP
+  tag_name: "AMP-MEGAPHONE"
+  requires_extension: "amp-megaphone"
+  spec_name: "amp-megaphone [data-playlist]"
+
+  attrs: {
+    name: "data-playlist"
+    mandatory: true
+    value_regex: "[A-Za-z0-9]+"
+    dispatch_key: NAME_DISPATCH
+  }
+
+  attrs: {
+    name: "data-episodes"
+    value_regex: "[0-9]+"
+  }
+
+  attr_lists: "amp-megaphone-common"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+  }
+}
+
+tags: {  # <amp-megaphone> for episodes
+  html_format: AMP
+  tag_name: "AMP-MEGAPHONE"
+  requires_extension: "amp-megaphone"
+  spec_name: "amp-megaphone [data-episode]"
+  attrs: {
+    name: "data-episode"
+    mandatory: true
+    value_regex: "[A-Za-z0-9]+"
+    dispatch_key: NAME_DISPATCH
+  }
+  attrs: {
+    name: "data-start"
+    value_regex: "\\d+(\\.\\d+)?"
+  }
+  attrs: {
+    name: "data-tile"
+    value: ""
+  }
+
+  attr_lists: "amp-megaphone-common"
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+  }
+}
diff --git a/extensions/amp-date-display/validator-amp-date-display.protoascii b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
similarity index 51%
copy from extensions/amp-date-display/validator-amp-date-display.protoascii
copy to extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
index e7e1550bb..9dbfa2e67 100644
--- a/extensions/amp-date-display/validator-amp-date-display.protoascii
+++ b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2018 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,52 +14,51 @@
 # limitations under the license.
 #
 
-tags: {  # amp-date-display
+tags: {  # amp-minute-media-player
   html_format: AMP
   tag_name: "SCRIPT"
   extension_spec: {
-    name: "amp-date-display"
+    name: "amp-minute-media-player"
     version: "0.1"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-date-display>
+tags: {  # <amp-minute-media-player>
   html_format: AMP
-  tag_name: "AMP-DATE-DISPLAY"
-  requires_extension: "amp-date-display"
+  tag_name: "AMP-MINUTE-MEDIA-PLAYER"
+  requires_extension: "amp-minute-media-player"
+  attrs: { name: "autoplay" }
   attrs: {
-    name: "datetime"
-    mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"
-    value_regex: "now|(\\d{4}-[01]\\d-[0-3]\\d(T[0-2]\\d:[0-5]\\d(:[0-6]\\d(\\.\\d\\d?\\d?)?)?(Z|[+-][0-1]\\d:[0-5]\\d)?)?)"
+    name: "dock"
+    requires_extension: "amp-video-docking"
   }
   attrs: {
-    name: "display-in"
-    value_casei: "utc"
+    name: "data-content-type"
+    mandatory: true
+    value: "curated"
+    value: "specific"
+    value: "semantic"
   }
+  attrs: { name: "data-content-id" }
+  attrs: { name: "data-scanned-element" }
   attrs: {
-    name: "offset-seconds"
-    value_regex: "-?\\d+"
-  }
-  attrs: { name: "locale" }
-  attrs: { name: "template" }
-  attrs: {
-    name: "timestamp-ms"
-    mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"
-    value_regex: "\\d+"
-  }
-  attrs: {
-    name: "timestamp-seconds"
-    mandatory_oneof: "['datetime', 'timestamp-ms', 'timestamp-seconds']"
-    value_regex: "\\d+"
+    name: "data-scanned-element-type"
+    value: "className"
+    value: "id"
+    value: "tag"
   }
+  attrs: { name: "data-tags" }
+  attrs: { name: "data-minimum-date-factor" }
+  attrs: { name: "data-scoped-keywords" }
+
   attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-minute-media-player"
   amp_layout: {
+    supported_layouts: RESPONSIVE
     supported_layouts: FILL
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
-    supported_layouts: NODISPLAY
-    supported_layouts: RESPONSIVE
   }
 }
diff --git a/extensions/amp-mustache/validator-amp-mustache.protoascii b/extensions/amp-mustache/validator-amp-mustache.protoascii
index 351872b1c..dc2acc1e5 100644
--- a/extensions/amp-mustache/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/validator-amp-mustache.protoascii
@@ -140,6 +140,131 @@ tags: {
   disallowed_ancestor: "FORM DIV [submitting][template]"
   disallowed_ancestor: "FORM DIV [verify-error][template]"
   requires_extension: "amp-mustache"
+  attrs: {
+    name: "id"
+    add_value_to_set: TEMPLATE_IDS
+    # When updating this blacklisted_value_regex, also update below, and in
+    # mandatory-id-attr and $GLOBAL_ATTRS in validator-main.protoascii.
+    blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "__amp_\\S*|"
+        "__count__|"
+        "__defineGetter__|"
+        "__defineSetter__|"
+        "__lookupGetter__|"
+        "__lookupSetter__|"
+        "__noSuchMethod__|"
+        "__parent__|"
+        "__proto__|"
+        "__AMP_\\S*|"
+        "\\$p|"
+        "\\$proxy|"
+        "acceptCharset|"
+        "addEventListener|"
+        "appendChild|"
+        "assignedSlot|"
+        "attachShadow|"
+        "AMP|"
+        "baseURI|"
+        "checkValidity|"
+        "childElementCount|"
+        "childNodes|"
+        "classList|"
+        "className|"
+        "clientHeight|"
+        "clientLeft|"
+        "clientTop|"
+        "clientWidth|"
+        "compareDocumentPosition|"
+        "computedName|"
+        "computedRole|"
+        "contentEditable|"
+        "createShadowRoot|"
+        "enqueAction|"
+        "firstChild|"
+        "firstElementChild|"
+        "getAnimations|"
+        "getAttribute|"
+        "getAttributeNS|"
+        "getAttributeNode|"
+        "getAttributeNodeNS|"
+        "getBoundingClientRect|"
+        "getClientRects|"
+        "getDestinationInsertionPoints|"
+        "getElementsByClassName|"
+        "getElementsByTagName|"
+        "getElementsByTagNameNS|"
+        "getRootNode|"
+        "hasAttribute|"
+        "hasAttributeNS|"
+        "hasAttributes|"
+        "hasChildNodes|"
+        "hasPointerCapture|"
+        "i-amphtml-\\S*|"
+        "innerHTML|"
+        "innerText|"
+        "inputMode|"
+        "insertAdjacentElement|"
+        "insertAdjacentHTML|"
+        "insertAdjacentText|"
+        "isContentEditable|"
+        "isDefaultNamespace|"
+        "isEqualNode|"
+        "isSameNode|"
+        "lastChild|"
+        "lastElementChild|"
+        "lookupNamespaceURI|"
+        "namespaceURI|"
+        "nextElementSibling|"
+        "nextSibling|"
+        "nodeName|"
+        "nodeType|"
+        "nodeValue|"
+        "offsetHeight|"
+        "offsetLeft|"
+        "offsetParent|"
+        "offsetTop|"
+        "offsetWidth|"
+        "outerHTML|"
+        "outerText|"
+        "ownerDocument|"
+        "parentElement|"
+        "parentNode|"
+        "previousElementSibling|"
+        "previousSibling|"
+        "querySelector|"
+        "querySelectorAll|"
+        "releasePointerCapture|"
+        "removeAttribute|"
+        "removeAttributeNS|"
+        "removeAttributeNode|"
+        "removeChild|"
+        "removeEventListener|"
+        "replaceChild|"
+        "reportValidity|"
+        "requestPointerLock|"
+        "scrollHeight|"
+        "scrollIntoView|"
+        "scrollIntoViewIfNeeded|"
+        "scrollLeft|"
+        "scrollWidth|"
+        "setAttribute|"
+        "setAttributeNS|"
+        "setAttributeNode|"
+        "setAttributeNodeNS|"
+        "setPointerCapture|"
+        "shadowRoot|"
+        "styleMap|"
+        "tabIndex|"
+        "tagName|"
+        "textContent|"
+        "toString|"
+        "valueOf|"
+        "(webkit|ms|moz|o)dropzone|"
+        "(webkit|moz|ms|o)MatchesSelector|"
+        "(webkit|moz|ms|o)RequestFullScreen|"
+        "(webkit|moz|ms|o)RequestFullscreen"
+        ")(\\s|$)"
+  }
   attrs: {
     name: "type"
     mandatory: true
@@ -167,6 +292,131 @@ tags: {
   # AMP4EMAIL addition.
   disallowed_ancestor: "FORM DIV [submitting]"
   requires_extension: "amp-mustache"
+  attrs: {
+    name: "id"
+    add_value_to_set: TEMPLATE_IDS
+    # When updating this blacklisted_value_regex, also update above, and in
+    # mandatory-id-attr and $GLOBAL_ATTRS in validator-main.protoascii.
+    blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "__amp_\\S*|"
+        "__count__|"
+        "__defineGetter__|"
+        "__defineSetter__|"
+        "__lookupGetter__|"
+        "__lookupSetter__|"
+        "__noSuchMethod__|"
+        "__parent__|"
+        "__proto__|"
+        "__AMP_\\S*|"
+        "\\$p|"
+        "\\$proxy|"
+        "acceptCharset|"
+        "addEventListener|"
+        "appendChild|"
+        "assignedSlot|"
+        "attachShadow|"
+        "AMP|"
+        "baseURI|"
+        "checkValidity|"
+        "childElementCount|"
+        "childNodes|"
+        "classList|"
+        "className|"
+        "clientHeight|"
+        "clientLeft|"
+        "clientTop|"
+        "clientWidth|"
+        "compareDocumentPosition|"
+        "computedName|"
+        "computedRole|"
+        "contentEditable|"
+        "createShadowRoot|"
+        "enqueAction|"
+        "firstChild|"
+        "firstElementChild|"
+        "getAnimations|"
+        "getAttribute|"
+        "getAttributeNS|"
+        "getAttributeNode|"
+        "getAttributeNodeNS|"
+        "getBoundingClientRect|"
+        "getClientRects|"
+        "getDestinationInsertionPoints|"
+        "getElementsByClassName|"
+        "getElementsByTagName|"
+        "getElementsByTagNameNS|"
+        "getRootNode|"
+        "hasAttribute|"
+        "hasAttributeNS|"
+        "hasAttributes|"
+        "hasChildNodes|"
+        "hasPointerCapture|"
+        "i-amphtml-\\S*|"
+        "innerHTML|"
+        "innerText|"
+        "inputMode|"
+        "insertAdjacentElement|"
+        "insertAdjacentHTML|"
+        "insertAdjacentText|"
+        "isContentEditable|"
+        "isDefaultNamespace|"
+        "isEqualNode|"
+        "isSameNode|"
+        "lastChild|"
+        "lastElementChild|"
+        "lookupNamespaceURI|"
+        "namespaceURI|"
+        "nextElementSibling|"
+        "nextSibling|"
+        "nodeName|"
+        "nodeType|"
+        "nodeValue|"
+        "offsetHeight|"
+        "offsetLeft|"
+        "offsetParent|"
+        "offsetTop|"
+        "offsetWidth|"
+        "outerHTML|"
+        "outerText|"
+        "ownerDocument|"
+        "parentElement|"
+        "parentNode|"
+        "previousElementSibling|"
+        "previousSibling|"
+        "querySelector|"
+        "querySelectorAll|"
+        "releasePointerCapture|"
+        "removeAttribute|"
+        "removeAttributeNS|"
+        "removeAttributeNode|"
+        "removeChild|"
+        "removeEventListener|"
+        "replaceChild|"
+        "reportValidity|"
+        "requestPointerLock|"
+        "scrollHeight|"
+        "scrollIntoView|"
+        "scrollIntoViewIfNeeded|"
+        "scrollLeft|"
+        "scrollWidth|"
+        "setAttribute|"
+        "setAttributeNS|"
+        "setAttributeNode|"
+        "setAttributeNodeNS|"
+        "setPointerCapture|"
+        "shadowRoot|"
+        "styleMap|"
+        "tabIndex|"
+        "tagName|"
+        "textContent|"
+        "toString|"
+        "valueOf|"
+        "(webkit|ms|moz|o)dropzone|"
+        "(webkit|moz|ms|o)MatchesSelector|"
+        "(webkit|moz|ms|o)RequestFullScreen|"
+        "(webkit|moz|ms|o)RequestFullscreen"
+        ")(\\s|$)"
+  }
   attrs: {
     name: "type"
     mandatory: true
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index 7e7c62f01..bf05ad10c 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -62,11 +62,11 @@ tags: {  # <amp-script>
   attrs: { name: "sandbox" }
   attrs: {
     name: "script"
-    mandatory_anyof: "['script', 'src']"
+    mandatory_oneof: "['script', 'src']"
   }
   attrs: {
     name: "src"
-    mandatory_anyof: "['script', 'src']"
+    mandatory_oneof: "['script', 'src']"
     value_url: {
       protocol: "https"
       allow_relative: false
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index afc738f2f..d798ffdac 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -804,6 +804,7 @@ descendant_tag_list {
   tag: "AMP-LIVE-LIST"
   tag: "AMP-LIVE-LIST"
   tag: "AMP-MATHML"
+  tag: "AMP-MEGAPHONE"
   tag: "AMP-MOWPLAYER"
   tag: "AMP-NEXXTV-PLAYER"
   tag: "AMP-O2-PLAYER"
diff --git a/extensions/amp-viewer-gpay-button/validator-amp-viewer-gpay-button.protoascii b/extensions/amp-viewer-gpay-button/validator-amp-viewer-gpay-button.protoascii
new file mode 100644
index 000000000..0dd3de865
--- /dev/null
+++ b/extensions/amp-viewer-gpay-button/validator-amp-viewer-gpay-button.protoascii
@@ -0,0 +1,36 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+# tags: {  # amp-viewer-gpay-button
+#  html_format: AMP
+#  tag_name: "SCRIPT"
+#  extension_spec: {
+#    name: "amp-viewer-gpay-button"
+#    version: "0.1"
+#    version: "latest"
+#  }
+#  attr_lists: "common-extension-attrs"
+#}
+#tags: {  # <amp-viewer-gpay-button>
+#  html_format: AMP
+#  tag_name: "AMP-VIEWER-GPAY-BUTTON"
+#  requires_extension: "amp-viewer-gpay-button"
+#  attr_lists: "extended-amp-global"
+#  spec_url: "https://amp.dev/documentation/components/amp-viewer-gpay-button"
+#  amp_layout: {
+#    supported_layouts: RESPONSIVE
+#  }
+#}
diff --git a/extensions/amp-viewer-gpay-inline/validator-amp-viewer-gpay-inline.protoascii b/extensions/amp-viewer-gpay-inline/validator-amp-viewer-gpay-inline.protoascii
new file mode 100644
index 000000000..40036bcdb
--- /dev/null
+++ b/extensions/amp-viewer-gpay-inline/validator-amp-viewer-gpay-inline.protoascii
@@ -0,0 +1,36 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+#tags: {  # amp-viewer-gpay-inline
+#  html_format: AMP
+#  tag_name: "SCRIPT"
+#  extension_spec: {
+#    name: "amp-viewer-gpay-inline"
+#    version: "0.1"
+#    version: "latest"
+#  }
+#  attr_lists: "common-extension-attrs"
+#}
+#tags: {  # <amp-viewer-gpay-inline>
+#  html_format: AMP
+#  tag_name: "AMP-VIEWER-GPAY-INLINE"
+#  requires_extension: "amp-viewer-gpay-inline"
+#  attr_lists: "extended-amp-global"
+#  spec_url: "https://amp.dev/documentation/components/amp-viewer-gpay-inline"
+#  amp_layout: {
+#    supported_layouts: RESPONSIVE
+#  }
+#}
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index aa86c144e..aaa099d82 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 935
+spec_file_revision: 957
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -310,6 +310,7 @@ tags: {
   spec_name: "link rel=stylesheet for fonts"
   named_id: LINK_FONT_STYLESHEET
   mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
   attrs: { name: "async" }
   attrs: { name: "crossorigin" }  # SRI attribute (https://www.w3.org/TR/SRI/)
   attrs: {
@@ -1115,6 +1116,40 @@ tags: {  # Special custom 'author' spreadsheet for AMP
   }
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#stylesheets"
 }
+# This variant of <style amp-custom> is designed to help developers see how
+# close they are to the byte limit, even if the page is passing. By changing
+# the attribute to <style amp-custom-length-check>, this tagspec will be used
+# to match errors. It cannot pass however as it has a cdata.max_bytes set to
+# -1. As a result, it will always fail and report the length found in the
+# tag's cdata. This is a small hack, and may be deleted in the future if there
+# are problems maintaining it. Deleting this tagspec will of course never
+# break any valid AMP documents as if it matches, the page will be invalid.
+tags: {
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: ACTIONS
+  disabled_by: "transformed"
+  tag_name: "STYLE"
+  spec_name: "style amp-custom-length-check"
+  unique: true
+  mandatory_parent: "HEAD"
+  attrs: {
+    name: "amp-custom-length-check"
+    mandatory: true
+    value: ""
+    dispatch_key: NAME_DISPATCH
+  }
+  attr_lists: "nonce-attr"
+  attrs: {  # This is a default, but it doesn't hurt.
+    name: "type"
+    value_casei: "text/css"
+  }
+  cdata: {
+    # This will always cause the tagspec matching to fail.
+    max_bytes: -1
+  }
+}
 # For transformed AMP non-data URLs are not counted against the total byte
 # limit for <style amp-custom>. This is done by setting url_bytes_included
 # to false for CdataSpec below.
@@ -1984,7 +2019,6 @@ tags: {
     name: "type"
     value_casei: "text/html"
   }
-  attr_lists: "name-attr"
 }
 
 # 4.5.2 The em element
@@ -2298,8 +2332,9 @@ tags: {
     mandatory: true
     value_url: {
       protocol: "data"
+      protocol: "http" # For parity with amp-img's mandatory-src-or-srcset.
       protocol: "https"
-      allow_relative: true  # Will be set to false at a future date.
+      allow_relative: true
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
@@ -6376,7 +6411,7 @@ attr_lists: {
   attrs: {
     name: "id"
     # When updating this blacklisted_value_regex, also update for
-    # mandatory-id-attr.
+    # mandatory-id-attr and validator-amp-mustache.protoascii.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
@@ -6874,6 +6909,10 @@ error_specificity {
   code: DOCUMENT_SIZE_LIMIT_EXCEEDED
   specificity: 120
 }
+error_specificity {
+  code: VALUE_SET_MISMATCH
+  specificity: 121
+}
 error_specificity {
   code: DEV_MODE_ONLY
   # This should always trump any other error. It is asserting
@@ -7346,8 +7385,13 @@ error_formats {
   code: DOCUMENT_SIZE_LIMIT_EXCEEDED
   format: "Document exceeded %1 bytes limit. Actual size %2 bytes."
 }
+error_formats {
+  code: VALUE_SET_MISMATCH
+  format: "Attribute '%1' in tag '%2' contains a value that does not match any "
+          "other tags on the page."
+}
 error_formats {
   code: DEV_MODE_ONLY
-  format: "Tag 'html' marked with attribute 'ampdevmode'. Validator "
+  format: "Tag 'html' marked with attribute 'data-ampdevmode'. Validator "
           "will suppress errors regarding any other tag with this attribute."
 }
```
</details>