### PR TITLE
Improve handling of Stories in Compatibility Tool

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2115,7 +2115,7 @@ class AMP_Theme_Support {
 				AMP_HTTP::send_server_timing( 'amp_processor_cache_hit', -$prepare_response_start );
 
 				// Redirect to non-AMP version.
-				if ( ! amp_is_canonical() && $blocking_error_count > 0 ) {
+				if ( ! amp_is_canonical() && ! is_singular( AMP_Story_Post_Type::POST_TYPE_SLUG ) && $blocking_error_count > 0 ) {
 					if ( AMP_Validation_Manager::has_cap() ) {
 						$non_amp_url = add_query_arg( AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR, $blocking_error_count, $non_amp_url );
 					}
@@ -2247,7 +2247,7 @@ class AMP_Theme_Support {
 			 * already surfaced inside of WordPress. This is intended to not serve dirty AMP, but rather a
 			 * non-AMP document (intentionally not valid AMP) that contains the AMP runtime and AMP components.
 			 */
-			if ( amp_is_canonical() ) {
+			if ( amp_is_canonical() || is_singular( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 				$dom->documentElement->removeAttribute( 'amp' );
 				$dom->documentElement->removeAttribute( '⚡️' );
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -598,8 +598,11 @@ class AMP_Validated_URL_Post_Type {
 		}
 		$url = $post->post_title;
 
+		$queried_object = get_post_meta( $post->ID, '_amp_queried_object', true );
+		$is_amp_story   = isset( $queried_object['id'], $queried_object['type'] ) && 'post' === $queried_object['type'] && AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type( $queried_object['id'] );
+
 		// Add AMP query var if in transitional mode.
-		if ( ! amp_is_canonical() ) {
+		if ( ! amp_is_canonical() && ! $is_amp_story ) {
 			$url = add_query_arg( amp_get_slug(), '', $url );
 		}
 


### PR DESCRIPTION
In #3321 it was discovered that rejecting the sanitization of a validation error on an AMP Story results in an infinite redirect when a site is not in Standard mode. When processing a Story, it should behave as if the site is in Standard mode. No redirection should be performed when there are rejected validation errors, but rather the `amp` attribute should be removed from the page to prevent it from being validated as a valid AMP page.

In the same way, when a Story is listed among the Validated URLs in the admin, there should be no `?amp` appearing in the displayed URLs.

Testing instructions:

1. Set mode to Transitional.
2. Create a Story and add a Custom HTML block with some invalid AMP markup, like `<script>bad</script>`
3. Publish Story.
4. A warning message should appear about validation errors. Click “Review Issues”.
5. With this ifx applied, the Validated URL screen should not show `?amp` in the heading.
5. On the Validated URL screen, set the validation error status as “Rejected” instead of “New Accepted”. Press Update.
6. Try navigating to the permalink of the post, and the Story should render but not as a valid AMP page; the Custom HTML markup should appear in the page, and the `html` element should have the `amp` attribute omitted.

# Before

![image](https://user-images.githubusercontent.com/134745/65466754-9ad6ee80-de14-11e9-91b0-0d2e5c5bb562.png)

Viewing the story:

![image](https://user-images.githubusercontent.com/134745/65467106-7af3fa80-de15-11e9-9dbf-5bf4c5f428e8.png)

# After

![image](https://user-images.githubusercontent.com/134745/65466721-8bf03c00-de14-11e9-97af-4a4d1564105f.png)

Viewing the story:

![image](https://user-images.githubusercontent.com/134745/65467051-59930e80-de15-11e9-9a47-ed140637f556.png)