### PR TITLE
Further improve compatibility tool design and UX

### DIFF
--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -245,26 +245,32 @@ dl.detailed {
 	margin-left: 10px;
 }
 
-body.taxonomy-amp_validation_error .wp-list-table .new th,
-body.taxonomy-amp_validation_error .wp-list-table .new td,
+/*body.taxonomy-amp_validation_error .wp-list-table .new th,*/
+/*body.taxonomy-amp_validation_error .wp-list-table .new td,*/
 tr.expanded.new + tr > td:first-of-type,
-body.post-type-amp_validated_url .wp-list-table .new th,
-body.post-type-amp_validated_url .wp-list-table .new td {
+.wp-list-table .new td,
+.wp-list-table .new th {
 	background-color: #fef7f1;
 }
 
-body.taxonomy-amp_validation_error .wp-list-table .new.odd th,
-body.taxonomy-amp_validation_error .wp-list-table .new.odd td,
-tr.expanded.new.odd + tr > td:first-of-type,
-body.post-type-amp_validated_url .wp-list-table .new.odd th,
-body.post-type-amp_validated_url .wp-list-table .new.odd td {
-	background-color: #f9eee5;
+tr.expanded.new + tr > td:first-of-type,
+.wp-list-table .new th.check-column {
+	border-left: 4px solid #d54e21;
 }
 
-body.taxonomy-amp_validation_error .wp-list-table .new th.check-column,
-tr.expanded.new + tr > td:first-of-type,
-body.post-type-amp_validated_url .wp-list-table .new th.check-column {
-	border-left: 4px solid #d54e21;
+.wp-list-table th,
+.wp-list-table td {
+	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+}
+
+.wp-list-table tr:last-child th,
+.wp-list-table tr:last-child td {
+	box-shadow: none;
+}
+
+.wp-list-table tr.unapproved + tr.approved th,
+.wp-list-table tr.unapproved + tr.approved td {
+	border-top: 1px solid rgba(0, 0, 0, 0.03);
 }
 
 body.taxonomy-amp_validation_error .wp-list-table .new th.check-column input {

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -181,7 +181,7 @@ dl.detailed details > summary {
 .column-details .error-details-toggle::before,
 .column-details .error-details-toggle::after {
 	width: 12px;
-	height: 12px;
+	height: 10px;
 	background-image: url("../images/down-triangle.svg");
 	background-size: cover;
 	background-position: center;

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -23,7 +23,7 @@ th.column-error_type {
 	width: 15%;
 }
 
-td.column-error .error-code {
+td.column-error_code .error-code {
 	font-family: Consolas, Monaco, monospace;
 }
 
@@ -43,6 +43,14 @@ details[open] .details-attributes__summary {
 	margin-bottom: 15px;
 }
 
+.details-attributes__summary {
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+	cursor: pointer;
+}
+
 .column-details .details-attributes__summary::-webkit-details-marker,
 .column-details .notice details > summary::-webkit-details-marker {
 	display: none;
@@ -60,7 +68,8 @@ details[open] .details-attributes__summary {
 }
 
 tr.expanded .details-attributes__summary::after,
-details.single-error-detail[open] .single-error-detail-summary::after {
+details[open] > .details-attributes__summary::after,
+details[open] > .single-error-detail-summary::after {
 	transform: rotate(180deg);
 }
 
@@ -338,18 +347,6 @@ body.taxonomy-amp_validation_error .wp-list-table .new th.check-column input {
 
 .wp-heading-inline code {
 	font-size: 1rem;
-}
-
-/** Details post action. */
-.details button {
-	display: inline-block;
-	background: none;
-	border: none;
-	padding: 0;
-	text-align: left;
-	color: #0073aa;
-	cursor: pointer;
-	text-decoration: underline;
 }
 
 .validation-error-sources th {

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -304,26 +304,6 @@ body.taxonomy-amp_validation_error .wp-list-table .new th.check-column input {
 	color: #a00;
 }
 
-.notice.accept-reject-error {
-	display: flex;
-	margin-bottom: 0;
-}
-
-.notice.accept-reject-error > p {
-	display: inline-block;
-	font-size: 14px;
-	flex-grow: 10;
-	margin-right: 20px;
-}
-
-.notice.accept-reject-error > .button {
-	display: inline-block;
-	margin: 5px 5px 0 5px;
-	padding: 0 26px 2px;
-	flex-grow: 1;
-	text-align: center;
-}
-
 .notice.accept-reject-error > .button.accept {
 
 	/* @todo Add green colors */

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -108,6 +108,14 @@ dl.detailed {
 	padding-bottom: 16px;
 }
 
+dl.detailed details > summary {
+	cursor: pointer;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
 .details-attributes__title,
 .notice .detailed summary code {
 	display: inline-block;

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -329,23 +329,32 @@ body.taxonomy-amp_validation_error .wp-list-table .new th.check-column input {
 	font-size: 1rem;
 }
 
-.validation-error-sources th {
-	font-weight: bold;
-	text-align: right;
+.validation-error-sources {
+	border-collapse: collapse;
+}
+
+.validation-error-sources tbody:not(:first-child) {
+	border-top: solid 1px #ddd;
+	margin: 0;
 }
 
 .validation-error-sources td,
 .validation-error-sources th {
 	vertical-align: top;
-	padding: 0 4px;
+	padding: 2px 4px;
 }
 
-.validation-error-sources > li {
-	border-top: solid 1px #ddd;
-	margin: 0;
-	padding: 6px 0;
+.validation-error-sources tbody > tr:first-child > th,
+.validation-error-sources tbody > tr:first-child > td {
+	padding-top: 0.75em;
 }
 
-.validation-error-sources > li:first-child {
-	border-top: 0;
+.validation-error-sources tbody > tr:last-child > th,
+.validation-error-sources tbody > tr:last-child > td {
+	padding-bottom: 0.75em;
+}
+
+.validation-error-sources th {
+	font-weight: bold;
+	text-align: right;
 }

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -243,12 +243,14 @@ dl.detailed {
 	margin-left: 10px;
 }
 
-/*body.taxonomy-amp_validation_error .wp-list-table .new th,*/
-/*body.taxonomy-amp_validation_error .wp-list-table .new td,*/
 tr.expanded.new + tr > td:first-of-type,
-.wp-list-table .new td,
-.wp-list-table .new th {
+.wp-list-table > tbody > .new > td,
+.wp-list-table > tbody > .new > th {
 	background-color: #fef7f1;
+}
+
+tr.expanded + tr > td:first-of-type {
+	border-left: solid 4px transparent;
 }
 
 tr.expanded.new + tr > td:first-of-type,
@@ -256,18 +258,20 @@ tr.expanded.new + tr > td:first-of-type,
 	border-left: 4px solid #d54e21;
 }
 
-.wp-list-table th,
-.wp-list-table td {
+.wp-list-table > tbody > tr > th,
+.wp-list-table > tbody > tr > td {
 	box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 }
 
-.wp-list-table tr:last-child th,
-.wp-list-table tr:last-child td {
+.wp-list-table > tbody > tr:last-child > th,
+.wp-list-table > tbody > tr.expanded > th,
+.wp-list-table > tbody > tr:last-child > td,
+.wp-list-table > tbody > tr.expanded > td {
 	box-shadow: none;
 }
 
-.wp-list-table tr.unapproved + tr.approved th,
-.wp-list-table tr.unapproved + tr.approved td {
+.wp-list-table > tbody > tr.unapproved + tr.approved th,
+.wp-list-table > tbody > tr.unapproved + tr.approved td {
 	border-top: 1px solid rgba(0, 0, 0, 0.03);
 }
 

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -31,10 +31,6 @@ th.column-status {
 	width: 15%;
 }
 
-.fixed th.column-posts {
-	width: 10%;
-}
-
 /* Details column */
 .column-details .details-attributes__summary {
 	display: flex;

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -155,14 +155,10 @@ dl.detailed {
 	flex-direction: column;
 	height: 14px;
 	padding: 0;
-	margin-top: 4px;
+	margin: 0;
 	background: none;
 	border: none;
 	cursor: pointer;
-}
-
-.error-details-toggle.is-open {
-	transform: rotate(180deg);
 }
 
 .column-details .error-details-toggle::before,
@@ -173,6 +169,11 @@ dl.detailed {
 	background-size: cover;
 	background-position: center;
 	content: "";
+}
+
+.error-details-toggle.is-open::before,
+.error-details-toggle.is-open::after {
+	transform: rotate(180deg);
 }
 
 /* Status text icons */

--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -108,7 +108,7 @@ dl.detailed {
 	padding-bottom: 16px;
 }
 
-.details-attributes__title code,
+.details-attributes__title,
 .notice .detailed summary code {
 	display: inline-block;
 	min-width: 240px;
@@ -116,8 +116,9 @@ dl.detailed {
 	font-weight: 600;
 }
 
-.details-attributes__title code {
+.details-attributes__title {
 	margin-left: 0;
+	font-weight: bold;
 }
 
 .details-attributes__list {

--- a/assets/css/src/amp-validation-single-error-url.css
+++ b/assets/css/src/amp-validation-single-error-url.css
@@ -75,7 +75,7 @@ table.striped > tbody > tr.even {
 #number-errors {
 	text-align: center;
 	background-color: #d3d3d3b8;
-	color: black;
+	color: #000;
 }
 
 #url-post-filter {

--- a/assets/css/src/amp-validation-single-error-url.css
+++ b/assets/css/src/amp-validation-single-error-url.css
@@ -1,5 +1,5 @@
 /** Arrow icon on title in error column. */
-.column-error > .single-url-detail-toggle {
+.column-error_code > .single-url-detail-toggle {
 	position: relative;
 	width: 100%;
 	padding: 5px 36px 5px 0;
@@ -11,7 +11,7 @@
 	cursor: pointer;
 }
 
-.column-error > .single-url-detail-toggle::after {
+.column-error_code > .single-url-detail-toggle::after {
 	position: absolute;
 	top: 0;
 	right: 0;
@@ -44,18 +44,6 @@ table.striped > tbody > tr.even {
 /** Hide original details content. */
 .details-attributes > .detailed {
 	display: none;
-}
-
-/** Details post action. */
-.details button {
-	display: inline-block;
-	background: none;
-	border: none;
-	padding: 0;
-	text-align: left;
-	color: #0073aa;
-	cursor: pointer;
-	text-decoration: underline;
 }
 
 /** Details row styles. */
@@ -117,7 +105,7 @@ table.striped > tbody > tr.even {
 	width: 20%;
 }
 
-.wp-list-table th.column-error {
+.wp-list-table th.column-error_type {
 	width: 25%;
 }
 

--- a/assets/css/src/amp-validation-single-error-url.css
+++ b/assets/css/src/amp-validation-single-error-url.css
@@ -96,21 +96,25 @@ table.striped > tbody > tr.even {
 	margin-top: 0.5rem;
 }
 
-/* Give enough width to prevent the widest column status, 'New Accepted,' from forcing the <select> below the icon. */
-.wp-list-table th.column-status {
-	width: 150px;
-}
-
-.wp-list-table th.column-sources_with_invalid_output {
-	width: 20%;
+.wp-list-table th.column-error_code {
+	width: 30%;
 }
 
 .wp-list-table th.column-error_type {
-	width: 25%;
+	width: 15%;
 }
 
 .wp-list-table th.column-details {
-	width: 20%;
+	width: 15%;
+}
+
+.wp-list-table th.column-sources_with_invalid_output {
+	width: 30%;
+}
+
+/* Give enough width to prevent the widest column status, 'New Accepted,' from forcing the <select> below the icon. */
+.wp-list-table th.column-status {
+	width: 150px;
 }
 
 /** Add space between list table and the filter and search box above it. */

--- a/assets/css/src/amp-validation-single-error-url.css
+++ b/assets/css/src/amp-validation-single-error-url.css
@@ -75,7 +75,7 @@ table.striped > tbody > tr.even {
 #number-errors {
 	text-align: center;
 	background-color: #d3d3d3b8;
-	color: #1e8cbecc;
+	color: black;
 }
 
 #url-post-filter {

--- a/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
+++ b/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
@@ -286,26 +286,32 @@ const updateSelectIcon = ( select ) => {
 };
 
 /**
+ * Set the row status class.
+ *
+ * @param {HTMLSelectElement} select Select element.
+ */
+const setRowStatusClass = ( select ) => {
+	const acceptedValue = 3;
+	const rejectedValue = 2;
+	const status = parseInt( select.options[ select.selectedIndex ].value );
+	const row = select.closest( 'tr' );
+
+	row.classList.toggle( 'new', isNaN( status ) );
+	row.classList.toggle( 'accepted', acceptedValue === status );
+	row.classList.toggle( 'rejected', rejectedValue === status );
+};
+
+/**
  * Handles a change in the error status, like from 'New' to 'Accepted'.
  *
  * Gets the data-status-icon value from the newly-selected <option>.
  * And sets this as the src of the status icon <img>.
  */
 const handleStatusChange = () => {
-	const setRowStatusClass = ( { row, select } ) => {
-		const acceptedValue = 3;
-		const rejectedValue = 2;
-		const status = parseInt( select.options[ select.selectedIndex ].value );
-
-		row.classList.toggle( 'new', isNaN( status ) );
-		row.classList.toggle( 'accepted', acceptedValue === status );
-		row.classList.toggle( 'rejected', rejectedValue === status );
-	};
-
-	const onChange = ( { event, row, select } ) => {
+	const onChange = ( { event, select } ) => {
 		if ( event.target.matches( 'select' ) ) {
 			updateSelectIcon( event.target );
-			setRowStatusClass( { row, select } );
+			setRowStatusClass( select );
 		}
 	};
 
@@ -313,7 +319,7 @@ const handleStatusChange = () => {
 		const select = row.querySelector( '.amp-validation-error-status' );
 
 		if ( select ) {
-			setRowStatusClass( { row, select } );
+			setRowStatusClass( /** @type {HTMLSelectElement} */ select );
 			select.addEventListener( 'change', ( event ) => {
 				onChange( { event, row, select } );
 			} );
@@ -370,6 +376,7 @@ const handleBulkActions = () => {
 			if ( select.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).checked ) {
 				select.value = '3';
 				updateSelectIcon( select );
+				setRowStatusClass( select );
 				addBeforeUnloadPrompt();
 			}
 		} );
@@ -381,6 +388,7 @@ const handleBulkActions = () => {
 			if ( select.closest( 'tr' ).querySelector( '.check-column input[type=checkbox]' ).checked ) {
 				select.value = '2';
 				updateSelectIcon( select );
+				setRowStatusClass( select );
 				addBeforeUnloadPrompt();
 			}
 		} );

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1319,26 +1319,26 @@ class AMP_Validated_URL_Post_Type {
 			if ( ! $sanitization['forced'] ) {
 				echo '<div class="notice accept-reject-error">';
 
-				if ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_ACCEPTED_STATUS === $sanitization['term_status'] || AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS === $sanitization['term_status'] ) {
+				if ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS === $sanitization['term_status'] ) {
 					if ( amp_is_canonical() ) {
 						$info = __( 'Rejecting an error means that any URL on which it occurs will not be served as AMP.', 'amp' );
 					} else {
 						$info = __( 'Rejecting an error means that any URL on which it occurs will redirect to the non-AMP version.', 'amp' );
 					}
 					printf(
-						'<p>%s</p><a class="button button-primary reject" href="%s">%s</a>',
+						'<p>%s</p><p><a class="button button-primary reject" href="%s">%s</a></p>',
 						esc_html__( 'Reject this validation error for all instances.', 'amp' ) . ' ' . esc_html( $info ),
 						esc_url( $reject_all_url ),
 						esc_html__( 'Reject', 'amp' )
 					);
-				} elseif ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS === $sanitization['term_status'] || AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS === $sanitization['term_status'] ) {
+				} elseif ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS === $sanitization['term_status'] ) {
 					if ( amp_is_canonical() ) {
 						$info = __( 'Accepting all validation errors which occur on a URL will allow it to be served as AMP.', 'amp' );
 					} else {
 						$info = __( 'Accepting all validation errors which occur on a URL will allow it to be served as AMP.', 'amp' );
 					}
 					printf(
-						'<p>%s</p><a class="button button-primary accept" href="%s">%s</a>',
+						'<p>%s</p><p><a class="button button-primary accept" href="%s">%s</a></p>',
 						esc_html__( 'Accept this error for all instances.', 'amp' ) . ' ' . esc_html( $info ),
 						esc_url( $accept_all_url ),
 						esc_html__( 'Accept', 'amp' )
@@ -1350,12 +1350,12 @@ class AMP_Validated_URL_Post_Type {
 						$info = __( 'Rejecting an error means that any URL on which it occurs will redirect to the non-AMP version. If all errors occurring on a URL are accepted, then it will not redirect.', 'amp' );
 					}
 					printf(
-						'<p>%s</p><a class="button reject" href="%s">%s</a><a class="button button-primary accept" href="%s">%s</a>',
+						'<p>%s</p><p><a class="button button-primary accept" href="%s">%s</a> <a class="button button-primary reject" href="%s">%s</a></p>',
 						esc_html__( 'Accept or Reject this error for all instances.', 'amp' ) . ' ' . esc_html( $info ),
-						esc_url( $reject_all_url ),
-						esc_html__( 'Reject', 'amp' ),
 						esc_url( $accept_all_url ),
-						esc_html__( 'Accept', 'amp' )
+						esc_html__( 'Accept', 'amp' ),
+						esc_url( $reject_all_url ),
+						esc_html__( 'Reject', 'amp' )
 					);
 				}
 				echo '</div>';

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -933,7 +933,7 @@ class AMP_Validated_URL_Post_Type {
 	public static function add_single_post_columns() {
 		return [
 			'cb'                          => '<input type="checkbox" />',
-			'error'                       => __( 'Error', 'amp' ),
+			'error_code'                  => __( 'Error', 'amp' ),
 			'error_type'                  => __( 'Type', 'amp' ),
 			'details'                     => sprintf(
 				'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -842,7 +842,7 @@ class AMP_Validation_Error_Taxonomy {
 					),
 					'error_type'       => esc_html__( 'Type', 'amp' ),
 					'created_date_gmt' => esc_html__( 'Last Seen', 'amp' ),
-					'posts'            => esc_html__( 'Found URLs', 'amp' ),
+					'posts'            => esc_html__( 'URLs', 'amp' ),
 				];
 			}
 		);
@@ -2150,7 +2150,7 @@ class AMP_Validation_Error_Taxonomy {
 					<?php if ( in_array( $key, [ 'node_name', 'parent_name' ], true ) ) : ?>
 						<code><?php echo esc_html( $value ); ?></code>
 					<?php elseif ( 'sources' === $key ) : ?>
-						<?php self::render_sources( $value, $validation_error ); ?>
+						<?php self::render_sources( $value ); ?>
 					<?php elseif ( $is_element_attributes ) : ?>
 						<table class="element-attributes">
 							<?php foreach ( $value as $attr_name => $attr_value ) : ?>

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2407,8 +2407,8 @@ class AMP_Validation_Error_Taxonomy {
 					sprintf(
 						/* translators: %s: number of sources. */
 						_n(
-							'%s possible source',
-							'%s possible sources',
+							'Source stack (%s)',
+							'Source stack (%s)',
 							$source_count,
 							'amp'
 						),

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2160,8 +2160,19 @@ class AMP_Validation_Error_Taxonomy {
 								printf( '<th class="%1$s"><code>%2$s</code></th>', esc_attr( $attr_name_class ), esc_html( $attr_name ) );
 								echo '<td>';
 								if ( ! empty( $attr_value ) ) {
-									printf( '<code>%s</code>', esc_html( $attr_value ) );
+									echo '<code>';
+									$is_url = in_array( $attr_name, [ 'href', 'src' ], true );
+									if ( $is_url ) {
+										// @todo There should be a link to the file editor as well, if available.
+										printf( '<a href="%s" target="_blank">', esc_url( $attr_value ) );
+									}
+									echo esc_html( $attr_value );
+									if ( $is_url ) {
+										echo '</a>';
+									}
+									echo '</code>';
 								}
+
 								echo '</td>';
 								?>
 								</tr>

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1627,7 +1627,7 @@ class AMP_Validation_Error_Taxonomy {
 
 			if ( 'post.php' === $pagenow ) {
 				$actions['details'] = sprintf(
-					'<button type="button" aria-label="%s" class="single-url-detail-toggle">%s</button>',
+					'<button type="button" aria-label="%s" class="single-url-detail-toggle button-link">%s</button>',
 					esc_attr__( 'Toggle error details', 'amp' ),
 					esc_html__( 'Details', 'amp' )
 				);
@@ -1793,7 +1793,7 @@ class AMP_Validation_Error_Taxonomy {
 				} else {
 					$content .= '<p>';
 					$content .= sprintf(
-						'<a href="%s">%s</a>',
+						'<a href="%s">%s',
 						admin_url(
 							add_query_arg(
 								[
@@ -1818,6 +1818,7 @@ class AMP_Validation_Error_Taxonomy {
 				if ( 'post.php' === $pagenow ) {
 					$content .= '</button>';
 				} else {
+					$content .= '</a>';
 					$content .= '</p>';
 				}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1939,11 +1939,11 @@ class AMP_Validation_Error_Taxonomy {
 					$attributes         = [];
 					$attributes_heading = '';
 					if ( ! empty( $validation_error['node_attributes'] ) ) {
-						$attributes_heading = sprintf( '<div class="details-attributes__title"><code>%s</code></div>', esc_html__( 'Element attributes:', 'amp' ) );
+						$attributes_heading = sprintf( '<div class="details-attributes__title">%s:</div>', esc_html( self::get_source_key_label( 'node_attributes', $validation_error ) ) );
 						$attributes         = $validation_error['node_attributes'];
 					} elseif ( ! empty( $validation_error['element_attributes'] ) ) {
-						$attributes_heading = sprintf( '<div class="details-attributes__title"><code>%s</code></div>', esc_html__( 'Other attributes:', 'amp' ) );
 						$attributes         = $validation_error['element_attributes'];
+						$attributes_heading = sprintf( '<div class="details-attributes__title">%s:</div>', esc_html( self::get_source_key_label( 'element_attributes', $validation_error ) ) );
 					}
 
 					if ( empty( $attributes ) ) {
@@ -1960,7 +1960,7 @@ class AMP_Validation_Error_Taxonomy {
 						foreach ( $attributes as $attr => $value ) {
 							$content .= sprintf( '<li><span class="details-attributes__attr">%s</span>', esc_html( $attr ) );
 
-							if ( isset( $value ) ) {
+							if ( ! empty( $value ) ) {
 								$content .= sprintf( ': <span class="details-attributes__value">%s</span>', esc_html( $value ) );
 							}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -817,7 +817,7 @@ class AMP_Validation_Error_Taxonomy {
 
 				return [
 					'cb'               => $old_columns['cb'],
-					'error'            => esc_html__( 'Error', 'amp' ),
+					'error_code'       => esc_html__( 'Error', 'amp' ),
 					'status'           => sprintf(
 						'%s<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="%s"></div>',
 						esc_html__( 'Status', 'amp' ),
@@ -853,7 +853,7 @@ class AMP_Validation_Error_Taxonomy {
 			static function( $sortable_columns ) {
 				$sortable_columns['created_date_gmt'] = 'term_id';
 				$sortable_columns['error_type']       = AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR;
-				$sortable_columns['error']            = AMP_Validation_Error_Taxonomy::VALIDATION_DETAILS_ERROR_CODE_QUERY_VAR;
+				$sortable_columns['error_code']       = AMP_Validation_Error_Taxonomy::VALIDATION_DETAILS_ERROR_CODE_QUERY_VAR;
 				return $sortable_columns;
 			}
 		);
@@ -965,7 +965,7 @@ class AMP_Validation_Error_Taxonomy {
 			'list_table_primary_column',
 			static function( $primary_column ) {
 				if ( get_current_screen() && AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG === get_current_screen()->taxonomy ) {
-					$primary_column = 'error';
+					$primary_column = 'error_code';
 				}
 				return $primary_column;
 			}
@@ -1783,7 +1783,7 @@ class AMP_Validation_Error_Taxonomy {
 		}
 
 		switch ( $column_name ) {
-			case 'error':
+			case 'error_code':
 				if ( 'post.php' === $pagenow ) {
 					$content .= sprintf(
 						'<button type="button" aria-label="%s" class="single-url-detail-toggle">',
@@ -2017,7 +2017,7 @@ class AMP_Validation_Error_Taxonomy {
 		return array_merge(
 			$sortable_columns,
 			[
-				'error'      => self::VALIDATION_DETAILS_ERROR_CODE_QUERY_VAR,
+				'error_code' => self::VALIDATION_DETAILS_ERROR_CODE_QUERY_VAR,
 				'error_type' => self::VALIDATION_ERROR_TYPE_QUERY_VAR,
 			]
 		);

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2417,178 +2417,184 @@ class AMP_Validation_Error_Taxonomy {
 				);
 				?>
 			</summary>
-			<ol class="validation-error-sources">
-				<?php foreach ( $sources as $source ) : ?>
+			<table class="validation-error-sources">
+				<?php foreach ( $sources as $i => $source ) : ?>
 					<?php
-					$file_text = null;
-					$edit_url  = self::get_file_editor_url( $source );
+					$source_table_rows = $source;
+
 					if ( isset( $source['file'], $source['line'] ) ) {
-						$file_text = $source['file'] . ':' . $source['line'];
-						unset( $source['file'], $source['line'] );
+						unset( $source_table_rows['file'], $source_table_rows['line'] );
+						$source_table_rows['location'] = [
+							'link_text' => $source['file'] . ':' . $source['line'],
+							'link_url'  => self::get_file_editor_url( $source ),
+						];
 					}
 					$is_filter = ! empty( $source['filter'] );
-					unset( $source['filter'] );
+					unset( $source_table_rows['filter'] );
 
 					$dependency_type = null;
 					if ( isset( $source['dependency_type'] ) ) {
 						$dependency_type = $source['dependency_type'];
-						unset( $source['dependency_type'] );
+						unset( $source_table_rows['dependency_type'] );
 					}
 
 					$priority = null;
 					if ( isset( $source['priority'] ) ) {
 						$priority = $source['priority'];
-						unset( $source['priority'] );
+						unset( $source_table_rows['priority'] );
 					}
 
+					$row_span = count( $source_table_rows );
 					?>
-					<li>
-						<table>
-							<?php foreach ( $source as $key => $value ) : ?>
-								<tr>
-									<th>
+					<tbody>
+						<?php foreach ( array_keys( $source_table_rows ) as $j => $key ) : ?>
+							<?php
+							$value = $source_table_rows[ $key ];
+							?>
+							<tr>
+								<?php if ( 0 === $j ) : ?>
+									<th rowspan="<?php echo esc_attr( $row_span ); ?>" scope="rowgroup">
+										#<?php echo esc_html( $i + 1 ); ?>
+									</th>
+								<?php endif; ?>
+								<th scope="row">
+									<?php
+									switch ( $key ) {
+										case 'name':
+											esc_html_e( 'Name', 'amp' );
+											break;
+										case 'post_id':
+											esc_html_e( 'Post ID', 'amp' );
+											break;
+										case 'post_type':
+											esc_html_e( 'Post Type', 'amp' );
+											break;
+										case 'handle':
+											if ( 'script' === $dependency_type ) {
+												esc_html_e( 'Script Handle', 'amp' );
+											} elseif ( 'style' === $dependency_type ) {
+												esc_html_e( 'Style Handle', 'amp' );
+											} else {
+												esc_html_e( 'Handle', 'amp' );
+											}
+											break;
+										case 'block_content_index':
+											esc_html_e( 'Block Index', 'amp' );
+											break;
+										case 'block_name':
+											esc_html_e( 'Block Name', 'amp' );
+											break;
+										case 'shortcode':
+											esc_html_e( 'Shortcode', 'amp' );
+											break;
+										case 'type':
+											esc_html_e( 'Type', 'amp' );
+											break;
+										case 'function':
+											esc_html_e( 'Function', 'amp' );
+											break;
+										case 'location':
+											esc_html_e( 'Location', 'amp' );
+											break;
+										case 'sources':
+											esc_html_e( 'Sources', 'amp' );
+											break;
+										case 'hook':
+											if ( $is_filter ) {
+												esc_html_e( 'Filter', 'amp' );
+											} else {
+												esc_html_e( 'Action', 'amp' );
+											}
+											break;
+										default:
+											echo esc_html( $key );
+									}
+									echo ':';
+									?>
+								</th>
+								<td>
+									<?php if ( 'sources' === $key && is_array( $value ) ) : ?>
+										<?php self::render_sources( $value ); ?>
+									<?php elseif ( 'type' === $key ) : ?>
 										<?php
-										switch ( $key ) {
-											case 'name':
-												esc_html_e( 'Name', 'amp' );
+										switch ( $value ) {
+											case 'theme':
+												echo '<span class="dashicons dashicons-admin-appearance"></span> ';
+												esc_html_e( 'Theme', 'amp' );
 												break;
-											case 'post_id':
-												esc_html_e( 'Post ID', 'amp' );
+											case 'plugin':
+												echo '<span class="dashicons dashicons-admin-plugins"></span> ';
+												esc_html_e( 'Plugin', 'amp' );
 												break;
-											case 'post_type':
-												esc_html_e( 'Post Type', 'amp' );
+											case 'mu-plugin':
+												echo '<span class="dashicons dashicons-admin-plugins"></span> ';
+												esc_html_e( 'Must-Use Plugin', 'amp' );
 												break;
-											case 'handle':
-												if ( 'script' === $dependency_type ) {
-													esc_html_e( 'Script Handle', 'amp' );
-												} elseif ( 'style' === $dependency_type ) {
-													esc_html_e( 'Style Handle', 'amp' );
-												} else {
-													esc_html_e( 'Handle', 'amp' );
-												}
-												break;
-											case 'block_content_index':
-												esc_html_e( 'Block Index', 'amp' );
-												break;
-											case 'block_name':
-												esc_html_e( 'Block Name', 'amp' );
-												break;
-											case 'shortcode':
-												esc_html_e( 'Shortcode', 'amp' );
-												break;
-											case 'type':
-												esc_html_e( 'Type', 'amp' );
-												break;
-											case 'function':
-												esc_html_e( 'Function', 'amp' );
-												break;
-											case 'sources':
-												esc_html_e( 'Sources', 'amp' );
-												break;
-											case 'hook':
-												if ( $is_filter ) {
-													esc_html_e( 'Filter', 'amp' );
-												} else {
-													esc_html_e( 'Action', 'amp' );
-												}
+											case 'core':
+												echo '<span class="dashicons dashicons-wordpress-alt"></span> ';
+												esc_html_e( 'Core', 'amp' );
 												break;
 											default:
-												echo esc_html( $key );
+												echo esc_html( (string) $value );
 										}
-										echo ':';
 										?>
-									</th>
-									<td>
-										<?php if ( 'sources' === $key && is_array( $value ) ) : ?>
-											<?php self::render_sources( $value ); ?>
-										<?php elseif ( 'type' === $key ) : ?>
-											<?php
-											switch ( $value ) {
-												case 'theme':
-													echo '<span class="dashicons dashicons-admin-appearance"></span> ';
-													esc_html_e( 'Theme', 'amp' );
-													break;
-												case 'plugin':
-													echo '<span class="dashicons dashicons-admin-plugins"></span> ';
-													esc_html_e( 'Plugin', 'amp' );
-													break;
-												case 'mu-plugin':
-													echo '<span class="dashicons dashicons-admin-plugins"></span> ';
-													esc_html_e( 'Must-Use Plugin', 'amp' );
-													break;
-												case 'core':
-													echo '<span class="dashicons dashicons-wordpress-alt"></span> ';
-													esc_html_e( 'Core', 'amp' );
-													break;
-												default:
-													echo esc_html( (string) $value );
-											}
-											?>
-										<?php elseif ( 'name' === $key && isset( $source['type'] ) ) : ?>
-											<?php self::render_source_name( $value, $source['type'] ); ?>
-										<?php elseif ( 'hook' === $key ) : ?>
-											<code><?php echo esc_html( (string) $value ); ?></code>
-											<?php
-											if ( null !== $priority ) {
-												echo esc_html(
-													sprintf(
-														/* translators: %d is the hook priority */
-														__( '(priority %d)', 'amp' ),
-														$priority
-													)
-												);
-											}
-											?>
-										<?php elseif ( 'function' === $key ) : ?>
-											<code><?php echo esc_html( '{closure}' === $value ? $value : $value . '()' ); ?></code>
-										<?php elseif ( 'block_name' === $key || 'shortcode' === $key || 'handle' === $key ) : ?>
-											<code><?php echo esc_html( $value ); ?></code>
-										<?php elseif ( 'post_type' === $key ) : ?>
-											<?php
-											$post_type = get_post_type_object( $value );
-											if ( $post_type && isset( $post_type->labels->singular_name ) ) {
-												echo esc_html( $post_type->labels->singular_name );
-												printf( ' (<code>%s</code>)', esc_html( $value ) );
-											} else {
-												printf( '<code>%s</code>', esc_html( $value ) );
-											}
-											?>
-										<?php elseif ( is_scalar( $value ) ) : ?>
-											<?php echo esc_html( (string) $value ); ?>
-										<?php else : ?>
-											<pre><?php echo esc_html( wp_json_encode( $source, 128 /* JSON_PRETTY_PRINT */ | 64 /* JSON_UNESCAPED_SLASHES */ ) ); ?></pre>
-										<?php endif; ?>
-									</td>
-								</tr>
-							<?php endforeach; ?>
-							<?php if ( $file_text ) : ?>
-								<tr>
-									<th>
-										<?php esc_html_e( 'Location', 'amp' ); ?>:
-									</th>
-									<td>
+									<?php elseif ( 'name' === $key && isset( $source['type'] ) ) : ?>
+										<?php self::render_source_name( $value, $source['type'] ); ?>
+									<?php elseif ( 'hook' === $key ) : ?>
+										<code><?php echo esc_html( (string) $value ); ?></code>
 										<?php
-										if ( $edit_url ) {
-											printf(
-												'<a href="%s" %s>',
-												// Note that esc_attr() used instead of esc_url() to allow IDE protocols.
-												esc_attr( $edit_url ),
-												// Open link in new window unless the user has filtered the URL to open their system IDE.
-												in_array( wp_parse_url( $edit_url, PHP_URL_SCHEME ), [ 'http', 'https' ], true ) ? 'target="_blank"' : ''
+										if ( null !== $priority ) {
+											echo esc_html(
+												sprintf(
+													/* translators: %d is the hook priority */
+													__( '(priority %d)', 'amp' ),
+													$priority
+												)
 											);
 										}
 										?>
-										<?php echo esc_html( $file_text ); ?>
-										<?php if ( $edit_url ) : ?>
+									<?php elseif ( 'location' === $key ) : ?>
+										<?php
+										if ( ! empty( $value['link_url'] ) ) {
+											printf(
+												'<a href="%s" %s>',
+												// Note that esc_attr() used instead of esc_url() to allow IDE protocols.
+												esc_attr( $value['link_url'] ),
+												// Open link in new window unless the user has filtered the URL to open their system IDE.
+												in_array( wp_parse_url( $value['link_url'], PHP_URL_SCHEME ), [ 'http', 'https' ], true ) ? 'target="_blank"' : ''
+											);
+										}
+										?>
+										<?php echo esc_html( $value['link_text'] ); ?>
+										<?php if ( ! empty( $value['link_url'] ) ) : ?>
 											</a>
 										<?php endif; ?>
-									</td>
-								</tr>
-							<?php endif; ?>
-						</table>
-					</li>
+									<?php elseif ( 'function' === $key ) : ?>
+										<code><?php echo esc_html( '{closure}' === $value ? $value : $value . '()' ); ?></code>
+									<?php elseif ( 'block_name' === $key || 'shortcode' === $key || 'handle' === $key ) : ?>
+										<code><?php echo esc_html( $value ); ?></code>
+									<?php elseif ( 'post_type' === $key ) : ?>
+										<?php
+										$post_type = get_post_type_object( $value );
+										if ( $post_type && isset( $post_type->labels->singular_name ) ) {
+											echo esc_html( $post_type->labels->singular_name );
+											printf( ' (<code>%s</code>)', esc_html( $value ) );
+										} else {
+											printf( '<code>%s</code>', esc_html( $value ) );
+										}
+										?>
+									<?php elseif ( is_scalar( $value ) ) : ?>
+										<?php echo esc_html( (string) $value ); ?>
+									<?php else : ?>
+										<pre><?php echo esc_html( wp_json_encode( $source, 128 /* JSON_PRETTY_PRINT */ | 64 /* JSON_UNESCAPED_SLASHES */ ) ); ?></pre>
+									<?php endif; ?>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
 				<?php endforeach; ?>
-			</ol>
+				</tbody>
+			</table>
 		</details>
 		<?php
 	}

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -556,7 +556,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'cb'                          => '<input type="checkbox" />',
-				'error'                       => 'Error',
+				'error_code'                  => 'Error',
 				'status'                      => 'Status<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Status&lt;/h3&gt;&lt;p&gt;An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.&lt;/p&gt;"></div>',
 				'details'                     => 'Context<span class="dashicons dashicons-editor-help tooltip-button" tabindex="0"></span><div class="tooltip" hidden data-content="&lt;h3&gt;Context&lt;/h3&gt;&lt;p&gt;The parent element of where the error occurred.&lt;/p&gt;"></div>',
 				'sources_with_invalid_output' => 'Sources',

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -583,7 +583,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			array_keys(
 				[
 					'cb'               => $cb,
-					'error'            => 'Error',
+					'error_code'       => 'Error',
 					'status'           => 'Status<div class="tooltip dashicons dashicons-editor-help"><h3>Statuses tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 					'details'          => 'Details<div class="tooltip dashicons dashicons-editor-help"><h3>Details tooltip title</h3><p>An accepted validation error is one that will not block a URL from being served as AMP; the validation error will be sanitized, normally resulting in the offending markup being stripped from the response to ensure AMP validity.</p></div>',
 					'error_type'       => 'Type',
@@ -1111,7 +1111,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// Test the 'error' block in the switch.
 		$GLOBALS['pagenow'] = 'post.php';
-		$filtered_content   = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'error', $term_id );
+		$filtered_content   = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'error_code', $term_id );
 		$this->assertStringStartsWith( $initial_content . '<button type="button" aria-label="Toggle error details"', $filtered_content );
 
 		// Test the 'status' block in the switch for the error taxonomy page.
@@ -1151,7 +1151,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			'links'       => 'count',
 		];
 		$columns_expected_to_be_added = [
-			'error'      => 'amp_validation_code',
+			'error_code' => 'amp_validation_code',
 			'error_type' => 'amp_validation_error_type',
 		];
 		$this->assertEquals(
@@ -1161,7 +1161,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// In the unlikely case that the initial columns has an 'error' value, this method should overwrite it.
 		$initial_columns_with_error = [
-			'error' => 'foobar',
+			'error_code' => 'foobar',
 		];
 		$this->assertEquals(
 			$columns_expected_to_be_added,


### PR DESCRIPTION
## Summary

See #2316. Follow up on #3505.

### Improve table row styling (before/after)

* Eliminate zebra striping (shades of red) for new errors is eliminated in favor of gray borders, to align with comments.
* Improve column widths.

<img width="1286" alt="Screen Shot 2019-10-22 at 16 31 11" src="https://user-images.githubusercontent.com/134745/67343321-c9b2b400-f4e9-11e9-8094-cab5a8208adb.png">

<img width="1287" alt="Screen Shot 2019-10-22 at 16 31 31" src="https://user-images.githubusercontent.com/134745/67343322-c9b2b400-f4e9-11e9-9c3b-09feeb738943.png">

### Ensure bulk accept/reject buttons cause new state to be cleared for validation errors on validated URL screen (before/after)

This aligns the behavior for when just changing the status in the dropdown.

<img width="977" alt="Screen Shot 2019-10-22 at 16 56 32" src="https://user-images.githubusercontent.com/134745/67344495-1cda3600-f4ed-11e9-9c34-6363e16ece07.png">

<img width="976" alt="Screen Shot 2019-10-22 at 16 57 01" src="https://user-images.githubusercontent.com/134745/67344502-24014400-f4ed-11e9-8d8d-2ad94014575a.png">

### Improve sources list (before/after)

* Put the entire source stack in a table to ensure alignment.
* Give `details > summary` a `cursor:pointer` and disable `user-select` to prevent text from being selected when clicking.
* Improve `summary` text to indicate the contents is a source stack (not “possible sources”).

<img width="913" alt="Screen Shot 2019-10-22 at 16 36 07" src="https://user-images.githubusercontent.com/134745/67343423-201ff280-f4ea-11e9-87ea-8bd5ed80c132.png">

<img width="902" alt="Screen Shot 2019-10-22 at 16 36 24" src="https://user-images.githubusercontent.com/134745/67343424-201ff280-f4ea-11e9-85bd-9a5a96f2b478.png">

### Linkify Element Attribute Values (before/after)

To facilitate investigating the functionality of a script or stylesheet that is being excluded, the URL attribute value is linked to open it in a new tab:

<img width="925" alt="Screen Shot 2019-10-22 at 16 38 00" src="https://user-images.githubusercontent.com/134745/67343508-59f0f900-f4ea-11e9-942d-25b781599e11.png">

<img width="916" alt="Screen Shot 2019-10-22 at 16 37 41" src="https://user-images.githubusercontent.com/134745/67343514-5e1d1680-f4ea-11e9-9c7e-356c200aefdb.png">

### Improve styling of validated URL errors list table (before/after)

* Improve color of “Showing” message
* Fix alignment of expand/collapse all button in column header (fixes #2078)
* Improve column widths.

<img width="976" alt="Screen Shot 2019-10-22 at 16 39 59" src="https://user-images.githubusercontent.com/134745/67343682-d71c6e00-f4ea-11e9-9269-2400976bc6df.png">

<img width="977" alt="Screen Shot 2019-10-22 at 16 40 19" src="https://user-images.githubusercontent.com/134745/67343692-dd124f00-f4ea-11e9-8499-60c23cfd4a22.png">

### Improve styling of validation error list table (before/after)

* Align styling with Comments list table (removing underlines from hyperlinks).
* Shorten “Found URLs” to just “URLs”
* Add gray borders between each row (aligning with Comments list table design)

<img width="1271" alt="Screen Shot 2019-10-22 at 16 45 13" src="https://user-images.githubusercontent.com/134745/67343906-76d9fc00-f4eb-11e9-98c3-53ac4404fc16.png">
<img width="1272" alt="Screen Shot 2019-10-22 at 16 45 35" src="https://user-images.githubusercontent.com/134745/67343909-77729280-f4eb-11e9-93a4-87a04ff9c5c5.png">

### Improve design of error details shown on the single validation error view (before/after)

* Fix positioning of accept/reject button.
* Show both accept and reject buttons when the error is in a new state.

<img width="1272" alt="Screen Shot 2019-10-22 at 16 48 10" src="https://user-images.githubusercontent.com/134745/67344057-ee0f9000-f4eb-11e9-80e7-f9fc74416e6c.png">

<img width="1275" alt="Screen Shot 2019-10-22 at 16 49 52" src="https://user-images.githubusercontent.com/134745/67344077-fcf64280-f4eb-11e9-93e2-c6ff70d9f8b2.png">


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
