### PR TITLE
Fix XPath for fetching the closest submenu

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1877,7 +1877,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		$sub_menu = $this->xpath->query( "//*[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' sub-menu ' ) ]", $menu_item )->item( 0 );
+		$sub_menu = $this->xpath->query( ".//*[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' sub-menu ' ) ]", $menu_item )->item( 0 );
 
 		if ( ! $sub_menu instanceof DOMElement ) {
 			return $element;

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -13,9 +13,6 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	/**
 	 * Call a private method as if it was public.
 	 *
-	 * This is used as a temporary measure to test `xpath_from_css_selector()`, which
-	 * should reside in `AMP_DOM_Utils` once it is mature enough.
-	 *
 	 * @param object $object      Object instance to call the method on.
 	 * @param string $method_name Name of the method to call.
 	 * @param array  $args        Optional. Array of arguments to pass to the method.
@@ -26,6 +23,20 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$method = ( new ReflectionClass( $object ) )->getMethod( $method_name );
 		$method->setAccessible( true );
 		return $method->invokeArgs( $object, $args );
+	}
+
+	/**
+	 * Set a private property as if it was public.
+	 *
+	 * @param object $object        Object instance to the property of.
+	 * @param string $property_name Name of the property to set.
+	 * @param mixed  $value         Value to set the property to.
+	 * @throws ReflectionException If the object could not be reflected upon.
+	 */
+	private function set_private_property( $object, $property_name, $value ) {
+		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
+		$property->setAccessible( true );
+		$property->setValue( $object, $value );
 	}
 
 	public function get_xpath_from_css_selector_data() {
@@ -57,6 +68,58 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 		$dom       = new DOMDocument();
 		$sanitizer = new AMP_Core_Theme_Sanitizer( $dom );
 		$actual    = $this->call_private_method( $sanitizer, 'xpath_from_css_selector', [ $css_selector ] );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	public function get_get_closest_submenu_data() {
+		$html  = '
+			<nav>
+				<ul class="primary-menu">
+					<li id="menu-item-1" class="menu-item menu-item-1"><a href="https://example.com/a">Link A</a></li>
+					<li id="menu-item-2" class="menu-item menu-item-2"><a href="https://example.com/b">Link B</a><span class="icon"></span>
+						<ul id="sub-menu-1" class="sub-menu">
+							<li id="menu-item-3" class="menu-item menu-item-3"><a href="https://example.com/c">Link C</a></li>
+							<li id="menu-item-4" class="menu-item menu-item-4"><a href="https://example.com/d">Link D</a></li>
+						</ul>
+					</li>
+					<li id="menu-item-5" class="menu-item menu-item-5"><a href="https://example.com/e">Link E</a><span class="icon"></span>
+						<ul id="sub-menu-2" class="sub-menu">
+							<li id="menu-item-6" class="menu-item menu-item-6"><a href="https://example.com/f">Link F</a><span class="icon"></span>
+								<ul id="sub-menu-3" class="sub-menu">
+									<li id="menu-item-7" class="menu-item menu-item-7"><a href="https://example.com/g">Link G</a></li>
+									<li id="menu-item-8" class="menu-item menu-item-8"><a href="https://example.com/h">Link H</a></li>
+								</ul>
+							</li>
+							<li id="menu-item-9" class="menu-item menu-item-9"><a href="https://example.com/i">Link I</a></li>
+						</ul>
+					</li>
+				</ul>
+			</nav>
+		';
+		$dom   = AMP_DOM_Utils::get_dom_from_content( $html );
+		$xpath = new DOMXPath( $dom );
+		return [
+			// First sub-menu.
+			[ $dom, $xpath, $xpath->query( "//*[ @id = 'menu-item-2' ]" )->item( 0 ), $xpath->query( "//*[ @id = 'sub-menu-1' ]" )->item( 0 ) ],
+
+			// Second sub-menu.
+			[ $dom, $xpath, $xpath->query( "//*[ @id = 'menu-item-5' ]" )->item( 0 ), $xpath->query( "//*[ @id = 'sub-menu-2' ]" )->item( 0 ) ],
+
+			// Sub-menu of second sub-menu.
+			[ $dom, $xpath, $xpath->query( "//*[ @id = 'menu-item-6' ]" )->item( 0 ), $xpath->query( "//*[ @id = 'sub-menu-3' ]" )->item( 0 ) ],
+		];
+	}
+
+	/**
+	 * Test get_closest_submenu().
+	 *
+	 * @dataProvider get_get_closest_submenu_data
+	 * @covers AMP_Core_Theme_Sanitizer::get_closest_submenu()
+	 */
+	public function test_get_closest_submenu( $dom, $xpath, $element, $expected ) {
+		$sanitizer = new AMP_Core_Theme_Sanitizer( $dom );
+		$this->set_private_property( $sanitizer, 'xpath', $xpath );
+		$actual = $this->call_private_method( $sanitizer, 'get_closest_submenu', [ $element ] );
 		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
## Summary

The XPath for fetching the closest submenu was set to be absolute instead of relative.

Why this was never broken for me on my machine is a mystery, though...

- [x] Add tests for AMP_Core_Theme_Sanitizer::get_closest_submenu()

Fixes #3559

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
