### PR TITLE
Remove ver=__normalized__ query param from displayed URLs in compatibility tool

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2171,7 +2171,12 @@ class AMP_Validation_Error_Taxonomy {
 									echo '<code>';
 									$is_url = in_array( $attr_name, [ 'href', 'src' ], true );
 									if ( $is_url ) {
-										// @todo There should be a link to the file editor as well, if available.
+										// Remove non-helpful normalized version.
+										$url_query = wp_parse_url( $attr_value, PHP_URL_QUERY );
+										if ( $url_query && false !== strpos( 'ver=__normalized__', $url_query ) ) {
+											$attr_value = remove_query_arg( 'ver', $attr_value );
+										}
+
 										printf( '<a href="%s" target="_blank">', esc_url( $attr_value ) );
 									}
 									echo esc_html( $attr_value );


### PR DESCRIPTION
## Summary

The inclusion of `?ver=__normalized_` in the URLs displayed in the compatibility tool is just visual noise. It doesn't help, so let's remove it.

### Before

<img width="911" alt="Screen Shot 2019-10-30 at 10 12 48" src="https://user-images.githubusercontent.com/134745/67881596-ff652780-fafd-11e9-888f-b2d258c4cc4b.png">

### After

<img width="899" alt="Screen Shot 2019-10-30 at 10 12 26" src="https://user-images.githubusercontent.com/134745/67881602-0429db80-fafe-11e9-9230-0731850ccd2c.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
