### PR TITLE
Fix submenus not opening on the desktop horizontal menu in Twenty Twenty theme

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1030,6 +1030,19 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						}
 					}
 
+					/* Allow submenus to be opened via its icon on the desktop horizontal menu if
+					its a touch interface */
+					body.amp-mode-touch .primary-menu > li.menu-item-has-children > a {
+						padding-right: 0;
+						margin-right: 2rem;
+					}
+
+					body.amp-mode-touch .primary-menu ul li.menu-item-has-children > a {
+						margin-right: 4.5rem;
+						padding-right: 0;
+						width: unset;
+					}
+
 				}
 				<?php elseif ( 'twentyseventeen' === get_template() ) : ?>
 					/* Show the button*/


### PR DESCRIPTION
## Summary

Account for submenus not opening on the desktop horizontal menu in the Twenty Twenty theme on touch devices.

See related PR for fix done in Twenty Twenty: https://github.com/WordPress/twentytwenty/pull/949

### Demo

Before|After
---|---
![deepin-screen-recorder_Select area_20191107010307](https://user-images.githubusercontent.com/16200219/68363945-7308c500-00fa-11ea-8292-26a3a91d2d0e.gif) | ![deepin-screen-recorder_Select area_20191107010019](https://user-images.githubusercontent.com/16200219/68363839-21f8d100-00fa-11ea-8adb-b4b5b5176c2f.gif)


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
