### PR TITLE
Close modals when clicking outside of them

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1675,14 +1675,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				break;
 			}
 
-			// Add class(es) of removed wrapper to lightbox to avoid breaking CSS selectors.
-			if ( $modal_content_node->hasAttribute( 'class' ) ) {
-				$classes = $modal_content_node->getAttribute( 'class' );
-				if ( $amp_lightbox->hasAttribute( 'class' ) ) {
-					$classes .= ' ' . $amp_lightbox->getAttribute( 'class' );
-				}
-				$amp_lightbox->setAttribute( 'class', $classes );
-			}
+			// Add class(es) and action(s) of removed wrapper to lightbox to avoid breaking CSS selectors.
+			AMP_DOM_Utils::copy_attributes( [ 'class', 'on', 'data-toggle-target' ], $modal_content_node, $amp_lightbox );
 
 			$modal_content_node = $modal_content_node->removeChild( $children[0] );
 
@@ -1745,9 +1739,17 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				}
 			}
 
+			$modal_id = AMP_DOM_Utils::get_element_id( $modal );
+
+			// Add the lightbox itself as a close button xpath as well.
+			// With twentytwenty compat, the lightbox fills the entire screen, and only an inner wrapper will contain
+			// the actionable elements in the modal. Therefore, the lightbox represents the "background".
+			$close_button_xpaths[] = "//*[ @id = '{$modal_id}' ]";
+			$modal->setAttribute( 'data-toggle-target', "#{$modal_id}" );
+
 			$this->wrap_modal_in_lightbox(
 				[
-					'modal_id'             => AMP_DOM_Utils::get_element_id( $modal ),
+					'modal_id'             => $modal_id,
 					'modal_content_xpath'  => $modal->getNodePath(),
 					'open_button_xpath'    => $open_button_xpaths,
 					'close_button_xpath'   => $close_button_xpaths,


### PR DESCRIPTION
## Summary

This PR adds a set of AMP actions to the `<amp-lightbox>` element that is used to replace the TwentyTwenty modals. Basically, the `<amp-lightbox>` is yet another "toggle" to close the modal.

As there's another `.modal-inner` element that contains all the actionable elements of the modal including its container, the `<amp-lightbox>` is effectively the background in the AMP context.

This PR offered a few technical challenges that made the solution non-trivial and required adding two helper methods:

- `AMP_DOM_Utils::copy_attributes()` is used to copy a set of attributes from one element to the other. This helper method makes it easier in our case to move all the relevant bits from the original modal element to the `<amp-lightbox>` replacements. This was previously just a class attribute, but is now the following attributes instead: `'class'`, `'on'` (for moving the actions over), `'data-toggle-target'` (which is needed for the generic toggle functionality to know what to target).
- `AMP_DOM_Utils::merge_amp_actions()` is added (and used as part of `AMP_DOM_Utils::add_amp_action()`) to allow for smart deduplication of AMP actions. This is now needed as the `<amp-lightbox>` is turned into a toggle as well, while already being a modal. As the toggle functionality adds `toggleClass()` actions for the `'active'` class on both toggles and their modals, we ended up with a duplicate toggle on the modal, which cancel each other out. The deduplication in `merge_amp_actions()` makes sure this doesn't happen.

Both helper methods are generic tools that prove to be useful and come with tests, so they were added to `AMP_DOM_Utils`, and not as internal helpers for the `AMP_Core_Theme_Sanitizer`.

Fixes #3570

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
