### PR TITLE
Ensure smooth snap line display

### DIFF
--- a/assets/src/stories-editor/components/block-mover/draggable.js
+++ b/assets/src/stories-editor/components/block-mover/draggable.js
@@ -127,8 +127,8 @@ class Draggable extends Component {
 			setSnapLines,
 			clearSnapLines,
 			parentBlockElement,
-			horizontalSnaps,
-			verticalSnaps,
+			horizontalTargets,
+			verticalTargets,
 			setHighlightByOffset,
 		} = this.props;
 
@@ -154,11 +154,11 @@ class Draggable extends Component {
 		const snappingEnabled = ! event.getModifierState( 'Alt' );
 
 		if ( snappingEnabled ) {
-			const horizontalSnapsForPosition = horizontalSnaps( actualTop, actualBottom );
-			const verticalSnapsForPosition = verticalSnaps( actualLeft, actualRight );
+			const [ horizontalEdgeSnaps, horizontalCenterSnaps ] = horizontalTargets( actualTop, actualBottom );
+			const [ verticalEdgeSnaps, verticalCenterSnaps ] = verticalTargets( actualLeft, actualRight );
 			setSnapLines( [
-				...getBestSnapLines( horizontalSnapsForPosition, actualLeft, actualRight, BLOCK_DRAGGING_SNAP_GAP ),
-				...getBestSnapLines( verticalSnapsForPosition, actualTop, actualBottom, BLOCK_DRAGGING_SNAP_GAP ),
+				...getBestSnapLines( horizontalEdgeSnaps, horizontalCenterSnaps, actualLeft, actualRight, BLOCK_DRAGGING_SNAP_GAP ),
+				...getBestSnapLines( verticalEdgeSnaps, verticalCenterSnaps, actualTop, actualBottom, BLOCK_DRAGGING_SNAP_GAP ),
 			] );
 		} else {
 			clearSnapLines();
@@ -355,8 +355,8 @@ Draggable.propTypes = {
 	dropElementByOffset: PropTypes.func.isRequired,
 	setTimeout: PropTypes.func.isRequired,
 	children: PropTypes.func.isRequired,
-	horizontalSnaps: PropTypes.func.isRequired,
-	verticalSnaps: PropTypes.func.isRequired,
+	horizontalTargets: PropTypes.func.isRequired,
+	verticalTargets: PropTypes.func.isRequired,
 	setSnapLines: PropTypes.func.isRequired,
 	clearSnapLines: PropTypes.func.isRequired,
 	parentBlockElement: PropTypes.object,

--- a/assets/src/stories-editor/components/contexts/snapping/index.js
+++ b/assets/src/stories-editor/components/contexts/snapping/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import debounce from 'lodash/debounce';
 
 /**
  * WordPress dependencies
@@ -19,7 +20,8 @@ import './edit.css';
 const SnapContext = createContext();
 
 const Snapping = ( { children } ) => {
-	const [ snapLines, setSnapLines ] = useState( [] );
+	const [ snapLines, setRawSnapLines ] = useState( [] );
+	const setSnapLines = debounce( setRawSnapLines, 10 );
 
 	const clearSnapLines = () => setSnapLines( [] );
 

--- a/assets/src/stories-editor/components/contexts/test/snapping.js
+++ b/assets/src/stories-editor/components/contexts/test/snapping.js
@@ -9,6 +9,9 @@ import { act } from 'react-dom/test-utils';
  */
 import { default as Snapping, withSnapContext } from '../snapping';
 
+// Mock debounce by just returning the original function
+jest.mock( 'lodash/debounce', () => ( f ) => f );
+
 const setup = () => {
 	const Dummy = () => null;
 	// Disable reason: I have no idea why eslint thinks this variable is unused?

--- a/assets/src/stories-editor/components/higher-order/with-snap-targets.js
+++ b/assets/src/stories-editor/components/higher-order/with-snap-targets.js
@@ -8,7 +8,7 @@ import { compose, createHigherOrderComponent } from '@wordpress/compose';
  * Internal dependencies
  */
 import { getBlockInnerElement, getRelativeElementPosition } from '../../helpers';
-import { getHorizontalSnaps, getVerticalSnaps } from '../../helpers/snapping';
+import { getHorizontalTargets, getVerticalTargets } from '../../helpers/snapping';
 import { withSnapContext } from '../contexts/snapping';
 
 /**
@@ -33,8 +33,8 @@ const applyWithSelect = withSelect( ( select, { clientId } ) => {
 	const parentBlock = getBlockRootClientId( clientId );
 
 	const defaultData = {
-		horizontalSnaps: () => [],
-		verticalSnaps: () => [],
+		horizontalTargets: () => [],
+		verticalTargets: () => [],
 		parentBlockElement: null,
 	};
 
@@ -54,12 +54,12 @@ const applyWithSelect = withSelect( ( select, { clientId } ) => {
 		.filter( Boolean )
 		.map( ( el ) => getRelativeElementPosition( el, parentBlockElement ) );
 
-	const horizontalSnaps = getHorizontalSnaps( siblingPositions );
-	const verticalSnaps = getVerticalSnaps( siblingPositions );
+	const horizontalTargets = getHorizontalTargets( siblingPositions );
+	const verticalTargets = getVerticalTargets( siblingPositions );
 
 	return {
-		horizontalSnaps,
-		verticalSnaps,
+		horizontalTargets,
+		verticalTargets,
 		parentBlockElement,
 	};
 } );

--- a/assets/src/stories-editor/components/resizable-box/index.js
+++ b/assets/src/stories-editor/components/resizable-box/index.js
@@ -76,8 +76,8 @@ class EnhancedResizableBox extends Component {
 		const {
 			clientId,
 			snapGap,
-			horizontalSnaps,
-			verticalSnaps,
+			horizontalTargets,
+			verticalTargets,
 			setSnapLines,
 			clearSnapLines,
 			parentBlockElement,
@@ -278,11 +278,11 @@ class EnhancedResizableBox extends Component {
 					const snappingEnabled = ! event.getModifierState( 'Alt' );
 
 					if ( snappingEnabled ) {
-						const horizontalSnapsForPosition = horizontalSnaps( actualTop, actualBottom );
-						const verticalSnapsForPosition = verticalSnaps( actualLeft, actualRight );
+						const [ horizontalEdgeSnaps, horizontalCenterSnaps ] = horizontalTargets( actualTop, actualBottom );
+						const [ verticalEdgeSnaps, verticalCenterSnaps ] = verticalTargets( actualLeft, actualRight );
 						setSnapLines( [
-							...getBestSnapLines( horizontalSnapsForPosition, actualLeft, actualRight, BLOCK_RESIZING_SNAP_GAP ),
-							...getBestSnapLines( verticalSnapsForPosition, actualTop, actualBottom, BLOCK_RESIZING_SNAP_GAP ),
+							...getBestSnapLines( horizontalEdgeSnaps, horizontalCenterSnaps, actualLeft, actualRight, BLOCK_RESIZING_SNAP_GAP ),
+							...getBestSnapLines( verticalEdgeSnaps, verticalCenterSnaps, actualTop, actualBottom, BLOCK_RESIZING_SNAP_GAP ),
 						] );
 					} else {
 						clearSnapLines();
@@ -329,8 +329,8 @@ EnhancedResizableBox.propTypes = {
 	children: PropTypes.node.isRequired,
 	width: PropTypes.number,
 	height: PropTypes.number,
-	horizontalSnaps: PropTypes.func.isRequired,
-	verticalSnaps: PropTypes.func.isRequired,
+	horizontalTargets: PropTypes.func.isRequired,
+	verticalTargets: PropTypes.func.isRequired,
 	snapGap: PropTypes.number.isRequired,
 	setSnapLines: PropTypes.func.isRequired,
 	clearSnapLines: PropTypes.func.isRequired,

--- a/assets/src/stories-editor/helpers/snapping/createSnapList.js
+++ b/assets/src/stories-editor/helpers/snapping/createSnapList.js
@@ -53,19 +53,25 @@ const getSetter = ( lowerBound, upperBound ) => ( obj, prop, value ) => {
 /**
  * Create snap list via proxy that contains initial snap lines for edges and center of page.
  *
- * @param {import('./types').LineCreator} getLine Function to create lines based off maximum value.
- * @param {number} maxValue Maximum value of page in this direction.
+ * @param {import('./types').LineCreator} getLine       Function to create lines based off maximum value.
+ * @param {number}                        maxValue      Maximum value of page in this direction.
+ * @param {boolean}                       includeEdges  Include edges in initial list.
  * @return {import('./types').SnapLines} An initial list of snap lines ready to be extended.
  */
-const createSnapList = ( getLine, maxValue ) => new Proxy(
+const createSnapList = ( getLine, maxValue, includeEdges = true ) => new Proxy(
 	// Create initial list of snap lines.
 	{
-		// Start page border.
-		0: [ getLine( 0 ) ],
 		// Center of the page.
 		[ maxValue / 2 ]: [ getLine( maxValue / 2 ) ],
-		// End page border.
-		[ maxValue ]: [ getLine( maxValue ) ],
+		...( includeEdges ?
+			{
+				// Start page border.
+				0: [ getLine( 0 ) ],
+				// End page border.
+				[ maxValue ]: [ getLine( maxValue ) ],
+			} :
+			{}
+		),
 	},
 	{
 		set: getSetter( 0, maxValue ),

--- a/assets/src/stories-editor/helpers/snapping/findBestMatch.js
+++ b/assets/src/stories-editor/helpers/snapping/findBestMatch.js
@@ -1,23 +1,21 @@
 /**
  * Get the best match for a list of values each creating a match
  *
- * @param {Function.<number>} matcher Function finding closest match for a single value or null
- * @param {Array.<number>} values List of values to find a best match between.
+ * @param {Array.<Object>} targets List of values and matchers to find a best match between.
  * @return {number} The single best matching value or undefined.
  */
-const findBestMatch = ( matcher, ...values ) => values
-	.map( ( value ) => {
+const findBestMatch = ( ...targets ) => targets
+	.map( ( { value, matcher, ...rest } ) => {
 		const best = matcher( value );
 		if ( ! best ) {
 			return null;
 		}
-		return { value: best, distance: Math.abs( best - value ) };
+		return { value: best, distance: Math.abs( best - value ), ...rest };
 	} )
 	.filter( Boolean )
 	.reduce(
 		( best, candidate ) => candidate.distance < best.distance ? candidate : best,
 		{ distance: Number.MAX_VALUE, value: null },
-	)
-	.value;
+	);
 
 export default findBestMatch;

--- a/assets/src/stories-editor/helpers/snapping/findBestMatch.js
+++ b/assets/src/stories-editor/helpers/snapping/findBestMatch.js
@@ -2,7 +2,7 @@
  * Get the best match for a list of values each creating a match
  *
  * @param {Array.<Object>} targets List of values and matchers to find a best match between.
- * @return {number} The single best matching value or undefined.
+ * @return {Object} The single best matching object with value and distance (and any extra props from target object)
  */
 const findBestMatch = ( ...targets ) => targets
 	.map( ( { value, matcher, ...rest } ) => {

--- a/assets/src/stories-editor/helpers/snapping/getBestSnapLines.js
+++ b/assets/src/stories-editor/helpers/snapping/getBestSnapLines.js
@@ -7,27 +7,33 @@ import findBestMatch from './findBestMatch';
 /**
  * Get the best match(es) from a list of snap lines based on actual position.
  *
- * @param {import('./types').SnapLines} snapLines Object with lists of snap lines indexes by coordinate.
+ * @param {import('./types').SnapLines} edgeLines Object with lists of snap lines indexes by coordinate for edges of object.
+ * @param {import('./types').SnapLines} centerLines Object with lists of snap lines indexes by coordinate for center of object.
  * @param {number} start Value of near edge of current object
  * @param {number} end Value of far edge of current object
  * @param {number} gap Maximum gap from edge to snap line for line to be considered.
  * @return {Array.<import('./types').Line>} The lines that correspond to the single best match for any edge.
  */
-const getBestSnapLines = ( snapLines, start, end, gap ) => {
+const getBestSnapLines = ( edgeLines, centerLines, start, end, gap ) => {
 	// Go through all snap targets and find the one that is closest.
-	const snapTargets = Object.keys( snapLines );
+	const edgeTargets = Object.keys( edgeLines );
+	const centerTargets = Object.keys( centerLines );
 
 	const center = ( start + end ) / 2;
 
-	const matcher = ( value ) => findClosestSnap( value, snapTargets, gap );
+	const matcher = ( targets ) => ( value ) => findClosestSnap( value, targets, gap );
 
-	const bestMatch = findBestMatch( matcher, start, end, center );
+	const { value, isEdgeTarget } = findBestMatch(
+		{ value: start, matcher: matcher( edgeTargets ), isEdgeTarget: true },
+		{ value: end, matcher: matcher( edgeTargets ), isEdgeTarget: true },
+		{ value: center, matcher: matcher( centerTargets ), isEdgeTarget: false },
+	);
 
-	if ( ! bestMatch ) {
+	if ( ! value ) {
 		return [];
 	}
 
-	return snapLines[ bestMatch ];
+	return isEdgeTarget ? edgeLines[ value ] : centerLines[ value ];
 };
 
 export default getBestSnapLines;

--- a/assets/src/stories-editor/helpers/snapping/getHorizontalTargets.js
+++ b/assets/src/stories-editor/helpers/snapping/getHorizontalTargets.js
@@ -10,11 +10,11 @@ const getVerticalLine = (
 	end = STORY_PAGE_INNER_HEIGHT,
 ) => [ [ offsetX, start ], [ offsetX, end ] ];
 
-const getHorizontalSnaps = getSnapCalculatorByDimension(
+const getHorizontalTargets = getSnapCalculatorByDimension(
 	getVerticalLine,
 	STORY_PAGE_INNER_WIDTH,
 	[ 'left', 'right' ],
 	[ 'top', 'bottom' ],
 );
 
-export default getHorizontalSnaps;
+export default getHorizontalTargets;

--- a/assets/src/stories-editor/helpers/snapping/getSnapCalculatorByDimension.js
+++ b/assets/src/stories-editor/helpers/snapping/getSnapCalculatorByDimension.js
@@ -7,7 +7,7 @@ import createSnapList from './createSnapList';
  * Higher-higher order function that in the end creates a list of snap targets.
  *
  * First it is invoked with the "direction" of the snaps to calculate, creating the two
- * functions below, `getHorizontalSnaps` and `getVerticalSnaps`.
+ * functions in separate helpers, `getHorizontalSnaps` and `getVerticalSnaps`.
  *
  * These functions in turn take a list of sibling element positions used to create the
  * snap calculator function.
@@ -20,7 +20,7 @@ import createSnapList from './createSnapList';
  * @param {number} maxValue Maximum value of page in this direction.
  * @param {Array.<string>} primary Coordinate property names in primary direction.
  * @param {Array.<string>} secondary Coordinate property names in secondary direction.
- * @return {import('./types').SnapTargetsEnhancer} Function mapping an actual object's position to all possible snap targets.
+ * @return {Array.<import('./types').SnapTargetsEnhancer>} Function mapping an actual object's position to all possible snap targets.
  */
 const getSnapCalculatorByDimension = (
 	getLine,
@@ -28,7 +28,8 @@ const getSnapCalculatorByDimension = (
 	[ startProp, endProp ],
 	[ minProp, maxProp ],
 ) => ( siblingPositions ) => ( targetMin, targetMax ) => {
-	const snaps = createSnapList( getLine, maxValue );
+	const edgeSnaps = createSnapList( getLine, maxValue );
+	const centerSnaps = createSnapList( getLine, maxValue, false );
 
 	for ( const coords of siblingPositions ) {
 		const start = coords[ startProp ];
@@ -38,12 +39,12 @@ const getSnapCalculatorByDimension = (
 		const min = Math.min( targetMin, coords[ minProp ] );
 		const max = Math.max( targetMax, coords[ maxProp ] );
 
-		snaps[ start ] = getLine( start, min, max );
-		snaps[ end ] = getLine( end, min, max );
-		snaps[ center ] = getLine( center, min, max );
+		edgeSnaps[ start ] = getLine( start, min, max );
+		edgeSnaps[ end ] = getLine( end, min, max );
+		centerSnaps[ center ] = getLine( center, min, max );
 	}
 
-	return snaps;
+	return [ edgeSnaps, centerSnaps ];
 };
 
 export default getSnapCalculatorByDimension;

--- a/assets/src/stories-editor/helpers/snapping/getVerticalTargets.js
+++ b/assets/src/stories-editor/helpers/snapping/getVerticalTargets.js
@@ -10,11 +10,11 @@ const getHorizontalLine = (
 	end = STORY_PAGE_INNER_WIDTH,
 ) => [ [ start, offsetY ], [ end, offsetY ] ];
 
-const getVerticalSnaps = getSnapCalculatorByDimension(
+const getVerticalTargets = getSnapCalculatorByDimension(
 	getHorizontalLine,
 	STORY_PAGE_INNER_HEIGHT,
 	[ 'top', 'bottom' ],
 	[ 'left', 'right' ],
 );
 
-export default getVerticalSnaps;
+export default getVerticalTargets;

--- a/assets/src/stories-editor/helpers/snapping/index.js
+++ b/assets/src/stories-editor/helpers/snapping/index.js
@@ -1,4 +1,4 @@
 export { default as findClosestSnap } from './findClosestSnap';
-export { default as getHorizontalSnaps } from './getHorizontalSnaps';
-export { default as getVerticalSnaps } from './getVerticalSnaps';
+export { default as getHorizontalTargets } from './getHorizontalTargets';
+export { default as getVerticalTargets } from './getVerticalTargets';
 export { default as getBestSnapLines } from './getBestSnapLines';

--- a/assets/src/stories-editor/helpers/snapping/test/createSnapList.js
+++ b/assets/src/stories-editor/helpers/snapping/test/createSnapList.js
@@ -19,6 +19,17 @@ describe( 'createSnapList', () => {
 		expect( snapLines ).toMatchObject( expected );
 	} );
 
+	it( 'should return an initial list of snap lines without edges', () => {
+		const maxValue = 1000;
+		const snapLines = createSnapList( getLine, maxValue, false );
+
+		const expected = {
+			500: [ [ [ 500, 0 ], [ 500, 1000 ] ] ],
+		};
+
+		expect( snapLines ).toMatchObject( expected );
+	} );
+
 	it( 'should allow adding new snap targets', () => {
 		const maxValue = 1000;
 		const snapLines = createSnapList( getLine, maxValue );

--- a/assets/src/stories-editor/helpers/snapping/test/findBestMatch.js
+++ b/assets/src/stories-editor/helpers/snapping/test/findBestMatch.js
@@ -11,26 +11,68 @@ describe( 'findBestMatch', () => {
 	};
 
 	it( 'should return the best match', () => {
-		const values = [ 33, 22, 11 ];
+		const values = [
+			{ value: 11, matcher },
+			{ value: 22, matcher },
+			{ value: 33, matcher },
+		];
 
-		expect( findBestMatch( matcher, ...values ) ).toStrictEqual( 10 );
+		expect( findBestMatch( ...values ) ).toStrictEqual( {
+			value: 10,
+			distance: 1,
+		} );
+	} );
+
+	it( 'should return extra values if present', () => {
+		const values = [
+			{ value: 11, matcher, a: 1, b: 2 },
+			{ value: 22, matcher },
+			{ value: 33, matcher },
+		];
+
+		expect( findBestMatch( ...values ) ).toStrictEqual( {
+			value: 10,
+			distance: 1,
+			a: 1,
+			b: 2,
+		} );
 	} );
 
 	it( 'should return ignore non-matches', () => {
-		const values = [ 46, 22, 51 ];
+		const values = [
+			{ value: 46, matcher },
+			{ value: 22, matcher },
+			{ value: 51, matcher },
+		];
 
-		expect( findBestMatch( matcher, ...values ) ).toStrictEqual( 20 );
+		expect( findBestMatch( ...values ) ).toStrictEqual( {
+			value: 20,
+			distance: 2,
+		} );
 	} );
 
 	it( 'should return null if none match', () => {
-		const values = [ 46, 51 ];
+		const values = [
+			{ value: 46, matcher },
+			{ value: 51, matcher },
+		];
 
-		expect( findBestMatch( matcher, ...values ) ).toBeNull();
+		expect( findBestMatch( ...values ) ).toStrictEqual( {
+			value: null,
+			distance: expect.any( Number ),
+		} );
 	} );
 
 	it( 'should return the first match if several match equally well', () => {
-		const values = [ 33, 22, 12 ];
+		const values = [
+			{ value: 33, matcher },
+			{ value: 22, matcher },
+			{ value: 12, matcher },
+		];
 
-		expect( findBestMatch( matcher, ...values ) ).toStrictEqual( 20 );
+		expect( findBestMatch( ...values ) ).toStrictEqual( {
+			value: 20,
+			distance: 2,
+		} );
 	} );
 } );

--- a/assets/src/stories-editor/helpers/snapping/test/getBestSnapLines.js
+++ b/assets/src/stories-editor/helpers/snapping/test/getBestSnapLines.js
@@ -4,11 +4,13 @@
 import getBestSnapLines from '../getBestSnapLines';
 
 describe( 'getBestSnapLines', () => {
-	const snapLines = {
+	const edgeLines = {
 		0: Array( 1 ),
-		100: Array( 2 ),
-		300: Array( 3 ),
-		305: Array( 4 ),
+		300: Array( 2 ),
+		305: Array( 3 ),
+	};
+	const centerLines = {
+		100: Array( 4 ),
 	};
 
 	const gap = 10;
@@ -17,28 +19,28 @@ describe( 'getBestSnapLines', () => {
 		const start = 40;
 		const end = 60;
 
-		expect( getBestSnapLines( snapLines, start, end, gap ) ).toHaveLength( 0 );
+		expect( getBestSnapLines( edgeLines, centerLines, start, end, gap ) ).toHaveLength( 0 );
 	} );
 
 	it( 'should return match if start matches within gap', () => {
 		const start = 5;
 		const end = 60;
 
-		expect( getBestSnapLines( snapLines, start, end, gap ) ).toHaveLength( 1 );
+		expect( getBestSnapLines( edgeLines, centerLines, start, end, gap ) ).toHaveLength( 1 );
 	} );
 
 	it( 'should return match if end matches within gap', () => {
 		const start = 40;
-		const end = 91;
+		const end = 291;
 
-		expect( getBestSnapLines( snapLines, start, end, gap ) ).toHaveLength( 2 );
+		expect( getBestSnapLines( edgeLines, centerLines, start, end, gap ) ).toHaveLength( 2 );
 	} );
 
 	it( 'should return match if center matches within gap', () => {
 		const start = 60;
 		const end = 135;
 
-		expect( getBestSnapLines( snapLines, start, end, gap ) ).toHaveLength( 2 );
+		expect( getBestSnapLines( edgeLines, centerLines, start, end, gap ) ).toHaveLength( 4 );
 	} );
 
 	it( 'should return best if multiple edges match within gap', () => {
@@ -46,7 +48,7 @@ describe( 'getBestSnapLines', () => {
 		const end = 190;
 
 		// Center coordinate will match 100 better than start coordinate will match 0.
-		expect( getBestSnapLines( snapLines, start, end, gap ) ).toHaveLength( 2 );
+		expect( getBestSnapLines( edgeLines, centerLines, start, end, gap ) ).toHaveLength( 4 );
 	} );
 
 	it( 'should return best if multiple lines match the same edge within gap', () => {
@@ -54,6 +56,6 @@ describe( 'getBestSnapLines', () => {
 		const end = 302;
 
 		// End will match 300 better than 305, and no other edge will match.
-		expect( getBestSnapLines( snapLines, start, end, gap ) ).toHaveLength( 3 );
+		expect( getBestSnapLines( edgeLines, centerLines, start, end, gap ) ).toHaveLength( 2 );
 	} );
 } );

--- a/assets/src/stories-editor/helpers/snapping/test/getSnapCalculatorByDimension.js
+++ b/assets/src/stories-editor/helpers/snapping/test/getSnapCalculatorByDimension.js
@@ -27,14 +27,19 @@ describe( 'getSnapCalculatorByDimension', () => {
 		const getSnapsWithSiblingPositions = getSnaps( siblingPositions );
 		const actual = getSnapsWithSiblingPositions( 100, 100 );
 
-		const expected = {
-			0: [ [ [ 0, 0 ], [ 0, 1000 ] ] ],
-			100: [ [ [ 100, 0 ], [ 100, 1000 ] ] ],
-			1000: [ [ [ 1000, 0 ], [ 1000, 1000 ] ] ],
-			150: [ [ [ 150, 0 ], [ 150, 1000 ] ] ],
-			200: [ [ [ 200, 0 ], [ 200, 1000 ] ] ],
-			500: [ [ [ 500, 0 ], [ 500, 1000 ] ] ],
-		};
+		const expected = [
+			{
+				0: [ [ [ 0, 0 ], [ 0, 1000 ] ] ],
+				100: [ [ [ 100, 0 ], [ 100, 1000 ] ] ],
+				1000: [ [ [ 1000, 0 ], [ 1000, 1000 ] ] ],
+				200: [ [ [ 200, 0 ], [ 200, 1000 ] ] ],
+				500: [ [ [ 500, 0 ], [ 500, 1000 ] ] ],
+			},
+			{
+				150: [ [ [ 150, 0 ], [ 150, 1000 ] ] ],
+				500: [ [ [ 500, 0 ], [ 500, 1000 ] ] ],
+			},
+		];
 
 		expect( actual ).toMatchObject( expected );
 	} );

--- a/assets/src/stories-editor/helpers/snapping/types.js
+++ b/assets/src/stories-editor/helpers/snapping/types.js
@@ -28,7 +28,7 @@
  * Function returning an enhanced list of snap targets based on the current element's siblings' dimensions.
  *
  * @typedef {SnapTargetsEnhancer} SnapTargetsEnhancer
- * @param {Array<BlockPosition>} blockPositions List of relative block dimensions.
+ * @param {Array.<BlockPosition>} blockPositions List of relative block dimensions.
  * @return {SnapTargetsProvider}
  */
 


### PR DESCRIPTION
## Summary

Optimizes snap line display while dragging elements on a page with multiple other elements.

Fixes #3458.

## Todo

- [x] Debounce the snap line setter by 10 ms to ensure smoother snap line display.

- [x] Split snap targets in edge targets and center targets and calculate potential snap lines for each separately.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
