### PR TITLE
Sanitize invalid children of amp-story and amp-story-page elements to prevent white story of death

### DIFF
--- a/includes/sanitizers/class-amp-story-sanitizer.php
+++ b/includes/sanitizers/class-amp-story-sanitizer.php
@@ -21,18 +21,14 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 	public static $tag = 'amp-story-page';
 
 	/**
-	 * AMP Story tag spec.
+	 * Allowed children for given tags.
 	 *
 	 * @var array
 	 */
-	private $amp_story_tag_spec;
-
-	/**
-	 * AMP Story Page tag spec.
-	 *
-	 * @var array
-	 */
-	private $amp_story_page_tag_spec;
+	private $tag_allowed_children = [
+		'amp-story'      => [],
+		'amp-story-page' => [],
+	];
 
 	/**
 	 * Sanitize the AMP elements contained by <amp-story-page> element where necessary.
@@ -40,8 +36,23 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 0.2
 	 */
 	public function sanitize() {
-		$this->amp_story_tag_spec      = AMP_Allowed_Tags_Generated::get_allowed_tag( 'amp-story' )[0];
-		$this->amp_story_page_tag_spec = AMP_Allowed_Tags_Generated::get_allowed_tag( 'amp-story-page' )[0];
+
+		// Gather the allowed children for amp-story and amp-story-page elements.
+		foreach ( array_keys( $this->tag_allowed_children ) as $tag_name ) {
+			$rule_specs = AMP_Allowed_Tags_Generated::get_allowed_tag( $tag_name );
+			if ( ! isset( $rule_specs ) ) {
+				continue;
+			}
+			foreach ( $rule_specs as $rule_spec ) {
+				if ( ! isset( $rule_spec['tag_spec']['child_tags']['child_tag_name_oneof'] ) ) {
+					continue;
+				}
+				$this->tag_allowed_children[ $tag_name ] = array_merge(
+					$this->tag_allowed_children[ $tag_name ],
+					$rule_spec['tag_spec']['child_tags']['child_tag_name_oneof']
+				);
+			}
+		}
 
 		$amp_story_element = $this->dom->getElementsByTagName( 'amp-story' )->item( 0 );
 		if ( $amp_story_element instanceof DOMElement ) {
@@ -64,8 +75,8 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 				if ( 'amp-story-page' === $node->nodeName ) {
 					$page_number++;
 					$this->sanitize_story_page_element( $node, $page_number );
-				} elseif ( ! in_array( $node->nodeName, $this->amp_story_tag_spec['tag_spec']['child_tags']['child_tag_name_oneof'], true ) ) {
-					$this->remove_invalid_child( $node );
+				} else {
+					$this->maybe_remove_disallowed_child( $node );
 				}
 			}
 			$node = $next_node;
@@ -97,12 +108,35 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 					if ( 1 === $page_number || $cta_layer_count > 1 ) {
 						$element->removeChild( $node );
 					}
-				} elseif ( ! in_array( $node->nodeName, $this->amp_story_page_tag_spec['tag_spec']['child_tags']['child_tag_name_oneof'], true ) ) {
-					$this->remove_invalid_child( $node );
+				} else {
+					$this->maybe_remove_disallowed_child( $node );
 				}
 			}
 			$node = $next_node;
 		}
 	}
 
+	/**
+	 * Remove an element if it is not allowed by the parent.
+	 *
+	 * @param DOMElement $node Child element.
+	 * @return bool Whether the child was removed.
+	 */
+	private function maybe_remove_disallowed_child( DOMElement $node ) {
+		if ( ! $node->parentNode ) {
+			return false;
+		}
+
+		$parent_node_name = $node->parentNode->nodeName;
+		if ( empty( $this->tag_allowed_children[ $parent_node_name ] ) ) {
+			return false;
+		}
+
+		if ( in_array( $node->nodeName, $this->tag_allowed_children[ $parent_node_name ], true ) ) {
+			return false;
+		}
+
+		$this->remove_invalid_child( $node );
+		return true;
+	}
 }

--- a/tests/php/test-amp-story-sanitizer.php
+++ b/tests/php/test-amp-story-sanitizer.php
@@ -46,6 +46,14 @@ class AMP_Story_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page><amp-story-page><amp-story-grid-layer></amp-story-grid-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer></amp-story-page>',
 				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page><amp-story-page><amp-story-grid-layer></amp-story-grid-layer><amp-story-cta-layer><a href="">Foo</a></amp-story-cta-layer></amp-story-page>',
 			],
+			'story_with_invalid_root_elements' => [
+				'<p>Word count: 4</p><amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page><p>Related posts: <a href="https://example.com/"><strong>Example</strong></a></p>',
+				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page>',
+			],
+			'story_with_invalid_layer_siblings' => [
+				'<amp-story-page><p>Before layer</p><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer><p>After layer</p></amp-story-page</p>',
+				'<amp-story-page><amp-story-grid-layer><p>Lorem Ipsum Demet Delorit.</p></amp-story-grid-layer></amp-story-page>',
+			],
 		];
 	}
 
@@ -57,8 +65,13 @@ class AMP_Story_Sanitizer_Test extends WP_UnitTestCase {
 	 * @dataProvider get_data
 	 */
 	public function test_converter( $source, $expected = null ) {
+		$amp_story_element = '<amp-story standalone title="Test" publisher="Tester" publisher-logo-src="https://example.com/favicons/tester-228x228.png" poster-portrait-src="https://example.com/test.jpg">%s</amp-story>';
+
+		$source = sprintf( $amp_story_element, $source );
 		if ( is_null( $expected ) ) {
 			$expected = $source;
+		} else {
+			$expected = sprintf( $amp_story_element, $expected );
 		}
 		$dom = AMP_DOM_Utils::get_dom_from_content( $source );
 


### PR DESCRIPTION
A compatibility issue was discovered in #3321 with the [Reading Time WP](https://wordpress.org/plugins/reading-time-wp/) plugin, but it is likely going to happen with other plugins as well. The Reading Time WP plugin filters `the_content` to inject this at the beginning:

```html
<span class="rt-reading-time" style="display: block;"><span class="rt-label">Reading Time: </span> <span class="rt-time">1</span> <span class="rt-label rt-postfix">minute</span></span>
```

This results in invalid `amp-story` which [restricts its children](https://github.com/ampproject/amphtml/blob/1c1e722ad99fc5352e5519b28cdb0db99854e2fd/extensions/amp-story/validator-amp-story.protoascii#L100-L111) to elements like `amp-story-page`. When this `span` is a direct child and the `child_tag_name_oneof` constraint is violated, the result is the entire `amp-story` being invalid and a white story of death (where the `body` has no children). The validation error is not helpful at all:

![image](https://user-images.githubusercontent.com/134745/65471275-78000680-de23-11e9-9ec7-f4d0ef55e724.png)

This problem was actually “prophesied” in #2926:

> 👉 A side-effect of the change here is the sanitization of AMP components with invalid children will be more draconian. For example, if an `amp-story` has an invalid child element, then the entire `amp-story` element will be removed, as opposed to the invalid child alone being removed. Nevertheless, since only AMP components have such validation constraints for children, it should not so common for this to occur in WordPress sites that are just outputting normal HTML. It only will become an issue when starting to use AMP components, and this makes https://github.com/ampproject/amp-wp/issues/1420 much more important as it will be needed to explain _why_ the element was removed.

So this PR fixes the problem by extending the `AMP_Story_Sanitizer` to preemptively remove AMP Story elements under `amp-story` and `amp-story-page` which are invalid. These are the two elements which have the `child_tag_name_oneof` constraint. This special case sanitizer is especially important for AMP Stories since all of the markup for a story is in `post_content` and is prone to be mutated with `the_content` filters to add elements like word counts, sharing buttons, and related posts. This PR prevents such elements from being seen by the tag-and-attribute sanitizer, thus preventing the `amp-story` and `amp-story-page` as a whole from being removed.

In the case of the `span` which the Reading Time WP plugin adds to `the_content`, the validation error now becomes much more helpful:

![image](https://user-images.githubusercontent.com/134745/65471480-2015cf80-de24-11e9-926a-b761b4a8b4dd.png)

And no white story of death occurs.

Fixes #3321.