### PR TITLE
Strip 100% width/height from layout=fill elements

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -284,12 +284,15 @@ abstract class AMP_Base_Sanitizer {
 				&& 0 === (int) $styles['left']
 				&& 0 === (int) $styles['bottom']
 				&& 0 === (int) $styles['right']
+				&& ( ! isset( $attributes['width'] ) || '100%' === $attributes['width'] )
+				&& ( ! isset( $attributes['height'] ) || '100%' === $attributes['height'] )
 			) {
 				unset( $attributes['style'], $styles['position'], $styles['top'], $styles['left'], $styles['bottom'], $styles['right'] );
 				if ( ! empty( $styles ) ) {
 					$attributes['style'] = $this->reassemble_style_string( $styles );
 				}
 				$attributes['layout'] = 'fill';
+				unset( $attributes['height'], $attributes['width'] );
 				return $attributes;
 			}
 

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -112,6 +112,17 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
+			'fill_100p_dimensions_and_absolute_position' => [
+				[
+					'style'  => 'position:absolute;top:0;left:0;right:0;bottom:0',
+					'width'  => '100%',
+					'height' => '100%',
+				],
+				[
+					'layout' => 'fill',
+				],
+			],
+
 			'fill_with_bottom_right_keeps_unrelated_styles' => [
 				[
 					'style' => 'position:absolute;background-color:white;top:0;left:0;right:0;bottom:0;color:red;',


### PR DESCRIPTION
Fixes #3277. Amends #3209.

It turns out that elements which are set to fill their container (`position: absolute; top: 0; right: 0; bottom: 0; left: 0;`) also sometimes redundantly set `width=100% height=100%`. After #3277 the `layout=fill` is set properly, but the dimensions come out incorrectly as: `width="640" height=""` (which leaks an AMP validation error to the frontend). This is in part due to https://github.com/ampproject/amp-wp/issues/2146 but we can avoid the problem in the first place by just removing the redundant `width=100% height=100%` attributes.

Given this input HTML:

```html
<div style="width: 100%; height: 500px; position: relative; overflow: hidden;">
    <iframe style="position: absolute; left: 0; right: 0; bottom: 0; top: 0; border: 0;" src="https://example.org/" width="100%" height="100%" frameborder="0"></iframe>
</div>

<div style="padding-top: 56.25%; position: relative;">
    <iframe style="position: absolute; top: 0; right: 0; bottom: 0; left: 0;" src="https://example.com/" scrolling="no" allowfullscreen="allowfullscreen" data-embed="true" width="100%" height="100%" frameborder="0"></iframe>
</div>
```

# Before

Notice the erroneous `width="640" height=""`:

```html
<div class="amp-wp-94ec1e2">
	<amp-iframe src="https://example.org/" width="640" height="" frameborder="0" style="" layout="fill" sandbox="allow-scripts allow-same-origin"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://example.org/" width="100%" height="100%" frameborder="0" class="amp-wp-fa1d77f"></iframe></noscript></amp-iframe>
</div>

<div class="amp-wp-293877e">
	<amp-iframe src="https://example.com/" scrolling="no" allowfullscreen="" data-embed="true" width="640" height="" frameborder="0" layout="fill" sandbox="allow-scripts allow-same-origin"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://example.com/" scrolling="no" width="100%" height="100%" frameborder="0" class="amp-wp-6d0e345"></iframe></noscript></amp-iframe>
</div>
```

# After

Notice `width="640" height=""` is removed:

```html
<div class="amp-wp-94ec1e2">
	<amp-iframe src="https://example.org/" frameborder="0" style="" layout="fill" sandbox="allow-scripts allow-same-origin"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://example.org/" width="100%" height="100%" frameborder="0" class="amp-wp-fa1d77f"></iframe></noscript></amp-iframe>
</div>

<div class="amp-wp-293877e">
	<amp-iframe src="https://example.com/" scrolling="no" allowfullscreen="" data-embed="true" frameborder="0" layout="fill" sandbox="allow-scripts allow-same-origin"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://example.com/" scrolling="no" width="100%" height="100%" frameborder="0" class="amp-wp-6d0e345"></iframe></noscript></amp-iframe>
</div>
```

----

Build for testing: [amp.zip](https://github.com/ampproject/amp-wp/files/3627789/amp.zip) - v1.3-beta1-20190918T181011Z-d7871424
