### PR TITLE
Enhance contributing guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,48 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+## Bug Description
+
+<!-- Please describe clearly and concisely what the bug is. -->
+
+## Steps to reproduce
+
+<!-- Please provide detailed steps on how to reproduce the bug. -->
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Screenshots
+
+<!-- If applicable, please add screenshots to help explain your problem. -->
+
+## Additional Context
+
+<!-- Please complete the following information. -->
+ - PHP Version: 
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Plugin Version [e.g. 22]
+ - Device: [e.g. iPhone6]
+
+<!-- Please add any additional information about the bug. -->
+
+---------------
+
+_Do not alter or remove anything below. The following sections will be managed by moderators only._
+
+## Acceptance criteria
+
+* <!-- One or more bullet points for acceptance criteria. -->
+
+## Implementation Brief
+
+* <!-- One or more bullet points for how to technically resolve the issue. -->
+
+## Changelog entry
+
+* <!-- One sentence summarizing the PR, to be used in the changelog. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,9 +8,13 @@ about: Create a report to help us improve
 
 <!-- Please describe clearly and concisely what the bug is. -->
 
+## Expected Behaviour
+
+<!-- Please describe clearly and concisely what the expected behaviour should be. -->
+
 ## Steps to reproduce
 
-<!-- Please provide detailed steps on how to reproduce the bug. -->
+<!-- Please provide detailed steps on how to reproduce the bug. Provide a URL where the issue can be seen on the frontend when possible, otherwise go to “View source” in the browser and copy all to paste in a [Gist](https://gist.github.com/) and share it. -->
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -18,18 +22,21 @@ about: Create a report to help us improve
 
 ## Screenshots
 
-<!-- If applicable, please add screenshots to help explain your problem. -->
+<!-- If applicable, please add screenshots to help explain your problem. Bonus points for videos! -->
 
-## Additional Context
+## Additional context
 
 <!-- Please complete the following information. -->
- - PHP Version: 
+ - WordPress version:
+ - Gutenberg plugin version (of applicable):
+ - AMP plugin template mode:
+ - PHP version:
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
- - Plugin Version [e.g. 22]
+ - Plugin version [e.g. 22]
  - Device: [e.g. iPhone6]
 
-<!-- Please add any additional information about the bug. -->
+<!-- Please add any additional information about the bug. Ideal dumping your [Site Health](https://wordpress.org/support/wordpress-version/version-5-2/#site-health-check) information here as well. -->
 
 ---------------
 
@@ -39,10 +46,18 @@ _Do not alter or remove anything below. The following sections will be managed b
 
 * <!-- One or more bullet points for acceptance criteria. -->
 
-## Implementation Brief
+## Implementation brief
 
-* <!-- One or more bullet points for how to technically resolve the issue. -->
+* <!-- One or more bullet points for how to technically resolve the issue. For significant Implementation Design, it is ok use a Google document **accessible by anyone**. -->
+
+## QA testing instructions
+
+* <!-- One or more bullet points to describe how to test the implementation in QA. -->
 
 ## Changelog entry
 
 * <!-- One sentence summarizing the PR, to be used in the changelog. -->
+
+## Demo
+
+* <!-- A video or screenshots demoing the implementation. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,7 @@ about: Suggest an idea for this project
 
 ---
 
-## Feature Description
+## Feature description
 
 <!-- Please describe clear and concisely which problem the feature would solve or which publisher needs it would address. -->
 
@@ -16,10 +16,18 @@ _Do not alter or remove anything below. The following sections will be managed b
 
 * <!-- One or more bullet points for acceptance criteria. -->
 
-## Implementation Brief
+## Implementation brief
 
-* <!-- One or more bullet points for how to technically resolve the issue. -->
+* <!-- One or more bullet points for how to technically resolve the issue. For significant Implementation Design, it is ok use a Google document **accessible by anyone**. -->
+
+## QA testing instructions
+
+* <!-- One or more bullet points to describe how to test the implementation in QA. -->
 
 ## Changelog entry
 
 * <!-- One sentence summarizing the PR, to be used in the changelog. -->
+
+## Demo
+
+* <!-- A video or screenshots demoing the implementation. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+## Feature Description
+
+<!-- Please describe clear and concisely which problem the feature would solve or which publisher needs it would address. -->
+
+---------------
+
+_Do not alter or remove anything below. The following sections will be managed by moderators only._
+
+## Acceptance criteria
+
+* <!-- One or more bullet points for acceptance criteria. -->
+
+## Implementation Brief
+
+* <!-- One or more bullet points for how to technically resolve the issue. -->
+
+## Changelog entry
+
+* <!-- One sentence summarizing the PR, to be used in the changelog. -->

--- a/.github/ISSUE_TEMPLATE/help_request.md
+++ b/.github/ISSUE_TEMPLATE/help_request.md
@@ -1,0 +1,9 @@
+---
+name: Help Request
+about: Please post help requests or ‘how to’ questions in support forum
+
+---
+
+For general, technical and product help requests, please post it on the [AMP Plugin support forum](https://wordpress.org/support/plugin/amp/). Support will not be provided on GitHub.
+
+Thank you!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- Please reference the issue this PR addresses. -->
+Addresses issue #
+
+## Checklist
+
+- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
+- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
+- [ ] My code follows the [coding standards](https://github.com/ampproject/amp-wp/contributing/engineering.md#coding-standards).
+- [ ] My code has proper inline documentation.
+- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,4 @@ Addresses issue #
 
 - [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
 - [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
-- [ ] My code follows the [coding standards](https://github.com/ampproject/amp-wp/contributing/engineering.md#coding-standards).
-- [ ] My code has proper inline documentation.
-- [ ] I have signed the Contributor License Agreement (see <https://cla.developers.google.com/>).
+- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).

--- a/contributing.md
+++ b/contributing.md
@@ -1,384 +1,46 @@
-# AMP Contributing Guide
+# AMP contributing guide
 
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
+We'd love to accept your patches and contributions to this project and hope you'll become an ongoing participant in our open source community but we also welcome one-off contributions for the issues you're particularly passionate about.
 
-## Contributor License Agreement
+**How would you like to help?**
 
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution;
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
+* [Report a bug](#report-a-bug)
+* [Make a suggestion](#make-a-suggestion)
+* [Contribute code](#product-and-code-contributions)
 
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
+## Report a bug
 
-## Contributors List Policy
+[File an issue](https://github.com/ampproject/amp-wp/issues/new?template=bug_report.md) if you find a bug in the AMP Plugin. Providing details for each section predefined in the issue template is much appreciated!
+
+Project maintainers are regularly monitoring issues and aim to fix open bugs quickly.
+
+## Make a suggestion
+
+[File a "feature request" issue](https://github.com/ampproject/amp-wp/issues/new?template=feature_request.md) if you have a suggestion for a way to improve the AMP Plugin, or a request for a new feature.
+
+## Product and code contributions
+
+We'd love to have your help contributing code and features to the AMP Plugin! Head to the [Project Management guidelines](https://github.com/ampproject/amp-wp/contributing/project-management.md) as well as [Engineering guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) for details on the process you can use to contribute.
+
+## Contributor license agreement
+
+Contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project. Head over to https://cla.developers.google.com/ to see your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project), you probably don't need to do it again.
+
+## Contributors list policy
 
 The list of contributors who are featured on the WordPress.org plugin directory are subject to change over time. The organizations and individuals who contribute significantly and consistently (e.g. 3-month period) to the project are eligible to be listed. Those listed should generally be considered as those who take responsibility for the project (i.e. owners). Note that contributions include more than just code, though contributors who commit are [most visible](https://github.com/ampproject/amp-wp/graphs/contributors). The sort order of the contributors list should generally follow the sort order of the GitHub contributors page, though again, this order does not consider work in issues and the support forum, so it cannot be relied on solely.
 
-## Branches
-
-To include your changes in the next patch release (e.g. `1.0.x`), please base your branch off of the current release branch (e.g. `1.0`) and open your pull request back to that branch. If you open your pull request with the `develop` branch then it will be by default included in the next minor version (e.g. `1.x`).
-
-## Code Reviews
-
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
-
-## Community Guidelines
+## Community guidelines
 
 This project follows
 [Google's Open Source Community Guidelines](https://opensource.google.com/conduct/).
 
-## Security Disclosures
+## Security disclosures
 
 The AMP Project accepts responsible security disclosures through the [Google Application Security program](https://www.google.com/about/appsecurity/).
 
-## Code of Conduct
+## Code of conduct
 
-In addition to the Community Guidelines, this project follows
-an explicit [Code of Conduct](https://github.com/ampproject/amp-wp/blob/develop/code_of_conduct.md).
-
-## Getting Started
-
-### Requirements
-
-To contribute to this plugin, you need the following tools installed on your computer:
-
-* [Composer](https://getcomposer.org/) - to install PHP dependencies.
-* [Node.js](https://nodejs.org/en/) - to install JavaScript dependencies.
-* [WordPress](https://wordpress.org/download/) - to run the actual plugin.
-
-You should be running a Node version matching the [current active LTS release](https://github.com/nodejs/Release#release-schedule) or newer for this plugin to work correctly. You can check your Node.js version by typing node -v in the Terminal prompt.
-
-If you have an incompatible version of Node in your development environment, you can use [nvm](https://github.com/creationix/nvm) to change node versions on the command line:
-
-```bash
-nvm install
-```
-
-## Local Environment
-
-Since you need a WordPress environment to run the plugin in, the quickest way to get up and running is to use the provided Docker setup. Install [Docker](https://www.docker.com/products/docker-desktop) and [Docker Compose](https://docs.docker.com/compose/install/) by following the instructions on their website.
-
-You can then clone this project somewhere on your computer:
-
-```bash
-git clone git@github.com:ampproject/amp-wp.git amp
-cd amp
-```
-
-After that, run a script to set up the local environment. It will automatically verify whether Docker, Composer and Node.js are configured properly and start the local WordPress instance. You may need to run this script multiple times if prompted.
-
-```bash
-./bin/local-env/start.sh
-```
-
-If everything was successful, you'll see this on your screen:
-
-```
-Welcome to...
-
-MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-MMMMMMMMMMMMMMMMWNXK0OOkkkkOO0KXNWMMMMMMMMMMMMMMMM
-MMMMMMMMMMMMWX0kdlc:::::::::::ccodk0NWMMMMMMMMMMMM
-MMMMMMMMMWXOdl::::::::::::::::::::::lx0NMMMMMMMMMM
-MMMMMMMWKxl::::::::::::::::::::::::::::oOXWMMMMMMM
-MMMMMMXkl:::::::::::::::::col::::::::::::oONMMMMMM
-MMMMW0o:::::::::::::::::ox0Xk:::::::::::::cxXWMMMM
-MMMW0l:::::::::::::::::dKWWXd:::::::::::::::dXMMMM
-MMW0l::::::::::::::::cxXWMM0l::::::::::::::::dXMMM
-MMXd::::::::::::::::ckNMMMWkc::::::::::::::::ckWMM
-MWOc:::::::::::::::lONMMMMNkooool:::::::::::::oXMM
-MWk:::::::::::::::l0WMMMMMMWNWNNOc::::::::::::l0MM
-MNx::::::::::::::oKWMMMMMMMMMMW0l:::::::::::::cOWM
-MNx:::::::::::::oKWWWMMMMMMMMNOl::::::::::::::c0MM
-MWOc::::::::::::cddddxKWMMMMNkc:::::::::::::::oKMM
-MMXd:::::::::::::::::l0MMMMXdc:::::::::::::::ckWMM
-MMW0l::::::::::::::::dXMWWKd:::::::::::::::::oXMMM
-MMMWOl:::::::::::::::kWW0xo:::::::::::::::::oKWMMM
-MMMMW0l:::::::::::::l0NOl::::::::::::::::::dKWMMMM
-MMMMMWKdc:::::::::::cooc:::::::::::::::::lkNMMMMMM
-MMMMMMMN0dc::::::::::::::::::::::::::::lxKWMMMMMMM
-MMMMMMMMMWKxoc::::::::::::::::::::::coOXWMMMMMMMMM
-MMMMMMMMMMMWNKkdoc:::::::::::::cloxOKWMMMMMMMMMMMM
-MMMMMMMMMMMMMMMWNX0OkkxxxxxxkO0KXWWMMMMMMMMMMMMMMM
-MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
-```
-
-The WordPress installation should be available at http://localhost:8890 (**Username**: admin, **Password**: password).
-
-To later turn off the local environment, you can run:
-
-```bash
-npm run env:stop
-```
-
-To bring it back later, run:
-
-```bash
-npm run env:start
-```
-
-Also, if you need to reset the local environment's database, you can run:
-
-```bash
-npm run env:reset-site
-```
-
-### Custom Environment
-
-Alternatively, you can use your own local WordPress environment and clone this repository right into your `wp-content/plugins` directory.
-
-```bash
-cd wp-content/plugins && git clone git@github.com:ampproject/amp-wp.git amp
-```
-
-Then install the packages:
-
-```bash
-composer install
-npm install
-```
-
-And lastly, do a build of the JavaScript:
-
-```bash
-npm run build:js
-```
-
-Lastly, to get the plugin running in your WordPress install, run `composer install` and then activate the plugin via the WordPress dashboard or `wp plugin activate amp`.
-
-## Developing the Plugin
-
-Whether you use the pre-existing local environment or a custom one, any PHP code changes will be directly visible during development.
-
-However, for JavaScript this involves a build process. To watch for any JavaScript file changes and re-build it when needed, you can run the following command:
-
-```bash
-npm run dev
-```
-
-This way you will get a development build of the JavaScript, which makes debugging easier.
-
-To get a production build, run:
-
-```bash
-npm run build:js
-```
-
-### Updating Google Fonts list
-
-**Note:** A [Google Fonts API key](https://developers.google.com/fonts/docs/developer_api) is required to update the list of Google Fonts that is included in the plugin. Details of how to get an API key can be found on in the [Google fonts docs](https://developers.google.com/fonts/docs/developer_api).
-
-Once obtained, follow these steps to configure the project appropriately: 
-
-1. Copy `example.env` to `.env`.
-1. Replace `replacemewithrealkey` with API key.
-1. Run `npm run download-fonts`
-
-The fonts will then be downloaded to `includes/data/fonts.json`. 
-
-### Creating a Plugin Build
-
-To create a build of the plugin for installing in WordPress as a ZIP package, run:
-
-```bash
-npm run build
-```
-
-This will create an `amp.zip` in the plugin directory which you can install. The contents of this ZIP are also located in the `build` directory which you can `rsync` somewhere as well if needed.
-
-### Writing Tests
-
-#### PHP Unit Tests
-
-The AMP plugin uses the [PHPUnit](https://phpunit.de/) testing framework to write unit and integration tests for the PHP part.
-
-To run the full test suite, you can use the following command:
-
-```bash
-npm run test:php
-```
-
-You can also just run test for a specific function or class by using something like this:
-
-```bash
-npm run test:php -- --filter=AMP_Theme_Support
-```
-
-See `npm run test:php:help` to see all the possible options.
-
-#### JavaScript Unit Tests
-
-[Jest](https://jestjs.io/) is used as the JavaScript unit testing framework.
-
-To run the full test suite, you can use the following command:
-
-```bash
-npm run test:js
-```
-
-You can also watch for any file changes and only run tests that failed or have been modified:
-
-```bash
-npm run test:js:watch
-```
-
-See `npm run test:js:help` to get a list of additional options that can be passed to the test runner. 
-
-#### End-to-End Tests
-
-This project leverages the local Docker-based environment to facilitate end-to-end (e2e) testing using Puppeteer.
-
-To run the full test suite, you can use the following command:
-
-```bash
-npm run test:e2e
-```
-
-You can also watch for any file changes and only run tests that failed or have been modified:
-
-```bash
-npm run test:e2e:watch
-```
-
-Not using the built-in local environment? You can also pass any other URL to run the tests against. Example:
-
-```bash
-npm run test:e2e -- --wordpress-base-url=https://my-amp-dev-site.local
-```
-
-For debugging purposes, you can also run the E2E tests in non-headless mode:
-
-```bash
-npm run test:e2e:interactive
-```
-
-Note that this will also slow down all interactions during tests by 80ms. You can control these values individually too:
-
-```bash
-PUPPETEER_HEADLESS=false npm run test:e2e # Interactive mode, normal speed.
-PUPPETEER_SLOWMO=200 npm run test:e2e # Headless mode, slowed down by 200ms.
-```
-
-Sometimes one might want to test additional scenarios that aren't possible in a WordPress installation out of the box. That's why the test setup allows for for adding some utility plugins that can be activated during E2E tests.
-                                                                                                                                                       
-For example, such a plugin could create a custom post type and the accompanying E2E test would verify that block validation errors are shown for this custom post type too.
-
-These plugins can be added to `tests/e2e/plugins` and then activated via the WordPress admin.
-
-### Coding Standards
-
-All contributions to this project will be checked against [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) with PHPCS, and for JavaScript linting is done with ESLint.
-
-To verify your code meets the requirements, you can run `npm run lint`.
-
-You can also install a `pre-commit` hook by running `bash vendor/xwp/wp-dev-lib/scripts/install-pre-commit-hook.sh`. This way, your code will be checked automatically before committing any changes.
-
-## Updating Allowed Tags And Attributes
-
-The file `class-amp-allowed-tags-generated.php` has the AMP specification's allowed tags and attributes. It's used in sanitization.
-
-To update that file, perform the following steps:
-
-1. `cd` to the root of this plugin
-2. Run `./bin/amphtml-update.sh` (or `lando ssh -c './bin/amphtml-update.sh'` if using Lando).
-3. Review the diff.
-4. Update tests based on changes to the spec.
-5. Commit changes.
-
-This script is intended for a Linux environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV) or [Lando wordpressdev](https://github.com/felixarntz/wordpressdev).
-
-## Testing Media And Embed Support
-
-The following script creates a post in order to test support for WordPress media and embeds.
-To run it:
-1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
-2. `cd` to the root of this plugin
-3. run `wp eval-file bin/create-embed-test-post.php`
-4. go to the URL that is output in the command line
-
-## Testing Widgets Support
-
-The following script adds an instance of every default WordPress widget to the first registered sidebar.
-To run it:
-1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
-2. `cd` to the root of this plugin
-3. run `wp eval-file bin/add-test-widgets-to-sidebar.php`
-4. There will be a message indicating which sidebar has the widgets. Please visit a page with that sidebar.
-
-## Testing Comments Support
-
-The following script creates a post with comments in order to test support for WordPress comments.
-To run it:
-1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
-2. `cd` to the root of this plugin
-3. run `wp eval-file bin/create-comments-on-test-post.php`
-4. go to the URL that is output in the command line
-
-## Testing Gutenberg Block Support
-
-The following script creates a post with all core Gutenberg blocks. To run it:
-1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
-2. `cd` to the root of this plugin
-3. run `bash bin/create-gutenberge-test-post.sh`
-4. go to the URL that is output in the command line
-
-## Creating a Prerelease
-
-1. Create changelog draft on [Wiki page](https://github.com/ampproject/amp-wp/wiki/Release-Changelog-Draft).
-1. Check out the branch intended for release (`develop` for major, `x.y` for minor) and pull latest commits.
-1. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant).
-1. Do `npm install && composer selfupdate && composer install`.
-1. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
-1. [Draft new release](https://github.com/ampproject/amp-wp/releases/new) on GitHub targeting the required branch (`develop` for major, `x.y` for minor).
-    1. Use the new plugin version as the tag (e.g. `1.2-beta3` or `1.2.1-RC1`)
-    1. USe new version as the title, followed by some highlight tagline of the release.
-    1. Attach the `amp.zip` build to the release.
-    1. Add changelog entry to the release, link to compare view comparing previous release, and link to milestone.
-    1. Make sure “Pre-release” is checked.
-1. Publish GitHub release.
-1. Create built release tag (from the just-created `build` directory):
-    1. do `git fetch --tags && ./bin/tag-built.sh`
-    1. Add link from release notes.
-1. Make announcements on Twitter and the #amp-wp channel on AMP Slack, linking to release post or GitHub release.
-1. Bump version in release branch, e.g. `…-alpha` to `…-beta1` and `…-beta2` to `…-RC1`
-
-## Creating a Stable Release
-
-Contributors who want to make a new release, follow these steps:
-
-1. Create changelog draft on [Wiki page](https://github.com/ampproject/amp-wp/wiki/Release-Changelog-Draft).
-    1. Gather props list of the entire release, including contributors of code, design, testing, project management, etc.
-1. Update readme including the description, contributors, and screenshots.
-1. Draft release post.
-1. For major release, draft blog post about the new release.
-1. For minor releases, make sure all merged commits in `develop` have been also merged onto release branch.
-1. Check out the branch intended for release (`develop` for major, `x.y` for minor) and pull latest commits.
-1. Do `npm install && composer selfupdate && composer install`.
-1. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant). Verify via `npx grunt shell:verify_matching_versions`. Ensure patch version number is supplied for major releases, so `1.2-RC1` should bump to `1.2.0`.
-1. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
-1. Optionally do sanity check by comparing the `build` directory with the previously-deployed plugin on WordPress.org for example: `svn export https://plugins.svn.wordpress.org/amp/trunk /tmp/amp-trunk; diff /tmp/amp-trunk/ ./build/` (instead of straight `diff`, it's best to use a GUI like `idea diff`, `phpstorm diff`, or `opendiff`).
-1. [Draft new release](https://github.com/ampproject/amp-wp/releases/new) on GitHub targeting the required branch (`develop` for major, `x.y` for minor):
-    1. Use the new plugin version as the tag (e.g. `1.2.0` or `1.2.1`)
-    1. Attach the `amp.zip` build to the release.
-    1. Add changelog entry to the release, link to compare view comparing previous release, and link to milestone.
-1. Run `npm run deploy` to commit the plugin to WordPress.org.
-1. Confirm the release is available on WordPress.org; try installing it on a WordPress install and confirm it works.
-1. Publish GitHub release.
-1. Create built release tag (from the just-created `build` directory):
-    1. do `git fetch --tags && ./bin/tag-built.sh`
-    1. Add link from release notes.
-1. For new major releases, create a release branch from the tag. Patch versions are made from the release branch.
-1. For minor releases, bump `Stable tag` in the `readme.txt`/`readme.md` in `develop`. Cherry-pick other changes as necessary.
-1. Merge release tag into `master`.
-1. Close the GitHub milestone (and project).
-1. Publish release blog post (if applicable), including link to GitHub release.
-1. Make announcements on Twitter and the #amp-wp channel on AMP Slack, linking to release post or GitHub release.
-1. Bump version in release branch. After major release (e.g. `1.2.0`), bump to `1.3.0-alpha` on `develop`; after minor release (e.g. `1.2.1`) bump version to `1.2.2-alpha` on the release branch.
+In addition to the Community Guidelines, this project follows an explicit [Code of Conduct](https://github.com/ampproject/amp-wp/blob/develop/code_of_conduct.md).

--- a/contributing/engineering.md
+++ b/contributing/engineering.md
@@ -1,0 +1,388 @@
+# Engineering guidelines
+
+## Getting started
+
+### Requirements
+
+To contribute to this plugin, you need the following tools installed on your computer:
+
+* [Composer](https://getcomposer.org/) - to install PHP dependencies.
+* [Node.js](https://nodejs.org/en/) - to install JavaScript dependencies.
+* [WordPress](https://wordpress.org/download/) - to run the actual plugin.
+
+You should be running a Node version matching the [current active LTS release](https://github.com/nodejs/Release#release-schedule) or newer for this plugin to work correctly. You can check your Node.js version by typing node -v in the Terminal prompt.
+
+If you have an incompatible version of Node in your development environment, you can use [nvm](https://github.com/creationix/nvm) to change node versions on the command line:
+
+```bash
+nvm install
+```
+
+## Local environment
+
+Since you need a WordPress environment to run the plugin in, the quickest way to get up and running is to use the provided Docker setup. Install [Docker](https://www.docker.com/products/docker-desktop) and [Docker Compose](https://docs.docker.com/compose/install/) by following the instructions on their website.
+
+You can then clone this project somewhere on your computer:
+
+```bash
+git clone git@github.com:ampproject/amp-wp.git amp
+cd amp
+```
+
+After that, run a script to set up the local environment. It will automatically verify whether Docker, Composer and Node.js are configured properly and start the local WordPress instance. You may need to run this script multiple times if prompted.
+
+```bash
+./bin/local-env/start.sh
+```
+
+If everything was successful, you'll see this on your screen:
+
+```
+Welcome to...
+
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMWNXK0OOkkkkOO0KXNWMMMMMMMMMMMMMMMM
+MMMMMMMMMMMMWX0kdlc:::::::::::ccodk0NWMMMMMMMMMMMM
+MMMMMMMMMWXOdl::::::::::::::::::::::lx0NMMMMMMMMMM
+MMMMMMMWKxl::::::::::::::::::::::::::::oOXWMMMMMMM
+MMMMMMXkl:::::::::::::::::col::::::::::::oONMMMMMM
+MMMMW0o:::::::::::::::::ox0Xk:::::::::::::cxXWMMMM
+MMMW0l:::::::::::::::::dKWWXd:::::::::::::::dXMMMM
+MMW0l::::::::::::::::cxXWMM0l::::::::::::::::dXMMM
+MMXd::::::::::::::::ckNMMMWkc::::::::::::::::ckWMM
+MWOc:::::::::::::::lONMMMMNkooool:::::::::::::oXMM
+MWk:::::::::::::::l0WMMMMMMWNWNNOc::::::::::::l0MM
+MNx::::::::::::::oKWMMMMMMMMMMW0l:::::::::::::cOWM
+MNx:::::::::::::oKWWWMMMMMMMMNOl::::::::::::::c0MM
+MWOc::::::::::::cddddxKWMMMMNkc:::::::::::::::oKMM
+MMXd:::::::::::::::::l0MMMMXdc:::::::::::::::ckWMM
+MMW0l::::::::::::::::dXMWWKd:::::::::::::::::oXMMM
+MMMWOl:::::::::::::::kWW0xo:::::::::::::::::oKWMMM
+MMMMW0l:::::::::::::l0NOl::::::::::::::::::dKWMMMM
+MMMMMWKdc:::::::::::cooc:::::::::::::::::lkNMMMMMM
+MMMMMMMN0dc::::::::::::::::::::::::::::lxKWMMMMMMM
+MMMMMMMMMWKxoc::::::::::::::::::::::coOXWMMMMMMMMM
+MMMMMMMMMMMWNKkdoc:::::::::::::cloxOKWMMMMMMMMMMMM
+MMMMMMMMMMMMMMMWNX0OkkxxxxxxkO0KXWWMMMMMMMMMMMMMMM
+MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
+```
+
+The WordPress installation should be available at http://localhost:8890 (**Username**: admin, **Password**: password).
+
+To later turn off the local environment, you can run:
+
+```bash
+npm run env:stop
+```
+
+To bring it back later, run:
+
+```bash
+npm run env:start
+```
+
+Also, if you need to reset the local environment's database, you can run:
+
+```bash
+npm run env:reset-site
+```
+
+### Custom environment
+
+Alternatively, you can use your own local WordPress environment and clone this repository right into your `wp-content/plugins` directory.
+
+```bash
+cd wp-content/plugins && git clone git@github.com:ampproject/amp-wp.git amp
+```
+
+Then install the packages:
+
+```bash
+composer install
+npm install
+```
+
+And lastly, do a build of the JavaScript:
+
+```bash
+npm run build:js
+```
+
+Lastly, to get the plugin running in your WordPress install, run `composer install` and then activate the plugin via the WordPress dashboard or `wp plugin activate amp`.
+
+## Developing the plugin
+
+Whether you use the pre-existing local environment or a custom one, any PHP code changes will be directly visible during development.
+
+However, for JavaScript this involves a build process. To watch for any JavaScript file changes and re-build it when needed, you can run the following command:
+
+```bash
+npm run dev
+```
+
+This way you will get a development build of the JavaScript, which makes debugging easier.
+
+To get a production build, run:
+
+```bash
+npm run build:js
+```
+
+### Branches
+
+The branching strategy follows the [GitFlow schema](https://datasift.github.io/gitflow/IntroducingGitFlow.html); make sure to familiarize yourself with it.
+
+All branches are named with with the following pattern: `{type}`/`{issue_id}`-`{short_description}`
+
+*   `{type}` = issue Type label
+*   `{issue_id}` = issue ID
+*   `{short_description}` = short description of the PR
+
+To include your changes in the next patch release (e.g. `1.0.x`), please base your branch off of the current release branch (e.g. `1.0`) and open your pull request back to that branch. If you open your pull request with the `develop` branch then it will be by default included in the next minor version (e.g. `1.x`).
+
+### Code reviews
+
+All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://help.github.com/articles/about-pull-requests/) for more information on using pull requests.
+
+### Coding standards
+
+All contributions to this project will be checked against [WordPress-Coding-Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) with PHPCS, and for JavaScript linting is done with ESLint.
+
+To verify your code meets the requirements, you can run `npm run lint`.
+
+You can also install a `pre-commit` hook by running `bash vendor/xwp/wp-dev-lib/scripts/install-pre-commit-hook.sh`. This way, your code will be checked automatically before committing any changes.
+
+### Updating Google fonts list
+
+**Note:** A [Google Fonts API key](https://developers.google.com/fonts/docs/developer_api) is required to update the list of Google Fonts that is included in the plugin. Details of how to get an API key can be found on in the [Google fonts docs](https://developers.google.com/fonts/docs/developer_api).
+
+Once obtained, follow these steps to configure the project appropriately:
+
+1. Copy `example.env` to `.env`.
+1. Replace `replacemewithrealkey` with API key.
+1. Run `npm run download-fonts`
+
+The fonts will then be downloaded to `includes/data/fonts.json`.
+
+### Tests
+
+#### PHP Unit Tests
+
+The AMP plugin uses the [PHPUnit](https://phpunit.de/) testing framework to write unit and integration tests for the PHP part.
+
+To run the full test suite, you can use the following command:
+
+```bash
+npm run test:php
+```
+
+You can also just run test for a specific function or class by using something like this:
+
+```bash
+npm run test:php -- --filter=AMP_Theme_Support
+```
+
+See `npm run test:php:help` to see all the possible options.
+
+#### JavaScript Unit Tests
+
+[Jest](https://jestjs.io/) is used as the JavaScript unit testing framework.
+
+To run the full test suite, you can use the following command:
+
+```bash
+npm run test:js
+```
+
+You can also watch for any file changes and only run tests that failed or have been modified:
+
+```bash
+npm run test:js:watch
+```
+
+See `npm run test:js:help` to get a list of additional options that can be passed to the test runner.
+
+#### End-to-End Tests
+
+This project leverages the local Docker-based environment to facilitate end-to-end (e2e) testing using Puppeteer.
+
+To run the full test suite, you can use the following command:
+
+```bash
+npm run test:e2e
+```
+
+You can also watch for any file changes and only run tests that failed or have been modified:
+
+```bash
+npm run test:e2e:watch
+```
+
+Not using the built-in local environment? You can also pass any other URL to run the tests against. Example:
+
+```bash
+npm run test:e2e -- --wordpress-base-url=https://my-amp-dev-site.local
+```
+
+For debugging purposes, you can also run the E2E tests in non-headless mode:
+
+```bash
+npm run test:e2e:interactive
+```
+
+Note that this will also slow down all interactions during tests by 80ms. You can control these values individually too:
+
+```bash
+PUPPETEER_HEADLESS=false npm run test:e2e # Interactive mode, normal speed.
+PUPPETEER_SLOWMO=200 npm run test:e2e # Headless mode, slowed down by 200ms.
+```
+
+Sometimes one might want to test additional scenarios that aren't possible in a WordPress installation out of the box. That's why the test setup allows for for adding some utility plugins that can be activated during E2E tests.
+
+For example, such a plugin could create a custom post type and the accompanying E2E test would verify that block validation errors are shown for this custom post type too.
+
+These plugins can be added to `tests/e2e/plugins` and then activated via the WordPress admin.
+
+#### Testing media and embed support
+
+The following script creates a post in order to test support for WordPress media and embeds.
+To run it:
+1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+2. `cd` to the root of this plugin
+3. run `wp eval-file bin/create-embed-test-post.php`
+4. go to the URL that is output in the command line
+
+#### Testing widgets support
+
+The following script adds an instance of every default WordPress widget to the first registered sidebar.
+To run it:
+1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+2. `cd` to the root of this plugin
+3. run `wp eval-file bin/add-test-widgets-to-sidebar.php`
+4. There will be a message indicating which sidebar has the widgets. Please visit a page with that sidebar.
+
+#### Testing comments support
+
+The following script creates a post with comments in order to test support for WordPress comments.
+To run it:
+1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+2. `cd` to the root of this plugin
+3. run `wp eval-file bin/create-comments-on-test-post.php`
+4. go to the URL that is output in the command line
+
+#### Testing Gutenberg block support
+
+The following script creates a post with all core Gutenberg blocks. To run it:
+1. `ssh` into an environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV)
+2. `cd` to the root of this plugin
+3. run `bash bin/create-gutenberge-test-post.sh`
+4. go to the URL that is output in the command line
+
+## Updating allowed tags and attributes
+
+The file `class-amp-allowed-tags-generated.php` has the AMP specification's allowed tags and attributes. It's used in sanitization.
+
+To update that file, perform the following steps:
+
+1. `cd` to the root of this plugin
+2. Run `./bin/amphtml-update.sh` (or `lando ssh -c './bin/amphtml-update.sh'` if using Lando).
+3. Review the diff.
+4. Update tests based on changes to the spec.
+5. Commit changes.
+
+This script is intended for a Linux environment like [VVV](https://github.com/Varying-Vagrant-Vagrants/VVV) or [Lando wordpressdev](https://github.com/felixarntz/wordpressdev).
+
+
+## Creating a plugin build
+
+To create a build of the plugin for installing in WordPress as a ZIP package, run:
+
+```bash
+npm run build
+```
+
+This will create an `amp.zip` in the plugin directory which you can install. The contents of this ZIP are also located in the `build` directory which you can `rsync` somewhere as well if needed.
+
+## Creating a prerelease
+
+1. Create changelog draft on [Wiki page](https://github.com/ampproject/amp-wp/wiki/Release-Changelog-Draft).
+1. Check out the branch intended for release (`develop` for major, `x.y` for minor) and pull latest commits.
+1. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant).
+1. Do `npm install && composer selfupdate && composer install`.
+1. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
+1. [Draft new release](https://github.com/ampproject/amp-wp/releases/new) on GitHub targeting the required branch (`develop` for major, `x.y` for minor).
+    1. Use the new plugin version as the tag (e.g. `1.2-beta3` or `1.2.1-RC1`)
+    1. USe new version as the title, followed by some highlight tagline of the release.
+    1. Attach the `amp.zip` build to the release.
+    1. Add changelog entry to the release, link to compare view comparing previous release, and link to milestone.
+    1. Make sure “Pre-release” is checked.
+1. Publish GitHub release.
+1. Create built release tag (from the just-created `build` directory):
+    1. do `git fetch --tags && ./bin/tag-built.sh`
+    1. Add link from release notes.
+1. Make announcements on Twitter and the #amp-wp channel on AMP Slack, linking to release post or GitHub release.
+1. Bump version in release branch, e.g. `…-alpha` to `…-beta1` and `…-beta2` to `…-RC1`
+
+## Creating a stable release
+
+Contributors who want to make a new release, follow these steps:
+
+1. Create changelog draft on [Wiki page](https://github.com/ampproject/amp-wp/wiki/Release-Changelog-Draft).
+    1. Gather props list of the entire release, including contributors of code, design, testing, project management, etc.
+1. Update readme including the description, contributors, and screenshots.
+1. Draft release post.
+1. For major release, draft blog post about the new release.
+1. For minor releases, make sure all merged commits in `develop` have been also merged onto release branch.
+1. Check out the branch intended for release (`develop` for major, `x.y` for minor) and pull latest commits.
+1. Do `npm install && composer selfupdate && composer install`.
+1. Bump plugin versions in `amp.php` (×2: the metadata block in the header and also the `AMP__VERSION` constant). Verify via `npx grunt shell:verify_matching_versions`. Ensure patch version number is supplied for major releases, so `1.2-RC1` should bump to `1.2.0`.
+1. Do `npm run build` and install the `amp.zip` onto a normal WordPress install running a stable release build; do smoke test to ensure it works.
+1. Optionally do sanity check by comparing the `build` directory with the previously-deployed plugin on WordPress.org for example: `svn export https://plugins.svn.wordpress.org/amp/trunk /tmp/amp-trunk; diff /tmp/amp-trunk/ ./build/` (instead of straight `diff`, it's best to use a GUI like `idea diff`, `phpstorm diff`, or `opendiff`).
+1. [Draft new release](https://github.com/ampproject/amp-wp/releases/new) on GitHub targeting the required branch (`develop` for major, `x.y` for minor):
+    1. Use the new plugin version as the tag (e.g. `1.2.0` or `1.2.1`)
+    1. Attach the `amp.zip` build to the release.
+    1. Add changelog entry to the release, link to compare view comparing previous release, and link to milestone.
+1. Run `npm run deploy` to commit the plugin to WordPress.org.
+1. Confirm the release is available on WordPress.org; try installing it on a WordPress install and confirm it works.
+1. Publish GitHub release.
+1. Create built release tag (from the just-created `build` directory):
+    1. do `git fetch --tags && ./bin/tag-built.sh`
+    1. Add link from release notes.
+1. For new major releases, create a release branch from the tag. Patch versions are made from the release branch.
+1. For minor releases, bump `Stable tag` in the `readme.txt`/`readme.md` in `develop`. Cherry-pick other changes as necessary.
+1. Merge release tag into `master`.
+1. Close the GitHub milestone (and project).
+1. Publish release blog post (if applicable), including link to GitHub release.
+1. Make announcements on Twitter and the #amp-wp channel on AMP Slack, linking to release post or GitHub release.
+1. Bump version in release branch. After major release (e.g. `1.2.0`), bump to `1.3.0-alpha` on `develop`; after minor release (e.g. `1.2.1`) bump version to `1.2.2-alpha` on the release branch.
+
+## Changelog
+
+Release changelogs are created by an automation script that accumulates changelog messages from issues associated with a given milestone.
+
+### Changelog messages
+
+* Changelog messages are added in the PR-related issue, within its reserved section, which is pre-populated from the issue template.
+* Changelog messages start with a verb in its imperative form (e.g. “Fix bug xyz”), preferably one of the following words:
+    * Add (for features)
+    * Introduce (for features)
+    * Enhance (for enhancements)
+    * Improve (for enhancements)
+    * Change (for misc changes)
+    * Update (for misc changes)
+    * Modify (for misc changes)
+    * Remove (for removal)
+    * Fix (for bug fixes)
+    * N/A (skip changelog message)
+
+### Changelog format
+
+* The changelog messages are categorized as follows:
+    * Added
+    * Enhanced
+    * Changed
+    * Fixed
+* Changelog messages are automatically assigned to one of the defined categories based on the first word the message starts with. Default: “Changed”.
+* Changelogs with the message “N/A” are skipped.
+
+Maintainers must ensure that changelog messages are clear and follow the formatting guidelines.

--- a/contributing/projet-management.md
+++ b/contributing/projet-management.md
@@ -28,6 +28,7 @@ The [Execution](https://github.com/ampproject/amp-wp/projects/15) project board 
 * In Progress
 * Code Review
 * QA
+* Demo
 * Approval
 * Done
 
@@ -62,8 +63,8 @@ The [GitHub issues](https://github.com/ampproject/amp-wp/issues) view serves as 
 | :--- | :--- | :--- |
 | 1. | An issue requiring work is added to the [Definition](https://github.com/ampproject/amp-wp/projects/14) project board (automatically added to Prioritization column). | `Product Manager` `Program Manager`
 | 2. | The issue is assigned a “Priority” and moved to the “Acceptance Criteria” column. | `Product Manager` `Program Manager`
-| 3. | “Acceptance Criteria” are added to the issue description, and the issue is moved to the “Implementation Brief” column. | `Product Manager` `Lead Engineer`
-| 4. | “Implementation Brief” is added to the issue description, and the issue is moved to the “Implementation Brief Review” column. NB: an estimate (step 6) may be added as part of this step. | `Engineer`
+| 3. | “Acceptance Criteria” are added to the issue description, and the issue is moved to the “Implementation Brief” column. | `Product Manager` `Product Owner` `Lead Engineer`
+| 4. | “Implementation Brief” is added to the issue description, and the issue is moved to the “Implementation Brief Review” column. | `Engineer`
 | 5. | The “Implementation Brief” is reviewed and the issue is moved to the “Estimate” column upon approval. The issue is moved back to the “Implementation Brief” column if changes in the “Implementation Brief” description are requested. | `Lead Engineer`
 | 6. | The issue is estimated using T-Shirt sizing and moved to the [Execution](https://github.com/ampproject/amp-wp/projects/15) project board (automatically added to the Backlog). | `Project Manager` `Engineer`
 
@@ -75,11 +76,14 @@ The [GitHub issues](https://github.com/ampproject/amp-wp/issues) view serves as 
 | 3. | The issue is moved to the “To Do” column if it is assigned to the current sprint. | `Project Manager`
 | 4. | The issue is assigned (or may be self-assigned) to an engineer. | `Project Manager` `Engineer`
 | 5. | The issue is moved to the “In Progress” column when development starts. A PR is created, following the [Branching Strategy](https://github.com/ampproject/amp-wp/contributing/engineering.md#branches). The PR must contain details for each section predefined in the PR template, with a reference to the associated issue. **IMPORTANT:** do not add [GitHub keywords](https://help.github.com/en/articles/closing-issues-using-keywords) which would automatically close an issue once the PR is merged. | `Engineer`
-| 6. | The “[Changelog Message](https://github.com/ampproject/amp-wp/contributing/engineering.md#changelog)” is added to the issue description and the issue is moved to the “Code Review” column once development is completed. | `Engineer`
-| 7. | The code review is done in the referred PR and the issue is moved to the “QA” column once the review is completed and the PR is approved, merged and deployed to the QA environment. The reviewer must ensure that the “Acceptance Criteria” match the implementation before moving the issue to QA. | `Engineer`
-| 8. | The issue is moved to the “Approval” column once QA is passed or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `QA Specialist`
-| 9. | The issue goes through a final review and moved to the “Done” once approved or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `Product Manager`
-| 10. | The issue is closed. | `Product Manager`
+| 6. | The “[Changelog Message](https://github.com/ampproject/amp-wp/contributing/engineering.md#changelog)” is added to the relevant section of the issue description once development is completed. | `Engineer`
+| 7. | The “QA Testing Instructions“ are added to the relevant section of the issue description and the issue is moved to the “Code Review” column. | `Engineer`
+| 8. | The code review is done in the referred PR and the issue is moved to the “QA” column once the review is completed and the PR is approved, merged and deployed to the QA environment. The reviewer must ensure that the “Acceptance Criteria” match the implementation and that the “QA Testing Instructions“ has been added to the issue before moving it to QA. | `Engineer`
+| 9. | The issue is moved to the “Demo” column once QA is passed or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `QA Specialist`
+| 9. | A video or screenshots demoing the implementation are added to the relevant section of the issue description. | `Engineer`
+| 10. | The issue is moved to the “Approval” column once the demo is added. | `Engineer`
+| 11. | The issue goes through a final review and moved to the “Done” once approved or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `Product Manager`
+| 12. | The issue is closed. | `Product Manager`
 
 #### Type: `Task`
 
@@ -89,7 +93,7 @@ The [GitHub issues](https://github.com/ampproject/amp-wp/issues) view serves as 
 | :--- | :--- | :--- |
 | 1. | An issue requiring work is added to the [Definition](https://github.com/ampproject/amp-wp/projects/14) project board (automatically added to Prioritization column). | `Product Manager` `Program Manager`
 | 2. | The issue is assigned a “Priority” and moved to the “Acceptance Criteria” column. | `Product Manager` `Program Manager`
-| 3. | “Acceptance Criteria” are added to the issue description, and the issue is moved to the “Estimate" column. | `Product Manager`
+| 3. | “Acceptance Criteria” are added to the issue description, and the issue is moved to the “Estimate" column. | `Product Manager` `Product Owner`
 | 4. | The issue is estimated using T-Shirt sizing and moved to the [Execution](https://github.com/ampproject/amp-wp/projects/15) project board (automatically added to the Backlog). | `Task specific`
 
 ##### Execution

--- a/contributing/projet-management.md
+++ b/contributing/projet-management.md
@@ -1,0 +1,105 @@
+# Project management guidelines
+
+|IMPORTANT: The project management guidelines are only applicable to AMP Stories at this stage.|
+| :--- |
+
+# Project boards
+
+In addition to [Milestones](https://github.com/ampproject/amp-wp/milestones), which are used to manage releases, project boards are used to manage issue statuses.
+
+### Definition project board
+
+The [Definition](https://github.com/ampproject/amp-wp/projects/14) project board covers the pipeline which issues go through in preparation for execution. The board contains the following columns:
+
+* Revisit Later
+* Prioritization
+* Acceptance Criteria
+* Implementation Brief / Estimate
+* Implementation Brief Review
+* Estimate
+
+### Execution project board
+
+The [Execution](https://github.com/ampproject/amp-wp/projects/15) project board covers the execution pipeline which issues go through for implementation. The board contains the following columns:
+
+* Blocked
+* Backlog
+* To Do
+* In Progress
+* Code Review
+* QA
+* Approval
+* Done
+
+## Labels
+
+The labels below are utilized to categorize issues:
+
+* Type: `{type}` = the issue type (ex. `Type: Bug`, `Type: Feature`, `Type: Support`)
+* P`{priority}` = the priority of the task (ex. `P1`, `P2`, `P3`)
+* Size: `{size`} = the issue size (ex. `S`, `M`, `L`)
+* Sprint: `{sprint_number`} = the sprint associated to the issue (ex. `Sprint: 1`, `Sprint: 2`, `Sprint: 3`)
+
+## Life of an issue
+
+|IMPORTANT: We use GitHub issues to track all task statuses, therefore PRs should **only** be associated with an issue, **not** assigned a label, project, and/or milestone.|
+| :--- |
+
+### Triage
+
+The [GitHub issues](https://github.com/ampproject/amp-wp/issues) view serves as the “Awaiting Triage” backlog.
+
+1. An issue is created.
+1. The issue “Type” label is assigned.
+
+### Issue cycle by type
+
+#### Type: `Bug`, `Enhancement`, `Feature`
+
+##### Definition
+
+| <br> Step | <br> Task | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br> Role  |
+| :--- | :--- | :--- |
+| 1. | An issue requiring work is added to the [Definition](https://github.com/ampproject/amp-wp/projects/14) project board (automatically added to Prioritization column). | `Product Manager` `Program Manager`
+| 2. | The issue is assigned a “Priority” and moved to the “Acceptance Criteria” column. | `Product Manager` `Program Manager`
+| 3. | “Acceptance Criteria” are added to the issue description, and the issue is moved to the “Implementation Brief” column. | `Product Manager` `Lead Engineer`
+| 4. | “Implementation Brief” is added to the issue description, and the issue is moved to the “Implementation Brief Review” column. NB: an estimate (step 6) may be added as part of this step. | `Engineer`
+| 5. | The “Implementation Brief” is reviewed and the issue is moved to the “Estimate” column upon approval. The issue is moved back to the “Implementation Brief” column if changes in the “Implementation Brief” description are requested. | `Lead Engineer`
+| 6. | The issue is estimated using T-Shirt sizing and moved to the [Execution](https://github.com/ampproject/amp-wp/projects/15) project board (automatically added to the Backlog). | `Project Manager` `Engineer`
+
+##### Execution
+| <br> Step | <br> Task | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br> Role  |
+| :--- | :--- | :--- |
+| 1. | An issue requiring work is added to the [Execution](https://github.com/ampproject/amp-wp/projects/15) project board (automatically added to the Backlog) after going through the [Definition](https://github.com/ampproject/amp-wp/projects/14) project board pipeline. | `Product Manager` `Program Manager`
+| 2. | The issue is assigned a “[Milestone](https://github.com/ampproject/amp-wp/milestones)” and “Sprint” label. | `Product Manager` `Program Manager`
+| 3. | The issue is moved to the “To Do” column if it is assigned to the current sprint. | `Project Manager`
+| 4. | The issue is assigned (or may be self-assigned) to an engineer. | `Project Manager` `Engineer`
+| 5. | The issue is moved to the “In Progress” column when development starts. A PR is created, following the [Branching Strategy](https://github.com/ampproject/amp-wp/contributing/engineering.md#branches). The PR must contain details for each section predefined in the PR template, with a reference to the associated issue. **IMPORTANT:** do not add [GitHub keywords](https://help.github.com/en/articles/closing-issues-using-keywords) which would automatically close an issue once the PR is merged. | `Engineer`
+| 6. | The “[Changelog Message](https://github.com/ampproject/amp-wp/contributing/engineering.md#changelog)” is added to the issue description and the issue is moved to the “Code Review” column once development is completed. | `Engineer`
+| 7. | The code review is done in the referred PR and the issue is moved to the “QA” column once the review is completed and the PR is approved, merged and deployed to the QA environment. The reviewer must ensure that the “Acceptance Criteria” match the implementation before moving the issue to QA. | `Engineer`
+| 8. | The issue is moved to the “Approval” column once QA is passed or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `QA Specialist`
+| 9. | The issue goes through a final review and moved to the “Done” once approved or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `Product Manager`
+| 10. | The issue is closed. | `Product Manager`
+
+#### Type: `Task`
+
+##### Definition
+
+| <br> Step | <br> Task | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br> Role  |
+| :--- | :--- | :--- |
+| 1. | An issue requiring work is added to the [Definition](https://github.com/ampproject/amp-wp/projects/14) project board (automatically added to Prioritization column). | `Product Manager` `Program Manager`
+| 2. | The issue is assigned a “Priority” and moved to the “Acceptance Criteria” column. | `Product Manager` `Program Manager`
+| 3. | “Acceptance Criteria” are added to the issue description, and the issue is moved to the “Estimate" column. | `Product Manager`
+| 4. | The issue is estimated using T-Shirt sizing and moved to the [Execution](https://github.com/ampproject/amp-wp/projects/15) project board (automatically added to the Backlog). | `Task specific`
+
+##### Execution
+| <br> Step | <br> Task | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<br> Role  |
+| :--- | :--- | :--- |
+| 1. | An issue requiring work is added to the [Execution](https://github.com/ampproject/amp-wp/projects/15) project board (automatically added to the Backlog) after going through the [Definition](https://github.com/ampproject/amp-wp/projects/14) project board pipeline. | `Product Manager` `Program Manager`
+| 2. | The issue is assigned a “Sprint” label. | `Product Manager` `Program Manager`
+| 3. | The issue is moved to the “To Do” column if it is assigned to the current sprint. | `Project Manager`
+| 4. | The issue is assigned (or may be self-assigned) | `Project Manager` `Assignee`
+| 5. | The issue is moved to the “In progress” column when work starts. | `Assignee`
+| 8. | The issue is moved to the “Approval” column the work is done. | `Assignee`
+| 9. | The issue goes through a final review and moved to the “Done” once approved or moved back to the “To Do” column if changes are required, in which case the cycle from the “To Do” column onwards is repeated. | `Product Manager`
+| 10. | The issue is closed. | `Product Manager`


### PR DESCRIPTION
This PR enhance the contributing guidelines mainly focused on the following:
- adding Project Management guidelines (only applicable to AMP Stories at this stage)
- simplifying contributing.md by decoupling Engineering and Project Management guidelines moved to the added `contributing/` directory
- adding issue templates to facilitate the new Project Management and Engineering guidelines 