### PR TITLE
Remove incorrect TODO comment

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -167,7 +167,6 @@ function amp_add_amphtml_link() {
 	/**
 	 * Filters whether to show the amphtml link on the frontend.
 	 *
-	 * @todo This filter's name is incorrect. It's not about adding a canonical link but adding the amphtml link.
 	 * @since 0.2
 	 */
 	if ( false === apply_filters( 'amp_frontend_show_canonical', true ) ) {


### PR DESCRIPTION
## Summary

Removes a `@todo` comment that points to an issue that was already solved in https://github.com/ampproject/amp-wp/commit/a7fbe8f4ffaffdba9e0cc16e2aa26d02821320cb

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).