### PR TITLE
Bump 1.3-RC1 and fix tests

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -5,7 +5,7 @@
  * Plugin URI: https://amp-wp.org
  * Author: AMP Project Contributors
  * Author URI: https://github.com/ampproject/amp-wp/graphs/contributors
- * Version: 1.3-beta1
+ * Version: 1.3-RC1
  * Text Domain: amp
  * Domain Path: /languages/
  * License: GPLv2 or later
@@ -15,7 +15,7 @@
 
 define( 'AMP__FILE__', __FILE__ );
 define( 'AMP__DIR__', dirname( __FILE__ ) );
-define( 'AMP__VERSION', '1.3-beta1' );
+define( 'AMP__VERSION', '1.3-RC1' );
 
 /**
  * Errors encountered while loading the plugin.

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -1,12 +1,27 @@
 <?php
+/**
+ * Tests for gallery embed.
+ *
+ * @package AMP
+ */
 
+/**
+ * Class AMP_Gallery_Embed_Test
+ */
 class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 
 	/**
+	 * Replacements.
+	 *
 	 * @var array Associative array of string replacements to process.
 	 */
 	private $replacements = [];
 
+	/**
+	 * Get conversion data.
+	 *
+	 * @return array[]
+	 */
 	public function get_conversion_data() {
 		return [
 			'shortcode_with_invalid_id'               => [
@@ -101,7 +116,11 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test conversion.
+	 *
 	 * @dataProvider get_conversion_data
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
 	 */
 	public function test__conversion( $source, $expected ) {
 		$source_files = [
@@ -116,7 +135,6 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 		// collisions. So we write the tests in a way that they don't rely on
 		// this, and str-replace the dynamic portions into the expected and
 		// actual output after the fact.
-
 		$ids   = [];
 		$files = [];
 
@@ -182,6 +200,9 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 		// We start by turning multiple whitespaces into one space, as the default WP gallery code
 		// creates a mess with lots of spaces.
 		$content = trim( preg_replace( '/\s+/', ' ', $content ) );
+
+		// Normalize attribute quote style for 5.3-alpha.
+		$content = str_replace( '<style type=\'text/css\'>', '<style type="text/css">', $content );
 
 		// Then we go through all previously defined replacements.
 		return str_replace(

--- a/tests/php/test-class-amp-story-post-type.php
+++ b/tests/php/test-class-amp-story-post-type.php
@@ -791,7 +791,9 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * Test the definitions return value
 	 *
 	 * @dataProvider get_default_settings_definitions
-	 * @covers AMP_Story_Post_Type::get_stories_settings_meta_definitions
+	 * @covers AMP_Story_Post_Type::get_stories_settings_definitions()
+	 *
+	 * @param array $default_definitions Default definitions.
 	 */
 	public function test_get_stories_settings_meta_definitions( $default_definitions ) {
 		$definitions = AMP_Story_Post_Type::get_stories_settings_definitions();

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -234,7 +234,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	/**
 	 * Test supports_reader_mode.
 	 *
-	 * @covers \AMP_Theme_Support::supports_reader_mode.
+	 * @covers \AMP_Theme_Support::supports_reader_mode()
 	 */
 	public function test_supports_reader_mode() {
 		$themes_directory = 'themes';


### PR DESCRIPTION
Also fix phpunit `@covers` tags and `\AMP_Gallery_Embed_Test::test__conversion` failure in WordPress 5.3-alpha due to [r46164](https://core.trac.wordpress.org/changeset/46164).