### PR TITLE
Account for filtering of gallery 'link' attribute

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -171,14 +171,20 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 					return $attr;
 				};
 
+				$set_link_attribute = static function ( $attributes ) {
+					$attributes['link'] = 'none';
+					return $attributes;
+				};
+
 				remove_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10 );
 				add_filter( 'wp_get_attachment_image_attributes', $add_lightbox_attribute );
+				add_filter( 'shortcode_atts_gallery', $set_link_attribute, PHP_INT_MAX );
 
-				$attributes['link'] = 'none';
-				$html               = gallery_shortcode( $attributes );
+				$html = gallery_shortcode( $attributes );
 
 				remove_filter( 'wp_get_attachment_image_attributes', $add_lightbox_attribute );
 				add_filter( 'post_gallery', [ $this, 'maybe_override_gallery' ], 10, 2 );
+				remove_filter( 'shortcode_atts_gallery', $set_link_attribute, PHP_INT_MAX );
 			}
 
 			return $html;


### PR DESCRIPTION
## Summary

This fixes a case where a gallery lightbox doesn't open, when adding a `$atts['link'] = 'file'` to a `'shortcode_atts_gallery'` filter.

Addresses an edge case from issue https://github.com/ampproject/amp-wp/issues/2850#issuecomment-537790526

## Steps to reproduce
1. Create a post
2. Add a Shortcode block
3. Enter a gallery, like:
```html
[gallery ids="3762, 3470, 3327, 2877"]
```
4. Select 'Add lightbox effect'
5. Publish the post, and go to the front-end
6. Add this to a plugin:

```php
add_filter(
	'shortcode_atts_gallery',
	function( $atts ) {
		$atts['link'] = 'file';
		return $atts;
	}
);
```
7. Reload the front-end
8. Expected: on clicking an image in the gallery, it opens a lightbox
9. Actual: it goes to the URL of the image:

<img width="1013" alt="goes-to-url-of-image" src="https://user-images.githubusercontent.com/4063887/66165112-a20eb100-e5f9-11e9-9fe6-1763eb9f4c89.png">

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
