### PR TITLE
Target all cover modals for respecting the admin bar offset

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1022,13 +1022,13 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						right: calc(100% + 2rem);
 					}
 
-					.admin-bar .menu-modal {
+					.admin-bar .cover-modal {
 						/* Use padding to shift down modal because amp-lightbox has top:0 !important. */
 						padding-top: 32px;
 					}
 
 					@media (max-width: 782px) {
-						.admin-bar .menu-modal {
+						.admin-bar .cover-modal {
 							/* Use padding to shift down modal because amp-lightbox has top:0 !important. */
 							padding-top: 46px;
 						}


### PR DESCRIPTION
## Summary

Instead of only targeting a specific modal (`.menu-modal`), this PR changes the admin-bar-specific CSS to target _all_ cover modals instead ( `.cover-modal`).

### Before

![Image 2019-10-21 at 2 30 12 PM](https://user-images.githubusercontent.com/83631/67205281-b501ed80-f40f-11e9-9370-35bd85eb7bdd.png)

### After

![Image 2019-10-21 at 2 30 33 PM](https://user-images.githubusercontent.com/83631/67205283-b7644780-f40f-11e9-85ea-1fbea66da3ec.png)

Fixes #3569

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
