### PR TITLE
Tidy up validation error details

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2375,8 +2375,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 					$ruleset->removeRule( $property->getRule() );
 				} else {
 					$error     = [
-						'code' => 'illegal_css_important',
-						'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
+						'code'           => 'illegal_css_important',
+						'type'           => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
+						'property_name'  => $property->getRule(),
+						'property_value' => $property->getValue(),
 					];
 					$sanitized = $this->should_sanitize_validation_error( $error );
 					if ( $sanitized ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2618,7 +2618,7 @@ class AMP_Validation_Error_Taxonomy {
 										<code><?php echo esc_html( '{closure}' === $value ? $value : $value . '()' ); ?></code>
 									<?php elseif ( 'shortcode' === $key || 'handle' === $key ) : ?>
 										<code><?php echo esc_html( $value ); ?></code>
-									<?php elseif ( 'block_name' ) : ?>
+									<?php elseif ( 'block_name' === $key ) : ?>
 										<?php
 										$block_title = self::get_block_title( $value );
 										if ( $block_title ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -1836,6 +1836,8 @@ class AMP_Validation_Error_Taxonomy {
 					$content .= sprintf( ': <code>@%s</code>', esc_html( $validation_error['at_rule'] ) );
 				} elseif ( 'invalid_processing_instruction' === $validation_error['code'] ) {
 					$content .= sprintf( ': <code>&lt;%s%s&hellip;%s&gt;</code>', '?', esc_html( $validation_error['node_name'] ), '?' );
+				} elseif ( isset( $validation_error['property_name'] ) ) {
+					$content .= sprintf( ': <code>%s</code>', esc_html( $validation_error['property_name'] ) );
 				}
 
 				if ( 'post.php' === $pagenow ) {
@@ -2149,7 +2151,7 @@ class AMP_Validation_Error_Taxonomy {
 				if ( $is_element_attributes && empty( $value ) ) {
 					continue;
 				}
-				if ( in_array( $key, [ 'code', 'type' ], true ) ) {
+				if ( in_array( $key, [ 'code', 'type', 'property_value' ], true ) ) {
 					continue; // Handled above.
 				}
 				?>
@@ -2157,6 +2159,17 @@ class AMP_Validation_Error_Taxonomy {
 				<dd class="detailed">
 					<?php if ( in_array( $key, [ 'node_name', 'parent_name' ], true ) ) : ?>
 						<code><?php echo esc_html( $value ); ?></code>
+					<?php elseif ( in_array( $key, [ 'node_name', 'parent_name' ], true ) ) : ?>
+						<pre><code><?php echo esc_html( $value ); ?></code></pre>
+					<?php elseif ( 'property_name' === $key ) : ?>
+						<?php
+						$property_value = isset( $validation_error['property_value'] ) ? $validation_error['property_value'] : '?';
+						printf(
+							'<code>%s: %s</code>',
+							esc_html( $value ),
+							esc_html( $property_value )
+						);
+						?>
 					<?php elseif ( 'text' === $key ) : ?>
 						<details>
 							<summary>
@@ -2904,6 +2917,8 @@ class AMP_Validation_Error_Taxonomy {
 				}
 			case 'parent_name':
 				return __( 'Parent element', 'amp' );
+			case 'property_name':
+				return __( 'CSS property', 'amp' );
 			case 'text':
 				return __( 'Text content', 'amp' );
 			case 'type':

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2188,7 +2188,7 @@ class AMP_Validation_Error_Taxonomy {
 								);
 								?>
 							</summary>
-							<p><code><?php echo esc_html( $value ); ?></code></p>
+							<pre><?php echo esc_html( $value ); ?></pre>
 						</details>
 					<?php elseif ( 'sources' === $key ) : ?>
 						<?php self::render_sources( $value ); ?>

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2159,8 +2159,6 @@ class AMP_Validation_Error_Taxonomy {
 				<dd class="detailed">
 					<?php if ( in_array( $key, [ 'node_name', 'parent_name' ], true ) ) : ?>
 						<code><?php echo esc_html( $value ); ?></code>
-					<?php elseif ( in_array( $key, [ 'node_name', 'parent_name' ], true ) ) : ?>
-						<pre><code><?php echo esc_html( $value ); ?></code></pre>
 					<?php elseif ( 'property_name' === $key ) : ?>
 						<?php
 						if ( isset( $validation_error['property_value'] ) && is_scalar( $validation_error['property_value'] ) ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2894,7 +2894,7 @@ class AMP_Validation_Error_Taxonomy {
 			case 'stylesheet_file_missing':
 				return __( 'Missing stylesheet file', 'amp' );
 			case 'illegal_css_important':
-				return __( 'Illegal CSS !important', 'amp' );
+				return __( 'Illegal CSS !important property', 'amp' );
 			default:
 				/* translators: %s error code */
 				return sprintf( __( 'Unknown error (%s)', 'amp' ), $error_code );

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2885,6 +2885,16 @@ class AMP_Validation_Error_Taxonomy {
 				return __( 'Disallowed CSS file extension', 'amp' );
 			case 'duplicate_element':
 				return __( 'Duplicate element', 'amp' );
+			case 'illegal_css_property':
+				return __( 'Illegal CSS property', 'amp' );
+			case 'unrecognized_css':
+				return __( 'Unrecognized CSS', 'amp' );
+			case 'css_parse_error':
+				return __( 'CSS parse error', 'amp' );
+			case 'stylesheet_file_missing':
+				return __( 'Missing stylesheet file', 'amp' );
+			case 'illegal_css_important':
+				return __( 'Illegal CSS !important', 'amp' );
 			default:
 				/* translators: %s error code */
 				return sprintf( __( 'Unknown error (%s)', 'amp' ), $error_code );

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2163,12 +2163,15 @@ class AMP_Validation_Error_Taxonomy {
 						<pre><code><?php echo esc_html( $value ); ?></code></pre>
 					<?php elseif ( 'property_name' === $key ) : ?>
 						<?php
-						$property_value = isset( $validation_error['property_value'] ) ? $validation_error['property_value'] : '?';
-						printf(
-							'<code>%s: %s</code>',
-							esc_html( $value ),
-							esc_html( $property_value )
-						);
+						if ( isset( $validation_error['property_value'] ) && is_scalar( $validation_error['property_value'] ) ) {
+							printf(
+								'<code>%s: %s</code>',
+								esc_html( $value ),
+								esc_html( $validation_error['property_value'] )
+							);
+						} else {
+							printf( '<code>%s</code>', esc_html( $value ) );
+						}
 						?>
 					<?php elseif ( 'text' === $key ) : ?>
 						<details>


### PR DESCRIPTION
## Summary

Given a Custom HTML block that contains this `style` element:

```html
<style amp-keyframes>
@-webkit-keyframes NAME-YOUR-ANIMATION {
  0%   { height: 0px !important; }
  100% { height: 100px !important; }
}
</style>
```

There should be 4 validation errors (two for `!important` and two for illegal `height`), but there are three:

![image](https://user-images.githubusercontent.com/134745/68707752-33e9d200-0547-11ea-8a6b-324e772c9c0c.png)

Also, the presentation of these validation errors is not ideal:

1. Translated error codes are not used.
2. The CSS property name is not mentioned in the summary.
3. The property name and value are not presented with a translated title in the details and they do not appear together.
4. Expanding the text content for a `style` (or `script`) element does not present the contents in a `pre` element, leading to the content appearing minified.
5. Multiple `illegal_css_important` errors get conflated because they lack `property` context (hence the 3 instead of 4 errors).
6. A blatant bug in the source logic causes some conditions to never be reached (e.g. post type info).

This PR fixes those problems.

### Before

![wordpressdev lndo site_core-dev_src_wp-admin_post php_post=2374 action=edit (2)](https://user-images.githubusercontent.com/134745/68707963-94790f00-0547-11ea-944d-0c04e371b4e0.png)

### After

![wordpressdev lndo site_core-dev_src_wp-admin_post php_post=2374 action=edit amp_urls_tested=1 amp_remaining_errors=0](https://user-images.githubusercontent.com/134745/68708362-68aa5900-0548-11ea-9e9d-930a55a55123.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
