### PR TITLE
Include text content of style element in validation error

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -551,8 +551,8 @@ abstract class AMP_Base_Sanitizer {
 				}
 			}
 
-			// Capture script contents.
-			if ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) ) {
+			// Capture element contents.
+			if ( ( 'script' === $node->nodeName && ! $node->hasAttribute( 'src' ) ) || 'style' === $node->nodeName ) {
 				$error['text'] = $node->textContent;
 			}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2157,6 +2157,26 @@ class AMP_Validation_Error_Taxonomy {
 				<dd class="detailed">
 					<?php if ( in_array( $key, [ 'node_name', 'parent_name' ], true ) ) : ?>
 						<code><?php echo esc_html( $value ); ?></code>
+					<?php elseif ( 'text' === $key ) : ?>
+						<details>
+							<summary>
+								<?php
+								echo esc_html(
+									sprintf(
+										/* translators: %s is the byte count */
+										_n(
+											'%s byte',
+											'%s bytes',
+											strlen( $value ),
+											'amp'
+										),
+										number_format_i18n( strlen( $value ) )
+									)
+								);
+								?>
+							</summary>
+							<p><code><?php echo esc_html( $value ); ?></code></p>
+						</details>
 					<?php elseif ( 'sources' === $key ) : ?>
 						<?php self::render_sources( $value ); ?>
 					<?php elseif ( $is_element_attributes ) : ?>


### PR DESCRIPTION
## Summary

In https://github.com/ampproject/amp-wp/issues/2326#issuecomment-552726579 it was discovered that an excessive CSS validation error for one `style` element will get conflated with validation error for another `style` element, if the `style` elements don't vary in their attributes. This is because the text content of the `style` element was not being included in the validation error attributes; this was unlike what is being done for inline `script` elements. So this PR ensures that the validation errors are distinct for distinct `style` elements.

This PR also improves the display of the text content by putting the contents in `code` element, and putting it inside of a `details` element that has the byte count.

### Before

![image](https://user-images.githubusercontent.com/134745/68648867-3cee8b00-04d6-11ea-8cc0-89e641bfa4ec.png)

![image](https://user-images.githubusercontent.com/134745/68648919-63142b00-04d6-11ea-9b8e-5fd2ecd71dae.png)

### After

![image](https://user-images.githubusercontent.com/134745/68648751-06b10b80-04d6-11ea-8a26-c94c057f3eab.png)

<img width="709" alt="Screen Shot 2019-11-11 at 22 53 23" src="https://user-images.githubusercontent.com/134745/68648811-25af9d80-04d6-11ea-9b0b-46ed31220eb6.png">

![image](https://user-images.githubusercontent.com/134745/68649041-a2427c00-04d6-11ea-9f67-a44b02d6e19c.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
