### PR TITLE
Fix expanded menu when screen width is <1000px for Twenty Twenty theme

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1031,8 +1031,8 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					}
 
 					@media (max-width: 999px) {
-						.show-modal {
-							display: unset !important;
+						amp-lightbox.cover-modal.show-modal {
+							display: unset;
 						}
 					}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -1030,6 +1030,12 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 						}
 					}
 
+					@media (max-width: 999px) {
+						.show-modal {
+							display: unset !important;
+						}
+					}
+
 				}
 				<?php elseif ( 'twentyseventeen' === get_template() ) : ?>
 					/* Show the button*/


### PR DESCRIPTION
## Summary

With the Twenty Twenty theme, when the expanded menu is active on a screen width <1000px, it is incorrectly shown:

### Before
![image](https://user-images.githubusercontent.com/16200219/69097837-6acb5680-0a25-11ea-8c2d-e8206383187b.png)

The root cause of this is due to the container that the menu is placed in by `amp-lightbox` upon initialization is not made to fill the content because [the `amp-lightbox` has the `scrollable` attribute](https://github.com/ampproject/amphtml/blob/master/extensions/amp-lightbox/0.1/amp-lightbox.js#L224-L226).

This PR fixes this issue by unsetting the `display` CSS property of the `amp-lightbox`, reverting it from `flex` to `block`.

### After

![image](https://user-images.githubusercontent.com/16200219/69098544-cba75e80-0a26-11ea-8beb-8b056bfd15a7.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
