### PR TITLE
Set layout to responsive if the iframe is aligned to full width

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -117,6 +117,19 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$this->did_convert_elements = true;
 			if ( empty( $normalized_attributes['layout'] ) && ! empty( $normalized_attributes['width'] ) && ! empty( $normalized_attributes['height'] ) ) {
 				$normalized_attributes['layout'] = 'intrinsic';
+
+				// Set layout to responsive if the iframe is aligned to full width.
+				$figure_node = null;
+				if ( $node->parentNode instanceof DOMElement && 'figure' === $node->parentNode->tagName ) {
+					$figure_node = $node->parentNode;
+				}
+				if ( $node->parentNode->parentNode instanceof DOMElement && 'figure' === $node->parentNode->parentNode->tagName ) {
+					$figure_node = $node->parentNode->parentNode;
+				}
+				if ( $figure_node && $figure_node->hasAttribute( 'class' ) && in_array( 'alignfull', explode( ' ', $figure_node->getAttribute( 'class' ) ), true ) ) {
+					$normalized_attributes['layout'] = 'responsive';
+				}
+
 				$this->add_or_append_attribute( $normalized_attributes, 'class', 'amp-wp-enforced-sizes' );
 			}
 

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -112,7 +112,7 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					<amp-iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
 						<noscript>
 							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="0"></iframe>
-						</noscript>					
+						</noscript>
 					</amp-iframe>
 				',
 			],
@@ -368,6 +368,24 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 							<iframe src="https://example.com/embed/132886713" width="500" height="281" frameborder="1" class="iframe-class"></iframe>
 						</noscript>
 					</amp-iframe>
+				',
+				[
+					'add_noscript_fallback' => true,
+					'add_placeholder'       => true,
+				],
+			],
+
+			'iframe_with_full_width_alignment'               => [
+				'<figure class="alignfull"><iframe width="580" height="326" src="https://videopress.com/embed/yFCmLMGL?hd=0" frameborder="0" allowfullscreen="" data-origwidth="580" data-origheight="326"></iframe></figure>',
+				'
+					<figure class="alignfull">
+						<amp-iframe width="580" height="326" src="https://videopress.com/embed/yFCmLMGL?hd=0" frameborder="0" allowfullscreen="" data-origwidth="580" data-origheight="326" sandbox="allow-scripts allow-same-origin" layout="responsive" class="amp-wp-enforced-sizes">
+							<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+							<noscript>
+								<iframe width="580" height="326" src="https://videopress.com/embed/yFCmLMGL?hd=0" frameborder="0"></iframe>
+							</noscript>
+						</amp-iframe>
+					</figure>
 				',
 				[
 					'add_noscript_fallback' => true,


### PR DESCRIPTION
## Summary

When an iframe is set to be "full width" in the block editor, it is currently broken because its `layout` attribute defaults to `'intrinsic'`.

This PR changes this behavior so that such an iframe is set to `layout=responsive` instead.

Fixes #3506 

## Screenshots

Comparison after the change:
<img width="1680" alt="Image 2019-10-15 at 2 10 27 PM" src="https://user-images.githubusercontent.com/83631/66831354-bf2b7400-ef57-11e9-94d7-fec45a8e9110.png">

Markup after the change:
<img width="767" alt="Image 2019-10-15 at 2 09 16 PM" src="https://user-images.githubusercontent.com/83631/66831288-92775c80-ef57-11e9-9790-fc48f2cf9cbd.png">

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).