### PR TITLE
Use length property instead of PHP≥7.2 count() method on DOMNodeList

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1594,7 +1594,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	public function add_twentytwenty_modals() {
 		$modals = $this->xpath->query( "//*[ @class and contains( concat( ' ', normalize-space( @class ), ' ' ), ' cover-modal ' ) ]" );
 
-		if ( false === $modals || 0 === $modals->count() ) {
+		if ( false === $modals || 0 === $modals->length ) {
 			return;
 		}
 
@@ -1672,7 +1672,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 		$toggles = $this->xpath->query( '//*[ @data-toggle-target ]' );
 		$body_id = AMP_DOM_Utils::get_element_id( $this->get_body_node(), 'body' );
 
-		if ( false === $toggles || 0 === $toggles->count() ) {
+		if ( false === $toggles || 0 === $toggles->length ) {
 			return;
 		}
 


### PR DESCRIPTION
## Summary

This fixes an issue reported in the support forums: https://wordpress.org/support/topic/error-1275/:

```
Fatal error: Uncaught Error: Call to undefined method DOMNodeList::count() in .../includes/sanitizers/class-amp-core-theme-sanitizer.php:1597 Stack trace: 
#0 .../includes/sanitizers/class-amp-core-theme-sanitizer.php(522): AMP_Core_Theme_Sanitizer->add_twentytwenty_modals(Array) 
#1 .../includes/templates/class-amp-content-sanitizer.php(117): AMP_Core_Theme_Sanitizer->sanitize() 
#2 .../includes/class-amp-theme-support.php(2275): AMP_Content_Sanitizer::sanitize_document(Object(DOMDocument), Array, Array) 
#3 .../includes/class-amp-theme-support.php(1963): AMP_Theme_Support::prepare_response(‘<!DOCTYPE html>…’) 
#4 [internal function]: AMP_Theme_Support::finish_output_buffering(‘<!DOCTYPE html>…’, 9) 
#5 /home2/gustavors/public_html/wp-includes/functions.php(4483): ob_end_flush() 
#6 /home in .../includes/sanitizers/class-amp-core-theme-sanitizer.php on line 1597
```

While not stated in the [`DOMNodeList` docs](https://www.php.net/manual/en/class.domnodelist.php), it appears that the `count()` method was introduced in PHP 7.2 because this is when the class became `Countable`:

> The Countable interface is implemented and returns the value of the length property.

Therefore, to be compatible with older versions of PHP we must use `length` instead of `count()`. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
