### PR TITLE
Fix cross-page element dragging in RTL

### DIFF
--- a/assets/src/stories-editor/components/block-mover/draggable.js
+++ b/assets/src/stories-editor/components/block-mover/draggable.js
@@ -99,7 +99,7 @@ class Draggable extends Component {
 			const currentElementTop = parseInt( this.cloneWrapper.style.top );
 			const currentElementLeft = parseInt( this.cloneWrapper.style.left );
 			const factor = isRTL ? 1 : -1;
-			const newLeft = currentElementLeft + factor * ( this.pageOffset * PAGE_AND_MARGIN );
+			const newLeft = currentElementLeft + ( factor * ( this.pageOffset * PAGE_AND_MARGIN ) );
 
 			let baseHeight, xAttribute, yAttribute;
 			if ( isCTABlock( blockName ) ) {

--- a/assets/src/stories-editor/components/block-mover/draggable.js
+++ b/assets/src/stories-editor/components/block-mover/draggable.js
@@ -77,7 +77,15 @@ class Draggable extends Component {
 	 * @param {Object} event The non-custom DragEvent.
 	 */
 	onDragEnd = ( event ) => {
-		const { clearHighlight, dropElementByOffset, blockName, setTimeout, clearSnapLines, onDragEnd = noop } = this.props;
+		const {
+			clearHighlight,
+			dropElementByOffset,
+			blockName,
+			setTimeout,
+			clearSnapLines,
+			isRTL,
+			onDragEnd = noop,
+		} = this.props;
 		if ( event ) {
 			event.preventDefault();
 		}
@@ -90,7 +98,8 @@ class Draggable extends Component {
 			// All this is about calculating the position of the (correct) element on the new page.
 			const currentElementTop = parseInt( this.cloneWrapper.style.top );
 			const currentElementLeft = parseInt( this.cloneWrapper.style.left );
-			const newLeft = currentElementLeft - ( this.pageOffset * PAGE_AND_MARGIN );
+			const factor = isRTL ? 1 : -1;
+			const newLeft = currentElementLeft + factor * ( this.pageOffset * PAGE_AND_MARGIN );
 
 			let baseHeight, xAttribute, yAttribute;
 			if ( isCTABlock( blockName ) ) {


### PR DESCRIPTION
As discovered in #3634 block dragging across pages doesn't work in RTL as the moved element is offset by several pages on the new page. This is fixed by changing the direction of the offsetting based off of RTL setting.

_Fixes #3634. Fixes #3012._

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
