### PR TITLE
Add cache pool abstraction to cache stylesheets

### DIFF
--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -94,6 +94,7 @@ class AMP_Autoloader {
 		'AMP_Content_Sanitizer'              => 'includes/templates/class-amp-content-sanitizer',
 		'AMP_Post_Template'                  => 'includes/templates/class-amp-post-template',
 		'AMP_DOM_Utils'                      => 'includes/utils/class-amp-dom-utils',
+		'AMP_Cache_Pool'                     => 'includes/utils/class-amp-cache-pool',
 		'AMP_HTML_Utils'                     => 'includes/utils/class-amp-html-utils',
 		'AMP_Image_Dimension_Extractor'      => 'includes/utils/class-amp-image-dimension-extractor',
 		'AMP_Validation_Manager'             => 'includes/validation/class-amp-validation-manager',

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1368,8 +1368,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * }
 	 */
 	private function process_stylesheet( $stylesheet, $options = [] ) {
-		$parsed      = null;
-		$cache_key   = null;
+		$parsed    = null;
+		$cache_key = null;
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -418,7 +418,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$this->base_url    = untrailingslashit( $guessurl );
 		$this->content_url = WP_CONTENT_URL;
 		$this->xpath       = new DOMXPath( $dom );
-		$this->cache_pool  = new AMP_Cache_Pool( self::CACHE_GROUP );
+		$this->cache_pool  = new AMP_Cache_Pool( self::CACHE_GROUP, isset( $this->args['cache_pool_size'] ) ? $this->args['cache_pool_size'] : AMP_Cache_Pool::DEFAULT_POOL_SIZE );
 	}
 
 	/**

--- a/includes/utils/class-amp-cache-pool.php
+++ b/includes/utils/class-amp-cache-pool.php
@@ -31,7 +31,7 @@ final class AMP_Cache_Pool {
 	 *
 	 * @var int
 	 */
-	private $pool_index;
+	private $pool_index = -1;
 
 	/**
 	 * Cache group to use.
@@ -107,7 +107,7 @@ final class AMP_Cache_Pool {
 	private function get_rotated_transient( $key ) {
 		$pool_index = array_search( $key, $this->pool_map, true );
 
-		if ( ! $pool_index ) {
+		if ( false === $pool_index ) {
 			return false;
 		}
 
@@ -129,7 +129,7 @@ final class AMP_Cache_Pool {
 		}
 
 		// As we didn't find the key, we create a new pool slot to store it.
-		if ( false === $pool_index ) {
+		if ( false === $pool_index || -1 === $this->pool_index ) {
 			$this->advance_pool_index();
 			$this->pool_map[ $this->pool_index ] = $key;
 		}
@@ -146,7 +146,7 @@ final class AMP_Cache_Pool {
 	 */
 	private function read_pool_meta() {
 		$this->pool_map   = get_transient( "{$this->group}-pool-map" ) ?: [];
-		$this->pool_index = get_transient( "{$this->group}-pool-index" ) ?: 0;
+		$this->pool_index = get_transient( "{$this->group}-pool-index" ) ?: -1;
 	}
 
 	/**

--- a/includes/utils/class-amp-cache-pool.php
+++ b/includes/utils/class-amp-cache-pool.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Class AMP_Cache_Pool
+ *
+ * @package AMP
+ */
+
+/**
+ * Cache pool abstraction based on WordPress transients.
+ *
+ * @since 1.4.0
+ */
+final class AMP_Cache_Pool {
+
+	/**
+	 * Pool map of cached entries.
+	 *
+	 * @var array
+	 */
+	private $pool_map = [];
+
+	/**
+	 * Index into the pool map.
+	 *
+	 * @var int
+	 */
+	private $pool_index;
+
+	/**
+	 * Cache group to use.
+	 *
+	 * @var string
+	 */
+	private $group;
+
+	/**
+	 * Whether an object cache is available.
+	 *
+	 * @var bool
+	 */
+	private $is_object_cache_available;
+
+	/**
+	 * Instantiate an AMP_Cache_Pool object.
+	 *
+	 * @param string $group Optional. Group to use. Defaults to an empty string.
+	 */
+	public function __construct( $group = '' ) {
+		$this->group                     = $group;
+		$this->is_object_cache_available = false; // wp_using_ext_object_cache();
+
+		if ( ! $this->is_object_cache_available ) {
+			$this->read_pool_meta();
+		}
+	}
+
+	/**
+	 * Get the value of a given key from the cache.
+	 *
+	 * @param string $key Key of the cached value to retrieve.
+	 *
+	 * @return mixed Value that was stored under the requested key.
+	 */
+	public function get( $key ) {
+		return $this->is_object_cache_available
+			? wp_cache_get( $key, $this->group )
+			: $this->get_rotated_transient( "{$this->group}-{$key}" );
+	}
+
+	/**
+	 * Store a value under a given key in the cache.
+	 *
+	 * @param string $key   Key under which to store the value.
+	 * @param mixed  $value Value to store in the cache.
+	 */
+	public function set( $key, $value ) {
+		if ( $this->is_object_cache_available ) {
+			wp_cache_set( $key, $value, $this->group );
+		} else {
+			$this->set_rotated_transient( "{$this->group}-{$key}", $value );
+		}
+	}
+
+	/**
+	 * Get a value from a rotating transient pool.
+	 *
+	 * @param string $key Key of the value to get.
+	 * @return mixed Value for the requested key.
+	 */
+	private function get_rotated_transient( $key ) {
+		$pool_index = array_search( $key, $this->pool_map, true );
+
+		if ( ! $pool_index ) {
+			return false;
+		}
+
+		return get_transient( "{$this->group}-pool-slot-{$pool_index}" );
+	}
+
+	/**
+	 * Store a value in the rotating transient pool under a given key.
+	 *
+	 * @param string $key   Key under which to store the value.
+	 * @param mixed  $value Value to store under the given key.
+	 */
+	private function set_rotated_transient( $key, $value ) {
+		if ( $this->has_key_value( $key, $value ) ) {
+			return;
+		}
+
+		$this->pool_index ++;
+
+		$this->pool_map[ $this->pool_index ] = $key;
+
+		// The expiration is to ensure transients don't stick around forever
+		// since no LRU flushing like with external object cache.
+		set_transient( "{$this->group}-pool-slot-{$this->pool_index}", $value, MONTH_IN_SECONDS );
+
+		$this->persist_pool_meta();
+	}
+
+	private function has_key_value( $key, $value ) {
+		$pool_index = array_search( $key, $this->pool_map, true );
+
+		if ( ! $pool_index ) {
+			return false;
+		}
+
+		if ( $this->pool_map[ $pool_index ] !== $value ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read the pool meta information that was persisted.
+	 */
+	private function read_pool_meta() {
+		$this->pool_map   = get_transient( "{$this->group}-pool-map" ) ?: [];
+		$this->pool_index = get_transient( "{$this->group}-pool-index" ) ?: 0;
+	}
+
+	/**
+	 * Persist the pool meta information.
+	 */
+	private function persist_pool_meta() {
+		set_transient( "{$this->group}-pool-map", $this->pool_map );
+		set_transient( "{$this->group}-pool-index", $this->pool_index );
+	}
+}

--- a/includes/utils/class-amp-cache-pool.php
+++ b/includes/utils/class-amp-cache-pool.php
@@ -20,7 +20,7 @@ final class AMP_Cache_Pool {
 	const DEFAULT_POOL_SIZE = 1000;
 
 	/**
-	 * Pool map of cached entries.
+	 * Pool map of cached entry keys.
 	 *
 	 * @var array
 	 */

--- a/tests/php/test-class-amp-cache-pool.php
+++ b/tests/php/test-class-amp-cache-pool.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Tests for AMP_Cache_Pool.
+ *
+ * @package AMP
+ * @since   1.0
+ */
+
+/**
+ * Tests for AMP_Cache_Pool.
+ *
+ * @covers AMP_Cache_Pool
+ */
+class Test_AMP_Cache_Pool extends WP_UnitTestCase {
+
+	public function test_transients_storing_a_value() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = false;
+
+		$cache = new AMP_Cache_Pool( 'testing', 5 );
+
+		$cache->set( 'foo', 'bar' );
+
+		$this->assertEquals( 'bar', $cache->get( 'foo' ) );
+	}
+
+	public function test_transients_overwriting_a_value() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = false;
+
+		$cache = new AMP_Cache_Pool( 'testing', 5 );
+
+		$cache->set( 'foo', 'bar' );
+		$cache->set( 'foo', 'baz' );
+
+		$this->assertEquals( 'baz', $cache->get( 'foo' ) );
+	}
+
+	public function test_transients_cycling_through_values() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = false;
+
+		$cache = new AMP_Cache_Pool( 'testing', 5 );
+
+		$cache->set( 'foo_1', 'bar_1' );
+		$cache->set( 'foo_2', 'bar_2' );
+		$cache->set( 'foo_3', 'bar_3' );
+		$cache->set( 'foo_4', 'bar_4' );
+		$cache->set( 'foo_5', 'bar_5' );
+		$cache->set( 'foo_6', 'bar_6' );
+
+		$this->assertEquals( false, $cache->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache->get( 'foo_4' ) );
+		$this->assertEquals( 'bar_5', $cache->get( 'foo_5' ) );
+		$this->assertEquals( 'bar_6', $cache->get( 'foo_6' ) );
+	}
+
+	public function test_transients_multiple_caches() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = false;
+
+		$cache_1 = new AMP_Cache_Pool( 'testing', 3 );
+		$cache_2 = new AMP_Cache_Pool( 'testing', 3 );
+		$cache_3 = new AMP_Cache_Pool( 'testing', 3 );
+
+		$cache_1->set( 'foo_1', 'bar_1' );
+		$cache_2->set( 'foo_2', 'bar_2' );
+		$cache_3->set( 'foo_3', 'bar_3' );
+		$cache_1->set( 'foo_4', 'bar_4' );
+
+		$this->assertEquals( false, $cache_1->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_1->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_1->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_1->get( 'foo_4' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_2->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_2->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_2->get( 'foo_4' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_3->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_3->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_3->get( 'foo_4' ) );
+	}
+
+	public function test_transients_multiple_groups() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = false;
+
+		$cache_1 = new AMP_Cache_Pool( 'testing_1', 3 );
+		$cache_2 = new AMP_Cache_Pool( 'testing_2', 3 );
+		$cache_3 = new AMP_Cache_Pool( 'testing_3', 3 );
+
+		$cache_1->set( 'foo_1', 'bar_1' );
+		$cache_2->set( 'foo_2', 'bar_2' );
+		$cache_3->set( 'foo_3', 'bar_3' );
+		$cache_1->set( 'foo_4', 'bar_4' );
+
+		$this->assertEquals( 'bar_1', $cache_1->get( 'foo_1' ) );
+		$this->assertEquals( false, $cache_1->get( 'foo_2' ) );
+		$this->assertEquals( false, $cache_1->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_1->get( 'foo_4' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_2->get( 'foo_2' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_3' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_4' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_1' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_3->get( 'foo_3' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_4' ) );
+	}
+
+	public function test_object_cache_storing_a_value() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		$cache = new AMP_Cache_Pool( 'testing', 5 );
+
+		$cache->set( 'foo', 'bar' );
+
+		$this->assertEquals( 'bar', $cache->get( 'foo' ) );
+	}
+
+	public function test_object_cache_overwriting_a_value() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		$cache = new AMP_Cache_Pool( 'testing', 5 );
+
+		$cache->set( 'foo', 'bar' );
+		$cache->set( 'foo', 'baz' );
+
+		$this->assertEquals( 'baz', $cache->get( 'foo' ) );
+	}
+
+	public function test_object_cache_cycling_through_values() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		$cache = new AMP_Cache_Pool( 'testing', 5 );
+
+		$cache->set( 'foo_1', 'bar_1' );
+		$cache->set( 'foo_2', 'bar_2' );
+		$cache->set( 'foo_3', 'bar_3' );
+		$cache->set( 'foo_4', 'bar_4' );
+		$cache->set( 'foo_5', 'bar_5' );
+		$cache->set( 'foo_6', 'bar_6' );
+
+		// Size does not apply to object caches.
+		$this->assertEquals( 'bar_1', $cache->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache->get( 'foo_4' ) );
+		$this->assertEquals( 'bar_5', $cache->get( 'foo_5' ) );
+		$this->assertEquals( 'bar_6', $cache->get( 'foo_6' ) );
+	}
+
+	public function test_object_cache_multiple_caches() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		$cache_1 = new AMP_Cache_Pool( 'testing', 3 );
+		$cache_2 = new AMP_Cache_Pool( 'testing', 3 );
+		$cache_3 = new AMP_Cache_Pool( 'testing', 3 );
+
+		$cache_1->set( 'foo_1', 'bar_1' );
+		$cache_2->set( 'foo_2', 'bar_2' );
+		$cache_3->set( 'foo_3', 'bar_3' );
+		$cache_1->set( 'foo_4', 'bar_4' );
+
+		// Size does not apply to object caches.
+		$this->assertEquals( 'bar_1', $cache_1->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_1->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_1->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_1->get( 'foo_4' ) );
+		$this->assertEquals( 'bar_1', $cache_2->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_2->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_2->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_2->get( 'foo_4' ) );
+		$this->assertEquals( 'bar_1', $cache_3->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_3->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_3->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_3->get( 'foo_4' ) );
+	}
+
+	public function test_object_cache_multiple_groups() {
+		global $_wp_using_ext_object_cache;
+		$_wp_using_ext_object_cache = true;
+
+		$cache_1 = new AMP_Cache_Pool( 'testing_1', 3 );
+		$cache_2 = new AMP_Cache_Pool( 'testing_2', 3 );
+		$cache_3 = new AMP_Cache_Pool( 'testing_3', 3 );
+
+		$cache_1->set( 'foo_1', 'bar_1' );
+		$cache_2->set( 'foo_2', 'bar_2' );
+		$cache_3->set( 'foo_3', 'bar_3' );
+		$cache_1->set( 'foo_4', 'bar_4' );
+
+		$this->assertEquals( 'bar_1', $cache_1->get( 'foo_1' ) );
+		$this->assertEquals( false, $cache_1->get( 'foo_2' ) );
+		$this->assertEquals( false, $cache_1->get( 'foo_3' ) );
+		$this->assertEquals( 'bar_4', $cache_1->get( 'foo_4' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_1' ) );
+		$this->assertEquals( 'bar_2', $cache_2->get( 'foo_2' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_3' ) );
+		$this->assertEquals( false, $cache_2->get( 'foo_4' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_1' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_2' ) );
+		$this->assertEquals( 'bar_3', $cache_3->get( 'foo_3' ) );
+		$this->assertEquals( false, $cache_3->get( 'foo_4' ) );
+	}
+}


### PR DESCRIPTION
This PR adds a cache pool abstraction that abstracts away the differences between the object cache and transients when caching stylesheets.

The transient cache implementation provides a fixed-size pool of cache entries that are rotated to enforce a maximum number of transients and avoid filling up the database.

Note: For the architecture rethink, this should be an interface with 2 separate implementations that will get injected, instead of a single class that contains all implementations.

See #2092