### PR TITLE
Fix summarizing error sources both parent theme and child theme

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1097,19 +1097,15 @@ class AMP_Validated_URL_Post_Type {
 			}
 		}
 		if ( isset( $sources['theme'] ) && empty( $sources['embed'] ) ) {
-			$output[] = '<div class="source">';
-			$output[] = '<span class="dashicons dashicons-admin-appearance"></span>';
-			$themes   = array_unique( $sources['theme'] );
-			foreach ( $themes as $theme_slug ) {
+			foreach ( array_unique( $sources['theme'] ) as $theme_slug ) {
 				$theme_obj = wp_get_theme( $theme_slug );
 				if ( ! $theme_obj->errors() ) {
 					$theme_name = $theme_obj->get( 'Name' );
 				} else {
 					$theme_name = $theme_slug;
 				}
-				$output[] = sprintf( '<strong>%s</strong>', esc_html( $theme_name ) );
+				$output[] = sprintf( '<strong class="source"><span class="dashicons dashicons-admin-appearance"></span>%s</strong>', esc_html( $theme_name ) );
 			}
-			$output[] = '</div>';
 		}
 		if ( isset( $sources['core'] ) ) {
 			$core_sources = array_unique( $sources['core'] );

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -670,7 +670,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		// If there is no embed source, but there is a theme, this should output the theme icon.
 		unset( $error_summary['sources_with_invalid_output']['embed'] );
 		$sources_column      = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary, $post_id ] );
-		$expected_theme_icon = '<div class="source"><span class="dashicons dashicons-admin-appearance"></span><strong>' . $theme_name . '</strong></div>';
+		$expected_theme_icon = '<strong class="source"><span class="dashicons dashicons-admin-appearance"></span>' . $theme_name . '</strong>';
 		$this->assertEquals( $expected_theme_icon, $sources_column );
 
 		// If there is a plugin and theme source, this should output icons for both of them.


### PR DESCRIPTION
## Summary

In the list of Validated URLs, there is a Sources summary column. When both the parent theme ([Varia](https://github.com/Automattic/themes/tree/master/varia)) and the child theme ([Stratford](https://github.com/Automattic/themes/tree/master/stratford)) have validation errors, it currently shows as this:

<img width="176" alt="Screen Shot 2019-11-10 at 22 48 56" src="https://user-images.githubusercontent.com/134745/68566935-9b4f3700-040c-11ea-8c2f-609496596964.png">

This PR fixes it to display as:

<img width="159" alt="Screen Shot 2019-11-10 at 22 49 06" src="https://user-images.githubusercontent.com/134745/68566950-a1451800-040c-11ea-9dcb-81b521bb93fd.png">

Follow-up on #3708.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
