### PR TITLE
Always request the `force_svg_support` theme feature

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -885,8 +885,11 @@ function amp_get_content_sanitizers( $post = null ) {
 
 	$sanitizers = [
 		'AMP_Core_Theme_Sanitizer'        => [
-			'template'   => get_template(),
-			'stylesheet' => get_stylesheet(),
+			'template'       => get_template(),
+			'stylesheet'     => get_stylesheet(),
+			'theme_features' => [
+				'force_svg_support' => [], // Always replace 'no-svg' class with 'svg' if it exists.
+			],
 		],
 		'AMP_Img_Sanitizer'               => [
 			'align_wide_support' => current_theme_supports( 'align-wide' ),

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -82,7 +82,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'twentyseventeen_javascript_detection', // AMP is essentially no-js, with any interactively added explicitly via amp-bind.
 				],
 			],
-			'force_svg_support'                   => [],
 			'force_fixed_background_support'      => [],
 			'add_twentyseventeen_masthead_styles' => [],
 			'add_twentyseventeen_image_styles'    => [],
@@ -570,14 +569,18 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @link https://caniuse.com/#feat=svg
 	 */
 	public function force_svg_support() {
-		$this->dom->documentElement->setAttribute(
-			'class',
-			preg_replace(
-				'/(^|\s)no-svg(\s|$)/',
-				' svg ',
-				$this->dom->documentElement->getAttribute( 'class' )
-			)
-		);
+		$class = $this->dom->documentElement->getAttribute( 'class' );
+
+		if ( strpos( $class, 'no-svg' ) ) {
+			$this->dom->documentElement->setAttribute(
+				'class',
+				preg_replace(
+					'/(^|\s)no-svg(\s|$)/',
+					' svg ',
+					$this->dom->documentElement->getAttribute( 'class' )
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -571,7 +571,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	public function force_svg_support() {
 		$class = $this->dom->documentElement->getAttribute( 'class' );
 
-		if ( strpos( $class, 'no-svg' ) !== false ) {
+		if ( false !== strpos( $class, 'no-svg' ) ) {
 			$this->dom->documentElement->setAttribute(
 				'class',
 				preg_replace(

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -571,15 +571,19 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	public function force_svg_support() {
 		$class = $this->dom->documentElement->getAttribute( 'class' );
 
-		if ( false !== strpos( $class, 'no-svg' ) ) {
-			$this->dom->documentElement->setAttribute(
-				'class',
-				preg_replace(
-					'/(^|\s)no-svg(\s|$)/',
-					' svg ',
-					$this->dom->documentElement->getAttribute( 'class' )
-				)
+		if ( $class ) {
+			$count = 0;
+			$class = preg_replace(
+				'/(^|\s)no-svg(\s|$)/',
+				' svg ',
+				$class,
+				-1,
+				$count
 			);
+
+			if ( $count > 0 ) {
+				$this->dom->documentElement->setAttribute( 'class', $class );
+			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -571,7 +571,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	public function force_svg_support() {
 		$class = $this->dom->documentElement->getAttribute( 'class' );
 
-		if ( strpos( $class, 'no-svg' ) ) {
+		if ( strpos( $class, 'no-svg' ) !== false ) {
 			$this->dom->documentElement->setAttribute(
 				'class',
 				preg_replace(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
This PR allows `force_svg_support` theme feature to always be requested.

Fixes #3009.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
