### PR TITLE
Add PHP 7.4 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,9 @@ jobs:
     - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
     # PHP and JavaScript unit tests (7.3, WordPress trunk, with code coverage)
     - env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1 RUN_PHPUNIT_COVERAGE=1
+    # PHP unit tests (7.4, WordPress trunk)
+    - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
+      php: 7.4snapshot
   include:
     - stage: lint
       name: Lint (PHP, JavaScript, and configuration files)
@@ -138,6 +141,10 @@ jobs:
 
     - name: PHP unit tests (7.3, WordPress trunk)
       php: "7.3"
+      env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
+
+    - name: PHP unit tests (7.4, WordPress trunk)
+      php: "7.4snapshot"
       env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
 
     - name: PHP and JavaScript unit tests (7.3, WordPress trunk, with code coverage)

--- a/tests/php/test-class-amp-story-post-type.php
+++ b/tests/php/test-class-amp-story-post-type.php
@@ -218,8 +218,8 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		];
 		$this->assertEquals( null, AMP_Story_Post_Type::override_story_embed_callback( null, $wrong_block ) );
 
-		// The conditional is now satisfied, so this should return the overriden callback.
-		$story_posts    = $this->create_story_posts_with_featured_images( [ 400, 400 ] );
+		// The conditional is now satisfied, so this should return the overridden callback.
+		$story_posts    = $this->create_story_posts_with_featured_images( [ [ 400, 400 ] ] );
 		$amp_story_post = reset( $story_posts );
 		$correct_url    = get_post_permalink( $amp_story_post );
 		$correct_block  = [


### PR DESCRIPTION
This lets us catch potential compatibility issues in advance while not failing the whole build.