### PR TITLE
Remove obsolete meta viewport properties from v0.3 back-compat template

### DIFF
--- a/back-compat/templates-v0-3/single.php
+++ b/back-compat/templates-v0-3/single.php
@@ -5,12 +5,18 @@
  * @package AMP
  */
 
+/**
+ * Context.
+ *
+ * @var AMP_Post_Template $this
+ */
+
 ?>
 <!doctype html>
 <html amp <?php language_attributes(); ?>>
 <head>
 	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>


### PR DESCRIPTION
## Summary

Follow up on #3681. When I found out that the old meta viewport was [added](https://github.com/ampproject/amp-wp/commit/6a3c6acd11a1129a048e174432c8a0823aa11452#diff-13e5580ca26ea5de947e855a28fb0774R7) in the initial version of the plugin, I then realized that it also would need to be updated in the (very) old v0.3 back-compat templates (which we should really deprecate now, cf. #2202). This PR updates the the old meta viewport to remove the [now-unnecessary](https://github.com/ampproject/amphtml/issues/592) meta viewport properties which cause a11y problems.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
