### PR TITLE
Remove skip-link-focus-fix in Twenty Twenty

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -57,8 +57,11 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				'twentytwenty-js',
 			],
 			'remove_actions'                          => [
-				'wp_head' => [
+				'wp_head'                 => [
 					'twentytwenty_no_js_class', // AMP is essentially no-js, with any interactivity added explicitly via amp-bind.
+				],
+				'wp_print_footer_scripts' => [
+					'twentytwenty_skip_link_focus_fix', // See <https://github.com/WordPress/twentynineteen/pull/47>.
 				],
 			],
 			'add_smooth_scrolling'                    => [


### PR DESCRIPTION
## Summary

WordPress 5.3-RC3 introduced a regression on Twenty Twenty's AMP-compatibility by adding the skip-link-focus-fix: https://github.com/WordPress/twentytwenty/pull/937 ([r46613](https://core.trac.wordpress.org/changeset/46613)). This PR ensures that that the script gets removed since it is not needed, as done with the other core themes, as the AMP framework internalizes the fix.

See #3342.

### Before

<img width="1508" alt="Screen Shot 2019-10-29 at 15 53 35" src="https://user-images.githubusercontent.com/134745/67815606-a0070900-fa64-11e9-898f-edb0aa3166da.png">

### After

<img width="1506" alt="Screen Shot 2019-10-29 at 15 53 50" src="https://user-images.githubusercontent.com/134745/67815614-a6958080-fa64-11e9-8e1f-159d9bc058ac.png">

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
