### PR TITLE
Auto-reject excessive CSS validation errors

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -671,7 +671,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $cdata_spec['max_bytes'] ) && strlen( $element->textContent ) > $cdata_spec['max_bytes'] ) {
 			// Skip the <style amp-custom> tag, as we want to display it even with an excessive size if it passed the style sanitizer.
 			// This would mean that AMP was disabled to not break the styling.
-			if ( $element->nodeName !== 'style' || ! $element->hasAttributes() || $element->attributes->item(0)->nodeName !== 'amp-custom' ) {
+			if ( 'style' !== $element->nodeName || ! $element->hasAttributes() || 'amp-custom' !== $element->attributes->item( 0 )->nodeName ) {
 				return new WP_Error( 'excessive_bytes' );
 			}
 		}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -668,12 +668,14 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return true|WP_Error True when valid or error when invalid.
 	 */
 	private function validate_cdata_for_node( DOMElement $element, $cdata_spec ) {
-		if ( isset( $cdata_spec['max_bytes'] ) && strlen( $element->textContent ) > $cdata_spec['max_bytes'] ) {
+		if (
+			isset( $cdata_spec['max_bytes'] ) && strlen( $element->textContent ) > $cdata_spec['max_bytes']
+			&&
 			// Skip the <style amp-custom> tag, as we want to display it even with an excessive size if it passed the style sanitizer.
 			// This would mean that AMP was disabled to not break the styling.
-			if ( 'style' !== $element->nodeName || ! $element->hasAttributes() || 'amp-custom' !== $element->attributes->item( 0 )->nodeName ) {
-				return new WP_Error( 'excessive_bytes' );
-			}
+			! ( 'style' === $element->nodeName && $element->hasAttributes() && 'amp-custom' === $element->attributes->item( 0 )->nodeName )
+		) {
+			return new WP_Error( 'excessive_bytes' );
 		}
 		if ( isset( $cdata_spec['blacklisted_cdata_regex'] ) ) {
 			if ( preg_match( '@' . $cdata_spec['blacklisted_cdata_regex']['regex'] . '@u', $element->textContent ) ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -673,7 +673,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			&&
 			// Skip the <style amp-custom> tag, as we want to display it even with an excessive size if it passed the style sanitizer.
 			// This would mean that AMP was disabled to not break the styling.
-			! ( 'style' === $element->nodeName && $element->hasAttributes() && 'amp-custom' === $element->attributes->item( 0 )->nodeName )
+			! ( 'style' === $element->nodeName && $element->hasAttribute( 'amp-custom' ) )
 		) {
 			return new WP_Error( 'excessive_bytes' );
 		}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -669,7 +669,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function validate_cdata_for_node( DOMElement $element, $cdata_spec ) {
 		if ( isset( $cdata_spec['max_bytes'] ) && strlen( $element->textContent ) > $cdata_spec['max_bytes'] ) {
-			return new WP_Error( 'excessive_bytes' );
+			// Skip the <style amp-custom> tag, as we want to display it even with an excessive size if it passed the style sanitizer.
+			// This would mean that AMP was disabled to not break the styling.
+			if ( $element->nodeName !== 'style' || ! $element->hasAttributes() || $element->attributes->item(0)->nodeName !== 'amp-custom' ) {
+				return new WP_Error( 'excessive_bytes' );
+			}
 		}
 		if ( isset( $cdata_spec['blacklisted_cdata_regex'] ) ) {
 			if ( preg_match( '@' . $cdata_spec['blacklisted_cdata_regex']['regex'] . '@u', $element->textContent ) ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -750,7 +750,7 @@ class AMP_Validated_URL_Post_Type {
 								'term_group' => $sanitization['status'],
 							]
 						);
-					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted() || $is_story ) {
+					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted( $data ) || $is_story ) {
 						$term_data['term_group'] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS;
 						wp_update_term(
 							$term_id,

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -453,7 +453,7 @@ class AMP_Validation_Error_Taxonomy {
 		if ( ! empty( $term ) && in_array( $term->term_group, $statuses, true ) ) {
 			$term_status = $term->term_group;
 		} else {
-			$term_status = AMP_Validation_Manager::is_sanitization_auto_accepted() ? self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS : self::VALIDATION_ERROR_NEW_REJECTED_STATUS;
+			$term_status = AMP_Validation_Manager::is_sanitization_auto_accepted( $error ) ? self::VALIDATION_ERROR_NEW_ACCEPTED_STATUS : self::VALIDATION_ERROR_NEW_REJECTED_STATUS;
 		}
 
 		$forced = false;

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -297,15 +297,11 @@ class AMP_Validation_Manager {
 	 */
 	public static function is_sanitization_auto_accepted( $error = null ) {
 		if ( ! amp_is_canonical() ) {
-			return false;
+			// @todo Eliminate auto_accept_sanitization altogether.
+			return AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
 		}
 
-		if ( $error && 'excessive_css' === $error['code'] ) {
-			return false;
-		}
-
-		// @todo Eliminate auto_accept_sanitization altogether.
-		return AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
+		return ! ( $error && 'excessive_css' === $error['code'] );
 	}
 
 	/**

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -292,10 +292,20 @@ class AMP_Validation_Manager {
 	/**
 	 * Return whether sanitization is forcibly accepted, whether because in AMP-first mode or via user option.
 	 *
+	 * @param array $error Optional. Validation error. Will query the general status if no error provided.
 	 * @return bool Whether sanitization is forcibly accepted.
 	 */
-	public static function is_sanitization_auto_accepted() {
-		return amp_is_canonical() || AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
+	public static function is_sanitization_auto_accepted( $error = null ) {
+		if ( ! amp_is_canonical() ) {
+			return false;
+		}
+
+		if ( $error && 'excessive_css' === $error['code'] ) {
+			return false;
+		}
+
+		// @todo Eliminate auto_accept_sanitization altogether.
+		return AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
 	}
 
 	/**

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1890,7 +1890,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 		);
 
 		$data['dont_strip_excessive_css_in_amp_custom_document'] = [
-			$dont_strip_excessive_css_in_amp_custom_document
+			$dont_strip_excessive_css_in_amp_custom_document,
 		];
 
 		// Also include the body tests.

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1820,7 +1820,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				<html amp data-ampdevmode>
 					<head>
 						<meta charset="utf-8">
-						<style amp-custom data-ampdevmode>%s</style>
+						<style data-ampdevmode>%s</style>
 					</head>
 					<body>
 						<amp-state id="something">

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1864,6 +1864,35 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 		];
 
+		$max_size = null;
+		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'style' ) as $spec_rule ) {
+			if ( isset( $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) && 'style amp-custom' === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
+				$max_size = $spec_rule[ AMP_Rule_Spec::CDATA ]['max_bytes'];
+				break;
+			}
+		}
+		if ( ! $max_size ) {
+			throw new Exception( 'Could not find amp-custom max_bytes' );
+		}
+
+		$dont_strip_excessive_css_in_amp_custom_document = sprintf(
+			'
+				<html amp>
+					<head>
+						<meta charset="utf-8">
+						<style amp-custom>%s</style>
+					</head>
+					<body>
+					</body>
+				</html>
+				',
+			'body::after { content:"' . str_repeat( 'a', $max_size ) . '";"}'
+		);
+
+		$data['dont_strip_excessive_css_in_amp_custom_document'] = [
+			$dont_strip_excessive_css_in_amp_custom_document
+		];
+
 		// Also include the body tests.
 		$html_doc_format = '<html amp><head><meta charset="utf-8"></head><body><!-- before -->%s<!-- after --></body></html>';
 		foreach ( $this->get_body_data() as $body_test ) {

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -229,8 +229,17 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::is_sanitization_auto_accepted()
 	 */
 	public function test_is_sanitization_auto_accepted() {
-		$some_error = [ 'node_name' => 'href', 'parent_name' => 'a', 'type' => 'html_attribute_error', 'code' => 'invalid_attribute' ];
-		$excessive_css_error = [ 'node_name' => 'style', 'type' => 'css', 'code' => 'excessive_css' ];
+		$some_error = [
+			'node_name'   => 'href',
+			'parent_name' => 'a',
+			'type'        => 'html_attribute_error',
+			'code'        => 'invalid_attribute',
+		];
+		$excessive_css_error = [
+			'node_name' => 'style',
+			'type'      => 'css',
+			'code'      => 'excessive_css',
+		];
 
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -223,28 +223,44 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	/**
 	 * Test add_validation_hooks.
 	 *
+	 * Excessive CSS validation errors have special case handling.
+	 * @see https://github.com/ampproject/amp-wp/issues/2326
+	 *
 	 * @covers AMP_Validation_Manager::is_sanitization_auto_accepted()
 	 */
 	public function test_is_sanitization_auto_accepted() {
+		$some_error = [ 'node_name' => 'href', 'parent_name' => 'a', 'type' => 'html_attribute_error', 'code' => 'invalid_attribute' ];
+		$excessive_css_error = [ 'node_name' => 'style', 'type' => 'css', 'code' => 'excessive_css' ];
+
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
+		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
+		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
+		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 	}
 
 	/**

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -251,7 +251,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
-		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
+		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
@@ -269,7 +269,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
-		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
+		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 	}
 
 	/**


### PR DESCRIPTION
The `AMP_Validation_Manager::is_sanitization_auto_accepted()` now accepts an `$error` as argument and auto-rejects the specific case of an excessive CSS validation error.

In addition, the Tag & Attribute sanitizer specifically ignores the `<style amp-custom>` tag when it comes to the `max_bytes` rule in the spec (introduced in #3084).

Finally, to ensure that the resulting `<style amp-custom>` is not stripped itself for excessive size, the tag & attribute sanitizer treats this tag as a special case for enforcing the `'max_bytes'` spec rule.

Fixes #2326 