### PR TITLE
Default to the homepage for the AMP Customizer menu item 

### DIFF
--- a/includes/admin/functions.php
+++ b/includes/admin/functions.php
@@ -101,7 +101,6 @@ function amp_add_customizer_link() {
 	$menu_slug = add_query_arg(
 		[
 			'autofocus[panel]' => AMP_Template_Customizer::PANEL_ID,
-			'url'              => rawurlencode( amp_admin_get_preview_permalink() ),
 			'return'           => rawurlencode( admin_url() ),
 		],
 		'customize.php'


### PR DESCRIPTION
## Summary

Let the AMP Customizer menu item default to the homepage, instead of the latest AMP compatible post.

### Before

<img src="https://user-images.githubusercontent.com/16200219/68622245-b323cb00-049f-11ea-9bed-985f99b6c928.png" />

### After

<img src="https://user-images.githubusercontent.com/16200219/68622557-67bdec80-04a0-11ea-86f8-18f667117e41.png" />

<!-- Please reference the issue this PR addresses. -->
Fixes #3684

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
