### PR TITLE
CTA responsiveness fixes

### DIFF
--- a/assets/css/src/amp-stories-frontend.css
+++ b/assets/css/src/amp-stories-frontend.css
@@ -19,6 +19,8 @@ amp-story-grid-layer {
 .amp-cta-button-wrapper {
 	max-width: 600px;
 	margin: 0 auto;
+	position: relative;
+	height: 100%;
 }
 
 .amp-block-story-cta__link {

--- a/assets/css/src/amp-stories.css
+++ b/assets/css/src/amp-stories.css
@@ -34,7 +34,7 @@ amp-story-grid-layer[template="fill"] .wp-block-image {
 	font-size: 18px;
 	margin: 0;
 	max-height: calc(100% - 24px);
-	padding: 12px 24px;
+	padding: 7px 24px;
 	text-align: center;
 	text-decoration: none;
 	white-space: normal;

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -22,9 +22,9 @@ import { getBackgroundColorWithOpacity } from '../../../common/helpers';
 import { DraggableText } from '../../components';
 import { STORY_PAGE_INNER_HEIGHT_FOR_CTA } from '../../constants';
 
-// Total padding of top + bottom / left + right.
-const CTA_BUTTON_PADDING_TOP_BOTTOM = 7;
-const CTA_BUTTON_PADDING_LEFT_RIGHT = 38;
+// Total padding of top + bottom (vertical) / left + right (horizontal).
+const CTA_BUTTON_PADDING_VERTICAL = 14;
+const CTA_BUTTON_PADDING_HORIZONTAL = 48;
 
 const CallToActionEdit = ( {
 	attributes,
@@ -102,10 +102,10 @@ const CallToActionEdit = ( {
 						onChange={ ( value ) => {
 							setAttributes( { text: value } );
 							// Also update width and height based on the room that the CTA button takes.
-							const element = document.querySelector( `#amp-story-cta-button-${ clientId } .amp-block-story-cta__link` );
+							const element = document.querySelector( `#amp-story-cta-button-${ clientId } .wp-block-amp-amp-story-cta` );
 							// Deduct the padding since this will be added extra otherwise.
-							const btnWidth = getPercentageFromPixels( 'x', element.clientWidth - CTA_BUTTON_PADDING_LEFT_RIGHT );
-							const btnHeight = getPercentageFromPixels( 'y', element.clientHeight - CTA_BUTTON_PADDING_TOP_BOTTOM, STORY_PAGE_INNER_HEIGHT_FOR_CTA );
+							const btnWidth = getPercentageFromPixels( 'x', element.clientWidth - CTA_BUTTON_PADDING_HORIZONTAL );
+							const btnHeight = getPercentageFromPixels( 'y', element.clientHeight - CTA_BUTTON_PADDING_VERTICAL, STORY_PAGE_INNER_HEIGHT_FOR_CTA );
 							setAttributes( {
 								btnWidth,
 								btnHeight,

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -22,6 +22,10 @@ import { getBackgroundColorWithOpacity } from '../../../common/helpers';
 import { DraggableText } from '../../components';
 import { STORY_PAGE_INNER_HEIGHT_FOR_CTA } from '../../constants';
 
+// Total padding of top + bottom / left + right.
+const CTA_BUTTON_PADDING_TOP_BOTTOM = 7;
+const CTA_BUTTON_PADDING_LEFT_RIGHT = 38;
+
 const CallToActionEdit = ( {
 	attributes,
 	backgroundColor,
@@ -99,8 +103,9 @@ const CallToActionEdit = ( {
 							setAttributes( { text: value } );
 							// Also update width and height based on the room that the CTA button takes.
 							const element = document.querySelector( `#amp-story-cta-button-${ clientId } .amp-block-story-cta__link` );
-							const btnWidth = getPercentageFromPixels( 'x', element.clientWidth );
-							const btnHeight = getPercentageFromPixels( 'y', element.clientHeight, STORY_PAGE_INNER_HEIGHT_FOR_CTA );
+							// Deduct the padding since this will be added extra otherwise.
+							const btnWidth = getPercentageFromPixels( 'x', element.clientWidth - CTA_BUTTON_PADDING_LEFT_RIGHT );
+							const btnHeight = getPercentageFromPixels( 'y', element.clientHeight - CTA_BUTTON_PADDING_TOP_BOTTOM, STORY_PAGE_INNER_HEIGHT_FOR_CTA );
 							setAttributes( {
 								btnWidth,
 								btnHeight,

--- a/assets/src/stories-editor/blocks/amp-story-cta/index.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/index.js
@@ -39,7 +39,7 @@ const schema = {
 	},
 	btnPositionLeft: {
 		type: 'number',
-		default: 30,
+		default: 5,
 	},
 	btnWidth: {
 		type: 'number',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #3343 

- [x] Positions the CTA button 5% from left as other blocks.
- [x] Fix width and height by considering 12px 24px padding assigned in the FE. Currently that creates inconsistencies between the FE and editor.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
