### PR TITLE
Delete transient for URLs with new validation errors when updating/trashing Validated URL posts

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -124,6 +124,16 @@ class AMP_Validated_URL_Post_Type {
 			]
 		);
 
+		// Ensure cached count of URLs with new validation errors is flushed whenever a URL is updated, trashed, or deleted.
+		$handle_delete = function ( $post_id ) {
+			if ( static::POST_TYPE_SLUG === get_post_type( $post_id ) ) {
+				delete_transient( static::NEW_VALIDATION_ERROR_URLS_COUNT_TRANSIENT );
+			}
+		};
+		add_action( 'save_post_' . self::POST_TYPE_SLUG, $handle_delete );
+		add_action( 'trash_post', $handle_delete );
+		add_action( 'delete_post', $handle_delete );
+
 		// Hide the add new post link.
 		$post_type->cap->create_posts = 'do_not_allow';
 


### PR DESCRIPTION
## Summary

I found that when selecting to “Forget” (Trash) the validated URL posts, I was not seeing the new count cleared:

<img width="1346" alt="Screen Shot 2019-10-29 at 16 33 37" src="https://user-images.githubusercontent.com/134745/67817332-32f67200-fa6a-11e9-88a1-e1a570a68576.png">

This is because trashing a post does not invoke `\AMP_Validated_URL_Post_Type::store_validation_errors()` which is currently what clears that transient. So this PR ensures that the transient is deleted whenever inserting/updating/trashing/deleting such `amp_validated_url` posts.

See #2736. Regression introduced by #3222. Also #3478. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
