### PR TITLE
Fix failing E2E tests

### DIFF
--- a/tests/e2e/config/bootstrap.js
+++ b/tests/e2e/config/bootstrap.js
@@ -210,7 +210,7 @@ beforeAll( async () => {
 	enablePageDialogAccept();
 	observeConsoleLogging();
 	await setBrowserViewport( 'large' );
-	await page.setDefaultNavigationTimeout( 5000 );
+	await page.setDefaultNavigationTimeout( 10000 );
 	await page.setDefaultTimeout( 3000 );
 } );
 

--- a/tests/e2e/specs/stories-editor/resizing.js
+++ b/tests/e2e/specs/stories-editor/resizing.js
@@ -348,6 +348,11 @@ describe( 'Resizing', () => {
 			await createNewPost( { postType: 'amp_story' } );
 			// Select the Text block inserted by default.
 			await selectBlockByClassName( 'wp-block-amp-story-text' );
+			/*
+			 * Some block handles are not visible upon block rotation. Scrolling the page up to the
+			 * Story controls should provide enough space to solve this.
+			 */
+			await page.$eval( '#amp-story-controls', ( el ) => el.scrollIntoView() );
 			await rotateSelectedBlock();
 		} );
 


### PR DESCRIPTION
## Summary

The main cause for the flaky tests were due to them failing to be executed within the 5s navigation timeout, so I've bumped it up to 10s.

There 2 tests that were actually failing, however: 

- [Resizing › Rotated Text block › should change the top and left position correctly when resizing a rotated block: topRight](https://github.com/ampproject/amp-wp/blob/9cc3e0e36b1b0f88b8b39ca1dfb1da144e838f0e/tests/e2e/specs/stories-editor/resizing.js#L398-L409)
- [Resizing › Rotated Text block › should change the top and left position correctly when resizing a rotated block: right](https://github.com/ampproject/amp-wp/blob/9cc3e0e36b1b0f88b8b39ca1dfb1da144e838f0e/tests/e2e/specs/stories-editor/resizing.js#L411-L422)

These were failing because the box handle which it tried to drag and resize was not in view. To fix this, I've made the page scroll up to the Story controls to give it some space and now makes those handles visible.

---

<!-- Please reference the issue this PR addresses. -->
Fixes #3671.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
