### PR TITLE
Improve admin bar validate link text

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -445,14 +445,14 @@ class AMP_Validation_Manager {
 			'href'   => esc_url( $validate_url ),
 		];
 		if ( $error_count <= 0 ) {
-			$validate_item['title'] = esc_html__( 'Re-validate', 'amp' );
+			$validate_item['title'] = esc_html__( 'Validate', 'amp' );
 		} else {
 			$validate_item['title'] = esc_html(
 				sprintf(
 					/* translators: %s is count of validation errors */
 					_n(
-						'Re-validate (%s validation error)',
-						'Re-validate (%s validation errors)',
+						'Review %s validation issue',
+						'Review %s validation issues',
 						$error_count,
 						'amp'
 					),
@@ -1681,8 +1681,8 @@ class AMP_Validation_Manager {
 						$link->textContent = sprintf(
 							/* translators: %s is count of validation errors */
 							_n(
-								'Re-validate (%s validation error)',
-								'Re-validate (%s validation errors)',
+								'Review %s validation issue',
+								'Review %s validation issues',
 								$error_count,
 								'amp'
 							),


### PR DESCRIPTION
## Summary

Under the AMP admin bar item:

* Replace “Re-validate” with just “Validate”
* Replace “Re-validate (%s validation errors)” with “Review %s validation issues”

In the post editor, the warning notice says “Review issues” so this use of issue aligns with that other usage. The word “issue” is less daunting than “error”, and the validation problem may not be an error on the site because its sanitization can be freely accepted.

See #2316.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
