### PR TITLE
Remove AMP icon in heading for Validated URL screen

### DIFF
--- a/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
+++ b/assets/src/amp-validation/amp-validated-url-post-edit-screen.js
@@ -9,8 +9,6 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import setValidationErrorRowsSeenClass from './set-validation-error-rows-seen-class';
 
-const { ampValidation } = window;
-
 /**
  * The id for the 'Showing x of y errors' notice.
  *
@@ -33,7 +31,6 @@ domReady( () => {
 	handleStatusChange();
 	handleBulkActions();
 	watchForUnsavedChanges();
-	showAMPIconIfEnabled();
 } );
 
 let beforeUnloadPromptAdded = false;
@@ -378,16 +375,4 @@ const handleBulkActions = () => {
 			}
 		} );
 	} );
-};
-
-/**
- * Adds the AMP icon to the page heading if AMP is enabled on this URL.
- */
-const showAMPIconIfEnabled = () => {
-	const heading = document.querySelector( 'h1.wp-heading-inline' );
-	if ( heading && true === Boolean( ampValidation.amp_enabled ) ) {
-		const ampIcon = document.createElement( 'span' );
-		ampIcon.classList.add( 'status-text', 'amp-enabled' );
-		heading.appendChild( ampIcon );
-	}
 };

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1693,6 +1693,7 @@ class AMP_Validated_URL_Post_Type {
 			true
 		);
 
+		// @todo This is likely dead code.
 		$current_screen = get_current_screen();
 		if ( $current_screen && 'post' === $current_screen->base && self::POST_TYPE_SLUG === $current_screen->post_type ) {
 			$post = get_post();


### PR DESCRIPTION
## Summary

The blue AMP icon is currently added to the end of the heading on the Validated URL screen when AMP is enabled. However, it is not aligned properly and I was not able to quickly figure out how to make it align. Nevertheless, the presence of the icon here is unnecessary because the information is already presented in the Status metabox:

![image](https://user-images.githubusercontent.com/134745/67876280-dd1adc00-faf4-11e9-8c07-609caf6f3b61.png)

Also, there is currently no corresponding gray AMP icon in the heading when AMP is disabled, so this makes it more consistent.

### Before

<img width="710" alt="Screen Shot 2019-10-30 at 09 05 11" src="https://user-images.githubusercontent.com/134745/67876108-9c22c780-faf4-11e9-97f5-0b07ec845c1e.png">

### After

<img width="709" alt="Screen Shot 2019-10-30 at 09 04 22" src="https://user-images.githubusercontent.com/134745/67876127-a2b13f00-faf4-11e9-8f49-f16f3c0bf773.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
