### PR TITLE
Optimize AMP_Style_Sanitizer::has_used_class_name()

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -512,7 +512,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
 			 */
 			if ( 'amp-active' === $class_name || 'amp-hidden' === $class_name ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) && ! $this->has_used_tag_names( [ 'amp-user-notification' ] ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
 					return false;
 				}
 				continue;

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -503,42 +503,44 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		foreach ( $class_names as $class_name ) {
 			// Only do element-specific checks on an AMP components.
 			if ( 'amp-' === substr( $class_name, 0, 4 ) ) {
-
-				// Class names for amp-dynamic-css-classes, see <https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
-				if ( 'amp-referrer-' === substr( $class_name, 0, 13 ) ) {
-					continue;
+				// Check exact matches first, as they are faster.
+				switch ( $class_name ) {
+					/*
+					 * Common class names used for amp-user-notification and amp-live-list.
+					 * See <https://www.ampproject.org/docs/reference/components/amp-user-notification#styling>.
+					 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
+					 */
+					case 'amp-active':
+					case 'amp-hidden':
+						if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
+							return false;
+						}
+						continue 2;
+					// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
+					case 'amp-image-lightbox-caption':
+						if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
+							return false;
+						}
+						continue 2;
+					// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
+					case 'user-valid':
+					case 'user-invalid':
+						if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
+							return false;
+						}
+						continue 2;
 				}
 
-				/*
-				 * Common class names used for amp-user-notification and amp-live-list.
-				 * See <https://www.ampproject.org/docs/reference/components/amp-user-notification#styling>.
-				 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
-				 */
-				if ( 'amp-active' === $class_name || 'amp-hidden' === $class_name ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
-						return false;
-					}
-					continue;
-				}
-
-				// Class names for amp-carousel, see <https://www.ampproject.org/docs/reference/components/amp-carousel#styling>.
-				if ( 'amp-carousel-' === substr( $class_name, 0, 13 ) ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-carousel' ] ) ) {
-						return false;
-					}
-					continue;
-				}
-
-				// Class names for amp-date-picker, see <https://www.ampproject.org/docs/reference/components/amp-date-picker>.
-				if ( 'amp-date-picker-' === substr( $class_name, 0, 16 ) ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-date-picker' ] ) ) {
+				// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
+				if ( 'amp-geo-' === substr( $class_name, 0, 8 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-geo' ] ) ) {
 						return false;
 					}
 					continue;
 				}
 
 				// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
-				if ( 'amp-form-' === substr( $class_name, 0, 9 ) || 'user-valid' === $class_name || 'user-invalid' === $class_name ) {
+				if ( 'amp-form-' === substr( $class_name, 0, 9 ) ) {
 					if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
 						return false;
 					}
@@ -555,40 +557,23 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					return false;
 				}
 
-				/*
-				 * Class names for amp-access and amp-access-laterpay.
-				 * See <https://www.ampproject.org/docs/reference/components/amp-access>.
-				 * See <https://www.ampproject.org/docs/reference/components/amp-access-laterpay#styling>
-				 */
-				if ( 'amp-access-' === substr( $class_name, 0, 11 ) ) {
-					if ( ! $this->has_used_attributes( [ 'amp-access' ] ) ) {
-						return false;
-					}
-					continue;
-				}
-
-				// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
-				if ( 'amp-geo-' === substr( $class_name, 0, 8 ) || 'amp-iso-country-' === substr( $class_name, 0, 16 ) ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-geo' ] ) ) {
-						return false;
-					}
-					continue;
-				}
-
-				// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
-				if ( 'amp-image-lightbox-caption' === $class_name ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
-						return false;
-					}
-					continue;
-				}
-
-				// Class names for amp-live-list, see <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
-				if ( 'amp-live-list-' === substr( $class_name, 0, 14 ) ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) ) {
-						return false;
-					}
-					continue;
+				switch ( substr( $class_name, 0, 11 ) ) {
+					/*
+					 * Class names for amp-access and amp-access-laterpay.
+					 * See <https://www.ampproject.org/docs/reference/components/amp-access>.
+					 * See <https://www.ampproject.org/docs/reference/components/amp-access-laterpay#styling>
+					 */
+					case 'amp-access-':
+						if ( ! $this->has_used_attributes( [ 'amp-access' ] ) ) {
+							return false;
+						}
+						continue 2;
+					// Class names for amp-video-docking, see <https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md#styling>.
+					case 'amp-docked-':
+						if ( ! $this->has_used_attributes( [ 'dock' ] ) ) {
+							return false;
+						}
+						continue 2;
 				}
 
 				// Class names for amp-sidebar, see <https://www.ampproject.org/docs/reference/components/amp-sidebar#styling-toolbar>.
@@ -599,20 +584,46 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					continue;
 				}
 
-				// Class names for amp-sticky-ad, see <https://www.ampproject.org/docs/reference/components/amp-sticky-ad#styling>.
-				if ( 'amp-sticky-ad-' === substr( $class_name, 0, 14 ) ) {
-					if ( ! $this->has_used_tag_names( [ 'amp-sticky-ad' ] ) ) {
-						return false;
-					}
-					continue;
+				switch ( substr( $class_name, 0, 13 ) ) {
+					// Class names for amp-dynamic-css-classes, see <https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
+					case 'amp-referrer-':
+						continue 2;
+					// Class names for amp-carousel, see <https://www.ampproject.org/docs/reference/components/amp-carousel#styling>.
+					case 'amp-carousel-':
+						if ( ! $this->has_used_tag_names( [ 'amp-carousel' ] ) ) {
+							return false;
+						}
+						continue 2;
 				}
 
-				// Class names for amp-video-docking, see <https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md#styling>.
-				if ( 'amp-docked-' === substr( $class_name, 0, 11 ) ) {
-					if ( ! $this->has_used_attributes( [ 'dock' ] ) ) {
-						return false;
-					}
-					continue;
+				switch ( substr( $class_name, 0, 14 ) ) {
+					// Class names for amp-sticky-ad, see <https://www.ampproject.org/docs/reference/components/amp-sticky-ad#styling>.
+					case 'amp-sticky-ad-':
+						if ( ! $this->has_used_tag_names( [ 'amp-sticky-ad' ] ) ) {
+							return false;
+						}
+						continue 2;
+					// Class names for amp-live-list, see <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
+					case 'amp-live-list-':
+						if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) ) {
+							return false;
+						}
+						continue 2;
+				}
+
+				switch ( substr( $class_name, 0, 16 ) ) {
+					// Class names for amp-date-picker, see <https://www.ampproject.org/docs/reference/components/amp-date-picker>.
+					case 'amp-date-picker-':
+						if ( ! $this->has_used_tag_names( [ 'amp-date-picker' ] ) ) {
+							return false;
+						}
+						continue 2;
+					// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
+					case 'amp-iso-country-':
+						if ( ! $this->has_used_tag_names( [ 'amp-geo' ] ) ) {
+							return false;
+						}
+						continue 2;
 				}
 			}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -501,35 +501,36 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		foreach ( $class_names as $class_name ) {
-			// Only do element-specific checks on an AMP components.
+			// Check exact matches first, as they are faster.
+			switch ( $class_name ) {
+				/*
+				 * Common class names used for amp-user-notification and amp-live-list.
+				 * See <https://www.ampproject.org/docs/reference/components/amp-user-notification#styling>.
+				 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
+				 */
+				case 'amp-active':
+				case 'amp-hidden':
+					if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
+						return false;
+					}
+					continue 2;
+				// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
+				case 'amp-image-lightbox-caption':
+					if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
+						return false;
+					}
+					continue 2;
+				// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
+				case 'user-valid':
+				case 'user-invalid':
+					if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
+						return false;
+					}
+					continue 2;
+			}
+
+			// Only do AMP element-specific checks on an AMP components with the corresponding prefix.
 			if ( 'amp-' === substr( $class_name, 0, 4 ) ) {
-				// Check exact matches first, as they are faster.
-				switch ( $class_name ) {
-					/*
-					 * Common class names used for amp-user-notification and amp-live-list.
-					 * See <https://www.ampproject.org/docs/reference/components/amp-user-notification#styling>.
-					 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
-					 */
-					case 'amp-active':
-					case 'amp-hidden':
-						if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
-							return false;
-						}
-						continue 2;
-					// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
-					case 'amp-image-lightbox-caption':
-						if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
-							return false;
-						}
-						continue 2;
-					// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
-					case 'user-valid':
-					case 'user-invalid':
-						if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
-							return false;
-						}
-						continue 2;
-				}
 
 				// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
 				if ( 'amp-geo-' === substr( $class_name, 0, 8 ) ) {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -501,6 +501,11 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		foreach ( $class_names as $class_name ) {
+			// Bail early with a common case scenario.
+			if ( isset( $this->used_class_names[ $class_name ] ) ) {
+				continue;
+			}
+
 			// Check exact matches first, as they are faster.
 			switch ( $class_name ) {
 				/*

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -501,115 +501,119 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		foreach ( $class_names as $class_name ) {
-			// Class names for amp-dynamic-css-classes, see <https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
-			if ( 'amp-referrer-' === substr( $class_name, 0, 13 ) ) {
-				continue;
-			}
+			// Only do element-specific checks on an AMP components.
+			if ( 'amp-' === substr( $class_name, 0, 4 ) ) {
 
-			/*
-			 * Common class names used for amp-user-notification and amp-live-list.
-			 * See <https://www.ampproject.org/docs/reference/components/amp-user-notification#styling>.
-			 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
-			 */
-			if ( 'amp-active' === $class_name || 'amp-hidden' === $class_name ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
-					return false;
+				// Class names for amp-dynamic-css-classes, see <https://www.ampproject.org/docs/reference/components/amp-dynamic-css-classes>.
+				if ( 'amp-referrer-' === substr( $class_name, 0, 13 ) ) {
+					continue;
 				}
-				continue;
-			}
 
-			// Class names for amp-carousel, see <https://www.ampproject.org/docs/reference/components/amp-carousel#styling>.
-			if ( 'amp-carousel-' === substr( $class_name, 0, 13 ) ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-carousel' ] ) ) {
-					return false;
-				}
-				continue;
-			}
-
-			// Class names for amp-date-picker, see <https://www.ampproject.org/docs/reference/components/amp-date-picker>.
-			if ( 'amp-date-picker-' === substr( $class_name, 0, 16 ) ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-date-picker' ] ) ) {
-					return false;
-				}
-				continue;
-			}
-
-			// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
-			if ( 'amp-form-' === substr( $class_name, 0, 9 ) || 'user-valid' === $class_name || 'user-invalid' === $class_name ) {
-				if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
-					return false;
-				}
-				continue;
-			}
-
-			// Class names for extensions which use the video-manager, and thus video-autoplay.css.
-			if ( 'amp-video-' === substr( $class_name, 0, 10 ) ) {
-				foreach ( $this->video_autoplay_elements as $video_autoplay_element ) {
-					if ( $this->has_used_tag_names( [ $video_autoplay_element ] ) ) {
-						continue 2;
+				/*
+				 * Common class names used for amp-user-notification and amp-live-list.
+				 * See <https://www.ampproject.org/docs/reference/components/amp-user-notification#styling>.
+				 * See <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
+				 */
+				if ( 'amp-active' === $class_name || 'amp-hidden' === $class_name ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-live-list', 'amp-user-notification' ] ) ) {
+						return false;
 					}
+					continue;
 				}
-				return false;
-			}
 
-			/*
-			 * Class names for amp-access and amp-access-laterpay.
-			 * See <https://www.ampproject.org/docs/reference/components/amp-access>.
-			 * See <https://www.ampproject.org/docs/reference/components/amp-access-laterpay#styling>
-			 */
-			if ( 'amp-access-' === substr( $class_name, 0, 11 ) ) {
-				if ( ! $this->has_used_attributes( [ 'amp-access' ] ) ) {
+				// Class names for amp-carousel, see <https://www.ampproject.org/docs/reference/components/amp-carousel#styling>.
+				if ( 'amp-carousel-' === substr( $class_name, 0, 13 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-carousel' ] ) ) {
+						return false;
+					}
+					continue;
+				}
+
+				// Class names for amp-date-picker, see <https://www.ampproject.org/docs/reference/components/amp-date-picker>.
+				if ( 'amp-date-picker-' === substr( $class_name, 0, 16 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-date-picker' ] ) ) {
+						return false;
+					}
+					continue;
+				}
+
+				// Class names for amp-form, see <https://www.ampproject.org/docs/reference/components/amp-form#classes-and-css-hooks>.
+				if ( 'amp-form-' === substr( $class_name, 0, 9 ) || 'user-valid' === $class_name || 'user-invalid' === $class_name ) {
+					if ( ! $this->has_used_tag_names( [ 'form' ] ) ) {
+						return false;
+					}
+					continue;
+				}
+
+				// Class names for extensions which use the video-manager, and thus video-autoplay.css.
+				if ( 'amp-video-' === substr( $class_name, 0, 10 ) ) {
+					foreach ( $this->video_autoplay_elements as $video_autoplay_element ) {
+						if ( $this->has_used_tag_names( [ $video_autoplay_element ] ) ) {
+							continue 2;
+						}
+					}
 					return false;
 				}
-				continue;
-			}
 
-			// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
-			if ( 'amp-geo-' === substr( $class_name, 0, 8 ) || 'amp-iso-country-' === substr( $class_name, 0, 16 ) ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-geo' ] ) ) {
-					return false;
+				/*
+				 * Class names for amp-access and amp-access-laterpay.
+				 * See <https://www.ampproject.org/docs/reference/components/amp-access>.
+				 * See <https://www.ampproject.org/docs/reference/components/amp-access-laterpay#styling>
+				 */
+				if ( 'amp-access-' === substr( $class_name, 0, 11 ) ) {
+					if ( ! $this->has_used_attributes( [ 'amp-access' ] ) ) {
+						return false;
+					}
+					continue;
 				}
-				continue;
-			}
 
-			// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
-			if ( 'amp-image-lightbox-caption' === $class_name ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
-					return false;
+				// Class names for amp-geo, see <https://www.ampproject.org/docs/reference/components/amp-geo#generated-css-classes>.
+				if ( 'amp-geo-' === substr( $class_name, 0, 8 ) || 'amp-iso-country-' === substr( $class_name, 0, 16 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-geo' ] ) ) {
+						return false;
+					}
+					continue;
 				}
-				continue;
-			}
 
-			// Class names for amp-live-list, see <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
-			if ( 'amp-live-list-' === substr( $class_name, 0, 14 ) ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) ) {
-					return false;
+				// Class names for amp-image-lightbox, see <https://www.ampproject.org/docs/reference/components/amp-image-lightbox#styling>.
+				if ( 'amp-image-lightbox-caption' === $class_name ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-image-lightbox' ] ) ) {
+						return false;
+					}
+					continue;
 				}
-				continue;
-			}
 
-			// Class names for amp-sidebar, see <https://www.ampproject.org/docs/reference/components/amp-sidebar#styling-toolbar>.
-			if ( 'amp-sidebar-' === substr( $class_name, 0, 12 ) ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-sidebar' ] ) ) {
-					return false;
+				// Class names for amp-live-list, see <https://www.ampproject.org/docs/reference/components/amp-live-list#styling>.
+				if ( 'amp-live-list-' === substr( $class_name, 0, 14 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-live-list' ] ) ) {
+						return false;
+					}
+					continue;
 				}
-				continue;
-			}
 
-			// Class names for amp-sticky-ad, see <https://www.ampproject.org/docs/reference/components/amp-sticky-ad#styling>.
-			if ( 'amp-sticky-ad-' === substr( $class_name, 0, 14 ) ) {
-				if ( ! $this->has_used_tag_names( [ 'amp-sticky-ad' ] ) ) {
-					return false;
+				// Class names for amp-sidebar, see <https://www.ampproject.org/docs/reference/components/amp-sidebar#styling-toolbar>.
+				if ( 'amp-sidebar-' === substr( $class_name, 0, 12 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-sidebar' ] ) ) {
+						return false;
+					}
+					continue;
 				}
-				continue;
-			}
 
-			// Class names for amp-video-docking, see <https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md#styling>.
-			if ( 'amp-docked-' === substr( $class_name, 0, 11 ) ) {
-				if ( ! $this->has_used_attributes( [ 'dock' ] ) ) {
-					return false;
+				// Class names for amp-sticky-ad, see <https://www.ampproject.org/docs/reference/components/amp-sticky-ad#styling>.
+				if ( 'amp-sticky-ad-' === substr( $class_name, 0, 14 ) ) {
+					if ( ! $this->has_used_tag_names( [ 'amp-sticky-ad' ] ) ) {
+						return false;
+					}
+					continue;
 				}
-				continue;
+
+				// Class names for amp-video-docking, see <https://github.com/ampproject/amphtml/blob/master/extensions/amp-video-docking/amp-video-docking.md#styling>.
+				if ( 'amp-docked-' === substr( $class_name, 0, 11 ) ) {
+					if ( ! $this->has_used_attributes( [ 'dock' ] ) ) {
+						return false;
+					}
+					continue;
+				}
 			}
 
 			if ( ! isset( $this->used_class_names[ $class_name ] ) ) {


### PR DESCRIPTION
This PR contains the following optimizations:

* Bails as soon as possible if the class is already known to be used
* Regroups exact comparisons in a switch statement
* Skips checking for AMP components if the element name is not prefixed with `'amp-'`
* Orders partial checks by string size
* Deduplicates `substr()` checks of same size through the use of `switch()` statements

Link to final comparison: https://blackfire.io/profiles/compare/9647f80b-61db-4687-8e0c-fdf851f4dcfa/graph

On a blank front page, saves 24% processing time, mostly by eliminating 27633 calls to `substr()`.

## Before

One can clearly see on the timeline that the `finalize_stylesheet_group()` call adds a big chunk of time to the page load.

<img width="1605" alt="Image 2019-09-21 at 1 03 47 AM" src="https://user-images.githubusercontent.com/83631/65363448-4c570380-dc0c-11e9-9b6e-878fc17dee3c.png">

## After

After the optimization, the `finalize_stylesheet_group()` is not as prominent anymore and more in line with the rest of the processing. The total execution time for the `AMP_Style_Sanitizer::has_used_class_names()` method was reduced by a whopping **92%**.

<img width="1596" alt="Image 2019-09-21 at 1 04 15 AM" src="https://user-images.githubusercontent.com/83631/65363445-495c1300-dc0c-11e9-96e7-f4a50320cd10.png">

Fixes #3310