### PR TITLE
Improve display of validation errors for processing instructions and duplicate elements

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -579,6 +579,8 @@ abstract class AMP_Base_Sanitizer {
 					}
 				}
 			}
+		} elseif ( $node instanceof DOMProcessingInstruction ) {
+			$error['text'] = trim( $node->data, '?' );
 		}
 
 		return $error;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1003,6 +1003,15 @@ class AMP_Validated_URL_Post_Type {
 						}
 					}
 				}
+				if ( ! empty( $error_summary['removed_pis'] ) ) {
+					foreach ( $error_summary['removed_pis'] as $name => $count ) {
+						if ( 1 === (int) $count ) {
+							$items[] = sprintf( '<code>&lt;?%s…?&gt;</code>', esc_html( $name ) );
+						} else {
+							$items[] = sprintf( '<code>&lt;?%s…?&gt;</code> (%d)', esc_html( $name ), $count );
+						}
+					}
+				}
 				if ( ! empty( $items ) ) {
 					$imploded_items = implode( ',</div><div>', $items );
 					echo sprintf( '<div>%s</div>', $imploded_items ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1006,9 +1006,9 @@ class AMP_Validated_URL_Post_Type {
 				if ( ! empty( $error_summary['removed_pis'] ) ) {
 					foreach ( $error_summary['removed_pis'] as $name => $count ) {
 						if ( 1 === (int) $count ) {
-							$items[] = sprintf( '<code>&lt;?%s…?&gt;</code>', esc_html( $name ) );
+							$items[] = sprintf( '<code>&lt;?%s&hellip;?&gt;</code>', esc_html( $name ) );
 						} else {
-							$items[] = sprintf( '<code>&lt;?%s…?&gt;</code> (%d)', esc_html( $name ), $count );
+							$items[] = sprintf( '<code>&lt;?%s&hellip;?&gt;</code> (%d)', esc_html( $name ), $count );
 						}
 					}
 				}

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2056,58 +2056,56 @@ class AMP_Validation_Error_Taxonomy {
 		?>
 
 		<dl class="detailed">
-			<?php if ( isset( $validation_error['type'], $validation_error['code'] ) ) : ?>
-				<dt><?php esc_html_e( 'Information', 'amp' ); ?></dt>
-				<dd class="detailed">
-					<p>
-						<?php if ( self::JS_ERROR_TYPE === $validation_error['type'] ) : ?>
-								<?php
-								echo wp_kses_post(
-									sprintf(
-										/* translators: 1: script,  2: Documentation URL, 3: Documentation URL, 4: Documentation URL, 5: onclick, 6: Documentation URL, 7: amp-bind, 8: Documentation URL, 9: amp-script */
-										__( 'Arbitrary JavaScript is not allowed in AMP. You cannot use JS %1$s tags unless they are for loading <a href="%2$s">AMP components</a> (which the AMP plugin will add for you automatically). In order for a page to be served as AMP, the invalid JS code must be removed from the page. Learn more about <a href="%3$s">how AMP works</a>. As an alternative to using custom JS, please consider using a pre-built AMP functionality, including <a href="%4$s">actions and events</a> (as opposed to JS event handler attributes like %5$s) and the <a href="%6$s">%7$s</a> component; you may also add custom JS if encapsulated in the <a href="%8$s">%9$s</a>.', 'amp' ),
-										'<code>&lt;script&gt;</code>',
-										'https://amp.dev/documentation/components/',
-										'https://amp.dev/about/how-amp-works/',
-										'https://amp.dev/documentation/guides-and-tutorials/learn/amp-actions-and-events/',
-										'<code>onclick</code>',
-										'https://amp.dev/documentation/components/amp-bind/',
-										'amp-bind',
-										'https://amp.dev/documentation/components/amp-script/',
-										'amp-script'
-									)
-								)
-								?>
-						<?php elseif ( self::CSS_ERROR_TYPE === $validation_error['type'] ) : ?>
-							<?php
-							echo wp_kses_post(
-								sprintf(
-									/* translators: 1: Documentation URL, 2: Documentation URL, 3: !important */
-									__( 'AMP allows you to <a href="%1$s">style your pages using CSS</a> in much the same way as regular HTML pages, however there are some <a href="%2$s">restrictions</a>. Nevertheless, the AMP plugin automatically inlines external stylesheets, transforms %3$s qualifiers, and uses tree shaking to remove the majority of CSS rules that do not apply to the current page. Nevertheless, AMP does have a 50KB limit and tree shaking cannot always reduce the amount of CSS under this limit; when this happens an excessive CSS error will result.', 'amp' ),
-									'https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/',
-									'https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/',
-									'<code>!important</code>'
-								)
+			<dt><?php esc_html_e( 'Information', 'amp' ); ?></dt>
+			<dd class="detailed">
+				<p>
+					<?php if ( isset( $validation_error['type'] ) && self::JS_ERROR_TYPE === $validation_error['type'] ) : ?>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: script,  2: Documentation URL, 3: Documentation URL, 4: Documentation URL, 5: onclick, 6: Documentation URL, 7: amp-bind, 8: Documentation URL, 9: amp-script */
+								__( 'Arbitrary JavaScript is not allowed in AMP. You cannot use JS %1$s tags unless they are for loading <a href="%2$s">AMP components</a> (which the AMP plugin will add for you automatically). In order for a page to be served as AMP, the invalid JS code must be removed from the page. Learn more about <a href="%3$s">how AMP works</a>. As an alternative to using custom JS, please consider using a pre-built AMP functionality, including <a href="%4$s">actions and events</a> (as opposed to JS event handler attributes like %5$s) and the <a href="%6$s">%7$s</a> component; you may also add custom JS if encapsulated in the <a href="%8$s">%9$s</a>.', 'amp' ),
+								'<code>&lt;script&gt;</code>',
+								'https://amp.dev/documentation/components/',
+								'https://amp.dev/about/how-amp-works/',
+								'https://amp.dev/documentation/guides-and-tutorials/learn/amp-actions-and-events/',
+								'<code>onclick</code>',
+								'https://amp.dev/documentation/components/amp-bind/',
+								'amp-bind',
+								'https://amp.dev/documentation/components/amp-script/',
+								'amp-script'
 							)
-							?>
-						<?php else : ?>
-							<?php
-							echo wp_kses_post(
-								sprintf(
-									/* translators: 1: Documentation URL, 2: Documentation URL. */
-									__( 'AMP has specific set of allowed elements and attributes that are allowed in valid AMP pages. Learn about the <a href="%1$s">AMP HTML specification</a>. If an element or attribute is not allowed in AMP, it must be removed for the page to <a href="%2$s">cached and be eligible for prerendering</a>.', 'amp' ),
-									'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/',
-									'https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached/'
-								)
+						)
+						?>
+					<?php elseif ( isset( $validation_error['type'] ) && self::CSS_ERROR_TYPE === $validation_error['type'] ) : ?>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: Documentation URL, 2: Documentation URL, 3: !important */
+								__( 'AMP allows you to <a href="%1$s">style your pages using CSS</a> in much the same way as regular HTML pages, however there are some <a href="%2$s">restrictions</a>. Nevertheless, the AMP plugin automatically inlines external stylesheets, transforms %3$s qualifiers, and uses tree shaking to remove the majority of CSS rules that do not apply to the current page. Nevertheless, AMP does have a 50KB limit and tree shaking cannot always reduce the amount of CSS under this limit; when this happens an excessive CSS error will result.', 'amp' ),
+								'https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/',
+								'https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages/',
+								'<code>!important</code>'
 							)
-							?>
-						<?php endif; ?>
-					</p>
-					<p>
-						<?php echo wp_kses_post( __( 'If you <strong>remove</strong> the invalid markup then it will not block this page from being served as AMP. Note that you need to check what impact the removal of the invalid markup has on the page to see if the result is acceptable. If you <strong>keep</strong> the invalid markup, then the page will not be served as AMP.', 'amp' ) ); ?>
-					</p>
-				</dd>
-			<?php endif; ?>
+						)
+						?>
+					<?php else : ?>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: 1: Documentation URL, 2: Documentation URL. */
+								__( 'AMP has specific set of allowed elements and attributes that are allowed in valid AMP pages. Learn about the <a href="%1$s">AMP HTML specification</a>. If an element or attribute is not allowed in AMP, it must be removed for the page to <a href="%2$s">cached and be eligible for prerendering</a>.', 'amp' ),
+								'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml/',
+								'https://amp.dev/documentation/guides-and-tutorials/learn/amp-caches-and-cors/how_amp_pages_are_cached/'
+							)
+						)
+						?>
+					<?php endif; ?>
+				</p>
+				<p>
+					<?php echo wp_kses_post( __( 'If you <strong>remove</strong> the invalid markup then it will not block this page from being served as AMP. Note that you need to check what impact the removal of the invalid markup has on the page to see if the result is acceptable. If you <strong>keep</strong> the invalid markup, then the page will not be served as AMP.', 'amp' ) ); ?>
+				</p>
+			</dd>
 
 			<?php if ( self::INVALID_ELEMENT_CODE === $validation_error['code'] && isset( $validation_error['node_attributes'] ) ) : ?>
 				<dt><?php esc_html_e( 'Invalid markup', 'amp' ); ?></dt>

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1772,7 +1772,8 @@ class AMP_Validation_Error_Taxonomy {
 		if (
 			self::INVALID_ATTRIBUTE_CODE === $validation_error['code'] ||
 			self::INVALID_ELEMENT_CODE === $validation_error['code'] ||
-			'invalid_processing_instruction' === $validation_error['code']
+			'invalid_processing_instruction' === $validation_error['code'] ||
+			'duplicate_element' === $validation_error['code']
 		) {
 			$summary_label = sprintf( '<%s>', $validation_error['parent_name'] );
 		} elseif ( isset( $validation_error['node_name'] ) ) {
@@ -1827,7 +1828,7 @@ class AMP_Validation_Error_Taxonomy {
 					);
 				}
 
-				if ( self::INVALID_ELEMENT_CODE === $validation_error['code'] ) {
+				if ( self::INVALID_ELEMENT_CODE === $validation_error['code'] || 'duplicate_element' === $validation_error['code'] ) {
 					$content .= sprintf( ': <code>&lt;%s&gt;</code>', esc_html( $validation_error['node_name'] ) );
 				} elseif ( self::INVALID_ATTRIBUTE_CODE === $validation_error['code'] ) {
 					$content .= sprintf( ': <code>%s</code>', esc_html( $validation_error['node_name'] ) );
@@ -2846,8 +2847,11 @@ class AMP_Validation_Error_Taxonomy {
 				return __( 'Illegal CSS at-rule', 'amp' );
 			case 'disallowed_file_extension':
 				return __( 'Disallowed CSS file extension', 'amp' );
+			case 'duplicate_element':
+				return __( 'Duplicate element', 'amp' );
 			default:
-				return __( 'Unknown error', 'amp' );
+				/* translators: %s error code */
+				return sprintf( __( 'Unknown error (%s)', 'amp' ), $error_code );
 		}
 	}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1835,7 +1835,7 @@ class AMP_Validation_Error_Taxonomy {
 				} elseif ( 'illegal_css_at_rule' === $validation_error['code'] ) {
 					$content .= sprintf( ': <code>@%s</code>', esc_html( $validation_error['at_rule'] ) );
 				} elseif ( 'invalid_processing_instruction' === $validation_error['code'] ) {
-					$content .= sprintf( ': <code>&lt;%s%s…%s&gt;</code>', '?', esc_html( $validation_error['node_name'] ), '?' );
+					$content .= sprintf( ': <code>&lt;%s%s&hellip;%s&gt;</code>', '?', esc_html( $validation_error['node_name'] ), '?' );
 				}
 
 				if ( 'post.php' === $pagenow ) {

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -537,6 +537,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 				'plugin' => [ 'foo' ],
 				'theme'  => [ 'bar' ],
 			],
+			'removed_pis' => [],
 		];
 		$this->assertEquals( $expected_results, $results );
 	}


### PR DESCRIPTION
## Summary

In looking at https://github.com/ampproject/amp-wp/issues/3409#issuecomment-547213190 I noticed that validation errors for processing instructions aren't being displayed properly. This fixes that.

Given a Custom HTML block that looks like:

![image](https://user-images.githubusercontent.com/134745/67740583-8e295580-f9d3-11e9-8196-eeeb5b9c1e5f.png)

The changes look as follows:

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/67740538-62a66b00-f9d3-11e9-975a-90ab103c7a7a.png) | ![image](https://user-images.githubusercontent.com/134745/67740561-7a7def00-f9d3-11e9-900b-ddba1362fe12.png)
![image](https://user-images.githubusercontent.com/134745/67740840-7d2d1400-f9d4-11e9-8559-dfaf786d5fcc.png) | ![image](https://user-images.githubusercontent.com/134745/67740790-4a831b80-f9d4-11e9-9443-4c0d5c461233.png)
<img alt="Screen Shot 2019-10-28 at 22 45 39" src="https://user-images.githubusercontent.com/134745/67740906-b82f4780-f9d4-11e9-9d37-75e5a780dee3.png"> | <img alt="Screen Shot 2019-10-28 at 22 45 51" src="https://user-images.githubusercontent.com/134745/67740907-b82f4780-f9d4-11e9-94f2-63a4d3ea0ca5.png">

This also fixes the presentation of `duplicate_element` errors, which was noticed when the AMP-to-AMP linking plugin was active after #3627 was merged.

Before | After
-------|-----
<img alt="Screen Shot 2019-10-29 at 11 25 38" src="https://user-images.githubusercontent.com/134745/67797629-4f30e980-fa3f-11e9-8892-c60bc0d30ec5.png"> | <img alt="Screen Shot 2019-10-29 at 11 25 31" src="https://user-images.githubusercontent.com/134745/67797628-4f30e980-fa3f-11e9-852c-4b95846b94bd.png">


See #3409. Amends #3544.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
