### PR TITLE
Omit `mozallowfullscreen` & `webkitallowfullscreen` when sanitizing iframe

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -217,6 +217,11 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					}
 					break;
 
+				case 'mozallowfullscreen':
+				case 'webkitallowfullscreen':
+					// Omit these since amp-iframe will add them if needed if the `allowfullscreen` attribute is present.
+					break;
+
 				default:
 					$out[ $name ] = $value;
 					break;

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -400,6 +400,16 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 					'add_dev_mode' => true,
 				],
 			],
+
+			'iframe_with_mozallowfullscreen_and_webkitallowfullscreen_attrs' => [
+				'<iframe title="Why Backbone" id="talk_frame_48643" src="//speakerdeck.com/player/4648d440a3230130452522b217532879" width="640" height="480" style="border:0; padding:0; margin:0; background:transparent;" frameborder="0" allowtransparency="true" allowfullscreen="allowfullscreen" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>',
+				'
+					<amp-iframe title="Why Backbone" id="talk_frame_48643" src="https://speakerdeck.com/player/4648d440a3230130452522b217532879" width="640" height="480" style="border:0; padding:0; margin:0; background:transparent;" frameborder="0" allowtransparency="" allowfullscreen="" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe title="Why Backbone" id="talk_frame_48643" src="https://speakerdeck.com/player/4648d440a3230130452522b217532879" width="640" height="480" style="border:0; padding:0; margin:0; background:transparent;" frameborder="0"></iframe>
+						</noscript>
+					</amp-iframe>',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Omit the `mozallowfullscreen` & `webkitallowfullscreen` attributes when sanitizing an iframe.

<!-- Please reference the issue this PR addresses. -->
Fixes #3425.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
