### PR TITLE
Fix `hasTextContent` for meta blocks

### DIFF
--- a/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
@@ -247,6 +247,11 @@ export default createHigherOrderComponent(
 			const animationDelay = parseInt( String( ampAnimationDelay ).replace( 'ms', '' ) );
 
 			const captionAttribute = isVideoBlock ? 'ampShowCaption' : 'ampShowImageCaption';
+			// A block has text content (in terms of resizable at least) if it's a "real" text block with content or
+			// any of the meta text blocks
+			const isMetaTextBlock = name.indexOf( 'amp/amp-story-post-' ) === 0;
+			const hasTextContent = ( isTextBlock && content.length > 0 ) || isMetaTextBlock;
+
 			return (
 				<>
 					{ ( ! isMovableBlock( name ) ) && ( <BlockEdit { ...props } /> ) }
@@ -255,7 +260,7 @@ export default createHigherOrderComponent(
 							width={ width }
 							height={ height }
 							angle={ rotationAngle }
-							hasTextContent={ Boolean( isTextBlock && content.length ) }
+							hasTextContent={ hasTextContent }
 							minHeight={ minHeight }
 							minWidth={ MIN_BLOCK_WIDTH }
 							onResizeStop={ ( value ) => {

--- a/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
@@ -28,6 +28,7 @@ import { __ } from '@wordpress/i18n';
 import { StoryBlockMover, FontFamilyPicker, ResizableBox, AnimationControls, RotatableBox } from '../';
 import {
 	ALLOWED_CHILD_BLOCKS,
+	BLOCKS_WITH_META_CONTENT,
 	BLOCKS_WITH_TEXT_SETTINGS,
 	BLOCKS_WITH_COLOR_SETTINGS,
 	MIN_BLOCK_WIDTH,
@@ -208,6 +209,7 @@ export default createHigherOrderComponent(
 			const isVideoBlock = 'core/video' === name;
 			const isTextBlock = 'amp/amp-story-text' === name;
 			const excludeOpacity = 'amp/amp-story-page-attachment' === name;
+			const isMetaTextBlock = BLOCKS_WITH_META_CONTENT.includes( name );
 
 			const needsTextSettings = BLOCKS_WITH_TEXT_SETTINGS.includes( name );
 			const needsColorSettings = BLOCKS_WITH_COLOR_SETTINGS.includes( name );
@@ -249,7 +251,6 @@ export default createHigherOrderComponent(
 			const captionAttribute = isVideoBlock ? 'ampShowCaption' : 'ampShowImageCaption';
 			// A block has text content (in terms of resizable at least) if it's a "real" text block with content or
 			// any of the meta text blocks
-			const isMetaTextBlock = name.indexOf( 'amp/amp-story-post-' ) === 0;
 			const hasTextContent = ( isTextBlock && content.length > 0 ) || isMetaTextBlock;
 
 			return (

--- a/assets/src/stories-editor/constants.js
+++ b/assets/src/stories-editor/constants.js
@@ -42,6 +42,12 @@ export const ALLOWED_MOVABLE_BLOCKS = [
 	'core/template', // Reusable blocks.
 ];
 
+export const BLOCKS_WITH_META_CONTENT = [
+	'amp/amp-story-post-author',
+	'amp/amp-story-post-date',
+	'amp/amp-story-post-title',
+];
+
 export const BLOCKS_WITH_TEXT_SETTINGS = [
 	'amp/amp-story-text',
 	'amp/amp-story-post-author',


### PR DESCRIPTION
## Summary

This addresses a regression, that was assumed to come from #3447, but actually arose from #3433.

`hasTextContent` must be set to true by default for all meta text blocks.

Suggestions for a better/cleaner `isMetaTextBlock` are very welcome as are references to a similar "calculation" elsewhere.

Fixes #3447

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
