### PR TITLE
Add lightbox support to Core Image blocks with links

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -405,7 +405,6 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			/*
 			 * Removes the <a> if the image is wrapped in one, as it can prevent the lightbox from working.
 			 * But this only removes the <a> if it links to the media file, not the attachment page.
-			 * If this feature is added, this can probably be removed: https://github.com/ampproject/amphtml/issues/25021
 			 */
 			if ( $is_node_wrapped_in_media_file_link ) {
 				$node->parentNode->parentNode->replaceChild( $node, $node->parentNode );

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -393,11 +393,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		if ( isset( $parent_attributes['data-amp-lightbox'] ) && true === filter_var( $parent_attributes['data-amp-lightbox'], FILTER_VALIDATE_BOOLEAN ) ) {
 			$attributes['data-amp-lightbox'] = '';
-			$attributes['on']                = 'tap:' . self::AMP_IMAGE_LIGHTBOX_ID;
-			$attributes['role']              = 'button';
-			$attributes['tabindex']          = 0;
-
-			$this->maybe_add_amp_image_lightbox_node();
+			$attributes['lightbox']          = '';
 
 			if ( $is_node_wrapped_in_anchor ) {
 				// Remove the <a> that the image is wrapped in, as it can prevent the lightbox from working.

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -395,8 +395,11 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			$attributes['data-amp-lightbox'] = '';
 			$attributes['lightbox']          = '';
 
+			/*
+			 * Remove the <a> if the image is wrapped in one, as it can prevent the lightbox from working.
+			 * If this feature is added, this can probably be removed: https://github.com/ampproject/amphtml/issues/25021
+			 */
 			if ( $is_node_wrapped_in_anchor ) {
-				// Remove the <a> that the image is wrapped in, as it can prevent the lightbox from working.
 				$node->parentNode->parentNode->replaceChild( $node, $node->parentNode );
 			}
 		}

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -372,13 +372,13 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 			return $attributes;
 		}
 
-		// This should be true for links to the actual media file, but not for links to the attachment page.
+		$is_file_url                        = preg_match( '/\.\w+$/', wp_parse_url( $parent_node->getAttribute( 'href' ), PHP_URL_PATH ) );
 		$is_node_wrapped_in_media_file_link = (
 			'a' === $parent_node->tagName
 			&&
 			( 'figure' === $parent_node->tagName || 'figure' === $parent_node->parentNode->tagName )
 			&&
-			attachment_url_to_postid( $parent_node->getAttribute( 'href' ) )
+			$is_file_url // This should be a link to the media file, not the attachment page.
 		);
 
 		if ( 'figure' !== $parent_node->tagName && ! $is_node_wrapped_in_media_file_link ) {

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -216,7 +216,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_with_custom_lightbox_attrs'         => [
 				'<figure data-amp-lightbox="true"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
-				'<figure data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure>',
 			],
 
 			'wide_image'                               => [
@@ -336,17 +336,17 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
 			'image_block_with_lightbox'                => [
 				'<figure class="wp-block-image" data-amp-lightbox="true"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure>',
-				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure>',
 			],
 
 			'image_block_wrapped_in_a_with_lightbox'   => [
 				'<figure class="wp-block-image" data-amp-lightbox="true"><a href="https://example.com/image.jpg"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></a></figure>',
-				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure>',
 			],
 
 			'aligned_image_block_with_lightbox'        => [
 				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure></div>',
-				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" lightbox="" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div>',
 			],
 
 			'test_with_dev_mode'                       => [

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -526,7 +526,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 		$method    = new ReflectionMethod( $sanitizer, 'does_node_have_block_class' );
 
 		$method->setAccessible( true );
-		$this->assertEquals( $expected, $method->invoke( $figures[0] ) );
+		$this->assertEquals( $expected, $method->invoke( $sanitizer, $figures[0] ) );
 	}
 
 	/**

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -526,7 +526,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 		$method    = new ReflectionMethod( $sanitizer, 'does_node_have_block_class' );
 
 		$method->setAccessible( true );
-		$this->assertEquals( $expected, $method->invoke( $sanitizer, $figures[0] ) );
+		$this->assertEquals( $expected, $method->invoke( $sanitizer, $figures->item( 0 ) ) );
 	}
 
 	/**

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -339,6 +339,11 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
 			],
 
+			'image_block_wrapped_in_a_with_lightbox'   => [
+				'<figure class="wp-block-image" data-amp-lightbox="true"><a href="https://example.com/image.jpg"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></a></figure>',
+				'<figure class="wp-block-image" data-amp-lightbox="true"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+			],
+
 			'aligned_image_block_with_lightbox'        => [
 				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" /></figure></div>',
 				'<div data-amp-lightbox="true" class="wp-block-image"><figure class="alignleft is-resized"><amp-img src="https://placehold.it/100x100" width="100" height="100" data-foo="bar" role="button" tabindex="0" data-amp-lightbox="" on="tap:amp-image-lightbox" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/100x100" width="100" height="100" role="button" tabindex="0"></noscript></amp-img></figure></div><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',


### PR DESCRIPTION
## Summary

As reported in #3450, there's an issue where images that are wrapped in `<a>` didn't support the lightbox feature. Clicking on them simply caused the browser to go to that link.

So this recognizes when an image is wrapped in `<a>`, and runs the lighbox logic for it.

Steps to reproduce:
1. Create a post
2. Add an Image block
3. Add any image to it
4. Click the 'link' icon, and click 'Media File' or 'Attachment Page':
<img width="978" alt="image-add-link" src="https://user-images.githubusercontent.com/4063887/66362986-42423e00-e94a-11e9-9f6a-6502b777ecf5.png">

5. Click 'Add lightbox effect'
6. Click 'Update,' and go to the front-end
7. Expected: Clicking that image causes the lightbox to display
8. Actual: it goes to the URL of the image:
<img width="1311" alt="image-attachment-url" src="https://user-images.githubusercontent.com/4063887/66363137-d01e2900-e94a-11e9-955d-d8aa872081c2.png">

Addresses issue #3450

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
