### PR TITLE
Fix infinite loop when uploading videos

### DIFF
--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -134,6 +134,8 @@ const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, 
 		if ( src && ! isBlobURL( src ) ) {
 			getContentLengthFromUrl( src ).then( setVideoSize );
 		}
+		// Disable reason: src is constantly changing, but we want this hook to fire only once (like componentDidMount).
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ allowedVideoMimeTypes, id, mediaUpload, noticeOperations, setAttributes ] );
 
 	useEffect( () => {

--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -136,7 +136,7 @@ const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, 
 		}
 		// Disable reason: src is constantly changing, but we want this hook to fire only once (like componentDidMount).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ allowedVideoMimeTypes, id, mediaUpload, noticeOperations, setAttributes ] );
+	}, [] );
 
 	useEffect( () => {
 		if ( videoPlayer.current ) {

--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -134,7 +134,7 @@ const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, 
 		if ( src && ! isBlobURL( src ) ) {
 			getContentLengthFromUrl( src ).then( setVideoSize );
 		}
-	}, [ allowedVideoMimeTypes, id, mediaUpload, noticeOperations, setAttributes, src ] );
+	}, [ allowedVideoMimeTypes, id, mediaUpload, noticeOperations, setAttributes ] );
 
 	useEffect( () => {
 		if ( videoPlayer.current ) {

--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -145,7 +145,7 @@ const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, 
 	}, [ poster ] );
 
 	useEffect( () => {
-		if ( ! isBlobURL( src ) ) {
+		if ( src && ! isBlobURL( src ) ) {
 			getContentLengthFromUrl( src ).then( setVideoSize );
 		}
 	}, [ src ] );


### PR DESCRIPTION
## Summary

Do not pass `src` in variable in the `useEffect`, as the function sets `src` and makes the code loop.

See #3463 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
