### PR TITLE
Fix bug in style sanitizer not freeing up memory because of wrong index

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2503,7 +2503,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $pending_stylesheet['stylesheet'] as $j => $part ) {
 				if ( is_string( $part ) && 0 === strpos( $part, '@import' ) ) {
 					$stylesheet_groups[ $pending_stylesheet['group'] ]['import_front_matter'] .= $part;
-					unset( $this->pending_stylesheets['stylesheet'][ $j ][ $i ] );
+					unset( $this->pending_stylesheets[ $i ]['stylesheet'][ $j ] );
 				}
 			}
 


### PR DESCRIPTION
In the style sanitizer, when the `@import` statements are being processed, there is an `unset()` operation that works against an invalid index. It looks like the iterating indexes were mixed up in the initial code and further broken in subsequent changes.

As this is within an `unset()`, it doesn't throw an immediate error, but trying to actually look at what is being unset returns an invalid index error.