### PR TITLE
Add function to print amp story bookend by default

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1304,6 +1304,53 @@ function amp_print_story_auto_ads() {
 	echo AMP_HTML_Utils::build_tag( 'amp-story-auto-ads', [], $script_element ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
+
+/**
+ * Prints AMP Stories bookend.
+ *
+ * @since 1.2
+ */
+function amp_print_story_bookend() {
+	$bookend = [
+		'bookendVersion' => 'v1.0',
+		'shareProviders' => [
+			'facebook',
+			'twitter',
+			'email',
+		],
+		// @todo: Add some components by default.
+		'components'     => [],
+	];
+
+	/**
+	 * Filters AMP story bookend data.
+	 *
+	 * @param array   $bookend Bookend data.
+	 * @param WP_Post $post    The current story's post object.
+	 */
+	$bookend = apply_filters( 'amp_story_bookend_data', $bookend, get_post() );
+
+	if ( empty( $bookend ) ) {
+		return;
+	}
+
+	$script_element = AMP_HTML_Utils::build_tag(
+		'script',
+		[
+			'type' => 'application/json',
+		],
+		wp_json_encode( $bookend )
+	);
+
+	echo AMP_HTML_Utils::build_tag( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		'amp-story-bookend',
+		[
+			'layout' => 'nodisplay',
+		],
+		$script_element
+	);
+}
+
 /*
  * The function below is copied from the ramsey/array_column package.
  *

--- a/includes/templates/single-amp_story.php
+++ b/includes/templates/single-amp_story.php
@@ -65,6 +65,7 @@ the_post();
 			amp_print_story_auto_ads();
 			the_content();
 			amp_print_analytics( '' );
+			amp_print_story_bookend();
 			?>
 		</amp-story>
 


### PR DESCRIPTION
## Summary

Addresses issue #2442

As an alternative to #3163, this addresses #2442 by adding the bare minimum functionality.

Before:

![Screenshot 2019-09-26 at 15 49 40](https://user-images.githubusercontent.com/841956/65694755-a9bcdb80-e076-11e9-98eb-fb61e57bc837.png)

After:

![Screenshot 2019-09-26 at 15 49 18](https://user-images.githubusercontent.com/841956/65694767-ade8f900-e076-11e9-88fb-77355be59134.png)

There is a discussion in #2442 about what should be included by default.

This PR just adds some sharing providers, without adding any other stories to the mix, while still allowing developers to do so.

I think that is a good compromise for now.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).