### PR TITLE
Remove maximum-scale=1 and user-scalable=no from Reader template meta viewport

### DIFF
--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -22,7 +22,7 @@
 <html amp <?php echo AMP_HTML_Utils::build_attributes_string( $this->get( 'html_tag_attributes' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 	<style amp-custom>
 		<?php $this->load_parts( [ 'style' ] ); ?>


### PR DESCRIPTION
The Reader mode templates includes `maximum-scale=1` and `user-scalable=no` in the meta viewport. This was pointed out by @rianrietveld as being a critical accessibility issue since it prevents users from being able to zoom to read text. AMP has no requirement to have these meta viewport properties. The bare minimum AMP requires is just having `device-width` defined.