### PR TITLE
Fix media uploader.

### DIFF
--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -59,7 +59,7 @@ const icon = (
  *
  * Also removes video settings that are not applicable / allowed in an AMP Stories context.
  */
-const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, setAttributes, mediaUpload, noticeUI, noticeOperations } ) => {
+const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, setAttributes, noticeUI, noticeOperations } ) => {
 	const {
 		caption,
 		loop,
@@ -102,6 +102,14 @@ const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, 
 			allowedVideoMimeTypes: getSettings().allowedVideoMimeTypes,
 		};
 	}, [ id, poster ] );
+
+	const { mediaUpload } = useSelect( ( select ) => {
+		const { getSettings } = select( 'core/block-editor' );
+		const { __experimentalMediaUpload } = getSettings();
+		return {
+			mediaUpload: __experimentalMediaUpload,
+		};
+	}, [] );
 
 	useEffect( () => {
 		if ( ! id && isBlobURL( src ) ) {
@@ -404,7 +412,6 @@ CustomVideoBlockEdit.propTypes = {
 	className: PropTypes.string,
 	instanceId: PropTypes.number,
 	isSelected: PropTypes.bool,
-	mediaUpload: PropTypes.func,
 	noticeUI: PropTypes.oneOfType( [ PropTypes.func, PropTypes.bool ] ),
 	noticeOperations: PropTypes.object,
 	setAttributes: PropTypes.func,


### PR DESCRIPTION
## Summary
Fixes #3463 

After the refactor https://github.com/ampproject/amp-wp/pull/3412 video upload was broken. This was because the component was expecting the mediaUpload function to be loaded on the page. This issue was found and patched upstream https://github.com/WordPress/gutenberg/pull/15548 . The fix is simple, just use `useSelect` to get mediaUpload using a `select`. This is basically a copy and paste what is found in gutenberg. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
