### PR TITLE
Remove validation handling option

### DIFF
--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -114,6 +114,7 @@ class AMP_Autoloader {
 		'AMP_Story_Export_Sanitizer'         => 'includes/sanitizers/class-amp-story-export-sanitizer',
 		'AMP_Test_Stub_Sanitizer'            => 'tests/php/stubs',
 		'AMP_Test_World_Sanitizer'           => 'tests/php/stubs',
+		'AMP_Test_HandleValidation'          => 'tests/php/validation/trait-handle-validation',
 	];
 
 	/**

--- a/includes/embeds/class-amp-scribd-embed-handler.php
+++ b/includes/embeds/class-amp-scribd-embed-handler.php
@@ -3,7 +3,7 @@
  * Class AMP_Scribd_Embed_Handler
  *
  * @package AMP
- * @since 1.3.1
+ * @since 1.4
  */
 
 /**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -39,7 +39,6 @@ class AMP_Options_Manager {
 		'theme_support'            => AMP_Theme_Support::READER_MODE_SLUG,
 		'supported_post_types'     => [ 'post' ],
 		'analytics'                => [],
-		'auto_accept_sanitization' => true,
 		'all_templates_supported'  => true,
 		'supported_templates'      => [ 'is_singular' ],
 		'enable_response_caching'  => true,
@@ -158,6 +157,11 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $defaults['theme_support'];
 		}
 
+		// Remove 'auto_accept_sanitization' option from 1.3.1-alpha.
+		if ( isset( $options['auto_accept_sanitization'] ) ) {
+			unset( $options['auto_accept_sanitization'] );
+		}
+
 		return $options;
 	}
 
@@ -250,8 +254,6 @@ class AMP_Options_Manager {
 				add_action( 'update_option_' . self::OPTION_NAME, [ __CLASS__, 'handle_updated_theme_support_option' ] );
 			}
 		}
-
-		$options['auto_accept_sanitization'] = ! empty( $new_options['auto_accept_sanitization'] );
 
 		// Validate post type support.
 		if ( in_array( self::WEBSITE_EXPERIENCE, $options['experiences'], true ) || isset( $new_options['supported_post_types'] ) ) {

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -157,9 +157,9 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $defaults['theme_support'];
 		}
 
-		// Remove 'accept_sanitization_by_default' option as of 1.4.
-		if ( isset( $options['accept_sanitization_by_default'] ) ) {
-			unset( $options['accept_sanitization_by_default'] );
+		// Remove 'auto_accept_sanitization' option as of 1.4.
+		if ( isset( $options['auto_accept_sanitization'] ) ) {
+			unset( $options['auto_accept_sanitization'] );
 		}
 
 		return $options;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -157,9 +157,9 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $defaults['theme_support'];
 		}
 
-		// Remove 'auto_accept_sanitization' option as of 1.4.
-		if ( isset( $options['auto_accept_sanitization'] ) ) {
-			unset( $options['auto_accept_sanitization'] );
+		// Remove 'accept_sanitization_by_default' option as of 1.4.
+		if ( isset( $options['accept_sanitization_by_default'] ) ) {
+			unset( $options['accept_sanitization_by_default'] );
 		}
 
 		return $options;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -157,7 +157,7 @@ class AMP_Options_Manager {
 			$options['theme_support'] = $defaults['theme_support'];
 		}
 
-		// Remove 'auto_accept_sanitization' option from 1.3.1-alpha.
+		// Remove 'auto_accept_sanitization' option as of 1.4.
 		if ( isset( $options['auto_accept_sanitization'] ) ) {
 			unset( $options['auto_accept_sanitization'] );
 		}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -35,17 +35,17 @@ class AMP_Options_Manager {
 	 * @var array
 	 */
 	protected static $defaults = [
-		'experiences'              => [ self::WEBSITE_EXPERIENCE ],
-		'theme_support'            => AMP_Theme_Support::READER_MODE_SLUG,
-		'supported_post_types'     => [ 'post' ],
-		'analytics'                => [],
-		'all_templates_supported'  => true,
-		'supported_templates'      => [ 'is_singular' ],
-		'enable_response_caching'  => true,
-		'version'                  => AMP__VERSION,
-		'story_templates_version'  => false,
-		'story_export_base_url'    => '',
-		'story_settings'           => [
+		'experiences'             => [ self::WEBSITE_EXPERIENCE ],
+		'theme_support'           => AMP_Theme_Support::READER_MODE_SLUG,
+		'supported_post_types'    => [ 'post' ],
+		'analytics'               => [],
+		'all_templates_supported' => true,
+		'supported_templates'     => [ 'is_singular' ],
+		'enable_response_caching' => true,
+		'version'                 => AMP__VERSION,
+		'story_templates_version' => false,
+		'story_export_base_url'   => '',
+		'story_settings'          => [
 			'auto_advance_after'          => '',
 			'auto_advance_after_duration' => 0,
 		],

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -102,17 +102,6 @@ class AMP_Options_Menu {
 		);
 
 		add_settings_field(
-			'validation',
-			__( 'Validation Handling', 'amp' ),
-			[ $this, 'render_validation_handling' ],
-			AMP_Options_Manager::OPTION_NAME,
-			'general',
-			[
-				'class' => 'amp-validation-field',
-			]
-		);
-
-		add_settings_field(
 			'supported_templates',
 			__( 'Supported Templates', 'amp' ),
 			[ $this, 'render_supported_templates' ],
@@ -151,8 +140,7 @@ class AMP_Options_Menu {
 				?>
 				<style>
 					body:not(.amp-experience-website) .amp-website-mode,
-					body:not(.amp-experience-website) .amp-template-support-field,
-					body:not(.amp-experience-website) .amp-validation-field {
+					body:not(.amp-experience-website) .amp-template-support-field {
 						display: none;
 					}
 					body:not(.amp-experience-stories) .amp-stories-export-field,
@@ -411,95 +399,6 @@ class AMP_Options_Menu {
 					<?php echo wp_kses_post( $ecosystem_description ); ?>
 				</p>
 			<?php endif; ?>
-		</fieldset>
-		<?php
-	}
-
-	/**
-	 * Post types support section renderer.
-	 *
-	 * @todo If dirty AMP is ever allowed (that is, post-processed documents which can be served with non-sanitized valdation errors), then automatically forcing sanitization in standard mode should be able to be turned off.
-	 *
-	 * @since 1.0
-	 */
-	public function render_validation_handling() {
-		?>
-		<fieldset>
-			<?php
-			$auto_sanitization = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization(
-				[
-					'code' => 'non_existent',
-				]
-			);
-
-			$forced_sanitization = 'with_filter' === $auto_sanitization['forced'];
-			?>
-
-			<?php if ( $forced_sanitization ) : ?>
-				<div class="notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'Your install is configured via a theme or plugin to automatically sanitize any AMP validation error that is encountered.', 'amp' ); ?></p>
-				</div>
-				<input type="hidden" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[auto_accept_sanitization]' ); ?>" value="<?php echo AMP_Options_Manager::get_option( 'auto_accept_sanitization' ) ? 'on' : ''; ?>">
-			<?php else : ?>
-				<div class="amp-auto-accept-sanitize-canonical notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'All new validation errors are automatically accepted when in standard mode.', 'amp' ); ?></p>
-				</div>
-				<div class="amp-auto-accept-sanitize">
-					<p>
-						<label for="auto_accept_sanitization">
-							<input id="auto_accept_sanitization" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[auto_accept_sanitization]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'auto_accept_sanitization' ) ); ?>>
-							<?php esc_html_e( 'Automatically accept sanitization for any newly encountered AMP validation errors.', 'amp' ); ?>
-						</label>
-					</p>
-					<p class="description">
-						<?php esc_html_e( 'This will ensure your responses are always valid AMP but some important content may get stripped out (e.g. scripts).', 'amp' ); ?>
-						<?php
-						echo wp_kses_post(
-							sprintf(
-								/* translators: %s is URL to validation errors screen */
-								__( 'Existing validation errors which you have already rejected will not be modified (you may want to consider <a href="%s">bulk-accepting them</a>).', 'amp' ),
-								esc_url(
-									add_query_arg(
-										[
-											'taxonomy'  => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG,
-											'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
-										],
-										admin_url( 'edit-tags.php' )
-									)
-								)
-							)
-						)
-						?>
-					</p>
-				</div>
-			<?php endif; ?>
-
-			<script>
-			(function( $, standardModeSlug, readerModeSlug ) {
-				const getThemeSupportMode = () => {
-					const checkedInput = $( 'input[type=radio][name="amp-options[theme_support]"]:checked' );
-					if ( 0 === checkedInput.length ) {
-						return standardModeSlug;
-					}
-					return checkedInput.val();
-				};
-
-				const updateHiddenClasses = function() {
-					const themeSupportMode = getThemeSupportMode();
-					$( '.amp-auto-accept-sanitize' ).toggleClass( 'hidden', standardModeSlug === themeSupportMode );
-					$( '.amp-validation-field' ).toggleClass( 'hidden', readerModeSlug === themeSupportMode );
-					$( '.amp-auto-accept-sanitize-canonical' ).toggleClass( 'hidden', standardModeSlug !== themeSupportMode );
-				};
-
-				$( 'input[type=radio][name="amp-options[theme_support]"]' ).change( updateHiddenClasses );
-
-				updateHiddenClasses();
-			})(
-				jQuery,
-				<?php echo wp_json_encode( AMP_Theme_Support::STANDARD_MODE_SLUG ); ?>,
-				<?php echo wp_json_encode( AMP_Theme_Support::READER_MODE_SLUG ); ?>
-			);
-			</script>
 		</fieldset>
 		<?php
 	}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1288,40 +1288,6 @@ class AMP_Validated_URL_Post_Type {
 			);
 		}
 
-		if ( 'post' !== get_current_screen()->base ) {
-			// Display admin notice according to the AMP mode.
-			if ( amp_is_canonical() ) {
-				$template_mode = AMP_Theme_Support::STANDARD_MODE_SLUG;
-			} elseif ( current_theme_supports( AMP_Theme_Support::SLUG ) ) {
-				$template_mode = AMP_Theme_Support::TRANSITIONAL_MODE_SLUG;
-			} else {
-				$template_mode = 'reader';
-			}
-			$auto_sanitization = AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
-
-			if ( AMP_Theme_Support::STANDARD_MODE_SLUG === $template_mode ) {
-				$message = __( 'The site is using standard AMP mode, the validation errors found are already automatically handled.', 'amp' );
-			} elseif ( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode && $auto_sanitization ) {
-				$message = __( 'The site is using transitional AMP mode with auto-sanitization turned on, the validation errors found are already automatically handled.', 'amp' );
-			} elseif ( AMP_Theme_Support::TRANSITIONAL_MODE_SLUG === $template_mode ) {
-				$message = sprintf(
-					/* translators: %s is a link to the AMP settings screen */
-					__( 'The site is using transitional AMP mode without auto-sanitization, the validation errors found require action and influence which pages are shown in AMP. For automatically handling the errors turn on auto-sanitization from <a href="%s">Validation Handling settings</a>.', 'amp' ),
-					esc_url( admin_url( 'admin.php?page=' . AMP_Options_Manager::OPTION_NAME ) )
-				);
-			} else {
-				$message = __( 'The site is using AMP reader mode, your theme templates are not used and the errors below are irrelevant.', 'amp' );
-			}
-
-			$class = 'info';
-			printf(
-				/* translators: 1. Notice classname; 2. Message text; 3. Screenreader text; */
-				'<div class="notice notice-%s"><p>%s</p></div>',
-				esc_attr( $class ),
-				wp_kses_post( $message )
-			);
-		}
-
 		/**
 		 * Adds notices to the single error page.
 		 * 1. Notice with detailed error information in an expanding box.

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -693,14 +693,6 @@ class AMP_Validated_URL_Post_Type {
 			);
 		}
 
-		$is_story = (
-			isset( $args['queried_object']['type'], $args['queried_object']['id'] )
-			&&
-			'post' === $args['queried_object']['type']
-			&&
-			AMP_Story_Post_Type::POST_TYPE_SLUG === get_post_type( $args['queried_object']['id'] )
-		);
-
 		/*
 		 * The details for individual validation errors is stored in the amp_validation_error taxonomy terms.
 		 * The post content just contains the slugs for these terms and the sources for the given instance of
@@ -754,7 +746,7 @@ class AMP_Validated_URL_Post_Type {
 								'term_group' => $sanitization['status'],
 							]
 						);
-					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted( $data ) || $is_story ) {
+					} elseif ( AMP_Validation_Manager::is_sanitization_auto_accepted( $data ) ) {
 						$term_data['term_group'] = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS;
 						wp_update_term(
 							$term_id,

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -415,8 +415,11 @@ class AMP_Validation_Error_Taxonomy {
 	/**
 	 * Determine whether a validation error should be sanitized.
 	 *
-	 * @param array $error Validation error.
+	 * @since 1.0
+	 * @see AMP_Validation_Error_Taxonomy::get_validation_error_sanitization()
+	 * @see AMP_Validation_Manager::is_sanitization_auto_accepted()
 	 *
+	 * @param array $error Validation error.
 	 * @return bool Whether error should be sanitized.
 	 */
 	public static function is_validation_error_sanitized( $error ) {
@@ -431,8 +434,10 @@ class AMP_Validation_Error_Taxonomy {
 	/**
 	 * Get the validation error sanitization.
 	 *
-	 * @param array $error Validation error.
+	 * @since 1.0
+	 * @see AMP_Validation_Manager::is_sanitization_auto_accepted()
 	 *
+	 * @param array $error Validation error.
 	 * @return array {
 	 *     Validation error sanitization.
 	 *
@@ -479,6 +484,7 @@ class AMP_Validation_Error_Taxonomy {
 		 * sanitization by.
 		 *
 		 * @since 1.0
+		 * @see AMP_Validation_Manager::is_sanitization_auto_accepted() Which controls whether an error is initially accepted or rejected for sanitization.
 		 *
 		 * @param null|bool $sanitized Whether sanitized; this is initially null, and changing it to bool causes the validation error to be forced.
 		 * @param array $error Validation error being sanitized.

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -297,8 +297,7 @@ class AMP_Validation_Manager {
 	 */
 	public static function is_sanitization_auto_accepted( $error = null ) {
 		if ( ! amp_is_canonical() ) {
-			// @todo Eliminate auto_accept_sanitization altogether.
-			return AMP_Options_Manager::get_option( 'auto_accept_sanitization' );
+			return apply_filters( 'amp_is_sanitization_auto_accepted', $error );
 		}
 
 		return ! ( $error && 'excessive_css' === $error['code'] );
@@ -898,7 +897,7 @@ class AMP_Validation_Manager {
 				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 			} else {
 				/*
-				 * Even if the 'auto_accept_sanitization' option is true, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
+				 * Even if sanitizations are auto accepted, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
 				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
 				 * In that case, this will block serving AMP.
 				 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -297,6 +297,13 @@ class AMP_Validation_Manager {
 	 */
 	public static function is_sanitization_auto_accepted( $error = null ) {
 		if ( ! amp_is_canonical() ) {
+			/**
+			 * Filters whether auto-sanitization is to be enabled or not.
+			 *
+			 * @since 1.3.1
+			 *
+			 * @param array $error Validation error.
+			 */
 			return apply_filters( 'amp_is_sanitization_auto_accepted', $error );
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -290,11 +290,11 @@ class AMP_Validation_Manager {
 	}
 
 	/**
-	 * Return whether sanitization is initially accepted for newly encountered validation errors.
+	 * Return whether sanitization is initially accepted (by default) for newly encountered validation errors.
 	 *
-	 * To auto-reject all validation errors, a filter can be used like so:
+	 * To reject all new validation errors by default, a filter can be used like so:
 	 *
-	 *     add_filter( 'amp_is_sanitization_auto_accepted', '__return_false' );
+	 *     add_filter( 'amp_validation_error_default_sanitized', '__return_false' );
 	 *
 	 * Whether or not a validation error is then actually sanitized is the ultimately determined by the
 	 * `amp_validation_error_sanitized` filter.
@@ -310,9 +310,9 @@ class AMP_Validation_Manager {
 
 		if ( $error && amp_is_canonical() ) {
 			// Excessive CSS on AMP-first sites must not be removed by default since removing CSS can severely break a site.
-			$auto_accepted = 'excessive_css' !== $error['code'];
+			$accepted = 'excessive_css' !== $error['code'];
 		} else {
-			$auto_accepted = true;
+			$accepted = true;
 		}
 
 		/**
@@ -322,12 +322,12 @@ class AMP_Validation_Manager {
 		 * status of existing validation errors, use the `amp_validation_error_sanitized` filter.
 		 *
 		 * @since 1.4
-		 * @see \AMP_Validation_Error_Taxonomy::get_validation_error_sanitization()
+		 * @see AMP_Validation_Error_Taxonomy::get_validation_error_sanitization()
 		 *
-		 * @param bool       $auto_accepted Auto accepted.
-		 * @param array|null $error         Validation error. May be null when asking if auto-accepting sanitization is generally enabled.
+		 * @param bool       $accepted Default accepted.
+		 * @param array|null $error    Validation error. May be null when asking if accepting sanitization is enabled by default.
 		 */
-		return apply_filters( 'amp_validation_error_auto_sanitized', $auto_accepted, $error );
+		return apply_filters( 'amp_validation_error_default_sanitized', $accepted, $error );
 	}
 
 	/**
@@ -918,13 +918,13 @@ class AMP_Validation_Manager {
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
 
-		// Auto-acceptance is enabled by default but can be overridden by the the `amp_validation_error_auto_sanitized` filter.
+		// Auto-acceptance is enabled by default but can be overridden by the the `amp_validation_error_default_sanitized` filter.
 		if ( self::is_sanitization_auto_accepted() ) {
 			if ( ! $has_rejected_error ) {
 				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 			} else {
 				/*
-				 * Even if sanitizations are auto-accepted, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
+				 * Even if sanitizations are accepted by default, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
 				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
 				 * In that case, this will block serving AMP.
 				 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -898,13 +898,13 @@ class AMP_Validation_Manager {
 		esc_html_e( 'There is content which fails AMP validation.', 'amp' );
 		echo ' ';
 
-		// Auto-acceptance is from either checking 'Automatically accept sanitization...' or from being in AMP-first.
+		// Auto-acceptance is from either the `amp_is_sanitization_auto_accepted` filter, or from being in AMP-first.
 		if ( self::is_sanitization_auto_accepted() ) {
 			if ( ! $has_rejected_error ) {
 				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
 			} else {
 				/*
-				 * Even if sanitizations are auto accepted, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
+				 * Even if sanitizations are auto-accepted, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
 				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
 				 * In that case, this will block serving AMP.
 				 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -328,7 +328,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_add_amphtml_link_transitional_mode( $canonical_url, $amphtml_url ) {
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Theme_Support::init();
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -10,6 +10,8 @@
  */
 class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
+	use AMP_Test_HandleValidation;
+
 	/**
 	 * The mock Site Icon value to use in a filter.
 	 *
@@ -326,7 +328,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_add_amphtml_link_transitional_mode( $canonical_url, $amphtml_url ) {
 		AMP_Options_Manager::update_option( 'theme_support', AMP_Theme_Support::TRANSITIONAL_MODE_SLUG );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		AMP_Theme_Support::read_theme_support();
 		AMP_Theme_Support::init();
 		$this->assertTrue( current_theme_supports( AMP_Theme_Support::SLUG ) );

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -112,18 +112,17 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		delete_option( AMP_Options_Manager::OPTION_NAME );
 		$this->assertEquals(
 			[
-				'experiences'              => [ AMP_Options_Manager::WEBSITE_EXPERIENCE ],
-				'theme_support'            => AMP_Theme_Support::READER_MODE_SLUG,
-				'supported_post_types'     => [ 'post' ],
-				'analytics'                => [],
-				'auto_accept_sanitization' => true,
-				'all_templates_supported'  => true,
-				'supported_templates'      => [ 'is_singular' ],
-				'enable_response_caching'  => true,
-				'version'                  => AMP__VERSION,
-				'story_templates_version'  => false,
-				'story_export_base_url'    => '',
-				'story_settings'           => [
+				'experiences'             => [ AMP_Options_Manager::WEBSITE_EXPERIENCE ],
+				'theme_support'           => AMP_Theme_Support::READER_MODE_SLUG,
+				'supported_post_types'    => [ 'post' ],
+				'analytics'               => [],
+				'all_templates_supported' => true,
+				'supported_templates'     => [ 'is_singular' ],
+				'enable_response_caching' => true,
+				'version'                 => AMP__VERSION,
+				'story_templates_version' => false,
+				'story_export_base_url'   => '',
+				'story_settings'          => [
 					'auto_advance_after'          => '',
 					'auto_advance_after_duration' => 0,
 				],

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -14,6 +14,8 @@
  */
 class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
+	use AMP_Test_HandleValidation;
+
 	const TESTED_CLASS = 'AMP_Validated_URL_Post_Type';
 
 	/**
@@ -152,7 +154,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::store_validation_errors()
 	 */
 	public function test_get_invalid_url_validation_errors() {
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 		$post = self::factory()->post->create();
@@ -709,7 +711,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::handle_bulk_action()
 	 */
 	public function test_handle_bulk_action() {
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
@@ -834,7 +836,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::handle_validate_request()
 	 */
 	public function test_handle_validate_request() {
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Manager::init();

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -154,7 +154,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::store_validation_errors()
 	 */
 	public function test_get_invalid_url_validation_errors() {
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
 		$post = self::factory()->post->create();
@@ -711,7 +711,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::handle_bulk_action()
 	 */
 	public function test_handle_bulk_action() {
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validation_Manager::init();
@@ -836,7 +836,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * @covers \AMP_Validated_URL_Post_Type::handle_validate_request()
 	 */
 	public function test_handle_validate_request() {
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		AMP_Validation_Manager::init();

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -275,7 +275,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $error_bar )
 		);
 
-		// New accepted, since canonical.
+		// New accepted.
+		$this->auto_accept_sanitization( true );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			[

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -12,6 +12,8 @@
  */
 class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
+	use AMP_Test_HandleValidation;
+
 	/**
 	 * The tested class.
 	 *
@@ -234,7 +236,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_is_validation_error_sanitized_and_get_validation_error_sanitization() {
 
 		// New accepted.
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
+		$this->auto_accept_sanitization( true );
 		$error_foo = array_merge(
 			$this->get_mock_error(),
 			[ 'foo' => 1 ]
@@ -254,7 +256,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		);
 
 		// New rejected.
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		$error_bar = array_merge(
 			$this->get_mock_error(),
 			[ 'bar' => 1 ]
@@ -1095,7 +1097,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::filter_manage_custom_columns()
 	 */
 	public function test_filter_manage_custom_columns() {
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		AMP_Validation_Error_Taxonomy::register();
 		$validation_error = $this->get_mock_error();
 		$initial_content  = 'example initial content';

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -236,7 +236,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	public function test_is_validation_error_sanitized_and_get_validation_error_sanitization() {
 
 		// New accepted.
-		$this->auto_accept_sanitization( true );
+		$this->accept_sanitization_by_default( true );
 		$error_foo = array_merge(
 			$this->get_mock_error(),
 			[ 'foo' => 1 ]
@@ -256,7 +256,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		);
 
 		// New rejected.
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		$error_bar = array_merge(
 			$this->get_mock_error(),
 			[ 'bar' => 1 ]
@@ -276,7 +276,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		);
 
 		// New accepted.
-		$this->auto_accept_sanitization( true );
+		$this->accept_sanitization_by_default( true );
 		add_theme_support(
 			AMP_Theme_Support::SLUG,
 			[
@@ -1098,7 +1098,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 	 * @covers \AMP_Validation_Error_Taxonomy::filter_manage_custom_columns()
 	 */
 	public function test_filter_manage_custom_columns() {
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		AMP_Validation_Error_Taxonomy::register();
 		$validation_error = $this->get_mock_error();
 		$initial_content  = 'example initial content';

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -257,8 +257,8 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->auto_accept_sanitization( false );
-		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
-		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
+		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
@@ -702,7 +702,8 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertContains( '<code>script</code>', $output );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 
-		// In 'Standard' mode, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
+		// When auto-accepting validation errors, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
+		$this->auto_accept_sanitization( true );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertContains( 'There is content which fails AMP validation. Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', $output );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -710,7 +710,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		/*
 		 * When there are 'Rejected' or 'New Rejected' errors, there should be a message that explains that this will serve a non-AMP URL.
-		 * This simulates 'accept_sanitization_by_default' being true, but it having been false when the validation errors were stored,
+		 * This simulates sanitization being accepted by default, but it having been false when the validation errors were stored,
 		 * as there are errors with 'New Rejected' status.
 		 */
 		$this->accept_sanitization_by_default( true );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -147,7 +147,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// Make sure should_locate_sources arg is recognized.
 		remove_all_filters( 'amp_validation_error_sanitized' );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		AMP_Validation_Manager::init(
 			[
 				'should_locate_sources' => true,
@@ -244,31 +244,31 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		];
 
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		$this->auto_accept_sanitization( true );
+		$this->accept_sanitization_by_default( true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		$this->auto_accept_sanitization( true );
+		$this->accept_sanitization_by_default( true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
@@ -280,7 +280,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::add_admin_bar_menu_items()
 	 */
 	public function test_add_admin_bar_menu_items() {
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 
 		// No admin bar item when user lacks capability.
 		$this->go_to( home_url( '/' ) );
@@ -483,7 +483,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_get_amp_validity_rest_field() {
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
 
@@ -668,7 +668,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_print_edit_form_validation_status() {
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
@@ -696,27 +696,27 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 
-		// In 'Transitional' mode with 'auto_accept_sanitization' set to false.
+		// When sanitization is accepted by default.
+		$this->accept_sanitization_by_default( true );
 		$expected_notice_non_accepted_errors = 'There is content which fails AMP validation. Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.';
 		$this->assertContains( 'notice notice-warning', $output );
 		$this->assertContains( '<code>script</code>', $output );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 
 		// When auto-accepting validation errors, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
-		$this->auto_accept_sanitization( true );
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertContains( 'There is content which fails AMP validation. Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', $output );
 
 		/*
 		 * When there are 'Rejected' or 'New Rejected' errors, there should be a message that explains that this will serve a non-AMP URL.
-		 * This simulates 'auto_accept_sanitization' being true, but it having been false when the validation errors were stored,
+		 * This simulates 'accept_sanitization_by_default' being true, but it having been false when the validation errors were stored,
 		 * as there are errors with 'New Rejected' status.
 		 */
-		$this->auto_accept_sanitization( true );
+		$this->accept_sanitization_by_default( true );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
-		$this->auto_accept_sanitization( false );
+		$this->accept_sanitization_by_default( false );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 	}

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -15,6 +15,8 @@
  */
 class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
+	use AMP_Test_HandleValidation;
+
 	/**
 	 * The name of the tested class.
 	 *
@@ -145,7 +147,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// Make sure should_locate_sources arg is recognized.
 		remove_all_filters( 'amp_validation_error_sanitized' );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		AMP_Validation_Manager::init(
 			[
 				'should_locate_sources' => true,
@@ -242,31 +244,31 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		];
 
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		remove_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
+		$this->auto_accept_sanitization( true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertFalse( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
+		$this->auto_accept_sanitization( true );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted() );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $some_error ) );
 		$this->assertTrue( AMP_Validation_Manager::is_sanitization_auto_accepted( $excessive_css_error ) );
@@ -278,7 +280,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 * @covers AMP_Validation_Manager::add_admin_bar_menu_items()
 	 */
 	public function test_add_admin_bar_menu_items() {
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 
 		// No admin bar item when user lacks capability.
 		$this->go_to( home_url( '/' ) );
@@ -481,7 +483,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_get_amp_validity_rest_field() {
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
 
@@ -666,7 +668,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_print_edit_form_validation_status() {
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 
 		AMP_Validated_URL_Post_Type::register();
 		AMP_Validation_Error_Taxonomy::register();
@@ -710,10 +712,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		 * This simulates 'auto_accept_sanitization' being true, but it having been false when the validation errors were stored,
 		 * as there are errors with 'New Rejected' status.
 		 */
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', true );
+		$this->auto_accept_sanitization( true );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
-		AMP_Options_Manager::update_option( 'auto_accept_sanitization', false );
+		$this->auto_accept_sanitization( false );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
 	}

--- a/tests/php/validation/trait-handle-validation.php
+++ b/tests/php/validation/trait-handle-validation.php
@@ -1,0 +1,21 @@
+<?php
+
+trait AMP_Test_HandleValidation {
+
+	/**
+	 * Whether or not to enable auto sanitization if AMP is not canonical.
+	 *
+	 * @param bool $value Value to return when AMP_Validation_Manager::is_sanitization_auto_accepted() is called.
+	 * @return void
+	 */
+	private function auto_accept_sanitization( $value ) {
+		remove_all_filters( 'amp_is_sanitization_auto_accepted' );
+
+		add_filter(
+			'amp_is_sanitization_auto_accepted',
+			static function () use ( $value ) {
+				return $value;
+			}
+		);
+	}
+}

--- a/tests/php/validation/trait-handle-validation.php
+++ b/tests/php/validation/trait-handle-validation.php
@@ -11,16 +11,16 @@
 trait AMP_Test_HandleValidation {
 
 	/**
-	 * Whether or not to enable auto-sanitization.
+	 * Whether or not to enable acceptance of sanitization by default.
 	 *
 	 * @param bool $value Value to return when AMP_Validation_Manager::is_sanitization_auto_accepted() is called.
 	 * @return void
 	 */
-	private function auto_accept_sanitization( $value ) {
-		remove_all_filters( 'amp_validation_error_auto_sanitized' );
+	private function accept_sanitization_by_default( $value ) {
+		remove_all_filters( 'amp_validation_error_default_sanitized' );
 
 		add_filter(
-			'amp_validation_error_auto_sanitized',
+			'amp_validation_error_default_sanitized',
 			static function () use ( $value ) {
 				return $value;
 			}

--- a/tests/php/validation/trait-handle-validation.php
+++ b/tests/php/validation/trait-handle-validation.php
@@ -3,7 +3,7 @@
 trait AMP_Test_HandleValidation {
 
 	/**
-	 * Whether or not to enable auto sanitization if AMP is not canonical.
+	 * Whether or not to enable auto-sanitization if AMP is not canonical.
 	 *
 	 * @param bool $value Value to return when AMP_Validation_Manager::is_sanitization_auto_accepted() is called.
 	 * @return void

--- a/tests/php/validation/trait-handle-validation.php
+++ b/tests/php/validation/trait-handle-validation.php
@@ -1,18 +1,26 @@
 <?php
+/**
+ * File containing helper trait for validation.
+ *
+ * @package AMP
+ */
 
+/**
+ * Helper trait for validation
+ */
 trait AMP_Test_HandleValidation {
 
 	/**
-	 * Whether or not to enable auto-sanitization if AMP is not canonical.
+	 * Whether or not to enable auto-sanitization.
 	 *
 	 * @param bool $value Value to return when AMP_Validation_Manager::is_sanitization_auto_accepted() is called.
 	 * @return void
 	 */
 	private function auto_accept_sanitization( $value ) {
-		remove_all_filters( 'amp_is_sanitization_auto_accepted' );
+		remove_all_filters( 'amp_validation_error_auto_sanitized' );
 
 		add_filter(
-			'amp_is_sanitization_auto_accepted',
+			'amp_validation_error_auto_sanitized',
 			static function () use ( $value ) {
 				return $value;
 			}


### PR DESCRIPTION
## Summary

- Remove validation handling setting field
- Remove relevant auto-sanitization notices
- Remove `auto_accept_sanitization` option
- Make `AMP_Validation_Manage::is_sanitization_auto_accepted()` filterable via `amp_validation_error_default_sanitized`. See https://gist.github.com/westonruter/c1496d668b2a73a44aa423e6547a59b7.
- Update tests to use new filter to set sanitization auto acceptance

<!-- Please reference the issue this PR addresses. -->
Fixes #3350.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
