### PR TITLE
Fix aria-label adding helper function

### DIFF
--- a/assets/src/stories-editor/helpers/index.js
+++ b/assets/src/stories-editor/helpers/index.js
@@ -1781,34 +1781,37 @@ export const processMedia = ( media ) => {
  * @return {ReactElement}  New React element
  */
 export const addVideoAriaLabel = ( element, { name }, attributes ) => {
-	// this filter only applies to core video objects where an aria label has been set
-	if ( name !== 'core/video' || ! attributes.ampAriaLabel ) {
+	// this filter only applies to core video objects (which always has children) where an aria label has been set
+	if ( name !== 'core/video' || ! element.props.children || ! attributes.ampAriaLabel ) {
 		return element;
 	}
 
 	/* `element` will be a react structure like:
 
 	<figure>
-		<amp-video>
+		<amp-video|video>
 			Fallback content
-		</amp-video>
+		</amp-video|video>
 		[<figcaption>Caption</figcaption>]
 	</figure>
 
+	The video element can be either an `<amp-video>`` or a regular `<video>`.
+
 	`<figcaption>` is not necessarily present.
 
-	We need to hook into this element and add an `aria-label` on the `<amp-video>` element.
+	We need to hook into this element and add an `aria-label` on the `<amp-video|video>` element.
 	*/
 
 	const isFigure = element.type === 'figure';
-	const hasAtLeastOneChild = element.props && element.props.children.length >= 1;
-	const isFirstChildAmpVideo = element.props && element.props.children[ 0 ] && element.props.children[ 0 ].type === 'amp-video';
-	if ( ! isFigure || ! hasAtLeastOneChild || ! isFirstChildAmpVideo ) {
+	const childNodes = Array.isArray( element.props.children ) ? element.props.children : [ element.props.children ];
+	const videoTypes = [ 'amp-video', 'video' ];
+	const isFirstChildVideoType = videoTypes.includes( childNodes[ 0 ].type );
+	if ( ! isFigure || ! isFirstChildVideoType ) {
 		return element;
 	}
 
 	const figure = element;
-	const [ video, ...rest ] = figure.props.children;
+	const [ video, ...rest ] = childNodes;
 
 	const newVideo = cloneElement(
 		video,

--- a/assets/src/stories-editor/helpers/test/__snapshots__/addVideoAriaLabel.js.snap
+++ b/assets/src/stories-editor/helpers/test/__snapshots__/addVideoAriaLabel.js.snap
@@ -1,19 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`addVideoAriaLabel adds an aria label to video content with a caption 1`] = `
-<figure>
-  <amp-video
-    aria-label="Aria label 2"
-  >
-    Fallback content
-  </amp-video>
-  <figcaption>
-    My video caption
-  </figcaption>
-</figure>
-`;
-
-exports[`addVideoAriaLabel adds an aria label to video content without a caption 1`] = `
+exports[`addVideoAriaLabel adds an aria label to amp-video content 1`] = `
 <figure>
   <amp-video
     aria-label="Aria label 1"
@@ -23,13 +10,47 @@ exports[`addVideoAriaLabel adds an aria label to video content without a caption
 </figure>
 `;
 
+exports[`addVideoAriaLabel adds an aria label to video content 1`] = `
+<figure>
+  <video
+    aria-label="Aria label 1"
+  >
+    Fallback content
+  </video>
+</figure>
+`;
+
+exports[`addVideoAriaLabel adds an aria label to video content with a caption 1`] = `
+<figure>
+  <video
+    aria-label="Aria label 2"
+  >
+    Fallback content
+  </video>
+  <figcaption>
+    Caption below content
+  </figcaption>
+</figure>
+`;
+
 exports[`addVideoAriaLabel ignores arbitrary content 1`] = `
 <div>
   Ignore me
 </div>
 `;
 
-exports[`addVideoAriaLabel ignores video content even with an aria label attribute if content does not have the right format 1`] = `
+exports[`addVideoAriaLabel ignores video content if content has incorrect node order 1`] = `
+<figure>
+  <figcaption>
+    Caption above content
+  </figcaption>
+  <video>
+    Fallback content
+  </video>
+</figure>
+`;
+
+exports[`addVideoAriaLabel ignores video content if content is not a figure object 1`] = `
 <div>
   Ignore me 3
 </div>

--- a/assets/src/stories-editor/helpers/test/addVideoAriaLabel.js
+++ b/assets/src/stories-editor/helpers/test/addVideoAriaLabel.js
@@ -3,15 +3,6 @@
  */
 import { addVideoAriaLabel } from '../';
 
-const getFigure = ( caption ) => (
-	<figure>
-		<amp-video>
-			Fallback content
-		</amp-video>
-		{ caption && <figcaption>{ caption }</figcaption> }
-	</figure>
-);
-
 describe( 'addVideoAriaLabel', () => {
 	it( 'ignores arbitrary content', () => {
 		const result = addVideoAriaLabel(
@@ -33,7 +24,7 @@ describe( 'addVideoAriaLabel', () => {
 		expect( result ).toMatchSnapshot();
 	} );
 
-	it( 'ignores video content even with an aria label attribute if content does not have the right format', () => {
+	it( 'ignores video content if content is not a figure object', () => {
 		const result = addVideoAriaLabel(
 			<div>Ignore me 3</div>,
 			{ name: 'core/video' },
@@ -43,9 +34,42 @@ describe( 'addVideoAriaLabel', () => {
 		expect( result ).toMatchSnapshot();
 	} );
 
-	it( 'adds an aria label to video content without a caption', () => {
+	it( 'ignores video content if content has incorrect node order', () => {
 		const result = addVideoAriaLabel(
-			getFigure(),
+			<figure>
+				<figcaption>Caption above content</figcaption>
+				<video>
+					Fallback content
+				</video>
+			</figure>,
+			{ name: 'core/video' },
+			{ ampAriaLabel: 'Ignored label' },
+		);
+
+		expect( result ).toMatchSnapshot();
+	} );
+
+	it( 'adds an aria label to video content', () => {
+		const result = addVideoAriaLabel(
+			<figure>
+				<video>
+					Fallback content
+				</video>
+			</figure>,
+			{ name: 'core/video' },
+			{ ampAriaLabel: 'Aria label 1' },
+		);
+
+		expect( result ).toMatchSnapshot();
+	} );
+
+	it( 'adds an aria label to amp-video content', () => {
+		const result = addVideoAriaLabel(
+			<figure>
+				<amp-video>
+					Fallback content
+				</amp-video>
+			</figure>,
 			{ name: 'core/video' },
 			{ ampAriaLabel: 'Aria label 1' },
 		);
@@ -55,7 +79,12 @@ describe( 'addVideoAriaLabel', () => {
 
 	it( 'adds an aria label to video content with a caption', () => {
 		const result = addVideoAriaLabel(
-			getFigure( 'My video caption' ),
+			<figure>
+				<video>
+					Fallback content
+				</video>
+				<figcaption>Caption below content</figcaption>
+			</figure>,
 			{ name: 'core/video' },
 			{ ampAriaLabel: 'Aria label 2' },
 		);


### PR DESCRIPTION
Fixes #3186.

This function can be invoked with both `<video>` and `<amp-video>` content, both must work.

Also, fetching child nodes is tricky if there's only one child, this has been fixed too.