### PR TITLE
Validate height, width & layout attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,16 +128,16 @@ jobs:
       php: "5.6"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit,phpsyntax                      INSTALL_PWA_PLUGIN=1
 
-    - name: PHP unit tests (5.6, WordPress 5.1)
-      php: "5.6"
+    - name: PHP unit tests (5.4, WordPress 5.1)
+      php: "5.4"
       env: WP_VERSION=5.1    DEV_LIB_ONLY=phpunit
 
     - name: PHP unit tests (5.5, WordPress 5.0)
       php: "5.5"
       env: WP_VERSION=5.0    DEV_LIB_ONLY=phpunit,phpsyntax
 
-    - name: PHP unit tests w/ external-http (5.4, WordPress 4.9)
-      php: "5.4"
+    - name: PHP unit tests w/ external-http (5.6, WordPress 4.9)
+      php: "5.6"
       env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax                     PHPUNIT_EXTRA_GROUP=external-http
 
     - name: PHP unit tests (7.3, WordPress trunk)

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -916,6 +916,7 @@ function amp_get_content_sanitizers( $post = null ) {
 			'include_manifest_comment' => ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? 'always' : 'when_excessive',
 		],
 		'AMP_Meta_Sanitizer'              => [],
+		'AMP_Layout_Sanitizer'            => [],
 		'AMP_Tag_And_Attribute_Sanitizer' => [], // Note: This whitelist sanitizer must come at the end to clean up any remaining issues the other sanitizers didn't catch.
 	];
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1348,7 +1348,10 @@ function amp_generate_script_hash( $script ) {
 }
 
 /**
- * Check if an HTML attribute has a value.
+ * Validate that an HTML attribute is empty.
+ *
+ * The function `empty()` can't be used instead as it returns true for the values
+ * `0` (int), `"0"` (string), and `0.0` (float), all of which are valid attribute values.
  *
  * @param string $attribute Attribute value.
  * @return bool

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1347,6 +1347,16 @@ function amp_generate_script_hash( $script ) {
 	return 'sha384-' . $hash;
 }
 
+/**
+ * Check if an HTML attribute has a value.
+ *
+ * @param string $attribute Attribute value.
+ * @return bool
+ */
+function amp_is_attribute_empty( $attribute ) {
+	return ! isset( $attribute ) || '' === $attribute;
+}
+
 /*
  * The function below is copied from the ramsey/array_column package.
  *

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1348,19 +1348,6 @@ function amp_generate_script_hash( $script ) {
 	return 'sha384-' . $hash;
 }
 
-/**
- * Validate that an HTML attribute is empty.
- *
- * The function `empty()` can't be used instead as it returns true for the values
- * `0` (int), `"0"` (string), and `0.0` (float), all of which are valid attribute values.
- *
- * @param string $attribute Attribute value.
- * @return bool
- */
-function amp_is_attribute_empty( $attribute ) {
-	return ! isset( $attribute ) || '' === $attribute;
-}
-
 /*
  * The function below is copied from the ramsey/array_column package.
  *

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -88,6 +88,7 @@ class AMP_Autoloader {
 		'AMP_Style_Sanitizer'                => 'includes/sanitizers/class-amp-style-sanitizer',
 		'AMP_Script_Sanitizer'               => 'includes/sanitizers/class-amp-script-sanitizer',
 		'AMP_Embed_Sanitizer'                => 'includes/sanitizers/class-amp-embed-sanitizer',
+		'AMP_Layout_Sanitizer'               => 'includes/sanitizers/class-amp-layout-sanitizer',
 		'AMP_Tag_And_Attribute_Sanitizer'    => 'includes/sanitizers/class-amp-tag-and-attribute-sanitizer',
 		'AMP_Video_Sanitizer'                => 'includes/sanitizers/class-amp-video-sanitizer',
 		'AMP_Core_Theme_Sanitizer'           => 'includes/sanitizers/class-amp-core-theme-sanitizer',

--- a/includes/class-amp-autoloader.php
+++ b/includes/class-amp-autoloader.php
@@ -104,6 +104,7 @@ class AMP_Autoloader {
 		'AMP_Validation_Callback_Wrapper'    => 'includes/validation/class-amp-validation-callback-wrapper',
 		'AMP_Validated_URL_Post_Type'        => 'includes/validation/class-amp-validated-url-post-type',
 		'AMP_Validation_Error_Taxonomy'      => 'includes/validation/class-amp-validation-error-taxonomy',
+		'AMP_CSS_Length'                     => 'includes/validation/class-amp-css-length',
 		'AMP_CLI_Namespace'                  => 'includes/cli/class-amp-cli-namespace',
 		'AMP_CLI_Validation_Command'         => 'includes/cli/class-amp-cli-validation-command',
 		'AMP_String_Utils'                   => 'includes/utils/class-amp-string-utils',

--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -21,6 +21,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 		'core/categories' => 'ampify_categories_block',
 		'core/archives'   => 'ampify_archives_block',
 		'core/video'      => 'ampify_video_block',
+		'core/cover'      => 'ampify_cover_block',
 	];
 
 	/**
@@ -153,6 +154,28 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 			);
 		}
 
+		return $block_content;
+	}
+
+	/**
+	 * Ampify cover block.
+	 *
+	 * This specifically fixes the layout of the block when a background video is assigned.
+	 *
+	 * @see \AMP_Video_Sanitizer::filter_video_dimensions()
+	 *
+	 * @param string $block_content The block content about to be appended.
+	 * @param array  $block         The full block, including name and attributes.
+	 * @return string Filtered block content.
+	 */
+	public function ampify_cover_block( $block_content, $block ) {
+		if ( isset( $block['attrs']['backgroundType'] ) && 'video' === $block['attrs']['backgroundType'] ) {
+			$block_content = preg_replace(
+				'/(?<=<video\s)/',
+				'layout="fill" object-fit="cover" ',
+				$block_content
+			);
+		}
 		return $block_content;
 	}
 }

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -192,6 +192,7 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		$attributes = [
 			// The layout sanitizer will convert this to `layout` when being sanitized.
+			// The data attribute needs to be used so that the layout sanitizer will process it.
 			'data-amp-layout' => 'responsive',
 			'width'           => $node->hasAttribute( 'data-width' ) ? $node->getAttribute( 'data-width' ) : $this->DEFAULT_WIDTH,
 			'height'          => $node->hasAttribute( 'data-height' ) ? $node->getAttribute( 'data-height' ) : $this->DEFAULT_HEIGHT,

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -195,10 +195,6 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 			'width'  => $node->hasAttribute( 'data-width' ) ? $node->getAttribute( 'data-width' ) : $this->DEFAULT_WIDTH,
 			'height' => $node->hasAttribute( 'data-height' ) ? $node->getAttribute( 'data-height' ) : $this->DEFAULT_HEIGHT,
 		];
-		if ( '100%' === $attributes['width'] ) {
-			$attributes['layout'] = 'fixed-height';
-			$attributes['width']  = 'auto';
-		}
 
 		$node->removeAttribute( 'data-width' );
 		$node->removeAttribute( 'data-height' );

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -191,9 +191,10 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	private function create_amp_facebook_and_replace_node( Document $dom, DOMElement $node, $embed_type ) {
 
 		$attributes = [
-			'layout' => 'responsive',
-			'width'  => $node->hasAttribute( 'data-width' ) ? $node->getAttribute( 'data-width' ) : $this->DEFAULT_WIDTH,
-			'height' => $node->hasAttribute( 'data-height' ) ? $node->getAttribute( 'data-height' ) : $this->DEFAULT_HEIGHT,
+			// The layout sanitizer will convert this to `layout` when being sanitized.
+			'data-amp-layout' => 'responsive',
+			'width'           => $node->hasAttribute( 'data-width' ) ? $node->getAttribute( 'data-width' ) : $this->DEFAULT_WIDTH,
+			'height'          => $node->hasAttribute( 'data-height' ) ? $node->getAttribute( 'data-height' ) : $this->DEFAULT_HEIGHT,
 		];
 
 		$node->removeAttribute( 'data-width' );

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -335,14 +335,18 @@ abstract class AMP_Base_Sanitizer {
 			}
 		}
 
-		if ( empty( $attributes['height'] ) ) {
-			unset( $attributes['width'] );
-			$attributes['height'] = self::FALLBACK_HEIGHT;
-		}
-
-		if ( empty( $attributes['width'] ) || '100%' === $attributes['width'] ) {
-			$attributes['layout'] = 'fixed-height';
-			$attributes['width']  = 'auto';
+		if ( isset( $attributes['width'], $attributes['height'] ) && '100%' === $attributes['width'] && '100%' === $attributes['height'] ) {
+			unset( $attributes['width'], $attributes['height'] );
+			$attributes['layout'] = 'fill';
+		} else {
+			if ( empty( $attributes['height'] ) ) {
+				unset( $attributes['width'] );
+				$attributes['height'] = self::FALLBACK_HEIGHT;
+			}
+			if ( empty( $attributes['width'] ) || '100%' === $attributes['width'] ) {
+				$attributes['layout'] = 'fixed-height';
+				$attributes['width']  = 'auto';
+			}
 		}
 
 		return $attributes;

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -249,6 +249,16 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Determine if an attribute is empty.
+	 *
+	 * @param string $attribute Attribute value.
+	 * @return bool True if empty, false if not.
+	 */
+	public function attr_empty( $attribute ) {
+		return ! isset( $attribute ) || '' === $attribute;
+	}
+
+	/**
 	 * Sets the layout, and possibly the 'height' and 'width' attributes.
 	 *
 	 * @param array $attributes {

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -326,9 +326,11 @@ abstract class AMP_Base_Sanitizer {
 				&& '100%' === $attributes['width']
 				&& '100%' === $attributes['height']
 			) {
-				unset( $attributes['style'], $attributes['width'], $attributes['height'] );
+				unset( $attributes['style'], $styles['position'], $attributes['width'], $attributes['height'] );
+				if ( ! empty( $styles ) ) {
+					$attributes['style'] = $this->reassemble_style_string( $styles );
+				}
 				$attributes['layout'] = 'fill';
-				unset( $attributes['height'], $attributes['width'] );
 				return $attributes;
 			}
 		}

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -254,7 +254,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @param string $attribute Attribute value.
 	 * @return bool True if empty, false if not.
 	 */
-	public function attr_empty( $attribute ) {
+	public function attribute_empty( $attribute ) {
 		return ! isset( $attribute ) || '' === $attribute;
 	}
 

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -249,13 +249,13 @@ abstract class AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Determine if an attribute is empty.
+	 * Determine if an attribute value is empty.
 	 *
-	 * @param string $attribute Attribute value.
+	 * @param string|null $value Attribute value.
 	 * @return bool True if empty, false if not.
 	 */
-	public function attribute_empty( $attribute ) {
-		return ! isset( $attribute ) || '' === $attribute;
+	public function is_empty_attribute_value( $value ) {
+		return ! isset( $value ) || '' === $value;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -254,11 +254,15 @@ abstract class AMP_Base_Sanitizer {
 	 * @param array $attributes {
 	 *      Attributes.
 	 *
+	 *      @type string     $bottom
 	 *      @type int|string $height
-	 *      @type int|string $width
-	 *      @type string     $sizes
-	 *      @type string     $class
 	 *      @type string     $layout
+	 *      @type string     $left
+	 *      @type string     $position
+	 *      @type string     $right
+	 *      @type string     $style
+	 *      @type string     $top
+	 *      @type int|string $width
 	 * }
 	 * @return array Attributes.
 	 */

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -18,7 +18,7 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function sanitize() {
 		$xpath = new DOMXPath( $this->dom );
-		$nodes = $xpath->query( '//*[ @layout or @data-amp-layout ]' );
+		$nodes = $xpath->query( '//*[ ( @data-amp-layout ) and ( @width or @height ) ]' );
 
 		foreach ( $nodes as $node ) {
 			$width  = $node->getAttribute( 'width' );

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -33,7 +33,7 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( 'data-amp-layout' );
 			}
 
-			if ( ! $this->attr_empty( $style ) ) {
+			if ( ! $this->attribute_empty( $style ) ) {
 				$styles = $this->parse_style_string( $style );
 
 				// If both height & width descriptors are 100%, apply fill layout.

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -36,12 +36,29 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 			if ( ! $this->attribute_empty( $style ) ) {
 				$styles = $this->parse_style_string( $style );
 
-				// If both height & width descriptors are 100%, apply fill layout.
+				/*
+				 * If both height & width descriptors are 100%, or
+				 *    width attribute is 100% and height style descriptor is 100%, or
+				 *    height attribute is 100% and width style descriptor is 100%
+				 * then apply fill layout.
+				 */
 				if (
-					isset( $styles['width'], $styles['height'] ) &&
-					( '100%' === $styles['width'] && '100%' === $styles['height'] )
+					(
+						isset( $styles['width'], $styles['height'] ) &&
+						( '100%' === $styles['width'] && '100%' === $styles['height'] )
+					) ||
+					(
+						( ! $this->attribute_empty( $width ) && '100%' === $width ) &&
+						( isset( $styles['height'] ) && '100%' === $styles['height'] )
+					) ||
+					(
+						( ! $this->attribute_empty( $height ) && '100%' === $height ) &&
+						( isset( $styles['width'] ) && '100%' === $styles['width'] )
+					)
 				) {
 					unset( $styles['width'], $styles['height'] );
+					$node->removeAttribute( 'width' );
+					$node->removeAttribute( 'height' );
 
 					if ( empty( $styles ) ) {
 						$node->removeAttribute( 'style' );

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -18,7 +18,8 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function sanitize() {
 		$xpath = new DOMXPath( $this->dom );
-		$nodes = $xpath->query( '//*[ ( @data-amp-layout ) and ( @width or @height ) ]' );
+		// Elements with the `layout` attribute will be validated by `AMP_Tag_And_Attribute_Sanitizer`.
+		$nodes = $xpath->query( '//*[ not( @layout ) and ( @data-amp-layout or @width or @height ) ]' );
 
 		foreach ( $nodes as $node ) {
 			$width  = $node->getAttribute( 'width' );

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class AMP_Layout_Sanitizer
+ *
+ * @since 1.5.0
+ * @package AMP
+ */
+
+/**
+ * Class AMP_Layout_Sanitizer
+ *
+ * @since 1.5.0
+ */
+class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
+
+	/**
+	 * Sanitize any element that has the `layout` or `data-amp-layout` attribute.
+	 */
+	public function sanitize() {
+		$xpath = new DOMXPath( $this->dom );
+		$nodes = $xpath->query( '//*[ @layout or @data-amp-layout ]' );
+
+		foreach ( $nodes as $node ) {
+			$width  = $node->getAttribute( 'width' );
+			$height = $node->getAttribute( 'height' );
+
+			// The `layout` attribute can also be defined through the `data-amp-layout` attribute.
+			if ( $node->hasAttribute( 'data-amp-layout' ) ) {
+				$layout = $node->getAttribute( 'data-amp-layout' );
+				$node->setAttribute( 'layout', $layout );
+				$node->removeAttribute( 'data-amp-layout' );
+			}
+
+			// If the width & height are `100%` the layout must be `fill`.
+			if ( '100%' === $width && '100%' === $height ) {
+				$node->removeAttribute( 'width' );
+				$node->removeAttribute( 'height' );
+				$node->setAttribute( 'layout', AMP_Rule_Spec::LAYOUT_FILL );
+				return;
+			}
+
+			// If the width is `100%`, convert the layout to `fixed-height` and width to `auto`.
+			if ( '100%' === $width ) {
+				$node->setAttribute( 'width', 'auto' );
+				$node->setAttribute( 'layout', AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT );
+			}
+		}
+
+		$this->did_convert_elements = true;
+	}
+}

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -19,6 +19,7 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	public function sanitize() {
 		$xpath = new DOMXPath( $this->dom );
+
 		// Elements with the `layout` attribute will be validated by `AMP_Tag_And_Attribute_Sanitizer`.
 		$nodes = $xpath->query( '//*[ not( @layout ) and ( @data-amp-layout or @width or @height or @style ) ]' );
 
@@ -28,6 +29,8 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 			 *
 			 * @var DOMElement $node
 			 */
+
+			// Layout does not apply inside of noscript.
 			if ( $this->is_inside_amp_noscript( $node ) ) {
 				continue;
 			}
@@ -43,7 +46,7 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( 'data-amp-layout' );
 			}
 
-			if ( ! $this->attribute_empty( $style ) ) {
+			if ( ! $this->is_empty_attribute_value( $style ) ) {
 				$styles = $this->parse_style_string( $style );
 
 				/*
@@ -58,11 +61,11 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 						( '100%' === $styles['width'] && '100%' === $styles['height'] )
 					) ||
 					(
-						( ! $this->attribute_empty( $width ) && '100%' === $width ) &&
+						( ! $this->is_empty_attribute_value( $width ) && '100%' === $width ) &&
 						( isset( $styles['height'] ) && '100%' === $styles['height'] )
 					) ||
 					(
-						( ! $this->attribute_empty( $height ) && '100%' === $height ) &&
+						( ! $this->is_empty_attribute_value( $height ) && '100%' === $height ) &&
 						( isset( $styles['width'] ) && '100%' === $styles['width'] )
 					)
 				) {
@@ -102,7 +105,7 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @param DOMElement $node Node.
 	 */
-	private function set_layout_fill( $node ) {
+	private function set_layout_fill( DOMElement $node ) {
 		if ( $node->hasAttribute( 'width' ) && $node->hasAttribute( 'height' ) ) {
 			$node->removeAttribute( 'width' );
 			$node->removeAttribute( 'height' );

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -19,11 +19,12 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 	public function sanitize() {
 		$xpath = new DOMXPath( $this->dom );
 		// Elements with the `layout` attribute will be validated by `AMP_Tag_And_Attribute_Sanitizer`.
-		$nodes = $xpath->query( '//*[ not( @layout ) and ( @data-amp-layout or @width or @height ) ]' );
+		$nodes = $xpath->query( '//*[ not( @layout ) and ( @data-amp-layout or @width or @height or @style ) ]' );
 
 		foreach ( $nodes as $node ) {
 			$width  = $node->getAttribute( 'width' );
 			$height = $node->getAttribute( 'height' );
+			$style  = $node->getAttribute( 'style' );
 
 			// The `layout` attribute can also be defined through the `data-amp-layout` attribute.
 			if ( $node->hasAttribute( 'data-amp-layout' ) ) {
@@ -32,12 +33,31 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 				$node->removeAttribute( 'data-amp-layout' );
 			}
 
-			// If the width & height are `100%` the layout must be `fill`.
+			if ( ! $this->attr_empty( $style ) ) {
+				$styles = $this->parse_style_string( $style );
+
+				// If both height & width descriptors are 100%, apply fill layout.
+				if (
+					isset( $styles['width'], $styles['height'] ) &&
+					( '100%' === $styles['width'] && '100%' === $styles['height'] )
+				) {
+					unset( $styles['width'], $styles['height'] );
+
+					if ( empty( $styles ) ) {
+						$node->removeAttribute( 'style' );
+					} else {
+						$node->setAttribute( 'style', $this->reassemble_style_string( $styles ) );
+					}
+
+					$this->set_layout_fill( $node );
+					continue;
+				}
+			}
+
+			// If the width & height are `100%` then apply fill layout.
 			if ( '100%' === $width && '100%' === $height ) {
-				$node->removeAttribute( 'width' );
-				$node->removeAttribute( 'height' );
-				$node->setAttribute( 'layout', AMP_Rule_Spec::LAYOUT_FILL );
-				return;
+				$this->set_layout_fill( $node );
+				continue;
 			}
 
 			// If the width is `100%`, convert the layout to `fixed-height` and width to `auto`.
@@ -48,5 +68,21 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		$this->did_convert_elements = true;
+	}
+
+	/**
+	 * Apply the `fill` layout.
+	 *
+	 * @param DOMElement $node Node.
+	 */
+	private function set_layout_fill( $node ) {
+		if ( $node->hasAttribute( 'width' ) && $node->hasAttribute( 'height' ) ) {
+			$node->removeAttribute( 'width' );
+			$node->removeAttribute( 'height' );
+		}
+
+		if ( AMP_Rule_Spec::LAYOUT_FILL !== $node->getAttribute( 'layout' ) ) {
+			$node->setAttribute( 'layout', AMP_Rule_Spec::LAYOUT_FILL );
+		}
 	}
 }

--- a/includes/sanitizers/class-amp-layout-sanitizer.php
+++ b/includes/sanitizers/class-amp-layout-sanitizer.php
@@ -12,6 +12,7 @@
  * @since 1.5.0
  */
 class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
+	use AMP_Noscript_Fallback;
 
 	/**
 	 * Sanitize any element that has the `layout` or `data-amp-layout` attribute.
@@ -22,6 +23,15 @@ class AMP_Layout_Sanitizer extends AMP_Base_Sanitizer {
 		$nodes = $xpath->query( '//*[ not( @layout ) and ( @data-amp-layout or @width or @height or @style ) ]' );
 
 		foreach ( $nodes as $node ) {
+			/**
+			 * Element.
+			 *
+			 * @var DOMElement $node
+			 */
+			if ( $this->is_inside_amp_noscript( $node ) ) {
+				continue;
+			}
+
 			$width  = $node->getAttribute( 'width' );
 			$height = $node->getAttribute( 'height' );
 			$style  = $node->getAttribute( 'style' );

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -54,6 +54,19 @@ abstract class AMP_Rule_Spec {
 	const VALUE_URL               = 'value_url';
 
 	/**
+	 * AMP layout types
+	 */
+	const LAYOUT_NODISPLAY    = 'nodisplay';
+	const LAYOUT_FIXED        = 'fixed';
+	const LAYOUT_FIXED_HEIGHT = 'fixed-height';
+	const LAYOUT_RESPONSIVE   = 'responsive';
+	const LAYOUT_CONTAINER    = 'container';
+	const LAYOUT_FILL         = 'fill';
+	const LAYOUT_FLEX_ITEM    = 'flex-item';
+	const LAYOUT_FLUID        = 'fluid';
+	const LAYOUT_INTRINSIC    = 'intrinsic';
+
+	/**
 	 * Attribute name for AMP dev mode.
 	 *
 	 * @since 1.2.2

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -11,15 +11,14 @@
  * Set of constants used throughout the sanitizer.
  */
 abstract class AMP_Rule_Spec {
-
-	/**
+	/*
 	 * AMP rule_spec types
 	 */
 	const ATTR_SPEC_LIST = 'attr_spec_list';
 	const TAG_SPEC       = 'tag_spec';
 	const CDATA          = 'cdata';
 
-	/**
+	/*
 	 * AMP attr_spec value check results.
 	 *
 	 * In 0.7 these changed from strings to integers to speed up comparisons.
@@ -28,7 +27,7 @@ abstract class AMP_Rule_Spec {
 	const FAIL           = 0;
 	const NOT_APPLICABLE = -1;
 
-	/**
+	/*
 	 * HTML Element Tag rule names
 	 */
 	const DISALLOWED_ANCESTOR = 'disallowed_ancestor';
@@ -37,7 +36,7 @@ abstract class AMP_Rule_Spec {
 	const DESCENDANT_TAG_LIST = 'descendant_tag_list';
 	const CHILD_TAGS          = 'child_tags';
 
-	/**
+	/*
 	 * HTML Element Attribute rule names
 	 */
 	const ALLOW_EMPTY             = 'allow_empty';
@@ -53,7 +52,7 @@ abstract class AMP_Rule_Spec {
 	const VALUE_PROPERTIES        = 'value_properties';
 	const VALUE_URL               = 'value_url';
 
-	/**
+	/*
 	 * AMP layout types
 	 */
 	const LAYOUT_NODISPLAY    = 'nodisplay';

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -646,9 +646,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			}
 		}
 
-		// Fix any values for width & height that may be AMP incompatible.
-		$this->adapt_dimensions_to_layout( $node );
-
 		// Identify attribute values that don't conform to the attr_spec.
 		$disallowed_attributes = $this->sanitize_disallowed_attribute_values_in_node( $node, $tag_spec, $merged_attr_spec_list );
 
@@ -1049,39 +1046,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			);
 		} else {
 			return $element->nodeName;
-		}
-	}
-
-	/**
-	 * Adapt width and height to conform to the AMP layout.
-	 *
-	 * @param DOMElement $node Node.
-	 */
-	private function adapt_dimensions_to_layout( DOMElement $node ) {
-		if ( $node->hasAttribute( 'layout' ) ) {
-			$width  = $node->getAttribute( 'width' );
-			$height = $node->getAttribute( 'height' );
-
-			// The `layout` attribute can also be defined through the `data-amp-layout` attribute.
-			if ( $node->hasAttribute( 'data-amp-layout' ) ) {
-				$layout = $node->getAttribute( 'data-amp-layout' );
-				$node->setAttribute( 'layout', $layout );
-				$node->removeAttribute( 'data-amp-layout' );
-			}
-
-			// If the width & height are `100%` the layout must be `fill`.
-			if ( '100%' === $width && '100%' === $height ) {
-				$node->removeAttribute( 'width' );
-				$node->removeAttribute( 'height' );
-				$node->setAttribute( 'layout', AMP_Rule_Spec::LAYOUT_FILL );
-				return;
-			}
-
-			// If the width is `100%`, convert the layout to `fixed-height` and width to `auto`.
-			if ( '100%' === $width ) {
-				$node->setAttribute( 'width', 'auto' );
-				$node->setAttribute( 'layout', AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT );
-			}
 		}
 	}
 

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1162,7 +1162,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
 	 * Validates the layout attributes for the given tag. This involves checking the
-	 * layout, width, height, sizes attributes with AMP specific logic.
+	 * layout, width, height and sizes attributes with AMP specific logic.
 	 *
 	 * @version 1911070201440
 	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3937
@@ -1180,7 +1180,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return true;
 		}
 
-		// Elements without a width nor height don't need to be validated.
+		// Elements without a width or height don't need to be validated.
 		if ( ! $node->hasAttribute( 'width' ) && ! $node->hasAttribute( 'height' ) ) {
 			return true;
 		}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1291,7 +1291,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return false;
 		}
 
-		// RESPONSIVE only allows heights attribute.
+		// Heights attribute is only allowed for RESPONSIVE layout.
 		if ( ( isset( $heights_attr ) && '' !== $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
 			return false;
 		}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1317,7 +1317,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @return AMP_CSS_Length
 	 */
-	private function calculate_width( $amp_layout_spec, $input_layout, $input_width ) {
+	private function calculate_width( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_width ) {
 		if (
 			(
 				( isset( $input_layout ) && '' !== $input_layout ) ||
@@ -1347,7 +1347,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @return AMP_CSS_Length
 	 */
-	private function calculate_height( $amp_layout_spec, $input_layout, $input_height ) {
+	private function calculate_height( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_height ) {
 		if (
 			(
 				( ( isset( $input_layout ) && '' !== $input_layout ) ) ||
@@ -1382,7 +1382,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string         $heights_attr Heights attribute.
 	 * @return string Layout type.
 	 */
-	private function calculate_layout( $layout_attr, $width, $height, $sizes_attr, $heights_attr ) {
+	private function calculate_layout( $layout_attr, AMP_CSS_Length $width, AMP_CSS_Length $height, $sizes_attr, $heights_attr ) {
 		if ( isset( $layout_attr ) && '' !== $layout_attr ) {
 			return $layout_attr;
 		} elseif ( ! $width->is_set() && ! $height->is_set() ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1204,6 +1204,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * Validates the layout for the given tag. This involves checking the
 	 * layout, width, height, sizes attributes with AMP specific logic.
 	 *
+	 * @version 1911070201440
+	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3937
+	 *
+	 * Adapted from the <code>validateLayout</code> method found in validator.js of the
+	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 *
 	 * @param array[][]  $tag_spec Tag spec list.
 	 * @param DOMElement $node     Tag to validate.
 	 * @return bool True if layout is valid, false if validation fails.
@@ -1300,6 +1306,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * amp-pixel, have natural dimensions (browser or implementation-specific
 	 * defaults for width / height).
 	 *
+	 * Adapted from the <code>CalculateWidth</code> method found in validator.js of the
+	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 *
+	 * @version 1911070201440
+	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3451
+	 *
 	 * @param array          $amp_layout_spec AMP layout specifications for tag.
 	 * @param string         $input_layout    Layout for tag.
 	 * @param AMP_CSS_Length $input_width     Parsed width.
@@ -1323,6 +1335,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 	/**
 	 * Calculates the effective height from input layout and input height.
+	 *
+	 * Adapted from the <code>CalculateHeight</code> method found in validator.js of the
+	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 *
+	 * @version 1911070201440
+	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3493
 	 *
 	 * @param array          $amp_layout_spec AMP layout specifications for tag.
 	 * @param string         $input_layout    Layout for tag.
@@ -1351,6 +1369,12 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * calculation above. It happens last because web designers often make
 	 * fixed-sized mocks first and then the layout determines how things
 	 * will change for different viewports / devices / etc.
+	 *
+	 * Adapted from the <code>CalculateLayout</code> method found in validator.js of the
+	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 *
+	 * @version 1911070201440
+	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3516
 	 *
 	 * @param string         $layout_attr  Layout attribute.
 	 * @param AMP_CSS_Length $width        Parsed width.

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1258,7 +1258,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Heights attribute is only allowed for RESPONSIVE layout.
-		if ( ( isset( $heights_attr ) && '' !== $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
+		if ( ! $this->attr_empty( $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
 			return false;
 		}
 
@@ -1285,10 +1285,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function calculate_width( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_width ) {
 		if (
-			(
-				( isset( $input_layout ) && '' !== $input_layout ) ||
-				AMP_Rule_Spec::LAYOUT_FIXED === $input_layout
-			) &&
+			( ! $this->attr_empty( $input_layout ) || AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ) &&
 			! $input_width->is_set() &&
 			isset( $amp_layout_spec['defines_default_width'] )
 		) {
@@ -1318,7 +1315,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function calculate_height( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_height ) {
 		if (
 			(
-				( isset( $input_layout ) && '' !== $input_layout ) ||
+				! $this->attr_empty( $input_layout ) ||
 				AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ||
 				AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $input_layout
 			) &&
@@ -1353,7 +1350,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string Layout type.
 	 */
 	private function calculate_layout( $layout_attr, AMP_CSS_Length $width, AMP_CSS_Length $height, $sizes_attr, $heights_attr ) {
-		if ( isset( $layout_attr ) && '' !== $layout_attr ) {
+		if ( ! $this->attr_empty( $layout_attr ) ) {
 			return $layout_attr;
 		} elseif ( ! $width->is_set() && ! $height->is_set() ) {
 			return AMP_Rule_Spec::LAYOUT_CONTAINER;
@@ -1365,10 +1362,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT;
 		} elseif (
 			$height->is_set() && $width->is_set() &&
-			(
-				( isset( $sizes_attr ) && '' !== $sizes_attr ) ||
-				( isset( $heights_attr ) && '' !== $heights_attr )
-			)
+			( ! $this->attr_empty( $sizes_attr ) || ! $this->attr_empty( $heights_attr ) )
 		) {
 			return AMP_Rule_Spec::LAYOUT_RESPONSIVE;
 		} else {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1058,11 +1058,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMElement $node Node.
 	 */
 	private function adapt_dimensions_to_layout( DOMElement $node ) {
-		$layout = $node->getAttribute( 'layout' );
-
-		if ( ! amp_is_attribute_empty( $layout ) ) {
+		if ( $node->hasAttribute( 'layout' ) ) {
 			$width  = $node->getAttribute( 'width' );
 			$height = $node->getAttribute( 'height' );
+
+			// The `layout` attribute can also be defined through the `data-amp-layout` attribute.
+			if ( $node->hasAttribute( 'data-amp-layout' ) ) {
+				$layout = $node->getAttribute( 'data-amp-layout' );
+				$node->setAttribute( 'layout', $layout );
+				$node->removeAttribute( 'data-amp-layout' );
+			}
 
 			// If the width & height are `100%` the layout must be `fill`.
 			if ( '100%' === $width && '100%' === $height ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1219,21 +1219,15 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		$allow_fluid = $node->hasAttribute( 'layout' ) ? AMP_Rule_Spec::LAYOUT_FLUID === $layout_attr : true;
 
 		// The layout is not validated as yet to allow for the width and height to be done first.
-		$input_width = new AMP_CSS_Length(
-			$node->getAttribute( 'width' ),
-			$allow_auto,
-			$allow_fluid
-		);
+		$input_width = new AMP_CSS_Length( $node->getAttribute( 'width' ) );
+		$input_width->validate( $allow_auto, $allow_fluid );
 
 		if ( ! $input_width->is_valid() ) {
 			return false;
 		}
 
-		$input_height = new AMP_CSS_Length(
-			$node->getAttribute( 'height' ),
-			$allow_auto,
-			$allow_fluid
-		);
+		$input_height = new AMP_CSS_Length( $node->getAttribute( 'height' ) );
+		$input_height->validate( $allow_auto, $allow_fluid );
 
 		if ( ! $input_height->is_valid() ) {
 			return false;
@@ -1332,7 +1326,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			! $input_width->is_set() &&
 			isset( $amp_layout_spec['defines_default_width'] )
 		) {
-			return new AMP_CSS_Length( '1px', false, false );
+			$css_length = new AMP_CSS_Length( '1px' );
+			$css_length->validate( false, false );
+			return $css_length;
 		}
 
 		return $input_width;
@@ -1363,7 +1359,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			! $input_height->is_set() &&
 			isset( $amp_layout_spec['defines_default_width'] )
 		) {
-			return new AMP_CSS_Length( '1px', false, false );
+			$css_length = new AMP_CSS_Length( '1px' );
+			$css_length->validate( false, false );
+			return $css_length;
 		}
 
 		return $input_height;

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1167,8 +1167,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @version 1911070201440
 	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3937
 	 *
-	 * Adapted from the <code>validateLayout</code> method found in validator.js of the
-	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 * Adapted from the `validateLayout` method found in `validator.js` from the `ampproject/amphtml`
+	 * project on GitHub.
 	 *
 	 * @param array[][]  $tag_spec Tag spec list.
 	 * @param DOMElement $node     Tag to validate.
@@ -1271,8 +1271,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * amp-pixel, have natural dimensions (browser or implementation-specific
 	 * defaults for width / height).
 	 *
-	 * Adapted from the <code>CalculateWidth</code> method found in validator.js of the
-	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 * Adapted from the `CalculateWidth` method found in `validator.js` from the `ampproject/amphtml`
+	 * project on GitHub.
 	 *
 	 * @version 1911070201440
 	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3451
@@ -1300,8 +1300,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Calculates the effective height from input layout and input height.
 	 *
-	 * Adapted from the <code>CalculateHeight</code> method found in validator.js of the
-	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 * Adapted from the `CalculateHeight` method found in `validator.js` from the `ampproject/amphtml`
+	 * project on GitHub.
 	 *
 	 * @version 1911070201440
 	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3493
@@ -1336,8 +1336,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * fixed-sized mocks first and then the layout determines how things
 	 * will change for different viewports / devices / etc.
 	 *
-	 * Adapted from the <code>CalculateLayout</code> method found in validator.js of the
-	 * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+	 * Adapted from the `CalculateLayout` method found in `validator.js` from the `ampproject/amphtml`
+	 * project on GitHub.
 	 *
 	 * @version 1911070201440
 	 * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3516

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1258,7 +1258,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Heights attribute is only allowed for RESPONSIVE layout.
-		if ( ! $this->attr_empty( $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
+		if ( ! $this->attribute_empty( $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
 			return false;
 		}
 
@@ -1285,7 +1285,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function calculate_width( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_width ) {
 		if (
-			( ! $this->attr_empty( $input_layout ) || AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ) &&
+			( ! $this->attribute_empty( $input_layout ) || AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ) &&
 			! $input_width->is_set() &&
 			isset( $amp_layout_spec['defines_default_width'] )
 		) {
@@ -1315,7 +1315,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function calculate_height( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_height ) {
 		if (
 			(
-				! $this->attr_empty( $input_layout ) ||
+				! $this->attribute_empty( $input_layout ) ||
 				AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ||
 				AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $input_layout
 			) &&
@@ -1350,7 +1350,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string Layout type.
 	 */
 	private function calculate_layout( $layout_attr, AMP_CSS_Length $width, AMP_CSS_Length $height, $sizes_attr, $heights_attr ) {
-		if ( ! $this->attr_empty( $layout_attr ) ) {
+		if ( ! $this->attribute_empty( $layout_attr ) ) {
 			return $layout_attr;
 		} elseif ( ! $width->is_set() && ! $height->is_set() ) {
 			return AMP_Rule_Spec::LAYOUT_CONTAINER;
@@ -1362,7 +1362,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT;
 		} elseif (
 			$height->is_set() && $width->is_set() &&
-			( ! $this->attr_empty( $sizes_attr ) || ! $this->attr_empty( $heights_attr ) )
+			( ! $this->attribute_empty( $sizes_attr ) || ! $this->attribute_empty( $heights_attr ) )
 		) {
 			return AMP_Rule_Spec::LAYOUT_RESPONSIVE;
 		} else {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1318,7 +1318,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function calculate_height( $amp_layout_spec, $input_layout, AMP_CSS_Length $input_height ) {
 		if (
 			(
-				! amp_is_attribute_empty( $input_layout ) ||
+				( isset( $input_layout ) && '' !== $input_layout ) ||
 				AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ||
 				AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $input_layout
 			) &&

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1286,7 +1286,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			}
 
 			// RESPONSIVE only allows heights attribute.
-			if ( ! empty( $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
+			if ( ( isset( $heights_attr ) && '' !== $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
 				return false;
 			}
 		}
@@ -1308,7 +1308,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	private function calculate_width( $amp_layout_spec, $input_layout, $input_width ) {
 		if (
-			( ! empty( $input_layout ) || AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ) &&
+			(
+				( isset( $input_layout ) && '' !== $input_layout ) ||
+				AMP_Rule_Spec::LAYOUT_FIXED === $input_layout
+			) &&
 			! $input_width->is_set() &&
 			isset( $amp_layout_spec['defines_default_width'] )
 		) {
@@ -1330,7 +1333,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function calculate_height( $amp_layout_spec, $input_layout, $input_height ) {
 		if (
 			(
-				! empty( $input_layout ) ||
+				( ( isset( $input_layout ) && '' !== $input_layout ) ) ||
 				AMP_Rule_Spec::LAYOUT_FIXED === $input_layout ||
 				AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $input_layout
 			) &&
@@ -1357,7 +1360,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string Layout type.
 	 */
 	private function calculate_layout( $layout_attr, $width, $height, $sizes_attr, $heights_attr ) {
-		if ( ! empty( $layout_attr ) ) {
+		if ( isset( $layout_attr ) && '' !== $layout_attr ) {
 			return $layout_attr;
 		} elseif ( ! $width->is_set() && ! $height->is_set() ) {
 			return AMP_Rule_Spec::LAYOUT_CONTAINER;
@@ -1369,7 +1372,10 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT;
 		} elseif (
 			$height->is_set() && $width->is_set() &&
-			( ! empty( $sizes_attr ) || ! empty( $heights_attr ) )
+			(
+				( isset( $sizes_attr ) && '' !== $sizes_attr ) ||
+				( isset( $heights_attr ) && '' !== $heights_attr )
+			)
 		) {
 			return AMP_Rule_Spec::LAYOUT_RESPONSIVE;
 		} else {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1076,6 +1076,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return false;
 		} elseif (
 			$node->hasAttribute( 'layout' ) &&
+			isset( $tag_spec['amp_layout'] ) &&
 			! $this->is_valid_layout( $tag_spec, $node )
 		) {
 			// If the layout is invalid, the node should be removed.
@@ -1237,64 +1238,62 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return false;
 		}
 
-		if ( isset( $tag_spec['amp_layout'] ) ) {
-			$sizes_attr   = $node->getAttribute( 'sizes' );
-			$heights_attr = $node->getAttribute( 'heights' );
+		$sizes_attr   = $node->getAttribute( 'sizes' );
+		$heights_attr = $node->getAttribute( 'heights' );
 
-			// Now calculate the effective layout attributes.
-			$width  = $this->calculate_width( $tag_spec['amp_layout'], $layout_attr, $input_width );
-			$height = $this->calculate_height( $tag_spec['amp_layout'], $layout_attr, $input_height );
-			$layout = $this->calculate_layout( $layout_attr, $width, $height, $sizes_attr, $heights_attr );
+		// Now calculate the effective layout attributes.
+		$width  = $this->calculate_width( $tag_spec['amp_layout'], $layout_attr, $input_width );
+		$height = $this->calculate_height( $tag_spec['amp_layout'], $layout_attr, $input_height );
+		$layout = $this->calculate_layout( $layout_attr, $width, $height, $sizes_attr, $heights_attr );
 
-			// Only FLEX_ITEM allows for height to be set to auto.
-			if ( $height->is_auto() && AMP_Rule_Spec::LAYOUT_FLEX_ITEM !== $layout ) {
-				return false;
-			}
+		// Only FLEX_ITEM allows for height to be set to auto.
+		if ( $height->is_auto() && AMP_Rule_Spec::LAYOUT_FLEX_ITEM !== $layout ) {
+			return false;
+		}
 
-			// FIXED, FIXED_HEIGHT, INTRINSIC, RESPONSIVE must have height set.
-			if (
-				(
-					AMP_Rule_Spec::LAYOUT_FIXED === $layout ||
-					AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $layout ||
-					AMP_Rule_Spec::LAYOUT_INTRINSIC === $layout ||
-					AMP_Rule_Spec::LAYOUT_RESPONSIVE === $layout
-				) &&
-				! $height->is_set()
-			) {
-				return false;
-			}
-
-			// For FIXED_HEIGHT if width is set it must be auto.
-			if ( AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $layout && $width->is_set() && ! $width->is_auto() ) {
-				$node->setAttribute( 'width', 'auto' );
-			}
-
-			// FIXED, INTRINSIC, RESPONSIVE must have width set and not be auto.
-			if (
+		// FIXED, FIXED_HEIGHT, INTRINSIC, RESPONSIVE must have height set.
+		if (
+			(
 				AMP_Rule_Spec::LAYOUT_FIXED === $layout ||
+				AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $layout ||
 				AMP_Rule_Spec::LAYOUT_INTRINSIC === $layout ||
 				AMP_Rule_Spec::LAYOUT_RESPONSIVE === $layout
-			) {
-				if ( ! $width->is_set() || $width->is_auto() ) {
-					return false;
-				}
-			}
+			) &&
+			! $height->is_set()
+		) {
+			return false;
+		}
 
-			// INTRINSIC, RESPONSIVE must have same units for height and width.
-			if (
-				(
-					AMP_Rule_Spec::LAYOUT_INTRINSIC === $layout ||
-					AMP_Rule_Spec::LAYOUT_RESPONSIVE === $layout
-				) &&
-				$width->get_unit() !== $height->get_unit()
-			) {
+		// For FIXED_HEIGHT if width is set it must be auto.
+		if ( AMP_Rule_Spec::LAYOUT_FIXED_HEIGHT === $layout && $width->is_set() && ! $width->is_auto() ) {
+			$node->setAttribute( 'width', 'auto' );
+		}
+
+		// FIXED, INTRINSIC, RESPONSIVE must have width set and not be auto.
+		if (
+			AMP_Rule_Spec::LAYOUT_FIXED === $layout ||
+			AMP_Rule_Spec::LAYOUT_INTRINSIC === $layout ||
+			AMP_Rule_Spec::LAYOUT_RESPONSIVE === $layout
+		) {
+			if ( ! $width->is_set() || $width->is_auto() ) {
 				return false;
 			}
+		}
 
-			// RESPONSIVE only allows heights attribute.
-			if ( ( isset( $heights_attr ) && '' !== $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
-				return false;
-			}
+		// INTRINSIC, RESPONSIVE must have same units for height and width.
+		if (
+			(
+				AMP_Rule_Spec::LAYOUT_INTRINSIC === $layout ||
+				AMP_Rule_Spec::LAYOUT_RESPONSIVE === $layout
+			) &&
+			$width->get_unit() !== $height->get_unit()
+		) {
+			return false;
+		}
+
+		// RESPONSIVE only allows heights attribute.
+		if ( ( isset( $heights_attr ) && '' !== $heights_attr ) && AMP_Rule_Spec::LAYOUT_RESPONSIVE !== $layout ) {
+			return false;
 		}
 
 		return true;

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -195,29 +195,38 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return array Modified attributes.
 	 */
 	protected function filter_video_dimensions( $new_attributes, $src ) {
-		if ( empty( $new_attributes['width'] ) || empty( $new_attributes['height'] ) ) {
 
-			// Get the width and height from the file.
-			$path = wp_parse_url( $src, PHP_URL_PATH );
-			$ext  = pathinfo( $path, PATHINFO_EXTENSION );
-			$name = sanitize_title( wp_basename( $path, ".$ext" ) );
-			$args = [
-				'name'        => $name,
-				'post_type'   => 'attachment',
-				'post_status' => 'inherit',
-				'numberposts' => 1,
-			];
+		// Short-circuit if width and height are already defined.
+		if ( ! empty( $new_attributes['width'] ) && ! empty( $new_attributes['height'] ) ) {
+			return $new_attributes;
+		}
 
-			$attachment = get_posts( $args );
+		// Short-circuit if no width and height are required based on the layout.
+		$layout = isset( $new_attributes['layout'] ) ? $new_attributes['layout'] : null;
+		if ( in_array( $layout, [ 'fill', 'nodisplay', 'flex-item' ], true ) ) {
+			return $new_attributes;
+		}
 
-			if ( ! empty( $attachment ) ) {
-				$meta_data = wp_get_attachment_metadata( $attachment[0]->ID );
-				if ( empty( $new_attributes['width'] ) && ! empty( $meta_data['width'] ) ) {
-					$new_attributes['width'] = $meta_data['width'];
-				}
-				if ( empty( $new_attributes['height'] ) && ! empty( $meta_data['height'] ) ) {
-					$new_attributes['height'] = $meta_data['height'];
-				}
+		// Get the width and height from the file.
+		$path = wp_parse_url( $src, PHP_URL_PATH );
+		$ext  = pathinfo( $path, PATHINFO_EXTENSION );
+		$name = sanitize_title( wp_basename( $path, ".$ext" ) );
+		$args = [
+			'name'        => $name,
+			'post_type'   => 'attachment',
+			'post_status' => 'inherit',
+			'numberposts' => 1,
+		];
+
+		$attachment = get_posts( $args );
+
+		if ( ! empty( $attachment ) ) {
+			$meta_data = wp_get_attachment_metadata( $attachment[0]->ID );
+			if ( empty( $new_attributes['width'] ) && ! empty( $meta_data['width'] ) && 'fixed-height' !== $layout ) {
+				$new_attributes['width'] = $meta_data['width'];
+			}
+			if ( empty( $new_attributes['height'] ) && ! empty( $meta_data['height'] ) ) {
+				$new_attributes['height'] = $meta_data['height'];
 			}
 		}
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -210,7 +210,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 		// Get the width and height from the file.
 		$path = wp_parse_url( $src, PHP_URL_PATH );
 		$ext  = pathinfo( $path, PATHINFO_EXTENSION );
-		$name = sanitize_title( wp_basename( $path, ".$ext" ) );
+		$name = sanitize_title( wp_basename( $path, ".$ext" ) ); // Extension removed by media_handle_upload().
 		$args = [
 			'name'        => $name,
 			'post_type'   => 'attachment',
@@ -218,10 +218,10 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			'numberposts' => 1,
 		];
 
-		$attachment = get_posts( $args );
-
-		if ( ! empty( $attachment ) ) {
-			$meta_data = wp_get_attachment_metadata( $attachment[0]->ID );
+		$attachments = get_posts( $args );
+		if ( ! empty( $attachments ) ) {
+			$attachment = array_shift( $attachments );
+			$meta_data  = wp_get_attachment_metadata( $attachment->ID );
 			if ( empty( $new_attributes['width'] ) && ! empty( $meta_data['width'] ) && 'fixed-height' !== $layout ) {
 				$new_attributes['width'] = $meta_data['width'];
 			}

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -64,31 +64,45 @@ class AMP_CSS_Length {
 	protected $unit = 'px';
 
 	/**
+	 * Value of attribute.
+	 *
+	 * @var string
+	 */
+	protected $attr_value;
+
+	/**
 	 * AMP_CSS_Length constructor.
 	 *
 	 * @param string $attr_value  Attribute value to be parsed.
-	 * @param bool   $allow_auto  Whether or not to allow the 'auto' value as a value.
-	 * @param bool   $allow_fluid Whether or not to allow the 'fluid' value as a value.
 	 */
-	public function __construct( $attr_value, $allow_auto, $allow_fluid ) {
-		if ( ! isset( $attr_value ) || '' === $attr_value ) {
+	public function __construct( $attr_value ) {
+		if ( amp_is_attribute_empty( $attr_value ) ) {
 			$this->is_valid = true;
 			return;
 		}
 
-		$this->is_set = true;
+		$this->attr_value = $attr_value;
+		$this->is_set     = true;
+	}
 
-		if ( 'auto' === $attr_value ) {
+	/**
+	 * Validate the attribute value.
+	 *
+	 * @param bool $allow_auto  Whether or not to allow the 'auto' value as a value.
+	 * @param bool $allow_fluid Whether or not to allow the 'fluid' value as a value.
+	 */
+	public function validate( $allow_auto, $allow_fluid ) {
+		if ( 'auto' === $this->attr_value ) {
 			$this->is_auto  = true;
 			$this->is_valid = $allow_auto;
 			return;
-		} elseif ( 'fluid' === $attr_value ) {
+		} elseif ( 'fluid' === $this->attr_value ) {
 			$this->is_fluid = true;
 			$this->is_valid = $allow_fluid;
 		}
 
 		$pattern = '/^(?<numeral>\d+(?:\.\d+)?)(?<unit>px|em|rem|vh|vw|vmin|vmax)?$/';
-		if ( preg_match( $pattern, $attr_value, $match ) ) {
+		if ( preg_match( $pattern, $this->attr_value, $match ) ) {
 			$this->is_valid = true;
 			$this->numeral  = isset( $match['numeral'] ) ? (float) $match['numeral'] : $this->numeral;
 			$this->unit     = isset( $match['unit'] ) ? $match['unit'] : $this->unit;

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -81,10 +81,10 @@ class AMP_CSS_Length {
 			$this->is_valid = $allow_fluid;
 		}
 
-		$pattern = '/^(?P<numeral>\d+(?:\.\d+)?)(?P<unit>px|em|rem|vh|vw|vmin|vmax)?$/';
+		$pattern = '/^(?<numeral>\d+(?:\.\d+)?)(?<unit>px|em|rem|vh|vw|vmin|vmax)?$/';
 		if ( preg_match( $pattern, $attr_value, $match ) ) {
 			$this->is_valid = true;
-			$this->numeral  = isset( $match['numeral'] ) ? floatval( $match['numeral'] ) : $this->numeral;
+			$this->numeral  = isset( $match['numeral'] ) ? (float) $match['numeral'] : $this->numeral;
 			$this->unit     = isset( $match['unit'] ) ? $match['unit'] : $this->unit;
 		}
 	}

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -65,7 +65,7 @@ class AMP_CSS_Length {
 	 * @param bool   $allow_fluid Whether or not to allow the 'fluid' value as a value.
 	 */
 	public function __construct( $attr_value, $allow_auto, $allow_fluid ) {
-		if ( empty( $attr_value ) ) {
+		if ( ! isset( $attr_value ) || '' === $attr_value ) {
 			$this->is_valid = true;
 			return;
 		}

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -8,6 +8,12 @@
 /**
  * Class AMP_CSS_Length
  *
+ * Adapted from the <code>amp.validator.CssLength</code> class found in validator.js of the
+ * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+ *
+ * @version 1911070201440
+ * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3351
+ *
  * @since 1.5
  */
 class AMP_CSS_Length {

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -8,8 +8,8 @@
 /**
  * Class AMP_CSS_Length
  *
- * Adapted from the <code>amp.validator.CssLength</code> class found in validator.js of the
- * <a href="https://github.com/ampproject/amphtml">ampproject/amphtml</a> project.
+ * Adapted from the `amp.validator.CssLength` class found in `validator.js` from the `ampproject/amphtml`
+ * project on GitHub.
  *
  * @version 1911070201440
  * @link https://github.com/ampproject/amphtml/blob/1911070201440/validator/engine/validator.js#L3351

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -76,7 +76,7 @@ class AMP_CSS_Length {
 	 * @param string $attr_value  Attribute value to be parsed.
 	 */
 	public function __construct( $attr_value ) {
-		if ( amp_is_attribute_empty( $attr_value ) ) {
+		if ( ( ! isset( $attr_value ) || '' === $attr_value ) ) {
 			$this->is_valid = true;
 			return;
 		}

--- a/includes/validation/class-amp-css-length.php
+++ b/includes/validation/class-amp-css-length.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Class AMP_CSS_Length
+ *
+ * @package AMP
+ */
+
+/**
+ * Class AMP_CSS_Length
+ *
+ * @since 1.5
+ */
+class AMP_CSS_Length {
+
+	/**
+	 * Whether the value or unit is invalid. Note that passing
+	 * an empty value as `$attr_value` is considered valid.
+	 *
+	 * @var bool
+	 */
+	protected $is_valid = false;
+
+	/**
+	 * Whether the attribute value is set.
+	 *
+	 * @var bool
+	 */
+	protected $is_set = false;
+
+	/**
+	 * Whether the attribute value is 'auto'. This is a special value that
+	 * indicates that the value gets derived from the context. In practice
+	 * that's only ever the case for a width.
+	 *
+	 * @var bool
+	 */
+	protected $is_auto = false;
+
+	/**
+	 * Whether the attribute value is 'fluid'.
+	 *
+	 * @var bool
+	 */
+	protected $is_fluid = false;
+
+	/**
+	 * The numeric value.
+	 *
+	 * @var float
+	 */
+	protected $numeral = 0;
+
+	/**
+	 * The unit, 'px' being the default in case it's absent.
+	 *
+	 * @var string
+	 */
+	protected $unit = 'px';
+
+	/**
+	 * AMP_CSS_Length constructor.
+	 *
+	 * @param string $attr_value  Attribute value to be parsed.
+	 * @param bool   $allow_auto  Whether or not to allow the 'auto' value as a value.
+	 * @param bool   $allow_fluid Whether or not to allow the 'fluid' value as a value.
+	 */
+	public function __construct( $attr_value, $allow_auto, $allow_fluid ) {
+		if ( empty( $attr_value ) ) {
+			$this->is_valid = true;
+			return;
+		}
+
+		$this->is_set = true;
+
+		if ( 'auto' === $attr_value ) {
+			$this->is_auto  = true;
+			$this->is_valid = $allow_auto;
+			return;
+		} elseif ( 'fluid' === $attr_value ) {
+			$this->is_fluid = true;
+			$this->is_valid = $allow_fluid;
+		}
+
+		$pattern = '/^(?P<numeral>\d+(?:\.\d+)?)(?P<unit>px|em|rem|vh|vw|vmin|vmax)?$/';
+		if ( preg_match( $pattern, $attr_value, $match ) ) {
+			$this->is_valid = true;
+			$this->numeral  = isset( $match['numeral'] ) ? floatval( $match['numeral'] ) : $this->numeral;
+			$this->unit     = isset( $match['unit'] ) ? $match['unit'] : $this->unit;
+		}
+	}
+
+	/**
+	 * Whether or not the attribute value is valid.
+	 *
+	 * @return bool
+	 */
+	public function is_valid() {
+		return $this->is_valid;
+	}
+
+	/**
+	 * Whether the attribute value is set.
+	 *
+	 * @return bool
+	 */
+	public function is_set() {
+		return $this->is_set;
+	}
+
+	/**
+	 * Whether the attribute value is 'fluid'.
+	 *
+	 * @return bool
+	 */
+	public function is_fluid() {
+		return $this->is_fluid;
+	}
+
+	/**
+	 * Whether the attribute value is 'auto'.
+	 *
+	 * @return bool
+	 */
+	public function is_auto() {
+		return $this->is_auto;
+	}
+
+	/**
+	 * The unit of the attribute.
+	 *
+	 * @return string
+	 */
+	public function get_unit() {
+		return $this->unit;
+	}
+}

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -125,7 +125,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 
 			'post_embed'            => [
 				'<div class="fb-post" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"></div>',
-				'<amp-facebook layout="responsive" width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post"></amp-facebook>',
+				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive"></amp-facebook>',
 			],
 
 			'post_with_fallbacks'   => [
@@ -137,7 +137,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 					</div>
 				',
 				'
-					<amp-facebook layout="responsive" width="500" height="400" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/"  data-show-text="true" data-embed-as="post">
+					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/"  data-show-text="true" data-embed-as="post" layout="responsive">
 						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore" fallback="">
 							Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on <a href="https://developers.facebook.com/20531316728/posts/10154009990506729/">Thursday, August 27, 2015</a>
 						</blockquote>
@@ -147,7 +147,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 
 			'video_embed'           => [
 				'<div class="fb-video" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false"></div>',
-				'<amp-facebook layout="responsive" width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video"></amp-facebook>',
+				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video" layout="responsive"></amp-facebook>',
 			],
 
 			'page_embed'            => [
@@ -159,7 +159,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 					</div>
 				',
 				'
-					<amp-facebook-page layout="responsive" width="340" height="432" data-href="https://www.facebook.com/xwp.co/" data-hide-cover="true" data-show-facepile="true" data-show-posts="false">
+					<amp-facebook-page width="340" height="432" data-href="https://www.facebook.com/xwp.co/" data-hide-cover="true" data-show-facepile="true" data-show-posts="false" layout="responsive">
 						<div class="fb-xfbml-parse-ignore" fallback="">
 							<blockquote cite="https://www.facebook.com/xwp.co/"><a href="https://www.facebook.com/xwp.co/">Like Us</a></blockquote>
 						</div>
@@ -172,7 +172,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 					<div class="fb-like" data-href="https://developers.facebook.com/docs/plugins/" data-width="400" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true"></div>
 				',
 				'
-					<amp-facebook-like layout="responsive" width="400" height="400" data-href="https://developers.facebook.com/docs/plugins/" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true">
+					<amp-facebook-like width="400" height="400" data-href="https://developers.facebook.com/docs/plugins/" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true" layout="responsive">
 					</amp-facebook-like>
 				',
 			],
@@ -181,21 +181,21 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></div>
 				',
-				'<amp-facebook-comments layout="responsive" width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
+				'<amp-facebook-comments width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="responsive"></amp-facebook-comments>',
 			],
 
 			'comments_full_width'   => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
 				',
-				'<amp-facebook-comments layout="fixed-height" width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
+				'<amp-facebook-comments width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
 			],
 
 			'comment_embed'         => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
 				',
-				'<amp-facebook layout="responsive" width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment"></amp-facebook>',
+				'<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment" layout="responsive"></amp-facebook>',
 			],
 
 			'remove_fb_root'        => [

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -184,13 +184,6 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'<amp-facebook-comments layout="responsive" width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
 			],
 
-			'comments_full_width'   => [
-				'
-					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
-				',
-				'<amp-facebook-comments layout="fixed-height" width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
-			],
-
 			'comment_embed'         => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -219,8 +219,8 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 
 		$embed->sanitize_raw_embeds( $dom );
 
-		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
-		$whitelist_sanitizer->sanitize();
+		$layout_sanitizer = new AMP_Layout_Sanitizer( $dom );
+		$layout_sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -191,6 +191,13 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'<amp-facebook-comments width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
 			],
 
+			'comments_full_width_2' => [
+				'
+					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-height="123" data-width="100%" data-numposts="5"></div>
+				',
+				'<amp-facebook-comments width="auto" height="123" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
+			],
+
 			'comment_embed'         => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -184,6 +184,13 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'<amp-facebook-comments layout="responsive" width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
 			],
 
+			'comments_full_width'   => [
+				'
+					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
+				',
+				'<amp-facebook-comments layout="fixed-height" width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></amp-facebook-comments>',
+			],
+
 			'comment_embed'         => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
@@ -211,6 +218,9 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 		$embed = new AMP_Facebook_Embed_Handler();
 
 		$embed->sanitize_raw_embeds( $dom );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+		$whitelist_sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
 

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -11,6 +11,16 @@
 class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 
 	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		if ( did_action( 'add_attachment' ) ) {
+			$this->remove_added_uploads();
+		}
+		parent::tearDown();
+	}
+
+	/**
 	 * Mock caption text.
 	 *
 	 * @var string

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -38,6 +38,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			}
 		}
 
+		if ( did_action( 'add_attachment' ) ) {
+			$this->remove_added_uploads();
+		}
+
 		parent::tearDown();
 	}
 

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -95,6 +95,17 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 				',
 			],
 
+			'iframe_with_100_percent_width_and_height'  => [
+				'<iframe src="https://example.com/video/132886713" width="100%" height="100%"></iframe>',
+				'
+					<amp-iframe src="https://example.com/video/132886713" layout="fill" sandbox="allow-scripts allow-same-origin">
+						<noscript>
+							<iframe src="https://example.com/video/132886713" width="100%" height="100%"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+			],
+
 			'iframe_with_width_only'                    => [
 				'<iframe src="https://example.com/video/132886713" width="600"></iframe>',
 				'
@@ -472,6 +483,9 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 		}
 
 		$sanitizer = new AMP_Iframe_Sanitizer( $dom, $args );
+		$sanitizer->sanitize();
+
+		$sanitizer = new AMP_Layout_Sanitizer( $dom, $args );
 		$sanitizer->sanitize();
 
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -20,39 +20,41 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 	public function get_body_data() {
 		return [
 			'no_width_or_height'                          => [
-				'<p data-amp-layout="fill"></p>',
-				'<p layout="fill"></p>',
+				'<amp-img src="foo.jpg" data-amp-layout="fill"></amp-img>',
+				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
 			],
 
 			'no_layout_attr'                              => [
-				'<p width="10"></p>',
+				'<amp-img src="foo.jpg" width="10"></amp-img>',
 			],
 
 			'no_data_layout_attr'                         => [
-				'<p width="10"></p>',
+				'<amp-img src="foo.jpg" width="10"></amp-img>',
 			],
 
 			'data_layout_attr'                            => [
-				'<p width="10" data-amp-layout="fill"></p>',
-				'<p width="10" layout="fill"></p>',
+				'<amp-img src="foo.jpg" width="10" data-amp-layout="fill"></amp-img>',
+				'<amp-img src="foo.jpg" width="10" layout="fill"></amp-img>',
 			],
 
 			'data_layout_attr_with_100%_width'            => [
-				'<p width="100%" data-amp-layout="fill"></p>',
-				'<p width="auto" layout="fixed-height"></p>',
+				'<amp-img src="foo.jpg" width="100%" height="10" data-amp-layout="fill"></amp-img>',
+				'<amp-img src="foo.jpg" width="auto" height="10" layout="fixed-height"></amp-img>',
 			],
 
 			'data_layout_attr_with_100%_width_and_height' => [
-				'<p width="100%" height="100%" data-amp-layout="fill"></p>',
-				'<p layout="fill"></p>',
+				'<amp-img src="foo.jpg" width="100%" height="100%" data-amp-layout="fill"></amp-img>',
+				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
 			],
 
 			'100%_width_with_layout_attr'                 => [
-				'<p width="100%" layout="fill"></p>',
+				'<amp-img src="foo.jpg" width="100%" height="10" layout="fill"></amp-img>',
+				'',
 			],
 
 			'100%_width_and_height_with_layout_attr'      => [
-				'<p width="100%" height="100%" layout="fill"></p>',
+				'<amp-img src="foo.jpg" width="100%" height="100%" layout="fill"></amp-img>',
+				'',
 			],
 		];
 	}

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -64,6 +64,16 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="foo.jpg" style="width:100%; height:100%; color:#000"></amp-img>',
 				'<amp-img src="foo.jpg" style="color:#000" layout="fill"></amp-img>',
 			],
+
+			'fill_height_attribute_and_width_style'       => [
+				'<amp-img src="foo.jpg" style="width:100%;" height="100%"></amp-img>',
+				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
+			],
+
+			'fill_width_attribute_and_height_style'       => [
+				'<amp-img src="foo.jpg" style="height:100%;" width="100%"></amp-img>',
+				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
+			],
 		];
 	}
 

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -55,12 +55,12 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="foo.jpg" width="100%" height="100%" layout="fill"></amp-img>',
 			],
 
-			'100%_width_and_height_style_descriptors'      => [
+			'100%_width_and_height_style_descriptors'     => [
 				'<amp-img src="foo.jpg" style="width:100%; height:100%" ></amp-img>',
 				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
 			],
 
-			'1002%_width_and_height_style_descriptors'      => [
+			'fill_layout_with_unrelated_style_descriptor' => [
 				'<amp-img src="foo.jpg" style="width:100%; height:100%; color:#000" ></amp-img>',
 				'<amp-img src="foo.jpg" style="color:#000" layout="fill"></amp-img>',
 			],

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -54,6 +54,16 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 			'100%_width_and_height_with_layout_attr'      => [
 				'<amp-img src="foo.jpg" width="100%" height="100%" layout="fill"></amp-img>',
 			],
+
+			'100%_width_and_height_style_descriptors'      => [
+				'<amp-img src="foo.jpg" style="width:100%; height:100%" ></amp-img>',
+				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
+			],
+
+			'1002%_width_and_height_style_descriptors'      => [
+				'<amp-img src="foo.jpg" style="width:100%; height:100%; color:#000" ></amp-img>',
+				'<amp-img src="foo.jpg" style="color:#000" layout="fill"></amp-img>',
+			],
 		];
 	}
 

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Class AMP_Layout_Sanitizer_Test
+ *
+ * @package AMP
+ */
+
+/**
+ * Test AMP_Layout_Sanitizer_Test
+ *
+ * @covers AMP_Layout_Sanitizer_Test
+ */
+class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
+
+	/**
+	 * Get body data.
+	 *
+	 * @return array Content.
+	 */
+	public function get_body_data() {
+		return [
+			'no_width_or_height'                          => [
+				'<p data-amp-layout="fill"></p>',
+			],
+
+			'no_layout_attr'                              => [
+				'<p width="10"></p>',
+			],
+
+			'no_data_layout_attr'                         => [
+				'<p width="10"></p>',
+			],
+
+			'data_layout_attr'                            => [
+				'<p width="10" data-amp-layout="fill"></p>',
+				'<p width="10" layout="fill"></p>',
+			],
+
+			'data_layout_attr_with_100%_width'            => [
+				'<p width="100%" data-amp-layout="fill"></p>',
+				'<p width="auto" layout="fixed-height"></p>',
+			],
+
+			'data_layout_attr_with_100%_width_and_height' => [
+				'<p width="100%" height="100%" data-amp-layout="fill"></p>',
+				'<p layout="fill"></p>',
+			],
+
+			'100%_width_with_layout_attr'                 => [
+				'<p width="100%" layout="fill"></p>',
+			],
+
+			'100%_width_and_height_with_layout_attr'      => [
+				'<p width="100%" height="100%" layout="fill"></p>',
+			],
+		];
+	}
+
+	/**
+	 * @param string $source  Content.
+	 * @param string $expected Expected content.
+	 * @dataProvider get_body_data
+	 * @covers AMP_Layout_Sanitizer::sanitize()
+	 */
+	public function test_sanitize( $source, $expected = null ) {
+		$expected  = isset( $expected ) ? $expected : $source;
+		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
+		$sanitizer = new AMP_Layout_Sanitizer( $dom );
+
+		$sanitizer->sanitize();
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+
+		$this->assertEqualMarkup( $expected, $content );
+	}
+
+	/**
+	 * Assert markup is equal.
+	 *
+	 * @param string $expected Expected markup.
+	 * @param string $actual   Actual markup.
+	 */
+	public function assertEqualMarkup( $expected, $actual ) {
+		$actual   = preg_replace( '/\s+/', ' ', $actual );
+		$expected = preg_replace( '/\s+/', ' ', $expected );
+		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
+
+		$this->assertEquals(
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE ) ),
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE ) )
+		);
+	}
+}

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -49,19 +49,17 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 
 			'100%_width_with_layout_attr'                 => [
 				'<amp-img src="foo.jpg" width="100%" height="10" layout="fill"></amp-img>',
-				'',
 			],
 
 			'100%_width_and_height_with_layout_attr'      => [
 				'<amp-img src="foo.jpg" width="100%" height="100%" layout="fill"></amp-img>',
-				'',
 			],
 		];
 	}
 
 	/**
-	 * @param string $source  Content.
-	 * @param string $expected Expected content.
+	 * @param string      $source  Content.
+	 * @param string|null $expected Expected content.
 	 * @dataProvider get_body_data
 	 * @covers AMP_Layout_Sanitizer::sanitize()
 	 */

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -56,12 +56,12 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'100%_width_and_height_style_descriptors'     => [
-				'<amp-img src="foo.jpg" style="width:100%; height:100%" ></amp-img>',
+				'<amp-img src="foo.jpg" style="width:100%; height:100%"></amp-img>',
 				'<amp-img src="foo.jpg" layout="fill"></amp-img>',
 			],
 
 			'fill_layout_with_unrelated_style_descriptor' => [
-				'<amp-img src="foo.jpg" style="width:100%; height:100%; color:#000" ></amp-img>',
+				'<amp-img src="foo.jpg" style="width:100%; height:100%; color:#000"></amp-img>',
 				'<amp-img src="foo.jpg" style="color:#000" layout="fill"></amp-img>',
 			],
 		];

--- a/tests/php/test-amp-layout-sanitizer.php
+++ b/tests/php/test-amp-layout-sanitizer.php
@@ -21,6 +21,7 @@ class AMP_Layout_Sanitizer_Test extends WP_UnitTestCase {
 		return [
 			'no_width_or_height'                          => [
 				'<p data-amp-layout="fill"></p>',
+				'<p layout="fill"></p>',
 			],
 
 			'no_layout_attr'                              => [

--- a/tests/php/test-class-amp-base-sanitizer.php
+++ b/tests/php/test-class-amp-base-sanitizer.php
@@ -136,6 +136,18 @@ class AMP_Base_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
+			'fill_both_dimensions_with_unrelated_style'  => [
+				[
+					'width'  => '100%',
+					'height' => '100%',
+					'style'  => 'position:absolute; color:red',
+				],
+				[
+					'layout' => 'fill',
+					'style'  => 'color:red',
+				],
+			],
+
 			'fill_with_bottom_right_keeps_unrelated_styles' => [
 				[
 					'style' => 'position:absolute;background-color:white;top:0;left:0;right:0;bottom:0;color:red;',

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -28,6 +28,35 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		if ( did_action( 'add_attachment' ) ) {
+			$this->remove_added_uploads();
+		}
+		parent::tearDown();
+	}
+
+	/**
+	 * Get video attachment ID.
+	 *
+	 * @return int|WP_Error ID or error.
+	 */
+	protected function get_video_attachment_id() {
+		$temp_file = trailingslashit( get_temp_dir() ) . 'core-block-handler-test-' . wp_generate_uuid4() . '.mp4';
+		copy( DIR_TESTDATA . '/uploads/small-video.mp4', $temp_file );
+		$attachment_id = self::factory()->attachment->create_upload_object( $temp_file );
+
+		// Remove the file extension from the post_title media_handle_upload().
+		$attachment               = get_post( $attachment_id, ARRAY_A );
+		$attachment['post_title'] = str_replace( '.mp4', '', $attachment['post_title'] );
+		$attachment['post_name']  = str_replace( '-mp4', '', $attachment['post_name'] );
+		wp_update_post( wp_slash( $attachment ) );
+
+		return $attachment_id;
+	}
+
+	/**
 	 * Test register_embed().
 	 *
 	 * @covers AMP_Core_Block_Handler::register_embed()
@@ -92,7 +121,7 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 	 * @covers \AMP_Core_Block_Handler::ampify_video_block()
 	 */
 	public function test_ampify_video_block() {
-		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );
+		$attachment_id = $this->get_video_attachment_id();
 
 		$post_id = self::factory()->post->create(
 			[
@@ -120,7 +149,7 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 	 * @covers \AMP_Core_Block_Handler::ampify_cover_block()
 	 */
 	public function test_ampify_cover_block() {
-		$attachment_id = self::factory()->attachment->create_upload_object( DIR_TESTDATA . '/uploads/small-video.mp4' );
+		$attachment_id = $this->get_video_attachment_id();
 
 		$post_id = self::factory()->post->create(
 			[

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2040,14 +2040,14 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" width="50%" height="50"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_WIDTH' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_WIDTH ],
 			],
 
 			'illegal_height_attribute'                     => [
 				'<amp-img src="/img1.png" width="50" height="50%"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_HEIGHT ],
 			],
 
 			'0_width_attribute'                            => [
@@ -2059,63 +2059,63 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" width="" height="50" layout="responsive"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_AUTO_WIDTH' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_AUTO_WIDTH ],
 			],
 
 			'auto_height_attribute'                        => [
 				'<amp-img src="/img1.png" width="50" height="auto" layout="responsive"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_AUTO_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_AUTO_HEIGHT ],
 			],
 
 			'no_height_fixed_layout'                       => [
 				'<amp-img src="/img1.png" width="50" height="" layout="fixed"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'no_height_fixed_height_layout'                => [
 				'<amp-img src="/img1.png" width="50" height="" layout="fixed-height"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'no_height_intrinsic_layout'                   => [
 				'<amp-img src="/img1.png" width="50" height="" layout="intrinsic"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'no_height_responsive_layout'                  => [
 				'<amp-img src="/img1.png" width="50" height="" layout="responsive"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_NO_HEIGHT ],
 			],
 
 			'static_width_fixed_height_layout'             => [
 				'<amp-img src="/img1.png" width="50" height="50" layout="fixed-height"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_FIXED_HEIGHT' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_FIXED_HEIGHT ],
 			],
 
 			'responsive_layout_different_unit_dimensions'  => [
 				'<amp-img src="/img1.png" width="50px" height="50em" layout="responsive"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_UNIT_DIMENSIONS' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_UNIT_DIMENSIONS ],
 			],
 
 			'intrinsic_layout_different_unit_dimensions'   => [
 				'<amp-img src="/img1.png" width="50px" height="50em" layout="intrinsic"></amp-img>',
 				'',
 				[],
-				[ 'INVALID_LAYOUT_UNIT_DIMENSIONS' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_UNIT_DIMENSIONS ],
 			],
 
 			'responsive_layout_heights_attribute'          => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2055,6 +2055,26 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
 				'',
 			],
+
+			'0_width_attribute'                            => [
+				'<amp-img src="/img1.png" width="0" height="50" layout="responsive"></amp-img>',
+				'<amp-img src="/img1.png" width="0" height="50" layout="responsive"></amp-img>',
+			],
+
+			'empty_width_attribute'                        => [
+				'<amp-img src="/img1.png" width="" height="50" layout="responsive"></amp-img>',
+				'',
+			],
+
+			'no_width_attribute'                           => [
+				'<amp-img src="/img1.png" height="50" layout="responsive"></amp-img>',
+				'',
+			],
+
+			'multiple_width_attributes'                    => [
+				'<amp-img src="/img1.png" width="50" width="40" width="30" height="50" layout="responsive"></amp-img>',
+				'<amp-img src="/img1.png" width="50" height="50" layout="responsive"></amp-img>',
+			],
 		];
 	}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2084,11 +2084,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" width="30" layout="fill"></amp-img>',
 				null,
 			],
-			'fill_layout_no_width'                        => [
+			'fill_layout_no_width'                         => [
 				'<amp-img src="/img1.png" height="30" layout="fill"></amp-img>',
 				null,
 			],
-			'fill_layout_no_dimensions'                        => [
+			'fill_layout_no_dimensions'                    => [
 				'<amp-img src="/img1.png" layout="fill"></amp-img>',
 				null,
 			],

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2080,6 +2080,18 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" width="30" height="30" layout="fill"></amp-img>',
 				null,
 			],
+			'fill_layout_no_height'                        => [
+				'<amp-img src="/img1.png" width="30" layout="fill"></amp-img>',
+				null,
+			],
+			'fill_layout_no_width'                        => [
+				'<amp-img src="/img1.png" height="30" layout="fill"></amp-img>',
+				null,
+			],
+			'fill_layout_no_dimensions'                        => [
+				'<amp-img src="/img1.png" layout="fill"></amp-img>',
+				null,
+			],
 		];
 	}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2008,6 +2008,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_PROCESSING_INSTRUCTION ],
 			],
 
+			'invalid_layout'                               => [
+				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
+				'',
+				[],
+				[ 'invalid_layout' ],
+			],
+
 			'invalid_xml_pi'                               => [
 				'<?xml version="1.0" encoding="utf-8"?>',
 				'',
@@ -2058,7 +2065,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'0_width_attribute'                            => [
 				'<amp-img src="/img1.png" width="0" height="50" layout="responsive"></amp-img>',
-				'<amp-img src="/img1.png" width="0" height="50" layout="responsive"></amp-img>',
+				null,
 			],
 
 			'empty_width_attribute'                        => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1430,7 +1430,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					[
 						'<amp-img src="/img1.png" width="50" height="50" layout="fill"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="fixed"></amp-img>',
-						'<amp-img src="/img1.png" width="50" height="50" layout="fixed-height"></amp-img>',
+						'<amp-img src="/img1.png" width="auto" height="50" layout="fixed-height"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="flex-item"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="intrinsic"></amp-img>',
 						'<amp-img src="/img1.png" width="50" height="50" layout="nodisplay"></amp-img>',
@@ -2034,6 +2034,26 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-social-share type="foo" data-param-text="Check out this article: TITLE - CANONICAL_URL"></amp-social-share>',
 				[ 'amp-social-share' ],
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_RELATIVE_URL ],
+			],
+
+			'illegal_width_attribute'                      => [
+				'<amp-img src="/img1.png" width="50%" height="50"></amp-img>',
+				'',
+			],
+
+			'illegal_height_attribute'                     => [
+				'<amp-img src="/img1.png" width="50" height="50%"></amp-img>',
+				'',
+			],
+
+			'illegal_width_attribute_with_layout'          => [
+				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
+				'',
+			],
+
+			'illegal_height_attribute_with_layout'         => [
+				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
+				'',
 			],
 		];
 	}

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2118,6 +2118,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_UNIT_DIMENSIONS ],
 			],
 
+			'fixed_layout_with_invalid_heights_attr'       => [
+				'<amp-img layout="fixed" alt="AMP" src="/static/inline-examples/images/amp.jpg" width="320" height="256" heights="(min-width:500px) 200px, 80%"></amp-img>',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_LAYOUT_HEIGHTS ],
+			],
+
 			'responsive_layout_heights_attribute'          => [
 				'<amp-img src="/img1.png" width="50" height="50" heights="(min-width:500px) 200px, 80%" layout="responsive"></amp-img>',
 				null,

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2075,6 +2075,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" width="50" width="40" width="30" height="50" layout="responsive"></amp-img>',
 				'<amp-img src="/img1.png" width="50" height="50" layout="responsive"></amp-img>',
 			],
+
+			'fill_layout'                                  => [
+				'<amp-img src="/img1.png" width="30" height="30" layout="fill"></amp-img>',
+				null,
+			],
 		];
 	}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2008,13 +2008,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_PROCESSING_INSTRUCTION ],
 			],
 
-			'invalid_layout'                               => [
-				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
-				'',
-				[],
-				[ 'invalid_layout' ],
-			],
-
 			'invalid_xml_pi'                               => [
 				'<?xml version="1.0" encoding="utf-8"?>',
 				'',
@@ -2046,21 +2039,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'illegal_width_attribute'                      => [
 				'<amp-img src="/img1.png" width="50%" height="50"></amp-img>',
 				'',
+				[],
+				[ 'INVALID_LAYOUT_WIDTH' ],
 			],
 
 			'illegal_height_attribute'                     => [
 				'<amp-img src="/img1.png" width="50" height="50%"></amp-img>',
 				'',
-			],
-
-			'illegal_width_attribute_with_layout'          => [
-				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
-				'',
-			],
-
-			'illegal_height_attribute_with_layout'         => [
-				'<amp-img src="/img1.png" width="50" height="50%" layout="responsive"></amp-img>',
-				'',
+				[],
+				[ 'INVALID_LAYOUT_HEIGHT' ],
 			],
 
 			'0_width_attribute'                            => [
@@ -2071,11 +2058,69 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'empty_width_attribute'                        => [
 				'<amp-img src="/img1.png" width="" height="50" layout="responsive"></amp-img>',
 				'',
+				[],
+				[ 'INVALID_LAYOUT_AUTO_WIDTH' ],
 			],
 
-			'no_width_attribute'                           => [
-				'<amp-img src="/img1.png" height="50" layout="responsive"></amp-img>',
+			'auto_height_attribute'                        => [
+				'<amp-img src="/img1.png" width="50" height="auto" layout="responsive"></amp-img>',
 				'',
+				[],
+				[ 'INVALID_LAYOUT_AUTO_HEIGHT' ],
+			],
+
+			'no_height_fixed_layout'                       => [
+				'<amp-img src="/img1.png" width="50" height="" layout="fixed"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+			],
+
+			'no_height_fixed_height_layout'                => [
+				'<amp-img src="/img1.png" width="50" height="" layout="fixed-height"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+			],
+
+			'no_height_intrinsic_layout'                   => [
+				'<amp-img src="/img1.png" width="50" height="" layout="intrinsic"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+			],
+
+			'no_height_responsive_layout'                  => [
+				'<amp-img src="/img1.png" width="50" height="" layout="responsive"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_NO_HEIGHT' ],
+			],
+
+			'static_width_fixed_height_layout'             => [
+				'<amp-img src="/img1.png" width="50" height="50" layout="fixed-height"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_FIXED_HEIGHT' ],
+			],
+
+			'responsive_layout_different_unit_dimensions'  => [
+				'<amp-img src="/img1.png" width="50px" height="50em" layout="responsive"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_UNIT_DIMENSIONS' ],
+			],
+
+			'intrinsic_layout_different_unit_dimensions'   => [
+				'<amp-img src="/img1.png" width="50px" height="50em" layout="intrinsic"></amp-img>',
+				'',
+				[],
+				[ 'INVALID_LAYOUT_UNIT_DIMENSIONS' ],
+			],
+
+			'responsive_layout_heights_attribute'          => [
+				'<amp-img src="/img1.png" width="50" height="50" heights="(min-width:500px) 200px, 80%" layout="responsive"></amp-img>',
+				null,
 			],
 
 			'multiple_width_attributes'                    => [


### PR DESCRIPTION
## Summary

As [noted by @westonruter](https://github.com/ampproject/amp-wp/issues/2146#issue-434545734), there are no constraints on the width and height attributes as defined in the [Validator protoascii](https://github.com/ampproject/amphtml/blob/master/validator/validator-main.protoascii#L5331-L5345), as the conditional logic is not feasible for the protoascii format.

This PR extends the method `AMP_Tag_And_Attribute_Sanitizer::sanitize_disallowed_attribute_values_in_node` so that the logic for the supported layouts of a given element are considered, and constraints for the width and height attributes are applied not only according to the layout, but also if a layout is not given.

The logic for validating these attributes is adapted from [validator.js](https://github.com/ampproject/amphtml/blob/ee0ad23d78800959f361a97af1bd0c99d91597f6/validator/engine/validator.js#L3938) of the [amproject/amphtml](/amproject/amphtml) repository.

### Video Cover Block

This PR also fixes the Cover Block when a video is selected as the background; the video in a Cover Block is filtered to get the `fill` layout and to have a `cover` object fit.

### Todo:

- [x] Remove the element if the width or height is invalid
- [x] Remove the element if the width or height does not conform to the specified layout
- [x] Set the width of the element to 'auto' if the width is not already set to 'auto' & the layout is 'fixed_height'

<!-- Please reference the issue this PR addresses. -->
Fixes #2146.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
