### PR TITLE
Reuse 'data-set-focus' to simulate twentytwenty keyboard focus

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1729,13 +1729,9 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					$focus_xpath   = $this->xpath_from_css_selector( $focus_selector );
 					$focus_element = $this->xpath->query( $focus_xpath )->item( 0 );
 
-					// Instead of manually setting or unsetting the focus here, we're going
-					// with the autofocus attribute instead (AMP does not have a "blur" action).
-					// According to the HTML 5 spec, only one element should have "autofocus",
-					// however it seems like AMP has turned this into a common mechanism for
-					// focusing on inputs after a lightbox (i.e. modal) opens.
-					if ( $focus_element instanceof DOMElement && in_array( $focus_element->tagName, [ 'input', 'select', 'textarea' ], true ) ) {
-						$focus_element->setAttribute( 'autofocus', true );
+					if ( $focus_element instanceof DOMElement ) {
+						$focus_element_id = AMP_DOM_Utils::get_element_id( $focus_element );
+						AMP_DOM_Utils::add_amp_action( $toggle, 'tap', "{$focus_element_id}.focus" );
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Changes the toggle emulation logic to reuse TwentyTwenty's `data-set-focus` attribute and manually set keyboard focus when triggering a toggle.

This ensures we correctly set keyboard focus on the Close button when opening the menu modal.

![Screen Recording 2019-10-25 at 06 58 AM](https://user-images.githubusercontent.com/83631/67544317-41a0fa00-f6f5-11e9-8a7e-5d76e885a0f2.gif)

Fixes #3618

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
