### PR TITLE
Add sideEffects property for webpack tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,15 @@
   "bugs": {
     "url": "https://github.com/ampproject/amp-wp/issues"
   },
+  "sideEffects": [
+    "./assets/src/block-editor/index.js",
+    "./assets/src/block-editor/store/index.js",
+    "./assets/src/block-validation/index.js",
+    "./assets/src/block-validation/store/index.js",
+    "./assets/src/stories-editor/index.js",
+    "./assets/src/stories-editor/helpers/index.js",
+    "./assets/src/stories-editor/store/index.js"
+  ],
   "dependencies": {
     "classnames": "2.2.6",
     "dom-scroll-into-view": "2.0.1",


### PR DESCRIPTION
## Summary

As explained on https://webpack.js.org/guides/tree-shaking/.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
