### PR TITLE
Add rel=preconnect link for AMP CDN

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1549,15 +1549,29 @@ class AMP_Theme_Support {
 			$head->appendChild( $script );
 		}
 
-		// Ensure rel=canonical link.
-		$links         = [];
+		// Gather all links.
+		$links         = [
+			'preconnect' => [
+				// Include preconnect link for AMP CDN for browsers that don't support preload.
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'rel'  => 'preconnect',
+						'href' => 'https://cdn.ampproject.org',
+					]
+				),
+			],
+		];
 		$link_elements = $head->getElementsByTagName( 'link' );
-		$rel_canonical = null;
 		foreach ( $link_elements as $link ) {
 			if ( $link->hasAttribute( 'rel' ) ) {
 				$links[ $link->getAttribute( 'rel' ) ][] = $link;
 			}
 		}
+
+		// Ensure rel=canonical link.
+		$rel_canonical = null;
 		if ( empty( $links['canonical'] ) ) {
 			$rel_canonical = AMP_DOM_Utils::create_node(
 				$dom,

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1590,6 +1590,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			'<meta name="viewport" content="width=device-width">',
 			'<meta name="generator" content="AMP Plugin',
 			'<title>',
+			'<link rel="preconnect" href="https://cdn.ampproject.org">',
 			'<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">',
 			'<link rel="dns-prefetch" href="//cdn.ampproject.org">',
 			'<link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">',


### PR DESCRIPTION
In a [support topic](https://wordpress.org/support/topic/add-google-font-in-the-footer/#post-11937934) I found out that Lighthouse audits are flagging the lack of `rel=preconnect` links for https://cdn.ampproject.org:

> ![image](https://user-images.githubusercontent.com/134745/64988195-c3dd0980-d87f-11e9-9c93-82c67c8af6f0.png)

This currently is not part of the [AMP optimization guide](https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp/), and I thought it was unnecessary because there is already more-specific `preload` links, like:

```html
<link rel="preload" as="script" href="https://cdn.ampproject.org/v0.js">
```

I checked with @sebastianbenz and he pointed out that not all browsers support `rel=preload`, so adding a `rel=preconnect` link would be a good thing to do.