### PR TITLE
Convert .focus class selectors to :focus-within pseudo-class selectors

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1011,17 +1011,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						display: inherit;
 					}
 
-					.primary-menu li.menu-item-has-children:focus-within > ul {
-						right: 0;
-						opacity: 1;
-						transform: translateY(0);
-						transition: opacity .15s linear, transform .15s linear;
-					}
-
-					.primary-menu ul li.menu-item-has-children:focus-within > ul {
-						right: calc(100% + 2rem);
-					}
-
 					.admin-bar .cover-modal {
 						/* Use padding to shift down modal because amp-lightbox has top:0 !important. */
 						padding-top: 32px;
@@ -1056,46 +1045,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						.no-js .main-navigation > div > ul {
 							display: block;
 						}
-						.main-navigation ul li.menu-item-has-children:focus-within:before,
-						.main-navigation ul li.menu-item-has-children:focus-within:after,
-						.main-navigation ul li.page_item_has_children:focus-within:before,
-						.main-navigation ul li.page_item_has_children:focus-within:after {
-							display: block;
-						}
-						.main-navigation ul ul li:focus-within > ul {
-							<?php if ( is_rtl() ) : ?>
-								left: auto;
-								right: 100%;
-							<?php else : ?>
-								left: 100%;
-								right: auto;
-							<?php endif; ?>
-						}
-						.main-navigation li li:focus-within {
-							background: #767676;
-						}
-						.main-navigation li li:focus-within > a,
-						.main-navigation li li a:focus-within,
-						.main-navigation li li.current_page_item a:focus-within,
-						.main-navigation li li.current-menu-item a:focus-within {
-							color: #fff;
-						}
-						.main-navigation ul li:focus-within > ul {
-							<?php if ( is_rtl() ) : ?>
-								left: auto;
-								right: 0.5em;
-							<?php else : ?>
-								left: 0.5em;
-								right: auto;
-							<?php endif; ?>
-						}
-
-						.main-navigation ul ul li.menu-item-has-children:focus-within:before,
-						.main-navigation ul ul li.menu-item-has-children:focus-within:after,
-						.main-navigation ul ul li.page_item_has_children:focus-within:before,
-						.main-navigation ul ul li.page_item_has_children:focus-within:after {
-							display: none;
-						}
 					}
 				<?php elseif ( 'twentysixteen' === get_template() ) : ?>
 					@media screen and (max-width: 56.875em) {
@@ -1114,27 +1063,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						.no-js .main-navigation ul ul {
 							display: block;
 						}
-						.main-navigation li:focus-within > a {
-							color: #007acc;
-						}
-						.main-navigation li:focus-within > ul {
-							<?php if ( is_rtl() ) : ?>
-								left: auto;
-								right: 0;
-							<?php else : ?>
-								left: 0;
-								right: auto;
-							<?php endif; ?>
-						}
-						.main-navigation ul ul li:focus-within > ul {
-							<?php if ( is_rtl() ) : ?>
-								left: 100%;
-								right: auto;
-							<?php else : ?>
-								left: auto;
-								right: 100%;
-							<?php endif; ?>
-						}
 					}
 				<?php elseif ( 'twentyfifteen' === get_template() ) : ?>
 					@media screen and (min-width: 59.6875em) {
@@ -1147,52 +1075,10 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						}
 					}
 
-				<?php elseif ( 'twentyfourteen' === get_template() ) : ?>
-					@media screen and (min-width: 783px) {
-						.primary-navigation li:focus-within > a {
-							background-color: #24890d;
-							color: #fff;
-						}
-
-						.primary-navigation ul ul li:focus-within > a {
-							background-color: #41a62a;
-						}
-
-						.primary-navigation ul li:focus-within > ul {
-							left: auto;
-						}
-
-						.primary-navigation ul ul li:focus-within > ul {
-							left: 100%;
-						}
-					}
-
-					@media screen and (min-width: 1008px) {
-						.secondary-navigation li:focus-within > a {
-							background-color: #24890d;
-							color: #fff;
-						}
-
-						.secondary-navigation ul ul li:focus-within > a {
-							background-color: #41a62a;
-						}
-
-						.secondary-navigation ul li:focus-within > ul {
-							left: 202px;
-						}
-					}
-
 				<?php elseif ( 'twentythirteen' === get_template() ) : ?>
 					@media (min-width: 644px) {
 						.dropdown-toggle {
 							display: none;
-						}
-						ul.nav-menu :focus-within > ul,
-						.nav-menu :focus-within > ul {
-							clip: inherit;
-							overflow: inherit;
-							height: inherit;
-							width: inherit;
 						}
 					}
 					@media (max-width: 643px) {
@@ -1275,18 +1161,6 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 							outline: 1px solid rgba(51, 51, 51, 0.3);
 						}
 					}
-
-				<?php elseif ( 'twentytwelve' === get_template() ) : ?>
-					@media screen and (min-width: 600px) {
-						.main-navigation .menu-item-has-children:focus-within > ul {
-							border-left: 0;
-							clip: inherit;
-							overflow: inherit;
-							height: inherit;
-							width: inherit;
-						}
-					}
-
 				<?php endif; ?>
 				</style>
 				<?php

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -185,7 +185,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private $used_class_names;
 
 	/**
-	 * Regular expression pattern to match focus_class_names in selectors.
+	 * Regular expression pattern to match focus class names in selectors.
 	 *
 	 * The computed pattern is cached to prevent re-constructing for each processed selector.
 	 *
@@ -2877,7 +2877,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$before_type_selector_pattern = '(?<=^|\(|\s|>|\+|~|,|})';
 			$after_type_selector_pattern  = '(?=$|[^a-zA-Z0-9_-])';
 
-			// Replace .focus selector with :focus-within.
+			// Replace focus selectors with :focus-within.
 			if ( $this->focus_class_name_selector_pattern ) {
 				$count    = 0;
 				$selector = preg_replace(
@@ -2945,12 +2945,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Given list of class names, create a regular expression pattern to match them in a selector.
+	 * Given a list of class names, create a regular expression pattern to match them in a selector.
 	 *
 	 * @since 1.4
 	 *
 	 * @param string[] $class_names Class names.
-	 * @return string Pattern,
+	 * @return string Regular expression pattern.
 	 */
 	private static function get_class_name_selector_pattern( $class_names ) {
 		$pattern  = '/\.(';
@@ -2960,7 +2960,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				function ( $class_name ) {
 					return preg_quote( $class_name, '/' );
 				},
-				$class_names
+				(array) $class_names
 			)
 		);
 		$pattern .= ')(?=$|[^a-zA-Z0-9_-])';

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2953,19 +2953,16 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string Regular expression pattern.
 	 */
 	private static function get_class_name_selector_pattern( $class_names ) {
-		$pattern  = '/\.(';
-		$pattern .= implode(
+		$class_pattern = implode(
 			'|',
 			array_map(
-				function ( $class_name ) {
+				static function ( $class_name ) {
 					return preg_quote( $class_name, '/' );
 				},
 				(array) $class_names
 			)
 		);
-		$pattern .= ')(?=$|[^a-zA-Z0-9_-])';
-		$pattern .= '/';
-		return $pattern;
+		return "/\.({$class_pattern})(?=$|[^a-zA-Z0-9_-])/";
 	}
 
 	/**

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -700,11 +700,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'.video{color:blue;} audio.audio{color:purple;} .iframe{color:black;} .img{color:purple;} .form:not(form){color:green;}',
 				'.video{color:blue}amp-audio.audio{color:purple}.iframe{color:black}.img{color:purple}.form:not(form){color:green}',
 			],
+			'focus_within_classes' => [
+				'<nav class="main-navigation focused"><ul><li><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
+				'.main-navigation ul ul li:hover > ul, .main-navigation ul ul li.focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
+				'.main-navigation ul ul li:hover > ul,.main-navigation ul ul li:focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
+			],
 		];
 	}
 
 	/**
 	 * Test AMP selector conversion.
+	 *
+	 * @covers AMP_Style_Sanitizer::ampify_ruleset_selectors()
 	 *
 	 * @dataProvider get_amp_selector_data
 	 * @param string $markup Markup.


### PR DESCRIPTION
## Summary

* Applies `.focus` => `:focus-within` conversion for all themes, including all themes based on _s.
* Reduces the amount of CSS required by preventing rule duplication for AMP compatibility (reduces Twenty Fourteen's CSS by 119 bytes). This also reduces the maintenance burden.

Fixes #3585.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
