### PR TITLE
Use template_dir consistently as signal for Transitional mode

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -318,7 +318,8 @@ class AMP_Theme_Support {
 				);
 			}
 
-			$is_paired = ! empty( $args[ self::PAIRED_FLAG ] );
+			// See amp_is_canonical().
+			$is_paired = isset( $args[ self::PAIRED_FLAG ] ) ? $args[ self::PAIRED_FLAG ] : ! empty( $args['template_dir'] );
 
 			self::$support_added_via_theme  = $is_paired ? self::TRANSITIONAL_MODE_SLUG : self::STANDARD_MODE_SLUG;
 			self::$support_added_via_option = $theme_support_option;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -126,9 +126,8 @@ class AMP_Options_Manager {
 
 		$defaults['enable_response_caching'] = wp_using_ext_object_cache();
 
-		$args = AMP_Theme_Support::get_theme_support_args();
-		if ( false !== $args ) {
-			$defaults['theme_support'] = empty( $args[ AMP_Theme_Support::PAIRED_FLAG ] ) ? AMP_Theme_Support::STANDARD_MODE_SLUG : AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
+		if ( current_theme_supports( 'amp' ) ) {
+			$defaults['theme_support'] = amp_is_canonical() ? AMP_Theme_Support::STANDARD_MODE_SLUG : AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
 		}
 
 		$options = array_merge( $defaults, $options );

--- a/tests/php/test-amp.php
+++ b/tests/php/test-amp.php
@@ -19,48 +19,79 @@ class Test_AMP extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Get data for test_amp_is_canonical.
+	 *
+	 * @return array
+	 */
+	public function get_amp_is_canonical_test_data() {
+		return [
+			'default'                     => [
+				null,
+				false,
+				null,
+			],
+			'no_args'                     => [
+				[],
+				true,
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+			],
+			'paired_implied'              => [
+				[
+					'template_dir' => 'amp-templates',
+				],
+				false,
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+			],
+			'paired_with_template_dir'    => [
+				[
+					AMP_Theme_Support::PAIRED_FLAG => true,
+					'template_dir'                 => 'amp-templates',
+				],
+				false,
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+			],
+			'canonical_with_template_dir' => [
+				[
+					// This should be a rare scenario, as standard mode should mean no separate templates.
+					AMP_Theme_Support::PAIRED_FLAG => false,
+					'template_dir'                 => 'amp-templates',
+				],
+				true,
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+			],
+			'paired_without_template_dir' => [
+				[
+					AMP_Theme_Support::PAIRED_FLAG => true,
+				],
+				false,
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+			],
+		];
+	}
+
+	/**
 	 * Test amp_is_canonical().
 	 *
+	 * @dataProvider get_amp_is_canonical_test_data
 	 * @covers ::amp_is_canonical()
+	 * @covers AMP_Theme_Support::get_support_mode_added_via_theme()
+	 * @covers AMP_Theme_Support::read_theme_support()
+	 * @param mixed  $theme_support_args Theme support args.
+	 * @param bool   $is_canonical       Whether canonical.
+	 * @param string $expected_mode      Expected mode.
 	 */
-	public function test_amp_is_canonical() {
+	public function test_amp_is_canonical( $theme_support_args, $is_canonical, $expected_mode ) {
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertFalse( amp_is_canonical() );
-
-		add_theme_support( AMP_Theme_Support::SLUG );
-		$this->assertTrue( amp_is_canonical() );
-
-		add_theme_support(
-			AMP_Theme_Support::SLUG,
-			[
-				'template_dir' => 'amp-templates',
-			]
-		);
-		$this->assertFalse( amp_is_canonical() );
-
-		add_theme_support(
-			AMP_Theme_Support::SLUG,
-			[
-				AMP_Theme_Support::PAIRED_FLAG => false,
-				'template_dir'                 => 'amp-templates',
-			]
-		);
-		$this->assertTrue( amp_is_canonical() );
-
-		add_theme_support(
-			AMP_Theme_Support::SLUG,
-			[
-				AMP_Theme_Support::PAIRED_FLAG => true,
-			]
-		);
-		$this->assertFalse( amp_is_canonical() );
-
-		add_theme_support(
-			AMP_Theme_Support::SLUG,
-			[
-				'custom_prop' => 'something',
-			]
-		);
-		$this->assertTrue( amp_is_canonical() );
+		delete_option( AMP_Options_Manager::OPTION_NAME );
+		if ( isset( $theme_support_args ) ) {
+			if ( is_array( $theme_support_args ) ) {
+				add_theme_support( AMP_Theme_Support::SLUG, $theme_support_args );
+			} else {
+				add_theme_support( AMP_Theme_Support::SLUG );
+			}
+		}
+		AMP_Theme_Support::read_theme_support();
+		$this->assertSame( $expected_mode, AMP_Theme_Support::get_support_mode_added_via_theme() );
+		$this->assertSame( $is_canonical, amp_is_canonical() );
 	}
 }

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -269,6 +269,95 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		}
 	}
 
+
+	public function get_test_get_options_defaults_data() {
+		return [
+			'reader'                               => [
+				null,
+				AMP_Theme_Support::READER_MODE_SLUG,
+			],
+			'transitional_without_template_dir'    => [
+				[
+					'paired' => true,
+				],
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+			],
+			'transitional_implied_by_template_dir' => [
+				[
+					'template_dir' => 'amp',
+				],
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+			],
+			'standard_paired_false'                => [
+				[
+					'paired' => false,
+				],
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+			],
+			'standard_paired_false'                => [
+				[
+					'paired' => false,
+				],
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+			],
+			'standard_no_args'                     => [
+				[],
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+			],
+			'standard_via_native'                  => [
+				null,
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+				[
+					'theme_support' => 'native',
+				],
+			],
+			'standard_via_native'                  => [
+				null,
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+				[
+					'theme_support' => 'paired',
+				],
+			],
+			'standard_upon_upgrade'                => [
+				[
+					'paired' => false,
+				],
+				AMP_Theme_Support::STANDARD_MODE_SLUG,
+				[
+					'theme_support' => 'disabled',
+				],
+			],
+			'transitional_upon_upgrade'            => [
+				[
+					'paired' => true,
+				],
+				AMP_Theme_Support::TRANSITIONAL_MODE_SLUG,
+				[
+					'theme_support' => 'disabled',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Test get_options defaults.
+	 *
+	 * @dataProvider get_test_get_options_defaults_data
+	 * @covers AMP_Options_Manager::get_options()
+	 * @covers AMP_Options_Manager::get_option()
+	 *
+	 * @param array|null $args           Theme support args.
+	 * @param string     $expected_mode  Expected mode.
+	 * @param array      $initial_option Initial option in DB.
+	 */
+	public function test_get_options_theme_support_defaults( $args, $expected_mode, $initial_option = [] ) {
+		update_option( AMP_Options_Manager::OPTION_NAME, $initial_option );
+		if ( isset( $args ) ) {
+			add_theme_support( 'amp', $args );
+		}
+		$this->assertEquals( $expected_mode, AMP_Options_Manager::get_option( 'theme_support' ) );
+	}
+
 	/**
 	 * Test check_supported_post_type_update_errors.
 	 *


### PR DESCRIPTION
An issue reported by @archon810 was that if if a theme contains a theme support declaration like the following:

```php
add_theme_support( 'amp', [
	'template_dir' => 'amp',
] );
```

The theme support option in the admin will default to Standard when first activating the plugin, as opposed to the Transitional mode, which is what is implied by supplying `template_dir` without `paired`. This is shown in `amp_is_canonical()`:

https://github.com/ampproject/amp-wp/blob/93276f713e78abf546c1277ee34564a9c4bdd123/amp.php#L600-L601

The issue is that this same logic is not being used `AMP_Theme_Support::read_theme_support()`:

https://github.com/ampproject/amp-wp/blob/93276f713e78abf546c1277ee34564a9c4bdd123/includes/class-amp-theme-support.php#L321

This is something that was likely missed in #2550.

So this PR ensures that `AMP_Theme_Support::read_theme_support()` results in the same theme support being derived as is indicated by `amp_is_canonical()`.

To test this PR:

1. Add the above `add_theme_support()` to a theme's `functions.php`
2. Run `wp option delete amp-options`.
3. Load the AMP settings screen.
4. You should see Transitional as the selected mode as opposed to Standard.