### PR TITLE
Adjust issue reference in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Summary
 
 <!-- Please reference the issue this PR addresses. -->
-Addresses issue #
+Fixes #
 
 ## Checklist
 


### PR DESCRIPTION
A small change to the PR template to invoke Github magic by using the phrase `Fixes #<id>` instead of `Addressses issue #<id>`.