### PR TITLE
Add direct support for Scribd embeds

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -810,6 +810,7 @@ function amp_get_content_embed_handlers( $post = null ) {
 			'AMP_Gfycat_Embed_Handler'      => [],
 			'AMP_Hulu_Embed_Handler'        => [],
 			'AMP_Imgur_Embed_Handler'       => [],
+			'AMP_Scribd_Embed_Handler'      => [],
 		],
 		$post
 	);

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -60,6 +60,7 @@ class AMP_Autoloader {
 		'AMP_Vimeo_Embed_Handler'            => 'includes/embeds/class-amp-vimeo-embed',
 		'AMP_Vine_Embed_Handler'             => 'includes/embeds/class-amp-vine-embed',
 		'AMP_YouTube_Embed_Handler'          => 'includes/embeds/class-amp-youtube-embed',
+		'AMP_Scribd_Embed_Handler'           => 'includes/embeds/class-amp-scribd-embed-handler',
 		'AMP_Analytics_Options_Submenu'      => 'includes/options/class-amp-analytics-options-submenu',
 		'AMP_Options_Menu'                   => 'includes/options/class-amp-options-menu',
 		'AMP_Options_Manager'                => 'includes/options/class-amp-options-manager',

--- a/includes/embeds/class-amp-scribd-embed-handler.php
+++ b/includes/embeds/class-amp-scribd-embed-handler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Class AMP_SoundCloud_Embed_Handler
+ * Class AMP_Scribd_Embed_Handler
  *
  * @package AMP
  * @since 1.3.1
@@ -22,7 +22,7 @@ class AMP_Scribd_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Unregisters embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ] );
 	}
 
 	/**
@@ -50,7 +50,7 @@ class AMP_Scribd_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string
 	 */
 	private function remove_script( $html ) {
-		$html_without_script = preg_replace( '#<script[^>].+?</script>#s', '', $html );
+		$html_without_script = preg_replace( '#<script.+?</script>#s', '', $html );
 
 		if ( null !== $html_without_script ) {
 			return $html_without_script;
@@ -68,8 +68,7 @@ class AMP_Scribd_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	private function inject_sandbox_attribute( $html ) {
 		if ( false === strpos( $html, 'sandbox="allow-scripts allow-popups"' ) ) {
-			preg_match( '#<iframe(?P<attributes>.+?)>#s', $html, $matches );
-			return "<iframe sandbox='allow-scripts allow-popups' ${matches['attributes']}></iframe>";
+			return str_replace( '<iframe ', '<iframe sandbox="allow-scripts allow-popups" ', $html );
 		}
 
 		return $html;

--- a/includes/embeds/class-amp-scribd-embed-handler.php
+++ b/includes/embeds/class-amp-scribd-embed-handler.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Class AMP_SoundCloud_Embed_Handler
+ *
+ * @package AMP
+ * @since 1.3.1
+ */
+
+/**
+ * Class AMP_Scribd_Embed_Handler
+ */
+class AMP_Scribd_Embed_Handler extends AMP_Base_Embed_Handler {
+
+	/**
+	 * Registers embed.
+	 */
+	public function register_embed() {
+		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 2 );
+	}
+
+	/**
+	 * Unregisters embed.
+	 */
+	public function unregister_embed() {
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10 );
+	}
+
+	/**
+	 * Filter oEmbed HTML for Scribd to to be AMP compatible.
+	 *
+	 * @param string $cache Cache for oEmbed.
+	 * @param string $url   Embed URL.
+	 * @return string Embed.
+	 */
+	public function filter_embed_oembed_html( $cache, $url ) {
+		if ( false === strpos( wp_parse_url( $url, PHP_URL_HOST ), 'scribd.com' ) ) {
+			return $cache;
+		}
+
+		$embed = $this->remove_script( $cache );
+		$embed = $this->inject_sandbox_attribute( $embed );
+
+		return $embed;
+	}
+
+	/**
+	 * Remove the 'script' element from the provided HTML if there is any.
+	 *
+	 * @param string $html HTML string.
+	 * @return string
+	 */
+	private function remove_script( $html ) {
+		$html_without_script = preg_replace( '#<script[^>].+?</script>#s', '', $html );
+
+		if ( null !== $html_without_script ) {
+			return $html_without_script;
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Add the sandbox attribute with 'allow-popups' & 'allow-scripts' permissions set so that the
+	 * full screen button works.
+	 *
+	 * @param string $html HTML string.
+	 * @return string
+	 */
+	private function inject_sandbox_attribute( $html ) {
+		if ( false === strpos( $html, 'sandbox="allow-scripts allow-popups"' ) ) {
+			preg_match( '#<iframe(?P<attributes>.+?)>#s', $html, $matches );
+			return "<iframe sandbox='allow-scripts allow-popups' ${matches['attributes']}></iframe>";
+		}
+
+		return $html;
+	}
+
+}

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -17,7 +17,7 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	protected $scribd_doc_url = 'https://www.scribd.com/document/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests';
+	protected $scribd_doc_url = 'https://www.scribd.com/doc/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests';
 
 	/**
 	 * Hypothetical Scribd document URL that would return an oEmbed response with a 'sandbox'
@@ -25,7 +25,7 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	protected $scribd_doc_with_sandbox_attr_url = 'https://www.scribd.com/document/NaN/Hypothetical-Book';
+	protected $scribd_doc_with_sandbox_attr_url = 'https://www.scribd.com/doc/NaN/Hypothetical-Book';
 
 	/**
 	 * Set up.
@@ -96,7 +96,6 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
-
 			'document_embed'                   => [
 				$this->scribd_doc_url . PHP_EOL,
 				'<p><iframe sandbox="allow-scripts allow-popups" title="Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
@@ -107,6 +106,19 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 				'<p><iframe title="Hypothetical Book" class="scribd_iframe_embed" sandbox="allow-forms allow-scripts allow-popups" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
 			],
 		];
+
+		// Prior to 5.2, there was no 'title' attribute on an iframe.
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.2', '<' ) ) {
+			$data['document_embed'] = [
+				$this->scribd_doc_url . PHP_EOL,
+				'<p><iframe sandbox="allow-scripts allow-popups" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+			];
+
+			$data['document_embed_with_sandbox_attr'] = [
+				$this->scribd_doc_with_sandbox_attr_url . PHP_EOL,
+				'<p><iframe class="scribd_iframe_embed" sandbox="allow-forms allow-scripts allow-popups" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+			];
+		}
 
 		return $data;
 	}

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -20,6 +20,14 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	protected $scribd_doc_url = 'https://www.scribd.com/document/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests';
 
 	/**
+	 * Hypothetical Scribd document URL that would return an oEmbed response with a 'sandbox'
+	 * attribute already set on the iframe.
+	 *
+	 * @var string
+	 */
+	protected $scribd_doc_with_sandbox_attr_url = 'https://www.scribd.com/document/NaN/Hypothetical-Book';
+
+	/**
 	 * Set up.
 	 *
 	 * @global WP_Post $post
@@ -28,10 +36,8 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 		global $post;
 		parent::setUp();
 
-		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
-
 		/*
-		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
+		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior to 4.9, the WP_Embed::shortcode()
 		 * method would short-circuit when this is the case:
 		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
 		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
@@ -39,6 +45,8 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
 			$post = self::factory()->post->create_and_get();
 		}
+
+		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
 	}
 
 	/**
@@ -62,8 +70,14 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 			return $preempt;
 		}
 
+		$body = '{"type":"rich","version":"1.0","provider_name":"Scribd","provider_url":"https://www.scribd.com/","cache_age":604800,"title":"Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests","author_name":"Joint Fire Science Program","author_url":"https://www.scribd.com/user/151878975/Joint-Fire-Science-Program","thumbnail_url":"https://imgv2-1-f.scribdassets.com/img/document/110799637/111x142/9fc8621525/1570598026?v=1","thumbnail_width":164,"thumbnail_height":212,"html":"\u003ciframe class=\"scribd_iframe_embed\" src=\"https://www.scribd.com/embeds/110799637/content\" data-aspect-ratio=\"1.2941176470588236\" scrolling=\"no\" id=\"110799637\" width=\"100%\" height=\"500\" frameborder=\"0\"\u003e\u003c/iframe\u003e\u003cscript type=\"text/javascript\"\u003e\n          (function() { var scribd = document.createElement(\"script\"); scribd.type = \"text/javascript\"; scribd.async = true; scribd.src = \"https://www.scribd.com/javascripts/embed_code/inject.js\"; var s = document.getElementsByTagName(\"script\")[0]; s.parentNode.insertBefore(scribd, s); })()\n        \u003c/script\u003e"}';
+
+		if ( false !== strpos( $url, 'Hypothetical-Book' ) ) {
+			$body = '{"type":"rich","version":"1.0","provider_name":"Scribd","provider_url":"https://www.scribd.com/","cache_age":604800,"title":"Hypothetical Book","author_name":"John Doe","author_url":"https://www.scribd.com/user/NaN/Hypothetical-Book","thumbnail_url":"https://imgv2-1-f.scribdassets.com/img/document/NaN/111x142/123/123?v=1","thumbnail_width":164,"thumbnail_height":212,"html":"\u003ciframe class=\"scribd_iframe_embed\" sandbox=\"allow-forms allow-scripts\" src=\"https://www.scribd.com/embeds/NaN/content\" data-aspect-ratio=\"1.2941176470588236\" scrolling=\"no\" id=\"NaN\" width=\"100%\" height=\"500\" frameborder=\"0\"\u003e\u003c/iframe\u003e\u003cscript type=\"text/javascript\"\u003e\n          (function() { var scribd = document.createElement(\"script\"); scribd.type = \"text/javascript\"; scribd.async = true; scribd.src = \"https://www.scribd.com/javascripts/embed_code/inject.js\"; var s = document.getElementsByTagName(\"script\")[0]; s.parentNode.insertBefore(scribd, s); })()\n        \u003c/script\u003e"}';
+		}
+
 		return [
-			'body'     => '{"type":"rich","version":"1.0","provider_name":"Scribd","provider_url":"https://www.scribd.com/","cache_age":604800,"title":"Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests","author_name":"Joint Fire Science Program","author_url":"https://www.scribd.com/user/151878975/Joint-Fire-Science-Program","thumbnail_url":"https://imgv2-1-f.scribdassets.com/img/document/110799637/111x142/9fc8621525/1570598026?v=1","thumbnail_width":164,"thumbnail_height":212,"html":"\u003ciframe class=\"scribd_iframe_embed\" src=\"https://www.scribd.com/embeds/110799637/content\" data-aspect-ratio=\"1.2941176470588236\" scrolling=\"no\" id=\"110799637\" width=\"100%\" height=\"500\" frameborder=\"0\"\u003e\u003c/iframe\u003e\u003cscript type=\"text/javascript\"\u003e\n          (function() { var scribd = document.createElement(\"script\"); scribd.type = \"text/javascript\"; scribd.async = true; scribd.src = \"https://www.scribd.com/javascripts/embed_code/inject.js\"; var s = document.getElementsByTagName(\"script\")[0]; s.parentNode.insertBefore(scribd, s); })()\n        \u003c/script\u003e"}',
+			'body'     => $body,
 			'response' => [
 				'code'    => 200,
 				'message' => 'OK',
@@ -78,14 +92,19 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	 */
 	public function get_conversion_data() {
 		$data = [
-			'no_embed'       => [
+			'no_embed'                         => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>' . PHP_EOL,
 			],
 
-			'document_embed' => [
+			'document_embed'                   => [
 				$this->scribd_doc_url . PHP_EOL,
 				'<p><iframe sandbox="allow-scripts allow-popups" title="Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+			],
+
+			'document_embed_with_sandbox_attr' => [
+				$this->scribd_doc_with_sandbox_attr_url . PHP_EOL,
+				'<p><iframe title="Hypothetical Book" class="scribd_iframe_embed" sandbox="allow-forms allow-scripts allow-popups" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
 			],
 		];
 
@@ -97,7 +116,7 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 	 *
 	 * @covers AMP_Scribd_Embed_Handler::filter_embed_oembed_html()
 	 * @covers AMP_Scribd_Embed_Handler::remove_script()
-	 * @covers AMP_Scribd_Embed_Handler::inject_sandbox_attribute()
+	 * @covers AMP_Scribd_Embed_Handler::inject_sandbox_permissions()
 	 * @dataProvider get_conversion_data
 	 *
 	 * @param $source

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Class AMP_Scribd_Embed_Handler_Test
+ *
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Scribd_Embed_Handler_Test
+ *
+ * @covers AMP_Scribd_Embed_Handler
+ */
+class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
+
+	/**
+	 * Scribd document URL.
+	 *
+	 * @var string
+	 */
+	protected $scribd_doc_url = 'https://www.scribd.com/document/110799637/Synthesis-of-Knowledge-Effects-of-Fire-and-Thinning-Treatments-on-Understory-Vegetation-in-Dry-U-S-Forests';
+
+	/**
+	 * Set up.
+	 *
+	 * @global WP_Post $post
+	 */
+	public function setUp() {
+		global $post;
+		parent::setUp();
+
+		add_filter( 'pre_http_request', [ $this, 'mock_http_request' ], 10, 3 );
+
+		/*
+		 * As #34115 in 4.9 a post is not needed for context to run oEmbeds. Prior ot 4.9, the WP_Embed::shortcode()
+		 * method would short-circuit when this is the case:
+		 * https://github.com/WordPress/wordpress-develop/blob/4.8.4/src/wp-includes/class-wp-embed.php#L192-L193
+		 * So on WP<4.9 we set a post global to ensure oEmbeds get processed.
+		 */
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.9', '<' ) ) {
+			$post = self::factory()->post->create_and_get();
+		}
+	}
+
+	/**
+	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 */
+	public function tearDown() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http_request' ] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Mock HTTP request.
+	 *
+	 * @param mixed  $preempt Whether to preempt an HTTP request's return value. Default false.
+	 * @param mixed  $r       HTTP request arguments.
+	 * @param string $url     The request URL.
+	 * @return array Response data.
+	 */
+	public function mock_http_request( $preempt, $r, $url ) {
+		if ( false === strpos( $url, 'scribd.com' ) ) {
+			return $preempt;
+		}
+
+		return [
+			'body'     => '{"type":"rich","version":"1.0","provider_name":"Scribd","provider_url":"https://www.scribd.com/","cache_age":604800,"title":"Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests","author_name":"Joint Fire Science Program","author_url":"https://www.scribd.com/user/151878975/Joint-Fire-Science-Program","thumbnail_url":"https://imgv2-1-f.scribdassets.com/img/document/110799637/111x142/9fc8621525/1570598026?v=1","thumbnail_width":164,"thumbnail_height":212,"html":"\u003ciframe class=\"scribd_iframe_embed\" src=\"https://www.scribd.com/embeds/110799637/content\" data-aspect-ratio=\"1.2941176470588236\" scrolling=\"no\" id=\"110799637\" width=\"100%\" height=\"500\" frameborder=\"0\"\u003e\u003c/iframe\u003e\u003cscript type=\"text/javascript\"\u003e\n          (function() { var scribd = document.createElement(\"script\"); scribd.type = \"text/javascript\"; scribd.async = true; scribd.src = \"https://www.scribd.com/javascripts/embed_code/inject.js\"; var s = document.getElementsByTagName(\"script\")[0]; s.parentNode.insertBefore(scribd, s); })()\n        \u003c/script\u003e"}',
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+	}
+
+	/**
+	 * Get conversion data.
+	 *
+	 * @return array
+	 */
+	public function get_conversion_data() {
+		$data = [
+			'no_embed'       => [
+				'<p>Hello world.</p>',
+				'<p>Hello world.</p>' . PHP_EOL,
+			],
+
+			'document_embed' => [
+				$this->scribd_doc_url . PHP_EOL,
+				'<p><iframe sandbox="allow-scripts allow-popups" title="Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+			],
+		];
+
+		return $data;
+	}
+
+	/**
+	 * Test conversion.
+	 *
+	 * @covers AMP_Scribd_Embed_Handler::filter_embed_oembed_html()
+	 * @covers AMP_Scribd_Embed_Handler::remove_script()
+	 * @covers AMP_Scribd_Embed_Handler::inject_sandbox_attribute()
+	 * @dataProvider get_conversion_data
+	 *
+	 * @param $source
+	 * @param $expected
+	 */
+	public function test__conversion( $source, $expected ) {
+		$embed = new AMP_Scribd_Embed_Handler();
+		$embed->register_embed();
+		$filtered_content = apply_filters( 'the_content', $source );
+
+		$this->assertEquals( $expected, $filtered_content );
+	}
+
+	/**
+	 * Get scripts data.
+	 *
+	 * @return array Scripts data.
+	 */
+	public function get_scripts_data() {
+		return [
+			'not_converted'      => [
+				'<p>Hello World.</p>',
+				[],
+			],
+			'converted_document' => [
+				$this->scribd_doc_url . PHP_EOL,
+				[],
+			],
+		];
+	}
+
+	/**
+	 * Test get_scripts().
+	 *
+	 * @covers AMP_Scribd_Embed_Handler::get_scripts()
+	 * @dataProvider get_scripts_data
+	 *
+	 * @param string $source   Source.
+	 * @param string $expected Expected.
+	 */
+	public function test__get_scripts( $source, $expected ) {
+		$embed = new AMP_Scribd_Embed_Handler();
+		$embed->register_embed();
+		$source = apply_filters( 'the_content', $source );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$whitelist_sanitizer->sanitize();
+
+		$scripts = array_merge(
+			$embed->get_scripts(),
+			$whitelist_sanitizer->get_scripts()
+		);
+
+		$this->assertEquals( $expected, $scripts );
+	}
+
+}

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -98,12 +98,12 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 			],
 			'document_embed'                   => [
 				$this->scribd_doc_url . PHP_EOL,
-				'<p><iframe sandbox="allow-scripts allow-popups" title="Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+				'<p><iframe title="Synthesis of Knowledge: Effects of Fire and Thinning Treatments on Understory Vegetation in Dry U.S. Forests" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0" sandbox="allow-popups allow-scripts"></iframe></p>' . PHP_EOL,
 			],
 
 			'document_embed_with_sandbox_attr' => [
 				$this->scribd_doc_with_sandbox_attr_url . PHP_EOL,
-				'<p><iframe title="Hypothetical Book" class="scribd_iframe_embed" sandbox="allow-forms allow-scripts allow-popups" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+				'<p><iframe title="Hypothetical Book" class="scribd_iframe_embed" sandbox="allow-popups allow-scripts allow-forms allow-scripts" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
 			],
 		];
 
@@ -111,12 +111,12 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '5.2', '<' ) ) {
 			$data['document_embed'] = [
 				$this->scribd_doc_url . PHP_EOL,
-				'<p><iframe sandbox="allow-scripts allow-popups" class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+				'<p><iframe class="scribd_iframe_embed" src="https://www.scribd.com/embeds/110799637/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="110799637" width="100%" height="500" frameborder="0" sandbox="allow-popups allow-scripts"></iframe></p>' . PHP_EOL,
 			];
 
 			$data['document_embed_with_sandbox_attr'] = [
 				$this->scribd_doc_with_sandbox_attr_url . PHP_EOL,
-				'<p><iframe class="scribd_iframe_embed" sandbox="allow-forms allow-scripts allow-popups" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
+				'<p><iframe class="scribd_iframe_embed" sandbox="allow-popups allow-scripts allow-forms allow-scripts" src="https://www.scribd.com/embeds/NaN/content" data-aspect-ratio="1.2941176470588236" scrolling="no" id="NaN" width="100%" height="500" frameborder="0"></iframe></p>' . PHP_EOL,
 			];
 		}
 


### PR DESCRIPTION
## Summary

Removes the script element from oEmbed response and adds a sandbox attribute to allow the 'Full screen' functionality to work.

At the moment Scribd does not perform a [iframe resize request](https://amp.dev/documentation/components/amp-iframe/?format=websites#iframe-resizing), so the height of the iframe is not the same as the non-AMP version.

<!-- Please reference the issue this PR addresses. -->
Fixes #3424.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
