### PR TITLE
Add missing space after sentence

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1396,6 +1396,7 @@ class AMP_Validated_URL_Post_Type {
 					);
 				}
 				if ( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS !== $sanitization['term_status'] ) {
+					$info .= ' ';
 					if ( amp_is_canonical() ) {
 						$info .= __( 'Keeping invalid markup means that any URL on which it occurs will not be served as AMP.', 'amp' );
 					} else {


### PR DESCRIPTION
## Summary

A space was missing between sentences. This fixes that.

### Before

<img width="1136" alt="Screen Shot 2019-11-12 at 10 47 05" src="https://user-images.githubusercontent.com/134745/68700635-15c9a500-053a-11ea-8c05-a5c4da2b3afe.png">

### After

<img width="1124" alt="Screen Shot 2019-11-12 at 10 47 13" src="https://user-images.githubusercontent.com/134745/68700648-1b26ef80-053a-11ea-8bd5-f6ea4f7e6bd3.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
