### PR TITLE
Remove amp_validate query var from Validated URL 'View' row action

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2256,7 +2256,7 @@ class AMP_Validated_URL_Post_Type {
 			if ( $url ) {
 				$actions['view'] = sprintf(
 					'<a href="%s">%s</a>',
-					esc_url( add_query_arg( AMP_Validation_Manager::VALIDATE_QUERY_VAR, '', $url ) ),
+					esc_url( $url ),
 					esc_html__( 'View', 'amp' )
 				);
 			}


### PR DESCRIPTION
## Summary

The "View" row action for Validated URLs includes the `amp_validate` query parameter which triggers validation sourcing. This is unnecessary and it differs from the other view links on the Validated URL screen:

<img width="584" alt="Screen Shot 2019-11-10 at 11 15 33" src="https://user-images.githubusercontent.com/134745/68549308-973efd00-03ab-11ea-92aa-716f7a8703fb.png">

Before:

<img width="443" alt="Screen Shot 2019-11-10 at 11 11 56" src="https://user-images.githubusercontent.com/134745/68549314-9efea180-03ab-11ea-84cd-d92fd203fc7f.png">

After:

<img width="449" alt="Screen Shot 2019-11-10 at 11 12 09" src="https://user-images.githubusercontent.com/134745/68549317-a6be4600-03ab-11ea-9e37-d8c94737d8b9.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
