### PR TITLE
Update allowed tags/attributes from spec in amphtml 1910161528000

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -505,6 +505,7 @@ def GetTagRules(tag_spec):
 		return None
 
 	# Ignore amp-custom-length-check because the AMP plugin will indicate how close they are to the limit.
+	# TODO: Remove the AMP4EMAIL check once this change is released: <https://github.com/ampproject/amphtml/pull/25246>.
 	if tag_spec.HasField('spec_name') and ( str(tag_spec.spec_name) == 'style amp-custom-length-check' or 'AMP4EMAIL' in str(tag_spec.spec_name) ):
 		return None
 

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -505,7 +505,7 @@ def GetTagRules(tag_spec):
 		return None
 
 	# Ignore amp-custom-length-check because the AMP plugin will indicate how close they are to the limit.
-	if tag_spec.HasField('spec_name') and str(tag_spec.spec_name) == 'style amp-custom-length-check':
+	if tag_spec.HasField('spec_name') and ( str(tag_spec.spec_name) == 'style amp-custom-length-check' or 'AMP4EMAIL' in str(tag_spec.spec_name) ):
 		return None
 
 	if tag_spec.HasField('extension_spec'):

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1309,6 +1309,29 @@ function amp_print_story_auto_ads() {
 	echo AMP_HTML_Utils::build_tag( 'amp-story-auto-ads', [], $script_element ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
+/**
+ * Generate hash for inline amp-script.
+ *
+ * @since 1.4.0
+ *
+ * @link https://amp.dev/documentation/components/amp-script/#security-features
+ * @link https://github.com/ampproject/amphtml/blob/e8707858895c2af25903af25d396e144e64690ba/extensions/amp-script/0.1/amp-script.js#L401-L425
+ * @param string $script Script.
+ * @return string|null Script hash or null if the sha384 algorithm is not supported.
+ */
+function amp_generate_script_hash( $script ) {
+	$sha384 = hash( 'sha384', $script, true );
+	if ( false === $sha384 ) {
+		return null;
+	}
+	$hash = str_replace(
+		[ '+', '/', '=' ],
+		[ '-', '_', '.' ],
+		base64_encode( $sha384 ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+	);
+	return 'sha384-' . $hash;
+}
+
 /*
  * The function below is copied from the ramsey/array_column package.
  *

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1312,10 +1312,16 @@ function amp_print_story_auto_ads() {
 /**
  * Generate hash for inline amp-script.
  *
- * @since 1.4.0
+ * The sha384 hash used by amp-script is represented not as hexadecimal but as base64url, which is defined in RFC 4648
+ * under section 5, "Base 64 Encoding with URL and Filename Safe Alphabet". It is sometimes referred to as "web safe".
  *
+ * @since 1.4.0
  * @link https://amp.dev/documentation/components/amp-script/#security-features
  * @link https://github.com/ampproject/amphtml/blob/e8707858895c2af25903af25d396e144e64690ba/extensions/amp-script/0.1/amp-script.js#L401-L425
+ * @link https://github.com/ampproject/amphtml/blob/27b46b9c8c0fb3711a00376668d808f413d798ed/src/service/crypto-impl.js#L67-L124
+ * @link https://github.com/ampproject/amphtml/blob/c4a663d0ba13d0488c6fe73c55dc8c971ac6ec0d/src/utils/base64.js#L52-L61
+ * @link https://tools.ietf.org/html/rfc4648#section-5
+ *
  * @param string $script Script.
  * @return string|null Script hash or null if the sha384 algorithm is not supported.
  */

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1641,17 +1641,21 @@ class AMP_Theme_Support {
 		}
 		$head->insertBefore( $meta_viewport, $meta_charset->nextSibling );
 
-		// Merge meta amp-script-src elements.
+		// Handle meta amp-script-src elements.
 		$first_meta_amp_script_src = array_shift( $meta_amp_script_srcs );
-		foreach ( $meta_amp_script_srcs as $meta_amp_script_src ) {
-			$first_meta_amp_script_src->setAttribute(
-				'content',
-				$first_meta_amp_script_src->getAttribute( 'content' ) . ' ' . $meta_amp_script_src->getAttribute( 'content' )
-			);
-			$meta_amp_script_src->parentNode->removeChild( $meta_amp_script_src );
-		}
 		if ( $first_meta_amp_script_src ) {
 			$meta_elements[] = $first_meta_amp_script_src;
+
+			// Merge (and remove) any subsequent meta amp-script-src elements.
+			if ( ! empty( $meta_amp_script_srcs ) ) {
+				$content_values = [ $first_meta_amp_script_src->getAttribute( 'content' ) ];
+				foreach ( $meta_amp_script_srcs as $meta_amp_script_src ) {
+					$meta_amp_script_src->parentNode->removeChild( $meta_amp_script_src );
+					$content_values[] = $meta_amp_script_src->getAttribute( 'content' );
+				}
+				$first_meta_amp_script_src->setAttribute( 'content', implode( ' ', $content_values ) );
+				unset( $meta_amp_script_src, $content_values );
+			}
 		}
 		unset( $meta_amp_script_srcs, $first_meta_amp_script_src );
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -12879,33 +12879,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'deprecated_allow_duplicates' => true,
-						'name' => 'amp-fit-text',
-						'requires_usage' => 2,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'SCRIPT[custom-element=amp-fit-text] (AMP4EMAIL)',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-font',
 						'requires_usage' => 2,
 						'version' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 957;
+	private static $spec_file_revision = 961;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -228,6 +228,7 @@ class AMP_Allowed_Tags_Generated {
 			'ruby',
 			's',
 			'samp',
+			'script',
 			'section',
 			'small',
 			'solidcolor',
@@ -1180,6 +1181,13 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'controls' => array(),
 					'controlslist' => array(),
+					'data-amp-bind-album' => array(),
+					'data-amp-bind-artist' => array(),
+					'data-amp-bind-artwork' => array(),
+					'data-amp-bind-controlslist' => array(),
+					'data-amp-bind-loop' => array(),
+					'data-amp-bind-src' => array(),
+					'data-amp-bind-title' => array(),
 					'loop' => array(
 						'value' => array(
 							'',
@@ -1245,6 +1253,13 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'controls' => array(),
 					'controlslist' => array(),
+					'data-amp-bind-album' => array(),
+					'data-amp-bind-artist' => array(),
+					'data-amp-bind-artwork' => array(),
+					'data-amp-bind-controlslist' => array(),
+					'data-amp-bind-loop' => array(),
+					'data-amp-bind-src' => array(),
+					'data-amp-bind-title' => array(),
 					'loop' => array(
 						'value' => array(
 							'',
@@ -4318,6 +4333,9 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'smoothing' => array(
+						'value_regex' => '[0-9]+|',
+					),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -4706,6 +4724,9 @@ class AMP_Allowed_Tags_Generated {
 		'amp-script' => array(
 			array(
 				'attr_spec_list' => array(
+					'max-age' => array(
+						'value_regex' => '[0-9]+',
+					),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -12858,6 +12879,33 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'extension_spec' => array(
 						'deprecated_allow_duplicates' => true,
+						'name' => 'amp-fit-text',
+						'requires_usage' => 2,
+						'version' => array(
+							'0.1',
+						),
+					),
+					'spec_name' => 'SCRIPT[custom-element=amp-fit-text] (AMP4EMAIL)',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'deprecated_allow_duplicates' => true,
 						'name' => 'amp-font',
 						'requires_usage' => 2,
 						'version' => array(
@@ -14120,6 +14168,43 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'id' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+						'mandatory' => true,
+					),
+					'nonce' => array(),
+					'target' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'amp-script',
+						),
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'text/plain',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+					'max_bytes' => 10000,
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-script#faq',
+				),
+				'tag_spec' => array(
+					'requires_extension' => array(
+						'amp-script',
+					),
+					'spec_name' => 'amp-script extension local script',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-script',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
 						'value' => array(
@@ -14452,6 +14537,31 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-story-consent extension .json script',
 					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'nonce' => array(),
+					'type' => array(
+						'dispatch_key' => 3,
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/json',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+					'max_bytes' => 15000,
+					'max_bytes_spec_url' => 'https://amp.dev/documentation/components/amp-experiment#configuration',
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-experiment',
+					'spec_name' => 'amp-experiment story extension .json script',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
 				),
 			),
 			array(

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1200,6 +1200,17 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test amp_generate_script_hash().
+	 *
+	 * @covers \amp_generate_script_hash()
+	 */
+	public function test_amp_generate_script_hash() {
+		$this->assertSame( 'sha384-nYSGte6layPrGqn7c1Om8wNCgSq5PU-56H0R6j1kTb7R3aLbWeM3ra0YF5xKFuI0', amp_generate_script_hash( 'document.body.textContent += \'Hello world!\';' ) );
+		$this->assertSame( 'sha384-Qdwpb9Wpgg4BE21ukx8rwjbJGEdW2xjanFfsRNtmYQH69a_QeI0it1V8N23ZdsRX', amp_generate_script_hash( 'document.body.textContent = \'¡Hola mundo!\';' ) );
+		$this->assertSame( 'sha384-_MAJ0_NC2k8jrjehfi-5LdQasBICZXvp4gOwOx0D3mIStvDCGvZDzcTfXLgMrLL1', amp_generate_script_hash( 'document.body.textContent = \'<Hi! & 👋>\';' ) );
+	}
+
+	/**
 	 * Get a mock publisher logo URL, to test that the filter works as expected.
 	 *
 	 * @param string $site_icon The publisher logo in the schema.org data.

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1777,10 +1777,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$script1 = 'document.body.textContent += "First!";';
 		$script2 = 'document.body.textContent += "Second!";';
 		$script3 = 'document.body.textContent += "Third!";';
+		$script4 = 'document.body.textContent += "Fourth! (And forbidden because no amp-script-src meta in head.)";';
 
 		$script1_hash = amp_generate_script_hash( $script1 );
 		$script2_hash = amp_generate_script_hash( $script2 );
 		$script3_hash = amp_generate_script_hash( $script3 );
+		$script4_hash = amp_generate_script_hash( $script4 );
 
 		ob_start();
 		?>
@@ -1794,11 +1796,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				<meta name="amp-script-src" content="<?php echo esc_attr( $script3_hash ); ?>">
 			</head>
 			<body>
-				<meta name="amp-script-src" content="<?php echo esc_attr( amp_generate_script_hash( 'This should not be considered!' ) ); ?>">
+				<meta name="amp-script-src" content="<?php echo esc_attr( $script4_hash ); ?>">
 
 				<amp-script script="s1" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s1"><?php echo $script1; // phpcs:ignore ?></script>
 				<amp-script script="s2" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s2"><?php echo $script2; // phpcs:ignore ?></script>
 				<amp-script script="s3" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s3"><?php echo $script3; // phpcs:ignore ?></script>
+				<amp-script script="s4" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s4"><?php echo $script4; // phpcs:ignore ?></script>
 			</body>
 		</html>
 		<?php

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1769,6 +1769,53 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test combining amp-script-src meta tags.
+	 *
+	 * @covers \amp_generate_script_hash()
+	 */
+	public function test_prepare_response_for_amp_script() {
+		$script1 = 'document.body.textContent += "First!";';
+		$script2 = 'document.body.textContent += "Second!";';
+		$script3 = 'document.body.textContent += "Third!";';
+
+		$script1_hash = amp_generate_script_hash( $script1 );
+		$script2_hash = amp_generate_script_hash( $script2 );
+		$script3_hash = amp_generate_script_hash( $script3 );
+
+		ob_start();
+		?>
+		<html>
+			<head>
+				<meta name="amp-script-src" content="<?php echo esc_attr( $script1_hash ); ?>">
+				<meta name="amp-script-src" content="<?php echo esc_attr( $script2_hash ); ?>">
+				<style>
+					body { background: black; color:white }
+				</style>
+				<meta name="amp-script-src" content="<?php echo esc_attr( $script3_hash ); ?>">
+			</head>
+			<body>
+				<meta name="amp-script-src" content="<?php echo esc_attr( amp_generate_script_hash( 'This should not be considered!' ) ); ?>">
+
+				<amp-script script="s1" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s1"><?php echo $script1; // phpcs:ignore ?></script>
+				<amp-script script="s2" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s2"><?php echo $script2; // phpcs:ignore ?></script>
+				<amp-script script="s3" layout="fixed-height" height="30"></amp-script><script type="text/plain" target="amp-script" id="s3"><?php echo $script3; // phpcs:ignore ?></script>
+			</body>
+		</html>
+		<?php
+		$output = ob_get_clean();
+
+		$processed = AMP_Theme_Support::prepare_response( $output );
+		$dom       = AMP_DOM_Utils::get_dom( $processed );
+		$xpath     = new DOMXPath( $dom );
+
+		$meta_elements = $xpath->query( '/html/head/meta[ @name = "amp-script-src" ]' );
+		$this->assertSame( 1, $meta_elements->length );
+
+		$meta = $meta_elements->item( 0 );
+		$this->assertSame( "$script1_hash $script2_hash $script3_hash", $meta->getAttribute( 'content' ) );
+	}
+
+	/**
 	 * Test post-processor cache effectiveness in AMP_Theme_Support::prepare_response().
 	 */
 	public function test_post_processor_cache_effectiveness() {

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1345,7 +1345,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'amp-orientation-observer'                     => [
-				'<amp-orientation-observer on="beta:clockAnim1.seekTo(percent=event.percent)" layout="nodisplay"></amp-orientation-observer>',
+				'<amp-orientation-observer on="beta:clockAnim1.seekTo(percent=event.percent)" alpha-range="0 180" beta-range="0 180" gamma-range="0 90" smoothing="5" layout="nodisplay"></amp-orientation-observer>',
 				null,
 				[ 'amp-orientation-observer' ],
 			],
@@ -1574,9 +1574,20 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'amp-script-4'                                 => [
 				'
-					<amp-script layout="container" src="https://example.com/examples/amp-script/empty.js">
+					<amp-script layout="container" src="https://example.com/examples/amp-script/empty.js" max-age="3600">
 						<div class="root">should be empty</div>
 					</amp-script>
+				',
+				null,
+				[ 'amp-script' ],
+			],
+
+			'amp-script-5'                                 => [
+				'
+					<amp-script script="myScript" layout="container"></amp-script>
+					<script type="text/plain" target="amp-script" id="myScript">
+					document.body.textContent += \'Hello world!\';
+					</script>
 				',
 				null,
 				[ 'amp-script' ],


### PR DESCRIPTION
Previously #3239.

- [x] Run `./bin/amphtml-update.sh`
- [x] Examine diff for changelog
- [x] Update spec generator as needed based on spec format changes.
- [x] Modify validating sanitizer based on changes to spec, if needed.
- [x] Add tests for key changes

# Changelog

* Support [inline `script` for `amp-script`](https://amp.dev/documentation/components/amp-script/#load-javascript-from-a-local-element), eliminating requirement that external scripts be used. Take note of the required `meta[name=amp-script-src]` tag, but the plugin will automatically merge multiple instances of the `meta` tag in the `head` into the one required. A new `amp_generate_script_hash()` function is provided to aid with generating the sha384 script hashes. See [demonstration plugin](https://gist.github.com/westonruter/d0bd2f39a45e664368d6e4ffc82da041) for usage. ✨
![image](https://user-images.githubusercontent.com/134745/67536145-93606a80-f68a-11e9-916f-513b3b4cae1d.png) 
* Add to list of bindable attributes for `amp-audio`.
* Add `smoothing` attribute to `amp-orientation-observer`.
* Add `max-age` attribute to `amp-script`.
* Add `amp-experiment story extension .json script`. Allow `script` in `amp-story-grid-layer`.

# Details

```bash
(
    PREV_VERSION=1910071803120;
    THIS_VERSION=1910161528000; 
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```

<details>
<summary>Compare 1910071803120..1910161528000</summary>

```diff
diff --git a/extensions/amp-accordion/validator-amp-accordion.protoascii b/extensions/amp-accordion/validator-amp-accordion.protoascii
index 66eea7306..c646ff1a8 100644
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -16,7 +16,6 @@
 tags: {  # amp-accordion
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
@@ -28,6 +27,19 @@ tags: {  # amp-accordion
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-accordion
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-accordion] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-accordion"
+    # AMP4EMAIL doesn't allow version: "latest".
+    version: "0.1"
+    requires_usage: GRANDFATHERED
+    deprecated_allow_duplicates: true
+  }
+  attr_lists: "common-extension-attrs"
+}
 tags: {  # <amp-accordion>
   html_format: AMP
   html_format: AMP4ADS
diff --git a/extensions/amp-anim/validator-amp-anim.protoascii b/extensions/amp-anim/validator-amp-anim.protoascii
index bdbdfb320..56cbfae06 100644
--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -34,8 +34,8 @@ tags: {  # amp-anim
   spec_name: "amp-anim extension .js script (AMP4EMAIL)"
   extension_spec: {
     name: "amp-anim"
+    # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-audio/validator-amp-audio.protoascii b/extensions/amp-audio/validator-amp-audio.protoascii
index 424c2fe84..8592a2f64 100644
--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -43,6 +43,14 @@ attr_lists: { # amp-audio attributes that are common to both AMP and A4A format.
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
+  # <amp-bind>
+  attrs: { name: "[album]" }
+  attrs: { name: "[artist]" }
+  attrs: { name: "[artwork]" }
+  attrs: { name: "[controlslist]" }
+  attrs: { name: "[loop]" }
+  attrs: { name: "[src]" }
+  attrs: { name: "[title]" }
 }
 tags: {  # <amp-audio> for AMP (autoplay attribute allowed)
   html_format: AMP
diff --git a/extensions/amp-bind/validator-amp-bind.protoascii b/extensions/amp-bind/validator-amp-bind.protoascii
index 9dfa91387..67b4208d1 100644
--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -16,7 +16,6 @@
 tags: {  # amp-bind
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
@@ -30,6 +29,21 @@ tags: {  # amp-bind
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-bind
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-bind] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-bind"
+    # AMP4EMAIL doesn't allow version: "latest"
+    version: "0.1"
+    # amp-bind has no associated tag which indicates usage of the extension.
+    # TODO(gregable): Implement a mechanism to associate attributes with
+    # extension usage and then set this to GRANDFATHERED or ERROR.
+    requires_usage: NONE
+  }
+  attr_lists: "common-extension-attrs"
+}
 tags: {  # <amp-state> (json)
   html_format: AMP
   html_format: AMP4ADS
diff --git a/extensions/amp-carousel/validator-amp-carousel.protoascii b/extensions/amp-carousel/validator-amp-carousel.protoascii
index b29a9b5e5..11b1e55ab 100644
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -35,6 +35,7 @@ tags: {  # amp-carousel for AMP4EMAIL
   spec_name: "SCRIPT[custom-element=amp-carousel] (AMP4EMAIL)"
   extension_spec: {
     name: "amp-carousel"
+    # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-fit-text/validator-amp-fit-text.protoascii b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
index e84f723a0..c29376537 100644
--- a/extensions/amp-fit-text/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
@@ -29,6 +29,22 @@ tags: {  # amp-fit-text
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-fit-text
+  html_format: AMP
+  html_format: AMP4ADS
+  html_format: AMP4EMAIL
+  html_format: ACTIONS
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-fit-text] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-fit-text"
+    # AMP4EMAIL doesn't allow version: "latest".
+    version: "0.1"
+    requires_usage: GRANDFATHERED
+    deprecated_allow_duplicates: true
+  }
+  attr_lists: "common-extension-attrs"
+}
 tags: {  # <amp-fit-text>
   html_format: AMP
   html_format: AMP4ADS
diff --git a/extensions/amp-form/validator-amp-form.protoascii b/extensions/amp-form/validator-amp-form.protoascii
index 74fc7e60d..e06e18b78 100644
--- a/extensions/amp-form/validator-amp-form.protoascii
+++ b/extensions/amp-form/validator-amp-form.protoascii
@@ -18,7 +18,6 @@ tags: {  # amp-form
   # under section "4.10 Forms"
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
@@ -30,3 +29,16 @@ tags: {  # amp-form
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-form
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-form] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-form"
+    # AMP4EMAIL doesn't allow version: "latest".
+    version: "0.1"
+    deprecated_allow_duplicates: true
+    requires_usage: GRANDFATHERED
+  }
+  attr_lists: "common-extension-attrs"
+}
diff --git a/extensions/amp-list/validator-amp-list.protoascii b/extensions/amp-list/validator-amp-list.protoascii
index f41c4446b..267713a0f 100644
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -31,8 +31,8 @@ tags: {  # amp-list
   spec_name: "SCRIPT[custom-element=amp-list] (AMP4EMAIL)"
   extension_spec: {
     name: "amp-list"
+    # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
@@ -212,6 +212,10 @@ tags: {  # <amp-list>
     value: "no"
     value: "refresh"
   }
+  attrs: {
+    name: "diffable"
+    value: ""
+  }
   attrs: { name: "items" }
   attrs: { name: "max-items" }
   attrs: { name: "single-item" }
@@ -262,6 +266,10 @@ tags: {  # <amp-list>
     name: "crossorigin"
     value: "amp-viewer-auth-token-via-post"
   }
+  attrs: {
+    name: "diffable"
+    value: ""
+  }
   attrs: { name: "items" }
   attrs: { name: "max-items" }
   attrs: {
diff --git a/extensions/amp-mustache/validator-amp-mustache.protoascii b/extensions/amp-mustache/validator-amp-mustache.protoascii
index dc2acc1e5..8f310f62d 100644
--- a/extensions/amp-mustache/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/validator-amp-mustache.protoascii
@@ -36,10 +36,9 @@ tags: {  # amp-mustache
 }
 tags: {  # amp-mustache
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
-  spec_name: "SCRIPT[custom-element=amp-mustache] (AMP4ADS/AMP4EMAIL)"
+  spec_name: "SCRIPT[custom-template=amp-mustache] (AMP4ADS/ACTIONS)"
   extension_spec: {
     name: "amp-mustache"
     extension_type: CUSTOM_TEMPLATE
@@ -50,7 +49,21 @@ tags: {  # amp-mustache
   }
   attr_lists: "common-extension-attrs"
 }
-# The script element.
+tags: {  # amp-mustache
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-template=amp-mustache] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-mustache"
+    extension_type: CUSTOM_TEMPLATE
+    # AMP4EMAIL doesn't allow version: "latest".
+    version: "0.1"
+    version: "0.2"
+    deprecated_version: "0.1"
+  }
+  attr_lists: "common-extension-attrs"
+}
+# Templates using script[type=text/plain].
 tags: {
   html_format: AMP
   html_format: AMP4ADS
diff --git a/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii b/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
index 3c4579bc4..ff0ffcd0a 100644
--- a/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
+++ b/extensions/amp-orientation-observer/validator-amp-orientation-observer.protoascii
@@ -49,6 +49,10 @@ tags: {  # <amp-orientation-observer>
     # Values such as: "100 100", "0 100", etc..
     value_regex: "(\\d+)\\s{1}(\\d+)"
   }
+  attrs: {
+    name: "smoothing"
+    value_regex: "[0-9]+|"
+  }
   amp_layout {
     supported_layouts: NODISPLAY
   }
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index bf05ad10c..c0f6d5c69 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -24,45 +24,176 @@ tags: {
   }
   attr_lists: "common-extension-attrs"
 }
-# Temporarily disable until interaction of amp-script and signed exchanges has
-# been security reviewed.
-#tags: {  # <amp-script> (local script)
-#  html_format: AMP
-#  tag_name: "SCRIPT"
-#  spec_name: "amp-script extension local script"
-#  requires_extension: "amp-script"
-#  attrs: {
-#    name: "target"
-#    mandatory: true
-#    value: "amp-script"
-#    dispatch_key: NAME_VALUE_DISPATCH
-#  }
-#  attrs: {
-#    name: "type"
-#    mandatory: true
-#    value_casei: "text/plain"
-#  }
-#  attr_lists: "mandatory-id-attr"
-#  attr_lists: "nonce-attr"
-#  cdata: {
-#    max_bytes: 10000
-#    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script#faq"
-#    blacklisted_cdata_regex: {
-#      regex: "<!--"
-#      error_message: "html comments"
-#    }
-#  }
-#  spec_url: "https://amp.dev/documentation/components/amp-script"
-#}
+tags: {  # <amp-script> (local script)
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amp-script extension local script"
+  requires_extension: "amp-script"
+  attrs: {
+    name: "id"
+    add_value_to_set: AMP_SCRIPT_IDS
+    mandatory: true
+    blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "__amp_\\S*|"
+        "__count__|"
+        "__defineGetter__|"
+        "__defineSetter__|"
+        "__lookupGetter__|"
+        "__lookupSetter__|"
+        "__noSuchMethod__|"
+        "__parent__|"
+        "__proto__|"
+        "__AMP_\\S*|"
+        "\\$p|"
+        "\\$proxy|"
+        "acceptCharset|"
+        "addEventListener|"
+        "appendChild|"
+        "assignedSlot|"
+        "attachShadow|"
+        "AMP|"
+        "baseURI|"
+        "checkValidity|"
+        "childElementCount|"
+        "childNodes|"
+        "classList|"
+        "className|"
+        "clientHeight|"
+        "clientLeft|"
+        "clientTop|"
+        "clientWidth|"
+        "compareDocumentPosition|"
+        "computedName|"
+        "computedRole|"
+        "contentEditable|"
+        "createShadowRoot|"
+        "enqueAction|"
+        "firstChild|"
+        "firstElementChild|"
+        "getAnimations|"
+        "getAttribute|"
+        "getAttributeNS|"
+        "getAttributeNode|"
+        "getAttributeNodeNS|"
+        "getBoundingClientRect|"
+        "getClientRects|"
+        "getDestinationInsertionPoints|"
+        "getElementsByClassName|"
+        "getElementsByTagName|"
+        "getElementsByTagNameNS|"
+        "getRootNode|"
+        "hasAttribute|"
+        "hasAttributeNS|"
+        "hasAttributes|"
+        "hasChildNodes|"
+        "hasPointerCapture|"
+        "i-amphtml-\\S*|"
+        "innerHTML|"
+        "innerText|"
+        "inputMode|"
+        "insertAdjacentElement|"
+        "insertAdjacentHTML|"
+        "insertAdjacentText|"
+        "isContentEditable|"
+        "isDefaultNamespace|"
+        "isEqualNode|"
+        "isSameNode|"
+        "lastChild|"
+        "lastElementChild|"
+        "lookupNamespaceURI|"
+        "namespaceURI|"
+        "nextElementSibling|"
+        "nextSibling|"
+        "nodeName|"
+        "nodeType|"
+        "nodeValue|"
+        "offsetHeight|"
+        "offsetLeft|"
+        "offsetParent|"
+        "offsetTop|"
+        "offsetWidth|"
+        "outerHTML|"
+        "outerText|"
+        "ownerDocument|"
+        "parentElement|"
+        "parentNode|"
+        "previousElementSibling|"
+        "previousSibling|"
+        "querySelector|"
+        "querySelectorAll|"
+        "releasePointerCapture|"
+        "removeAttribute|"
+        "removeAttributeNS|"
+        "removeAttributeNode|"
+        "removeChild|"
+        "removeEventListener|"
+        "replaceChild|"
+        "reportValidity|"
+        "requestPointerLock|"
+        "scrollHeight|"
+        "scrollIntoView|"
+        "scrollIntoViewIfNeeded|"
+        "scrollLeft|"
+        "scrollWidth|"
+        "setAttribute|"
+        "setAttributeNS|"
+        "setAttributeNode|"
+        "setAttributeNodeNS|"
+        "setPointerCapture|"
+        "shadowRoot|"
+        "styleMap|"
+        "tabIndex|"
+        "tagName|"
+        "textContent|"
+        "toString|"
+        "valueOf|"
+        "(webkit|ms|moz|o)dropzone|"
+        "(webkit|moz|ms|o)MatchesSelector|"
+        "(webkit|moz|ms|o)RequestFullScreen|"
+        "(webkit|moz|ms|o)RequestFullscreen"
+        ")(\\s|$)"
+  }
+  attrs: {
+    name: "target"
+    mandatory: true
+    value: "amp-script"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "text/plain"
+  }
+  attr_lists: "mandatory-id-attr"
+  attr_lists: "nonce-attr"
+  cdata: {
+    max_bytes: 10000
+    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-script#faq"
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/components/amp-script"
+}
 tags: {  # <amp-script>
   html_format: AMP
   tag_name: "AMP-SCRIPT"
   disallowed_ancestor: "AMP-SCRIPT"
   requires_extension: "amp-script"
+  attrs: {
+    name: "max-age"
+    value_regex: "[0-9]+"
+    trigger: {
+      # max-age only applies to inline scripts.
+      also_requires_attr: "script"
+    }
+  }
   attrs: { name: "sandbox" }
   attrs: {
     name: "script"
     mandatory_oneof: "['script', 'src']"
+    value_oneof_set: AMP_SCRIPT_IDS
   }
   attrs: {
     name: "src"
diff --git a/extensions/amp-selector/validator-amp-selector.protoascii b/extensions/amp-selector/validator-amp-selector.protoascii
index bb387392d..82d7e6b2b 100644
--- a/extensions/amp-selector/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/validator-amp-selector.protoascii
@@ -32,8 +32,8 @@ tags: {
   spec_name: "SCRIPT[custom-element=amp-selector] (AMP4EMAIL)"
   extension_spec: {
     name: "amp-selector"
+    # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    version: "latest"
     requires_usage: GRANDFATHERED
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-sidebar/validator-amp-sidebar.protoascii b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
index c2f39dc37..b4e5f7605 100644
--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -32,8 +32,8 @@ tags: {  # amp-sidebar
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-sidebar"
+    # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index d798ffdac..94c57912f 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -442,6 +442,29 @@ tags: {  # <amp-story-cta-layer>
     tag_spec_name: "AMP-STORY-CTA-LAYER animate-in"
   }
 }
+tags: {  # amp-experiment (json)
+  html_format: AMP
+  html_format: ACTIONS
+  tag_name: "SCRIPT"
+  spec_name: "amp-experiment story extension .json script"
+  mandatory_parent: "AMP-EXPERIMENT"
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
+    dispatch_key: NAME_VALUE_PARENT_DISPATCH
+  }
+  attr_lists: "nonce-attr"
+  cdata: {
+    max_bytes: 15000
+    max_bytes_spec_url: "https://amp.dev/documentation/components/amp-experiment#configuration"
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/components/amp-experiment"
+}
 tags: {
   html_format: AMP
   tag_name: "$REFERENCE_POINT"
@@ -704,6 +727,7 @@ descendant_tag_list: {
   tag: "RUBY"
   tag: "S"
   tag: "SAMP"
+  tag: "SCRIPT"
   tag: "SECTION"
   tag: "SMALL"
   tag: "SOLIDCOLOR"
diff --git a/extensions/amp-timeago/validator-amp-timeago.protoascii b/extensions/amp-timeago/validator-amp-timeago.protoascii
index 6568d6a4e..f80feff41 100644
--- a/extensions/amp-timeago/validator-amp-timeago.protoascii
+++ b/extensions/amp-timeago/validator-amp-timeago.protoascii
@@ -16,7 +16,6 @@
 
 tags: {  # amp-timeago
   html_format: AMP
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
@@ -26,6 +25,17 @@ tags: {  # amp-timeago
   }
   attr_lists: "common-extension-attrs"
 }
+tags: {  # amp-timeago
+  html_format: AMP4EMAIL
+  tag_name: "SCRIPT"
+  spec_name: "SCRIPT[custom-element=amp-timeago] (AMP4EMAIL)"
+  extension_spec: {
+    name: "amp-timeago"
+    # AMP4EMAIL doesn't allow version: "latest".
+    version: "0.1"
+  }
+  attr_lists: "common-extension-attrs"
+}
 tags: {  # <amp-timeago>
   html_format: AMP
   html_format: AMP4EMAIL
diff --git a/extensions/amp-youtube/validator-amp-youtube.protoascii b/extensions/amp-youtube/validator-amp-youtube.protoascii
index 5d3f90bc5..b87d55b5f 100644
--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -16,7 +16,6 @@
 
 tags: {  # amp-youtube
   html_format: AMP
-  html_format: AMP4ADS
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
@@ -30,7 +29,6 @@ tags: {  # amp-youtube
 }
 tags: {  # <amp-youtube>
   html_format: AMP
-  html_format: AMP4ADS
   html_format: ACTIONS
   tag_name: "AMP-YOUTUBE"
   requires_extension: "amp-youtube"
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index aaa099d82..f9b75ec6e 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,7 +26,7 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 957
+spec_file_revision: 961
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
@@ -5379,7 +5379,7 @@ attr_lists: {
     name: "id"
     mandatory: true
     # When updating this blacklisted_value_regex, also update the entry for
-    # "id" in $GLOBAL_ATTRS.
+    # "id" in $GLOBAL_ATTRS and "id" in "amp-script extension local script".
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
```
</details>