### PR TITLE
Add missing dependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3123,13 +3123,13 @@
       }
     },
     "@wordpress/dom": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.0.tgz",
-      "integrity": "sha512-nJUskVX/0RIskGgQBCXRrMMMxJcZ1UwQlpDBMNVPwMD9KPw13YnzCTzR6QgUMvCYF4pDUmxVIP+ao7CQzAL9lg==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.5.1.tgz",
+      "integrity": "sha512-ZdolWmJGFcyLHmTEWzlWpSoA8EmT163f2wDNKNRGkyFcQ2A3T4F75bE020x+W0JhDpM+EclOfyflIu79O8Tn+w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "@wordpress/dom-ready": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@wordpress/core-data": "2.7.1",
     "@wordpress/data": "4.9.1",
     "@wordpress/date": "3.5.0",
+    "@wordpress/dom": "2.5.1",
     "@wordpress/dom-ready": "2.5.0",
     "@wordpress/e2e-test-utils": "2.4.1",
     "@wordpress/edit-post": "3.8.1",


### PR DESCRIPTION
The `CopyPasteHandler` component uses a function from the `@wordpress/dom` package, which is not explicitly listed as a dependency in `package.json`.

Not a big deal, as it's only a dev dependency and not actually bundled with the code. Plus, it's a dependency of `@wordpress/block-editor`, which we already include, so the package should exist anyways. That means [`eslint-plugin-import`](https://www.npmjs.com/package/eslint-plugin-import) can find it.

Oddly enough though, it causes issues for #3375, which is currently [failing](https://travis-ci.org/ampproject/amp-wp/jobs/591658060) because of this:

```
/home/travis/build/ampproject/amp-wp/assets/src/stories-editor/blocks/amp-story-page/copy-paste-handler.js
  10:38  error  Unable to resolve path to module '@wordpress/dom'  import/no-unresolved
```