### PR TITLE
Remove running redundant phpunit during deploy

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,9 +62,6 @@ module.exports = function( grunt ) {
 			readme: {
 				command: './vendor/xwp/wp-dev-lib/scripts/generate-markdown-readme', // Generate the readme.md.
 			},
-			phpunit: {
-				command: 'phpunit',
-			},
 			verify_matching_versions: {
 				command: 'php bin/verify-version-consistency.php',
 			},
@@ -237,7 +234,6 @@ module.exports = function( grunt ) {
 	] );
 
 	grunt.registerTask( 'deploy', [
-		'shell:phpunit',
 		'shell:verify_matching_versions',
 		'wp_deploy',
 	] );


### PR DESCRIPTION
I just tried running `npm run deploy` and I got a failure about `phpunit` command not being present. It should be doing `npm run test:php`, but in reality this is entirely redundant since it is the Travis CI build that should be looked at before doing a release.