### PR TITLE
Restore DropZoneProvider

### DIFF
--- a/assets/src/stories-editor/components/editor-carousel/index.js
+++ b/assets/src/stories-editor/components/editor-carousel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { DropZoneProvider, IconButton } from '@wordpress/components';
 import { useEffect, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -74,31 +74,33 @@ const EditorCarousel = () => {
 	}
 
 	return (
-		<div className="amp-story-editor-carousel-navigation">
-			<IconButton
-				icon="arrow-left-alt2"
-				label={ __( 'Previous Page', 'amp' ) }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					goToPage( previousPage );
-				} }
-				disabled={ null === previousPage }
-			/>
-			<Indicator
-				pages={ pages }
-				currentPage={ currentPage }
-				onClick={ goToPage }
-			/>
-			<IconButton
-				icon="arrow-right-alt2"
-				label={ __( 'Next Page', 'amp' ) }
-				onClick={ ( e ) => {
-					e.preventDefault();
-					goToPage( nextPage );
-				} }
-				disabled={ null === nextPage }
-			/>
-		</div>
+		<DropZoneProvider>
+			<div className="amp-story-editor-carousel-navigation">
+				<IconButton
+					icon="arrow-left-alt2"
+					label={ __( 'Previous Page', 'amp' ) }
+					onClick={ ( e ) => {
+						e.preventDefault();
+						goToPage( previousPage );
+					} }
+					disabled={ null === previousPage }
+				/>
+				<Indicator
+					pages={ pages }
+					currentPage={ currentPage }
+					onClick={ goToPage }
+				/>
+				<IconButton
+					icon="arrow-right-alt2"
+					label={ __( 'Next Page', 'amp' ) }
+					onClick={ ( e ) => {
+						e.preventDefault();
+						goToPage( nextPage );
+					} }
+					disabled={ null === nextPage }
+				/>
+			</div>
+		</DropZoneProvider>
 	);
 };
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Addresses issue #2525

Restores `DropZoneProvider` removed within #3412.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
