### PR TITLE
Replace deprecated WP_Admin_Bar::add_menu() with WP_Admin_Bar::add_node()

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1295,7 +1295,7 @@ function amp_add_admin_bar_view_link( $wp_admin_bar ) {
 		'href'  => esc_url( $href ),
 	];
 
-	$wp_admin_bar->add_menu( $parent );
+	$wp_admin_bar->add_node( $parent );
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes deprecation notices that are now causing [build failures](https://travis-ci.org/ampproject/amp-wp/jobs/606974743#L970-L1010) when testing in trunk (WP 5.4-alpha):

```
There was 1 failure:
1) Test_AMP_Helper_Functions::test_amp_add_admin_bar_item
Unexpected deprecated notice for WP_Admin_Bar::add_menu
Failed asserting that an array is empty.
/tmp/wordpress/tests/phpunit/includes/abstract-testcase.php:485
/tmp/wordpress/tests/phpunit/includes/abstract-testcase.php:497
```

For more information, see https://core.trac.wordpress.org/ticket/19647

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
