### PR TITLE
Ensure all AMP scripts (including v0.js) get moved to the head

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2196,7 +2196,7 @@ class AMP_Theme_Support {
 
 		// Make sure scripts from the body get moved to the head.
 		if ( isset( $head ) ) {
-			foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template ]' ) as $script ) {
+			foreach ( $xpath->query( '//body//script[ @custom-element or @custom-template or @src = "https://cdn.ampproject.org/v0.js" ]' ) as $script ) {
 				$head->appendChild( $script->parentNode->removeChild( $script ) );
 			}
 		}

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1352,6 +1352,42 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test moving AMP scripts from body to head.
+	 *
+	 * @covers AMP_Theme_Support::prepare_response()
+	 * @covers AMP_Theme_Support::ensure_required_markup()
+	 */
+	public function test_scripts_get_moved_to_head() {
+		ob_start();
+		?>
+		<html>
+			<head></head>
+			<body>
+				<amp-list width="auto" height="100" layout="fixed-height" src="/static/inline-examples/data/amp-list-urls.json">
+					<template type="amp-mustache">
+						<div class="url-entry">
+							<a href="{{url}}">{{title}}</a>
+						</div>
+					</template>
+				</amp-list>
+				<?php wp_print_scripts( [ 'amp-runtime', 'amp-mustache', 'amp-list' ] ); ?>
+			</body>
+		</html>
+		<?php
+		$html = ob_get_clean();
+		$html = AMP_Theme_Support::prepare_response( $html );
+
+		$dom   = AMP_DOM_Utils::get_dom( $html );
+		$xpath = new DOMXPath( $dom );
+
+		$scripts = $xpath->query( '//script[ not( @type ) or @type = "text/javascript" ]' );
+		$this->assertSame( 3, $scripts->length );
+		foreach ( $scripts as $script ) {
+			$this->assertSame( 'head', $script->parentNode->nodeName );
+		}
+	}
+
+	/**
 	 * Test dequeue_customize_preview_scripts.
 	 *
 	 * @covers AMP_Theme_Support::dequeue_customize_preview_scripts()


### PR DESCRIPTION
When using a Latest Stories block on a page, this results on `amp-carousel` and `amp-runtime` scripts being enqueued on the page, and printed in the footer. While AMP component scripts are getting moved to the `head`, this was not being done for `v0.js`. So this ensures that no validation error from happening regarding `v0.js` being in the `body`:

![image](https://user-images.githubusercontent.com/134745/65466451-bab9e280-de13-11e9-9fbf-aaef829ed56d.png)

Steps to reproduce:

1. Create a story.
2. Create a page containing a Latest Stories block.
3. View the page as AMP.
4. Without the fix, a validation error should be reported (above); with the fix, no error should be reported.