### PR TITLE
Add AMP on protected posts

### DIFF
--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -88,8 +88,9 @@ class AMP_Post_Type_Support {
 			$errors[] = 'post-type-support';
 		}
 
-		if ( post_password_required( $post ) ) {
-			$errors[] = 'password-protected';
+		// Show password form instead of the post content.
+		if ( ! current_theme_supports( 'amp' ) && post_password_required( $post ) ) {
+			add_filter( 'the_content', [ __CLASS__, 'show_password_form' ] );
 		}
 
 		/**
@@ -152,5 +153,16 @@ class AMP_Post_Type_Support {
 			}
 		}
 		return $errors;
+	}
+
+	/**
+	 * Show the password form if the post password is required.
+	 *
+	 * @return string
+	 */
+	public static function show_password_form() {
+		$post = get_post();
+
+		return get_the_password_form( $post );
 	}
 }

--- a/includes/class-amp-post-type-support.php
+++ b/includes/class-amp-post-type-support.php
@@ -88,11 +88,6 @@ class AMP_Post_Type_Support {
 			$errors[] = 'post-type-support';
 		}
 
-		// Show password form instead of the post content.
-		if ( ! current_theme_supports( 'amp' ) && post_password_required( $post ) ) {
-			add_filter( 'the_content', [ __CLASS__, 'show_password_form' ] );
-		}
-
 		/**
 		 * Filters whether to skip the post from AMP.
 		 *
@@ -153,16 +148,5 @@ class AMP_Post_Type_Support {
 			}
 		}
 		return $errors;
-	}
-
-	/**
-	 * Show the password form if the post password is required.
-	 *
-	 * @return string
-	 */
-	public static function show_password_form() {
-		$post = get_post();
-
-		return get_the_password_form( $post );
 	}
 }

--- a/includes/templates/class-amp-post-template.php
+++ b/includes/templates/class-amp-post-template.php
@@ -322,7 +322,7 @@ class AMP_Post_Template {
 	 */
 	private function build_post_content() {
 		$amp_content = new AMP_Content(
-			$this->post->post_content,
+			post_password_required( $this->post ) ? get_the_password_form( $this->post ) : $this->post->post_content,
 			amp_get_content_embed_handlers( $this->post ),
 			amp_get_content_sanitizers( $this->post ),
 			[

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -106,7 +106,8 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 
 		// Password-protected.
 		add_filter( 'post_password_required', '__return_true' );
-		$this->assertEquals( [ 'password-protected' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
+		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
+		$this->assertEquals( 10, has_filter( 'the_content', [ 'AMP_Post_Type_Support', 'show_password_form' ] ) );
 		remove_filter( 'post_password_required', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
@@ -115,5 +116,18 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		$this->assertEquals( [ 'skip-post' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		remove_filter( 'amp_skip_post', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
+	}
+
+	/**
+	 * Test AMP_Post_Type_Support::show_password_form.
+	 *
+	 * @covers AMP_Post_Type_Support::show_password_form()
+	 */
+	public function test_show_password_form() {
+		$post = self::factory()->post->create_and_get();
+
+		add_filter( 'post_password_required', '__return_true' );
+		AMP_Post_Type_Support::get_support_errors( $post );
+		$this->assertEquals( get_the_password_form( $post ), get_the_content( null, false, $post ) );
 	}
 }

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -124,10 +124,10 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 	 * @covers AMP_Post_Type_Support::show_password_form()
 	 */
 	public function test_show_password_form() {
-		$post = self::factory()->post->create_and_get();
+		$GLOBALS['post'] = self::factory()->post->create_and_get();
 
 		add_filter( 'post_password_required', '__return_true' );
-		AMP_Post_Type_Support::get_support_errors( $post );
-		$this->assertEquals( get_the_password_form( $post ), get_the_content( null, false, $post ) );
+		AMP_Post_Type_Support::get_support_errors( $GLOBALS['post'] );
+		$this->assertEquals( get_the_password_form( $GLOBALS['post'] ), get_the_content( null, false, $GLOBALS['post'] ) );
 	}
 }

--- a/tests/php/test-class-amp-post-type-support.php
+++ b/tests/php/test-class-amp-post-type-support.php
@@ -104,30 +104,10 @@ class Test_AMP_Post_Type_Support extends WP_UnitTestCase {
 		add_post_type_support( 'book', AMP_Post_Type_Support::SLUG );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
 
-		// Password-protected.
-		add_filter( 'post_password_required', '__return_true' );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
-		$this->assertEquals( 10, has_filter( 'the_content', [ 'AMP_Post_Type_Support', 'show_password_form' ] ) );
-		remove_filter( 'post_password_required', '__return_true' );
-		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
-
 		// Skip-post.
 		add_filter( 'amp_skip_post', '__return_true' );
 		$this->assertEquals( [ 'skip-post' ], AMP_Post_Type_Support::get_support_errors( $book_id ) );
 		remove_filter( 'amp_skip_post', '__return_true' );
 		$this->assertEmpty( AMP_Post_Type_Support::get_support_errors( $book_id ) );
-	}
-
-	/**
-	 * Test AMP_Post_Type_Support::show_password_form.
-	 *
-	 * @covers AMP_Post_Type_Support::show_password_form()
-	 */
-	public function test_show_password_form() {
-		$GLOBALS['post'] = self::factory()->post->create_and_get();
-
-		add_filter( 'post_password_required', '__return_true' );
-		AMP_Post_Type_Support::get_support_errors( $GLOBALS['post'] );
-		$this->assertEquals( get_the_password_form( $GLOBALS['post'] ), get_the_content( null, false, $GLOBALS['post'] ) );
 	}
 }


### PR DESCRIPTION
## Summary

- Password protected post no longer disables AMP
- Password form is now shown for Reader mode

<!-- Please reference the issue this PR addresses. -->
Fixes #3428.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
