### PR TITLE
Only add all Google Font style rules in editor context

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -813,6 +813,16 @@ class AMP_Story_Post_Type {
 
 		wp_styles()->add_data( self::AMP_STORIES_EDITOR_STYLE_HANDLE, 'rtl', 'replace' );
 
+		// Include all fonts in the editor since new fonts can be selected at runtime.
+		// In a frontend context, the fonts are added only as needed via \AMP_Story_Post_Type::render_block_with_google_fonts().
+		$fonts = self::get_fonts();
+		foreach ( $fonts as $font ) {
+			wp_add_inline_style(
+				self::AMP_STORIES_EDITOR_STYLE_HANDLE,
+				self::get_inline_font_style_rule( $font )
+			);
+		}
+
 		self::enqueue_general_styles();
 	}
 
@@ -829,14 +839,6 @@ class AMP_Story_Post_Type {
 		);
 
 		wp_styles()->add_data( self::AMP_STORIES_STYLE_HANDLE, 'rtl', 'replace' );
-
-		$fonts = self::get_fonts();
-		foreach ( $fonts as $font ) {
-			wp_add_inline_style(
-				self::AMP_STORIES_STYLE_HANDLE,
-				self::get_inline_font_style_rule( $font )
-			);
-		}
 	}
 
 	/**
@@ -1379,6 +1381,8 @@ class AMP_Story_Post_Type {
 
 	/**
 	 * Include any required Google Font styles when rendering a block in AMP Stories.
+	 *
+	 * @see AMP_Story_Post_Type::enqueue_block_editor_styles() Where fonts are added in the story editor.
 	 *
 	 * @param string $block_content The block content about to be appended.
 	 * @param array  $block         The full block, including name and attributes.

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -1358,7 +1358,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			$validation_error_term = self::factory()->term->create(
 				[
 					'taxonomy'    => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-					'description' => wp_json_encode( [ 'code' => 'test' ], compact( 'i' ) ),
+					'description' => wp_json_encode( array_merge( [ 'code' => 'test' ], compact( 'i' ) ) ),
 				]
 			);
 			if ( $i < 9 ) {


### PR DESCRIPTION
I noticed there is an `excessive_css` problem with stories:

```html
<!--
The style[amp-custom] element is populated with:
   361 B (3%): link#wp-block-library-css[rel=stylesheet][href=https://stories-labs.dev/wp-content/plugins/gutenberg/build/block-library/style.css?ver=1568297729][type=text/css][media=all]
   543 B (47%): link#amp-stories-css[rel=stylesheet][href=https://stories-labs.dev/wp-content/plugins/amp/assets/css/amp-stories.css?ver=1.3-RC1-20190918T205018Z-820046ad][type=text/css][media=all]
   455 B (32%): link#amp-stories-frontend-css[rel=stylesheet][href=https://stories-labs.dev/wp-content/plugins/amp/assets/css/amp-stories-frontend.css?ver=1.3-RC1-20190918T205018Z-820046ad][type=text/css][media=]
   129 B: div.amp-story-block-wrapper amp-wp-2b4f3e6
   128 B: div.amp-story-block-wrapper amp-wp-a96837a
   127 B: div.amp-story-block-wrapper amp-wp-1d1a90b
    90 B: p.wp-block-amp-amp-story-text amp-text-content has-text-color amp-wp-7340773
   129 B: div.amp-story-block-wrapper amp-wp-0624f06
   122 B: h1.wp-block-amp-amp-story-text has-text-color has-background amp-wp-d164d38[data-font-family=Georgia]
    84 B: amp-story-page#14d45f4c-554e-49be-ac09-9b447acaba08.wp-block-amp-amp-story-page amp-wp-74885c3
   129 B: div.amp-story-block-wrapper amp-wp-2ad3080
    86 B: h2.wp-block-amp-amp-story-text has-text-color amp-wp-5ff4663[data-font-family=Georgia]
   127 B: div.amp-story-block-wrapper amp-wp-2040580
   110 B: h2.wp-block-amp-amp-story-text is-style-rounded has-text-color has-background has-vivid-red-color has-vivid-red-background-color amp-wp-2678cb0[data-font-family=Georgia]
   127 B: div.amp-story-block-wrapper amp-wp-20fe417
   121 B: h2.wp-block-amp-amp-story-text is-style-rounded has-text-color has-background has-vivid-red-background-color amp-wp-e8c9813[data-font-family=Georgia]
   128 B: div.amp-story-block-wrapper amp-wp-62c28cc
    90 B: h1.wp-block-amp-amp-story-text amp-text-content has-text-color amp-wp-5bc4f93[data-font-family=Georgia]
Total included size: 3,086 bytes (21% of 14,538 total after tree shaking)

The following stylesheets are too large to be included in style[amp-custom]:
 66365 B: style#amp-stories-inline-css[type=text/css]
Total excluded size: 66,365 bytes (100% of 66,365 total after tree shaking)

Total combined size: 69,451 bytes (85% of 80,903 total after tree shaking)
-->
```

Notice the `amp-stories-inline-css` here, being 66KB+.

I rejected the validation errors to see what the underlying markup was prior to sanitizing, and it was many rules like this:

```css
[data-font-family="Alef"] {
	font-family: "Alef", "sans-serif"
}
```

So the issue is custom font styles being added with this code:

https://github.com/ampproject/amp-wp/blob/b44ac6ac687008e4d1c5dd2ef78b2a5d3d9ecd23/includes/class-amp-story-post-type.php#L833-L839

The problem is that only the style rules for fonts that are actually being used should be added to the page. As @swissspidy this is already being done:

https://github.com/ampproject/amp-wp/blob/b44ac6ac687008e4d1c5dd2ef78b2a5d3d9ecd23/includes/class-amp-story-post-type.php#L1386-L1418

Therefore, it appears these style rules were being added redundantly in the admin editor context and they can just be moved to only be added there.

The reason why this issue would only sometimes occur is because it would only happen when someone picked a custom font. At that point, a `data-font-family` attribute would appear in the page and the style rules using selectors like `[data-font-family="..."]` would no longer be tree-shaken.

## Before

```html
<!--
The style[amp-custom] element is populated with:
  4343 B (30%): link#wp-block-library-css[rel=stylesheet][href=https://wordpressdev.lndo.site/content/plugins/gutenberg/build/block-library/style.css?ver=1569254363][media=all]
   658 B (57%): link#amp-stories-css[rel=stylesheet][href=https://wordpressdev.lndo.site/content/plugins/amp/assets/css/amp-stories.css?ver=1.3-RC1][media=all]
  1195 B (69%): link#amp-stories-frontend-css[rel=stylesheet][href=https://wordpressdev.lndo.site/content/plugins/amp/assets/css/amp-stories-frontend.css?ver=1.3-RC1][media=]
    75 B: style#bubblegum-sans-font-inline-css
    63 B: style#boogaloo-font-inline-css
    63 B: style#balthazar-font-inline-css
   129 B: div.amp-story-block-wrapper amp-wp-b3afd51
   126 B: div.amp-story-block-wrapper amp-wp-3612edb
   130 B: div.amp-story-block-wrapper amp-wp-5cc6f64
   130 B: h1.wp-block-amp-amp-story-text has-background has-very-light-gray-background-color amp-wp-13be987[data-font-family=Boogaloo]
   119 B: div.wp-block-cover has-background-dim alignwide amp-wp-d28a8c9
    79 B: p.amp-wp-f6e3d7f
    88 B: amp-img.wp-smiley amp-wp-enforced-sizes amp-wp-843f19c[src=https://s.w.org/images/core/emoji/12.0.0-1/72x72/1f642.png][alt=🙂][width=72][height=72][noloading=][layout=intrinsic]
    80 B: p.amp-wp-13076d9
    84 B: amp-story-page#3a7fb829-6179-4ccb-93a3-7ecda29a1b92.wp-block-amp-amp-story-page amp-wp-74885c3
   123 B: div.amp-story-block-wrapper amp-wp-7b64e67
    75 B: h1.wp-block-amp-amp-story-text amp-wp-f7dbba7[data-font-family=Balthazar]
Total included size: 7,560 bytes (40% of 18,658 total after tree shaking)

The following stylesheets are too large to be included in style[amp-custom]:
 66365 B: style#amp-stories-inline-css
Total excluded size: 66,365 bytes (100% of 66,365 total after tree shaking)

Total combined size: 73,925 bytes (86% of 85,023 total after tree shaking)
-->
```

## After


```html
<!--
The style[amp-custom] element is populated with:
  4343 B (30%): link#wp-block-library-css[rel=stylesheet][href=https://wordpressdev.lndo.site/content/plugins/gutenberg/build/block-library/style.css?ver=1569254363][media=all]
   658 B (57%): link#amp-stories-css[rel=stylesheet][href=https://wordpressdev.lndo.site/content/plugins/amp/assets/css/amp-stories.css?ver=1.3-RC1][media=all]
  1195 B (69%): link#amp-stories-frontend-css[rel=stylesheet][href=https://wordpressdev.lndo.site/content/plugins/amp/assets/css/amp-stories-frontend.css?ver=1.3-RC1][media=]
    75 B: style#bubblegum-sans-font-inline-css
    63 B: style#boogaloo-font-inline-css
    63 B: style#balthazar-font-inline-css
   129 B: div.amp-story-block-wrapper amp-wp-b3afd51
   126 B: div.amp-story-block-wrapper amp-wp-3612edb
   130 B: div.amp-story-block-wrapper amp-wp-5cc6f64
   130 B: h1.wp-block-amp-amp-story-text has-background has-very-light-gray-background-color amp-wp-13be987[data-font-family=Boogaloo]
   119 B: div.wp-block-cover has-background-dim alignwide amp-wp-d28a8c9
    79 B: p.amp-wp-f6e3d7f
    88 B: amp-img.wp-smiley amp-wp-enforced-sizes amp-wp-843f19c[src=https://s.w.org/images/core/emoji/12.0.0-1/72x72/1f642.png][alt=🙂][width=72][height=72][noloading=][layout=intrinsic]
    80 B: p.amp-wp-13076d9
    84 B: amp-story-page#3a7fb829-6179-4ccb-93a3-7ecda29a1b92.wp-block-amp-amp-story-page amp-wp-74885c3
   123 B: div.amp-story-block-wrapper amp-wp-7b64e67
    75 B: h1.wp-block-amp-amp-story-text amp-wp-f7dbba7[data-font-family=Balthazar]
Total included size: 7,560 bytes (40% of 18,658 total after tree shaking)
-->
```

----

This also fixes blatant error in `test_render_post_filters` which was introduced [a long time ago](https://github.com/ampproject/amp-wp/commit/a3d442d508ea9dd67bb5c1400df4f925e865ba10#diff-7cb041fee8b2b4136ee36be5573f28b6R1180), but for some reason it only showed up now. Fixes #3327.