### PR TITLE
Improve display of validation errors for scripts

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1430,11 +1430,7 @@ class AMP_Validated_URL_Post_Type {
 			</div>
 			<?php
 
-			$heading = sprintf(
-				'%s %s',
-				wp_kses_post( $error_title ),
-				wp_kses_post( $status_text )
-			);
+			$heading = wp_kses_post( $error_title ) . ' ' . wp_kses_post( $status_text );
 			?>
 			<script type="text/javascript">
 				jQuery( function( $ ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1358,10 +1358,10 @@ class AMP_Validated_URL_Post_Type {
 			if ( ! is_array( $validation_error ) ) {
 				$validation_error = [];
 			}
-			$sanitization     = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $validation_error );
-			$status_text      = AMP_Validation_Error_Taxonomy::get_status_text_with_icon( $sanitization );
-			$error_title      = AMP_Validation_Error_Taxonomy::get_error_title_from_code( $validation_error );
-			$accept_all_url   = wp_nonce_url(
+			$sanitization   = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $validation_error );
+			$status_text    = AMP_Validation_Error_Taxonomy::get_status_text_with_icon( $sanitization );
+			$error_title    = AMP_Validation_Error_Taxonomy::get_error_title_from_code( $validation_error );
+			$accept_all_url = wp_nonce_url(
 				add_query_arg(
 					[
 						'action'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION,
@@ -1370,7 +1370,7 @@ class AMP_Validated_URL_Post_Type {
 				),
 				AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION
 			);
-			$reject_all_url   = wp_nonce_url(
+			$reject_all_url = wp_nonce_url(
 				add_query_arg(
 					[
 						'action'  => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION,
@@ -1433,7 +1433,7 @@ class AMP_Validated_URL_Post_Type {
 			$heading = sprintf(
 				'%s: <code>%s</code>%s',
 				esc_html( $error_title ),
-				esc_html( $description['node_name'] ),
+				esc_html( $validation_error['node_name'] ),
 				wp_kses_post( $status_text )
 			);
 			?>

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1431,9 +1431,8 @@ class AMP_Validated_URL_Post_Type {
 			<?php
 
 			$heading = sprintf(
-				'%s: <code>%s</code>%s',
-				esc_html( $error_title ),
-				esc_html( $validation_error['node_name'] ),
+				'%s %s',
+				wp_kses_post( $error_title ),
 				wp_kses_post( $status_text )
 			);
 			?>

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1354,12 +1354,13 @@ class AMP_Validated_URL_Post_Type {
 			}
 
 			// @todo Update this to use the method which will be developed in PR #1429 AMP_Validation_Error_Taxonomy::get_term_error() .
-			$description      = json_decode( $error->description, true );
-			$sanitization     = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $description );
-			$status_text      = AMP_Validation_Error_Taxonomy::get_status_text_with_icon( $sanitization );
-			$error_code       = isset( $description['code'] ) ? $description['code'] : 'error';
-			$error_title      = AMP_Validation_Error_Taxonomy::get_error_title_from_code( $error_code );
 			$validation_error = json_decode( $error->description, true );
+			if ( ! is_array( $validation_error ) ) {
+				$validation_error = [];
+			}
+			$sanitization     = AMP_Validation_Error_Taxonomy::get_validation_error_sanitization( $validation_error );
+			$status_text      = AMP_Validation_Error_Taxonomy::get_status_text_with_icon( $sanitization );
+			$error_title      = AMP_Validation_Error_Taxonomy::get_error_title_from_code( $validation_error );
 			$accept_all_url   = wp_nonce_url(
 				add_query_arg(
 					[

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -566,7 +566,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'user_has_cap', [ self::TESTED_CLASS, 'filter_user_has_cap_for_hiding_term_list_table_checkbox' ] ) );
 		$this->assertEquals( 10, has_filter( 'terms_clauses', [ self::TESTED_CLASS, 'filter_terms_clauses_for_description_search' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_notices', [ self::TESTED_CLASS, 'add_admin_notices' ] ) );
-		$this->assertEquals( 10, has_filter( 'tag_row_actions', [ self::TESTED_CLASS, 'filter_tag_row_actions' ] ) );
+		$this->assertEquals( 10, has_filter( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_row_actions', [ self::TESTED_CLASS, 'filter_tag_row_actions' ] ) );
 		$this->assertEquals( 10, has_action( 'admin_menu', [ self::TESTED_CLASS, 'add_admin_menu_validation_error_item' ] ) );
 		$this->assertEquals( 10, has_filter( 'parse_term_query', [ self::TESTED_CLASS, 'parse_post_php_term_query' ] ) );
 		$this->assertEquals( 10, has_filter( 'manage_' . AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG . '_custom_column', [ self::TESTED_CLASS, 'filter_manage_custom_columns' ] ) );
@@ -989,10 +989,6 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$initial_actions = [
 			'delete' => '<a href="#">Delete</a>',
 		];
-
-		// When the term isn't for the invalid post type taxonomy, the actions shouldn't be altered.
-		$term_other_taxonomy = self::factory()->term->create_and_get();
-		$this->assertEquals( $initial_actions, AMP_Validation_Error_Taxonomy::filter_tag_row_actions( $initial_actions, $term_other_taxonomy ) );
 
 		// The term is for this taxonomy, so this should filter the actions.
 		$term_this_taxonomy = self::factory()->term->create_and_get(


### PR DESCRIPTION
## Summary

At present the list of validation errors for scripts is not helpful at all because it just says “Invalid Element: `<script>`” over and over again. You have to expand it to figure out what it is for. We can improve that by having it instead say “Invalid script” and then provide the basename of the script being included.

### Validated URL Screen

Before | After
-------|------
![wordpressdev lndo site_core-dev_src_wp-admin_post php_post=2371 action=edit](https://user-images.githubusercontent.com/134745/68710690-e07a8280-054c-11ea-85d1-816fc5acc76a.png) | ![wordpressdev lndo site_core-dev_src_wp-admin_post php_post=2371 action=edit amp_urls_tested=1 amp_remaining_errors=0](https://user-images.githubusercontent.com/134745/68710720-eec89e80-054c-11ea-9851-c8a6d73ad2c0.png)

### Validation Error Index Screen

Before | After
-------|------
![wordpressdev lndo site_core-dev_src_wp-admin_edit-tags php_taxonomy=amp_validation_error post_type=amp_validated_url (1)](https://user-images.githubusercontent.com/134745/68710758-ff791480-054c-11ea-97f0-21e8fa0afeb1.png) | ![wordpressdev lndo site_core-dev_src_wp-admin_edit-tags php_taxonomy=amp_validation_error post_type=amp_validated_url (2)](https://user-images.githubusercontent.com/134745/68710836-2df6ef80-054d-11ea-9874-0ca53d762fdc.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
