### PR TITLE
Add special-case handling for layout=fill when both dimensions are 100%

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -311,6 +311,18 @@ abstract class AMP_Base_Sanitizer {
 				$attributes['layout'] = 'fill';
 				return $attributes;
 			}
+
+			// Apply fill layout if width & height are 100%.
+			if ( isset( $styles['position'], $attributes['width'], $attributes['height'] )
+				&& 'absolute' === $styles['position']
+				&& '100%' === $attributes['width']
+				&& '100%' === $attributes['height']
+			) {
+				unset( $attributes['style'], $attributes['width'], $attributes['height'] );
+				$attributes['layout'] = 'fill';
+				unset( $attributes['height'], $attributes['width'] );
+				return $attributes;
+			}
 		}
 
 		if ( empty( $attributes['height'] ) ) {

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -123,6 +123,17 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
+			'fill_both_dimensions_and_absolute_position' => [
+				[
+					'width'  => '100%',
+					'height' => '100%',
+					'style'  => 'position:absolute',
+				],
+				[
+					'layout' => 'fill',
+				],
+			],
+
 			'fill_with_bottom_right_keeps_unrelated_styles' => [
 				[
 					'style' => 'position:absolute;background-color:white;top:0;left:0;right:0;bottom:0;color:red;',


### PR DESCRIPTION
## Summary

Apply `layout=fill` to the amp-iframe when both the width and height are 100%.

<!-- Please reference the issue this PR addresses. -->
Fixes #3501.

## Demo

![deepin-screen-recorder_Select area_20191016155338](https://user-images.githubusercontent.com/16200219/66958157-35e67100-f02d-11e9-8678-74ff6a91acd9.gif)


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
