### PR TITLE
Only support public post-types/taxonomies for template support

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -922,8 +922,8 @@ class AMP_Theme_Support {
 		}
 
 		$taxonomy_args = [
-			'_builtin'           => false,
-			'publicly_queryable' => true,
+			'_builtin' => false,
+			'public'   => true,
 		];
 		foreach ( get_taxonomies( $taxonomy_args, 'objects' ) as $taxonomy ) {
 			$templates[ sprintf( 'is_tax[%s]', $taxonomy->name ) ] = [
@@ -936,8 +936,8 @@ class AMP_Theme_Support {
 		}
 
 		$post_type_args = [
-			'has_archive'        => true,
-			'publicly_queryable' => true,
+			'has_archive' => true,
+			'public'      => true,
 		];
 		foreach ( get_post_types( $post_type_args, 'objects' ) as $post_type ) {
 			$templates[ sprintf( 'is_post_type_archive[%s]', $post_type->name ) ] = [

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -715,7 +715,27 @@ class AMP_Theme_Support {
 			if ( ! $has_children ) {
 				$supportable_template = $supportable_templates[ $id ];
 				while ( ! empty( $supportable_template['parent'] ) ) {
-					$parent               = $supportable_template['parent'];
+					$parent = $supportable_template['parent'];
+
+					/*
+					 * If the parent is not amongst the supportable templates, then something is off in terms of hierarchy.
+					 * Either the matching is off-track, or the template is badly configured.
+					 */
+					if ( ! array_key_exists( $parent, $supportable_templates ) ) {
+						_doing_it_wrong(
+							__METHOD__,
+							esc_html(
+								sprintf(
+									/* translators: %s: amp_supportable_templates */
+									__( 'An expected parent was not found. Did you filter %s to not honor the template hierarchy?', 'amp' ),
+									'amp_supportable_templates'
+								)
+							),
+							'1.4'
+						);
+						break;
+					}
+
 					$supportable_template = $supportable_templates[ $parent ];
 
 					// Let the child supported status override the parent's supported status.

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -783,8 +783,8 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		register_post_type(
 			$custom_post_type,
 			[
-				'has_archive'        => true,
-				'publicly_queryable' => true,
+				'has_archive' => true,
+				'public'      => true,
 			]
 		);
 		self::factory()->post->create(


### PR DESCRIPTION
## Summary

This PR changes the way templates are queried for custom post types and custom taxonomies to check for AMP support.

Instead of querying for `publicly_queryable`, we query for `public` instead.

Additionally, we add a `_doing_it_wrong()` for the case where we end up with a template that is matching but that references a parent template that is not matching or does not exist.

<img width="847" alt="Image 2019-10-25 at 7 42 32 AM" src="https://user-images.githubusercontent.com/83631/67551184-99952c00-f708-11e9-8b50-c57bc07b9928.png">

Fixes #1786 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
