### PR TITLE
Fix displaying warning in editor when there is kept invalid markup

### DIFF
--- a/assets/src/block-validation/helpers/index.js
+++ b/assets/src/block-validation/helpers/index.js
@@ -78,7 +78,7 @@ export const updateValidationErrors = () => {
 	 */
 	const validationErrors = ampValidity.results.filter( ( result ) => {
 		return result.term_status !== VALIDATION_ERROR_ACK_ACCEPTED_STATUS; // If not accepted by the user.
-	} ).map( ( { error } ) => error );
+	} ).map( ( { error, status } ) => ( { ...error, status } ) ); // Merge status into error since needed in maybeDisplayNotice.
 
 	if ( isEqual( validationErrors, previousValidationErrors ) ) {
 		return;
@@ -153,7 +153,7 @@ export const updateValidationErrors = () => {
  * @return {void}
  */
 export const maybeDisplayNotice = () => {
-	const { getValidationErrors, isSanitizationAutoAccepted, getReviewLink } = select( 'amp/block-validation' );
+	const { getValidationErrors, getReviewLink } = select( 'amp/block-validation' );
 	const { createWarningNotice } = dispatch( 'core/notices' );
 	const { getCurrentPost } = select( 'core/editor' );
 
@@ -196,35 +196,30 @@ export const maybeDisplayNotice = () => {
 
 		noticeMessage += ' ';
 
-		if ( isSanitizationAutoAccepted() ) {
-			const rejectedBlockValidationErrors = blockValidationErrors.filter( ( error ) => {
-				return (
-					VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
-					VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
-				);
-			} );
+		const rejectedBlockValidationErrors = blockValidationErrors.filter( ( error ) => {
+			return (
+				VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
+				VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
+			);
+		} );
 
-			const rejectedValidationErrors = validationErrors.filter( ( error ) => {
-				return (
-					VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
-					VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
-				);
-			} );
+		const rejectedValidationErrors = validationErrors.filter( ( error ) => {
+			return (
+				VALIDATION_ERROR_NEW_REJECTED_STATUS === error.status ||
+				VALIDATION_ERROR_ACK_REJECTED_STATUS === error.status
+			);
+		} );
 
-			const totalRejectedErrorsCount = rejectedBlockValidationErrors.length + rejectedValidationErrors.length;
-
-			if ( totalRejectedErrorsCount === 0 ) {
-				noticeMessage += __( 'However, your site is configured to automatically accept sanitization of the offending markup.', 'amp' );
-			} else {
-				noticeMessage += _n(
-					'Your site is configured to automatically accept sanitization errors, but this error could be from when auto-acceptance was not selected, or from manually rejecting an error.',
-					'Your site is configured to automatically accept sanitization errors, but these errors could be from when auto-acceptance was not selected, or from manually rejecting an error.',
-					validationErrors.length,
-					'amp',
-				);
-			}
+		const totalRejectedErrorsCount = rejectedBlockValidationErrors.length + rejectedValidationErrors.length;
+		if ( totalRejectedErrorsCount === 0 ) {
+			noticeMessage += __( 'Nevertheless, the invalid markup has been automatically removed.', 'amp' );
 		} else {
-			noticeMessage += __( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
+			noticeMessage += _n(
+				'You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.',
+				'You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.',
+				validationErrors.length,
+				'amp',
+			);
 		}
 	}
 

--- a/includes/cli/class-amp-cli-validation-command.php
+++ b/includes/cli/class-amp-cli-validation-command.php
@@ -233,7 +233,7 @@ final class AMP_CLI_Validation_Command {
 
 		WP_CLI::success(
 			sprintf(
-				'%3$d crawled URLs have unaccepted issue(s) out of %2$d total with AMP validation issue(s); %1$d URLs were crawled.',
+				'%3$d crawled URLs have invalid markup kept out of %2$d total with AMP validation issue(s); %1$d URLs were crawled.',
 				$this->number_crawled,
 				$this->total_errors,
 				$this->unaccepted_errors

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -919,20 +919,16 @@ class AMP_Validation_Manager {
 		echo ' ';
 
 		// Auto-acceptance is enabled by default but can be overridden by the the `amp_validation_error_default_sanitized` filter.
-		if ( self::is_sanitization_auto_accepted() ) {
-			if ( ! $has_rejected_error ) {
-				esc_html_e( 'However, your site is configured to automatically accept sanitization of the offending markup. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
-			} else {
-				/*
-				 * Even if sanitizations are accepted by default, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
-				 * For example, the errors could have been stored as 'New Rejected' when auto-accept was false, and now auto-accept is true.
-				 * In that case, this will block serving AMP.
-				 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.
-				 */
-				esc_html_e( 'Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', 'amp' );
-			}
+		if ( ! $has_rejected_error ) {
+			esc_html_e( 'Nevertheless, the invalid markup has been automatically removed.', 'amp' );
 		} else {
-			esc_html_e( 'Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.', 'amp' );
+			/*
+			 * Even if invalid markup is removed by default, if there are non-accepted errors in non-Standard mode, it will redirect to a non-AMP page.
+			 * For example, the errors could have been stored as 'New Kept' when auto-accept was false, and now auto-accept is true.
+			 * In that case, this will block serving AMP.
+			 * This could also apply if this is in 'Standard' mode and the user has rejected a validation error.
+			 */
+			esc_html_e( 'You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.', 'amp' );
 		}
 
 		echo sprintf(

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -698,7 +698,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		// When sanitization is accepted by default.
 		$this->accept_sanitization_by_default( true );
-		$expected_notice_non_accepted_errors = 'There is content which fails AMP validation. Non-accepted validation errors prevent AMP from being served, and the user will be redirected to the non-AMP version.';
+		$expected_notice_non_accepted_errors = 'There is content which fails AMP validation. You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.';
 		$this->assertContains( 'notice notice-warning', $output );
 		$this->assertContains( '<code>script</code>', $output );
 		$this->assertContains( $expected_notice_non_accepted_errors, $output );
@@ -706,7 +706,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		// When auto-accepting validation errors, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
-		$this->assertContains( 'There is content which fails AMP validation. Though your site is configured to automatically accept sanitization errors, there are rejected error(s). This could be because auto-acceptance of errors was disabled earlier. You should review the issues to confirm whether or not sanitization should be accepted or rejected.', $output );
+		$this->assertContains( 'There is content which fails AMP validation. You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.', $output );
 
 		/*
 		 * When there are 'Rejected' or 'New Rejected' errors, there should be a message that explains that this will serve a non-AMP URL.


### PR DESCRIPTION
## Summary

I discovered that the warning notices in the editor do not accurately reflect the scenario when there is one or more bit of invalid markup which is kept. The issue stems from the `status` not being included among the `validationErrors` which are stored.

I also realized that the the messages were not updated after the rebranding in #3630. Some of the code also could be simplified. (See #3545/#3350.)

### Validation Error(s) Kept

Given a URL that has errors in all 4 validation states:

![image](https://user-images.githubusercontent.com/134745/67903251-4e27b700-fb28-11e9-81ba-c284161789d4.png)

Before:

![image](https://user-images.githubusercontent.com/134745/67903285-6566a480-fb28-11e9-8c9d-447b79c421a8.png)

![image](https://user-images.githubusercontent.com/134745/67903416-beced380-fb28-11e9-82b7-d4912ed7b99d.png)

After:

![image](https://user-images.githubusercontent.com/134745/67903317-77484780-fb28-11e9-9fe4-500283cffd78.png)

![image](https://user-images.githubusercontent.com/134745/67903400-b4143e80-fb28-11e9-9fbf-109b3f46540e.png)

### Validation Errors Removed

Before:

![image](https://user-images.githubusercontent.com/134745/67903488-f473bc80-fb28-11e9-81a1-413787680e07.png)

![image](https://user-images.githubusercontent.com/134745/67903512-048b9c00-fb29-11e9-9cc8-210a23610dd0.png)

After:

![image](https://user-images.githubusercontent.com/134745/67903590-369cfe00-fb29-11e9-9cb6-85d806e78268.png)

![image](https://user-images.githubusercontent.com/134745/67903573-29800f00-fb29-11e9-9fa7-941a95ce474d.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
