### PR TITLE
Remove invalid processing instructions

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -291,6 +291,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 						$result
 					);
 				}
+			} elseif ( $this_child instanceof DOMProcessingInstruction ) {
+				$this->remove_invalid_child( $this_child, [ 'code' => 'invalid_processing_instruction' ] );
 			}
 			$this_child = $next_child;
 		}

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1689,6 +1689,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[],
 				[ 'invalid_processing_instruction' ],
 			],
+
+			'invalid_xml_pi'                               => [
+				'<?xml version="1.0" encoding="utf-8"?>',
+				'',
+				[],
+				[ 'invalid_processing_instruction' ],
+			],
 		];
 	}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1682,6 +1682,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[],
 				[ 'invalid_element' ],
 			],
+
+			'invalid_php_pi'                               => [
+				'<?php $schema = get_post_meta(get_the_ID(), \'schema\', true); if(!empty($schema)) { echo $schema; } ?>',
+				'',
+				[],
+				[ 'invalid_processing_instruction' ],
+			],
 		];
 	}
 


### PR DESCRIPTION
Co-Authored-By: Weston Ruter <westonruter@google.com>

## Summary

Remove all invalid processing instructions and also display the `invalid_processing_instruction` error code for such occurrences.

## Screenshot:

![image](https://user-images.githubusercontent.com/16200219/66959849-dbe7aa80-f030-11e9-938f-7e2a855e1960.png)

<!-- Please reference the issue this PR addresses. -->
Fixes #3409.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
