### PR TITLE
Fix DOM exception "Not Found Error" when cleaning up after invalid attribute removal

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -487,7 +487,6 @@ abstract class AMP_Base_Sanitizer {
 		$should_remove = $this->should_sanitize_validation_error( $validation_error, compact( 'node' ) );
 		if ( $should_remove ) {
 			$element->removeAttributeNode( $node );
-			$this->clean_up_after_attribute_removal( $element, $node, $validation_error );
 		}
 		return $should_remove;
 	}
@@ -591,12 +590,10 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @since 1.3
 	 *
-	 * @param DOMElement $element          The node for which he attribute was
-	 *                                     removed.
-	 * @param DOMAttr    $attribute        The attribute that was removed.
-	 * @param array      $validation_error Validation error details.
+	 * @param DOMElement $element   The node for which he attribute was removed.
+	 * @param DOMAttr    $attribute The attribute that was removed.
 	 */
-	protected function clean_up_after_attribute_removal( $element, $attribute, $validation_error ) {
+	protected function clean_up_after_attribute_removal( $element, $attribute ) {
 		static $attributes_tied_to_href = [ 'target', 'download', 'rel', 'rev', 'hreflang', 'type' ];
 
 		if ( 'href' === $attribute->nodeName ) {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -590,7 +590,7 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @since 1.3
 	 *
-	 * @param DOMElement $element   The node for which he attribute was removed.
+	 * @param DOMElement $element   The node for which the attribute was removed.
 	 * @param DOMAttr    $attribute The attribute that was removed.
 	 */
 	protected function clean_up_after_attribute_removal( $element, $attribute ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -592,11 +592,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 			/*
 			 * Only run cleanup after the fact to prevent a scenario where invalid markup is kept and so the attribute
-			 * is actually not removed. This prevents a "DOMException: Not Found Error" from happening in when calling
+			 * is actually not removed. This prevents a "DOMException: Not Found Error" from happening when calling
 			 * remove_invalid_attribute() since clean_up_after_attribute_removal() can end up removing invalid link
 			 * attributes (like 'target') when there is an invalid 'href' attribute, but if the 'target' attribute is
-			 * itself invalid, then if clean_up_after_attribute_removal is called inside of remove_invalid_attribute
-			 * then it can cause a subsequent invocation of remove_invalid_attribute to try to remove an invalid
+			 * itself invalid, then if clean_up_after_attribute_removal() is called inside of remove_invalid_attribute()
+			 * it can cause a subsequent invocation of remove_invalid_attribute() to try to remove an invalid
 			 * attribute that has already been removed from the DOM.
 			 */
 			foreach ( $removed_attributes as $removed_attribute ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -583,8 +583,24 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( $node->attributes as $attribute ) {
 				$validation_error['element_attributes'][ $attribute->nodeName ] = $attribute->nodeValue;
 			}
+			$removed_attributes = [];
 			foreach ( $disallowed_attributes as $disallowed_attribute ) {
-				$this->remove_invalid_attribute( $node, $disallowed_attribute, $validation_error );
+				if ( $this->remove_invalid_attribute( $node, $disallowed_attribute, $validation_error ) ) {
+					$removed_attributes[] = $disallowed_attribute;
+				}
+			}
+
+			/*
+			 * Only run cleanup after the fact to prevent a scenario where invalid markup is kept and so the attribute
+			 * is actually not removed. This prevents a "DOMException: Not Found Error" from happening in when calling
+			 * remove_invalid_attribute() since clean_up_after_attribute_removal() can end up removing invalid link
+			 * attributes (like 'target') when there is an invalid 'href' attribute, but if the 'target' attribute is
+			 * itself invalid, then if clean_up_after_attribute_removal is called inside of remove_invalid_attribute
+			 * then it can cause a subsequent invocation of remove_invalid_attribute to try to remove an invalid
+			 * attribute that has already been removed from the DOM.
+			 */
+			foreach ( $removed_attributes as $removed_attribute ) {
+				$this->clean_up_after_attribute_removal( $node, $removed_attribute );
 			}
 		}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1909,21 +1909,22 @@ class AMP_Validation_Manager {
 	 * @return string Error message.
 	 */
 	public static function get_validate_url_error_message( $error_code ) {
+		$check_error_log = __( 'Please check your server\'s PHP error logs; to do this you may need to enable WP_DEBUG_LOG.', 'amp' );
 		switch ( $error_code ) {
 			case 'http_request_failed':
-				return __( 'Failed to fetch URL(s) to validate. This may be due to a request timeout.', 'amp' );
+				return __( 'Failed to fetch URL(s) to validate. This may be due to a request timeout.', 'amp' ) . ' ' . $check_error_log;
 			case 'white_screen_of_death':
-				return __( 'Unable to validate URL. Encountered a white screen of death likely due to a fatal error. Please check your server\'s PHP error logs.', 'amp' );
+				return __( 'Unable to validate URL. Encountered a white screen of death likely due to a fatal error.', 'amp' ) . ' ' . $check_error_log;
 			case '404':
 				return __( 'The fetched URL was not found. It may have been deleted. If so, you can trash this.', 'amp' );
 			case '500':
-				return __( 'An internal server error occurred when fetching the URL for validation.', 'amp' );
+				return __( 'An internal server error occurred when fetching the URL for validation.', 'amp' ) . ' ' . $check_error_log;
 			case 'response_comment_absent':
 				return sprintf(
 					/* translators: %s: AMP_VALIDATION */
-					__( 'URL validation failed to due to the absence of the expected JSON-containing %s comment after the body.', 'amp' ),
+					__( 'URL validation failed to due to the absence of the expected JSON-containing %s comment after the body. This is often due to a PHP fatal error occurring.', 'amp' ),
 					'AMP_VALIDATION'
-				);
+				) . ' ' . $check_error_log;
 			case 'malformed_json_validation_errors':
 				return sprintf(
 					/* translators: %s: AMP_VALIDATION */

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1707,6 +1707,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[],
 				[ 'invalid_processing_instruction' ],
 			],
+
+			'malformed_attribute_syntax_curly_quotes'      => [
+				'<a href=“%E2%80%9Chttps://example.com/path/to/post/%E2%80%9D“ target=“_blank“ rel=“noopener“>Whatever</a>',
+				'<a>Whatever</a>',
+				[],
+				[ 'invalid_attribute', 'invalid_attribute' ],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Defer cleanup removal of invalid attributes until determining if they are actually removed. It turns out that calling `\AMP_Base_Sanitizer::clean_up_after_attribute_removal()` inside of `\AMP_Base_Sanitizer::remove_invalid_attribute()` can cause subsequent calls to `\AMP_Base_Sanitizer::remove_invalid_attribute()` to throw a `DOMException` “Not Found Error” if the former removed an attribute that needs to actually be removed by the latter.

For example, if there is a `<a href="…" target="…">` element, and both `href` and `target` are causing validation errors, then if the `target` attribute gets cleaned up at the same time as `href` is removed, then when `target` tries to get removed as well, it will cause an error because it no longer is in the DOM.

Fixes issues reported on support forum:

* https://wordpress.org/support/topic/php-fatal-error-uncaught-domexception-not-found-error-in/
* https://wordpress.org/support/topic/page-unable-to-reach/

Regression introduced 1.4.0 via #3151.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
