### PR TITLE
Prevent showing zero count with Validated URLs

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -376,6 +376,10 @@ class AMP_Validated_URL_Post_Type {
 		if ( false === $new_validation_error_urls ) {
 			$new_validation_error_urls = static::get_validation_error_urls_count();
 			set_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT, $new_validation_error_urls, DAY_IN_SECONDS );
+		} else {
+			// Handle case where integer stored in transient gets returned as string when persistent object cache is not
+			// used. This is due to wp_options.option_value being a string.
+			$new_validation_error_urls = (int) $new_validation_error_urls;
 		}
 
 		if ( 0 === $new_validation_error_urls ) {


### PR DESCRIPTION
## Summary

Fixes #3468. This handles a case where integer stored in transient gets returned as string when persistent object cache is not used. This is due to `wp_options.option_value` being a string, causing the strict equality with `0` to fail.

### Before

<img width="166" alt="Screen Shot 2019-10-09 at 13 46 44" src="https://user-images.githubusercontent.com/134745/66506859-1f27a380-ea9c-11e9-9d44-3a5e078d4bbb.png">

### After

<img width="166" alt="Screen Shot 2019-10-09 at 13 50 44" src="https://user-images.githubusercontent.com/134745/66506910-34043700-ea9c-11e9-80d0-3596b40b655b.png">

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
