### PR TITLE
Fix identifying sources for validation errors coming child themes

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1473,7 +1473,7 @@ class AMP_Validation_Manager {
 			$source['type'] = 'theme';
 			$source['name'] = self::$template_slug;
 			$source['file'] = $matches['file'];
-		} elseif ( ! empty( self::$stylesheet_directory ) && preg_match( ':' . preg_quote( trailingslashit( self::$stylesheet_directory ), ':' ) . '/(?P<file>.*$):s', $file, $matches ) ) {
+		} elseif ( ! empty( self::$stylesheet_directory ) && preg_match( ':' . preg_quote( trailingslashit( self::$stylesheet_directory ), ':' ) . '(?P<file>.*$):s', $file, $matches ) ) {
 			$source['type'] = 'theme';
 			$source['name'] = self::$stylesheet_slug;
 			$source['file'] = $matches['file'];

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1426,31 +1426,21 @@ class AMP_Validation_Manager {
 	 *     @type string $type Source type (core, plugin, mu-plugin, or theme).
 	 *     @type string $name Source name.
 	 *     @type string $function Normalized function name.
-	 *     @type ReflectionMethod|ReflectionFunction $reflection
+	 *     @type ReflectionMethod|ReflectionFunction $reflection Reflection.
 	 * }
 	 */
 	public static function get_source( $callback ) {
 		$reflection = null;
-		$class_name = null; // Because ReflectionMethod::getDeclaringClass() can return a parent class.
 		try {
 			if ( is_string( $callback ) && is_callable( $callback ) ) {
 				// The $callback is a function or static method.
 				$exploded_callback = explode( '::', $callback, 2 );
 				if ( 2 === count( $exploded_callback ) ) {
-					$class_name = $exploded_callback[0];
 					$reflection = new ReflectionMethod( $exploded_callback[0], $exploded_callback[1] );
 				} else {
 					$reflection = new ReflectionFunction( $callback );
 				}
 			} elseif ( is_array( $callback ) && isset( $callback[0], $callback[1] ) && method_exists( $callback[0], $callback[1] ) ) {
-				// The $callback is a method.
-				if ( is_string( $callback[0] ) ) {
-					$class_name = $callback[0];
-				} elseif ( is_object( $callback[0] ) ) {
-					$class_name = get_class( $callback[0] );
-				}
-
-				// This is needed later for AMP_Validation_Manager::has_parameters_passed_by_reference().
 				$reflection = new ReflectionMethod( $callback[0], $callback[1] );
 
 				// Handle the special case of the class being a widget, in which case the display_callback method should
@@ -1465,6 +1455,7 @@ class AMP_Validation_Manager {
 			return null;
 		}
 
+		// The reflection is needed later for AMP_Validation_Manager::has_parameters_passed_by_reference().
 		if ( ! $reflection ) {
 			return null;
 		}
@@ -1501,8 +1492,8 @@ class AMP_Validation_Manager {
 			$source['line'] = $reflection->getStartLine();
 		}
 
-		if ( $class_name ) {
-			$source['function'] = $class_name . '::' . $reflection->getName();
+		if ( $reflection instanceof ReflectionMethod ) {
+			$source['function'] = $reflection->getDeclaringClass()->getName() . '::' . $reflection->getName();
 		} else {
 			$source['function'] = $reflection->getName();
 		}


### PR DESCRIPTION
## Summary

The regexp pattern for matching child themes paths broke in 977ecd4b5328633901b48fe4662524ea15ff8cc3 for #3505, and as a result they were being shown as being `wp-includes` in summary and missing any specific source information.

This PR also removes some dead/redundant code after #3505.

To test, activate the `noman-cute` child theme of Twenty Nineteen.

### Before

<img width="1249" alt="Screen Shot 2019-11-10 at 18 07 28" src="https://user-images.githubusercontent.com/134745/68556116-c5413300-03e5-11ea-99f6-f107959aa959.png">

![image](https://user-images.githubusercontent.com/134745/68556161-ea35a600-03e5-11ea-9ba9-09366727d8f3.png)

### After

<img width="1240" alt="Screen Shot 2019-11-10 at 18 08 01" src="https://user-images.githubusercontent.com/134745/68556108-c07c7f00-03e5-11ea-92c5-a31ee8305890.png">

![image](https://user-images.githubusercontent.com/134745/68556130-d2f6b880-03e5-11ea-8219-1fee5712df88.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
