### PR TITLE
Fix Admin Bar positioning on mobile viewport

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1392,6 +1392,12 @@ class AMP_Theme_Support {
 			$header_callback();
 			$style = ob_get_clean();
 			$data  = trim( preg_replace( '#<style[^>]*>(.*)</style>#is', '$1', $style ) ); // See wp_add_inline_style().
+
+			// Override AMP's position:relative on the body for the sake of the AMP viewer, which is not relevant an an Admin Bar context.
+			if ( amp_is_dev_mode() ) {
+				$data .= 'html:not(#_) > body { position:unset !important; }';
+			}
+
 			wp_add_inline_style( 'admin-bar', $data );
 		}
 


### PR DESCRIPTION
## Summary

This override AMP's CSS:

```css
html.i-amphtml-fie:not(.i-amphtml-inabox)>body,
html.i-amphtml-singledoc:not(.i-amphtml-inabox)>body {
    position: relative!important;
}
```

By forcing the `position` to be `unset`, thus allowing the Admin Bar's `position:absolute` to be positioned outside of the `body`. AMP's CSS here is only relevant in the AMP viewer context, in which an AMP page with the Admin Bar in Dev Mode will never appear.

FIxes #3436.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
