### PR TITLE
Remove redundant data-ampdevmode attributes from admin bar descendants

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -973,7 +973,6 @@ function amp_get_content_sanitizers( $post = null ) {
 		$dev_mode_xpaths = (array) apply_filters( 'amp_dev_mode_element_xpaths', [] );
 		if ( is_admin_bar_showing() ) {
 			$dev_mode_xpaths[] = '//*[ @id = "wpadminbar" ]';
-			$dev_mode_xpaths[] = '//*[ @id = "wpadminbar" ]//*';
 			$dev_mode_xpaths[] = '//style[ @id = "admin-bar-inline-css" ]';
 		}
 		$sanitizers = array_merge(

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -785,7 +785,6 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				$element_xpaths,
 				[
 					'//*[ @id = "wpadminbar" ]',
-					'//*[ @id = "wpadminbar" ]//*',
 					'//style[ @id = "admin-bar-inline-css" ]',
 				]
 			),


### PR DESCRIPTION
## Summary

I [found out](https://github.com/ampproject/amphtml/issues/24987#issuecomment-551350675) from @Gregable that `data-ampdevmode` applies to the entire descendant DOM tree when it is added to an element:

> The way it works in the validator is that you add `data-ampdevmode` to the root `<html>` tag first. Then, any other tag that includes `data-ampdevmode` will have any errors suppressed on it **or it's descendants**.
> 
> If you want to do:
> 
> ```
> <html amp data-ampdevmode>
> <head>...</head>
> <body data-ampdevmode>
>   ... Anything goes in here ...
> </body>
> </html>
> ```
> 
> Then that would be consistent with the validator mode. The idea of requiring it twice is that you can decide which parts of the document you want errors for and which parts you don't. You can add it to the body and/or head (*) if you want to just disable all errors.
> 
> (*) This doesn't get rid of the mandatory document-level requirement errors, just the tag-level errors. Missing boilerplate will still be reported for example.

This means we can eliminate adding `data-ampdevmode` to every single element under `#wpadminbar` in addition to adding it to the `#wpadminbar` container element as well.

This is a follow-up on #3187.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
