### PR TITLE
Fix notice error for featured image in Reader Mode template when using Multisite-Global-Media plugin

### DIFF
--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -371,7 +371,7 @@ class AMP_Post_Template {
 		if ( ! $featured_image ) {
 			return;
 		}
-		
+
 		$sanitized_html = AMP_DOM_Utils::get_content_from_dom( $dom );
 
 		$this->add_data_by_key(

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -347,7 +347,11 @@ class AMP_Post_Template {
 			return;
 		}
 
-		$featured_id = get_post_thumbnail_id( $post_id );
+		$featured_id    = get_post_thumbnail_id( $post_id );
+		$featured_image = get_post( $featured_id );
+		if ( ! $featured_image ) {
+			return;
+		}
 
 		// If an image with the same ID as the featured image exists in the content, skip the featured image markup.
 		// Prevents duplicate images, which is especially problematic for photo blogs.
@@ -367,18 +371,13 @@ class AMP_Post_Template {
 			]
 		);
 
-		$featured_image = get_post( $featured_id );
-		if ( ! $featured_image ) {
-			return;
-		}
-
 		$sanitized_html = AMP_DOM_Utils::get_content_from_dom( $dom );
 
 		$this->add_data_by_key(
 			'featured_image',
 			[
 				'amp_html' => $sanitized_html,
-				'caption'  => get_the_excerpt( $featured_image ),
+				'caption'  => $featured_image->post_excerpt,
 			]
 		);
 

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -358,8 +358,6 @@ class AMP_Post_Template {
 			return;
 		}
 
-		$featured_image = get_post( $featured_id );
-
 		$dom    = AMP_DOM_Utils::get_dom_from_content( $featured_html );
 		$assets = AMP_Content_Sanitizer::sanitize_document(
 			$dom,
@@ -369,13 +367,18 @@ class AMP_Post_Template {
 			]
 		);
 
+		$featured_image = get_post( $featured_id );
+		if ( ! $featured_image ) {
+			return;
+		}
+		
 		$sanitized_html = AMP_DOM_Utils::get_content_from_dom( $dom );
 
 		$this->add_data_by_key(
 			'featured_image',
 			[
 				'amp_html' => $sanitized_html,
-				'caption'  => $featured_image->post_excerpt,
+				'caption'  => get_the_excerpt( $featured_image ),
 			]
 		);
 


### PR DESCRIPTION
Do some error handling for missing posts. Also make the excerpt is run through the get_the_excerpt filter.

Fixes #2869