### PR TITLE
Improve error messages when validation requests fail

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -718,23 +718,9 @@ class AMP_Options_Manager {
 			$validation = AMP_Validation_Manager::validate_url( $url );
 
 			if ( is_wp_error( $validation ) ) {
-				$review_messages[] = esc_html(
-					sprintf(
-						/* translators: 1: error message. 2: error code. */
-						__( 'However, there was an error when checking the AMP validity for your site.', 'amp' ),
-						$validation->get_error_message(),
-						$validation->get_error_code()
-					)
-				);
-
-				$error_message = $validation->get_error_message();
-				if ( $error_message ) {
-					$review_messages[] = $error_message;
-				} else {
-					/* translators: %s is the error code */
-					$review_messages[] = esc_html( sprintf( __( 'Error code: %s.', 'amp' ), $validation->get_error_code() ) );
-				}
-				$notice_type = 'error';
+				$review_messages[] = esc_html__( 'However, there was an error when checking the AMP validity for your site.', 'amp' );
+				$review_messages[] = AMP_Validation_Manager::get_validate_url_error_message( $validation->get_error_code(), $validation->get_error_message() );
+				$notice_type       = 'error';
 			} elseif ( is_array( $validation ) ) {
 				$new_errors      = 0;
 				$rejected_errors = 0;
@@ -757,7 +743,7 @@ class AMP_Options_Manager {
 				if ( $rejected_errors > 0 ) {
 					$notice_type = 'error';
 
-					$message = wp_kses_post(
+					$message = esc_html(
 						sprintf(
 							/* translators: %s is count of rejected errors */
 							_n(
@@ -772,43 +758,37 @@ class AMP_Options_Manager {
 					);
 
 					if ( $invalid_url_screen_url ) {
-						$message .= ' ' . wp_kses_post(
-							sprintf(
-								/* translators: %s is URL to review issues */
-								_n(
-									'<a href="%s">Review Issue</a>.',
-									'<a href="%s">Review Issues</a>.',
-									$rejected_errors,
-									'amp'
-								),
-								esc_url( $invalid_url_screen_url )
-							)
+						$message .= ' ' . sprintf(
+							/* translators: %s is URL to review issues */
+							_n(
+								'<a href="%s">Review Issue</a>.',
+								'<a href="%s">Review Issues</a>.',
+								$rejected_errors,
+								'amp'
+							),
+							esc_url( $invalid_url_screen_url )
 						);
 					}
 
 					$review_messages[] = $message;
 				} else {
-					$message = wp_kses_post(
-						sprintf(
-							/* translators: %s is an AMP URL */
-							__( 'View an <a href="%s">AMP version of your site</a>.', 'amp' ),
-							esc_url( $url )
-						)
+					$message = sprintf(
+						/* translators: %s is an AMP URL */
+						__( 'View an <a href="%s">AMP version of your site</a>.', 'amp' ),
+						esc_url( $url )
 					);
 
 					if ( $new_errors > 0 && $invalid_url_screen_url ) {
-						$message .= ' ' . wp_kses_post(
-							sprintf(
-								/* translators: 1: URL to review issues. 2: count of new errors. */
-								_n(
-									'Please also <a href="%1$s">review %2$s issue</a> which may need to be fixed (for one URL at least).',
-									'Please also <a href="%1$s">review %2$s issues</a> which may need to be fixed (for one URL at least).',
-									$new_errors,
-									'amp'
-								),
-								esc_url( $invalid_url_screen_url ),
-								number_format_i18n( $new_errors )
-							)
+						$message .= ' ' . sprintf(
+							/* translators: 1: URL to review issues. 2: count of new errors. */
+							_n(
+								'Please also <a href="%1$s">review %2$s issue</a> which may need to be fixed (for one URL at least).',
+								'Please also <a href="%1$s">review %2$s issues</a> which may need to be fixed (for one URL at least).',
+								$new_errors,
+								'amp'
+							),
+							esc_url( $invalid_url_screen_url ),
+							number_format_i18n( $new_errors )
 						);
 					}
 
@@ -831,18 +811,16 @@ class AMP_Options_Manager {
 				}
 				break;
 			case AMP_Theme_Support::READER_MODE_SLUG:
-				$message = wp_kses_post(
-					sprintf(
-						/* translators: %s is an AMP URL */
-						__( 'Reader mode activated! View the <a href="%s">AMP version of a recent post</a>. It is recommended that you upgrade to Standard or Transitional mode.', 'amp' ),
-						esc_url( $url )
-					)
+				$message = sprintf(
+					/* translators: %s is an AMP URL */
+					__( 'Reader mode activated! View the <a href="%s">AMP version of a recent post</a>. It is recommended that you upgrade to Standard or Transitional mode.', 'amp' ),
+					esc_url( $url )
 				);
 				break;
 		}
 
 		if ( isset( $message ) ) {
-			add_settings_error( self::OPTION_NAME, 'template_mode_updated', $message, $notice_type );
+			add_settings_error( self::OPTION_NAME, 'template_mode_updated', wp_kses_post( $message ), $notice_type );
 		}
 	}
 }

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2068,7 +2068,7 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		return wp_nonce_url(
-			add_query_arg( $args, admin_url() ),
+			add_query_arg( rawurlencode_deep( $args ), admin_url() ),
 			self::NONCE_ACTION
 		);
 	}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1274,7 +1274,7 @@ class AMP_Validated_URL_Post_Type {
 		}
 
 		if ( isset( $_GET['amp_validate_error'] ) && is_string( $_GET['amp_validate_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			// Note: The input var is validated by the deserialize_validation_error_messages method.
+			// Note: The input var is validated by the unserialize_validation_error_messages method.
 			$errors = AMP_Validation_Manager::unserialize_validation_error_messages( wp_unslash( $_GET['amp_validate_error'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( $errors ) {
 				foreach ( array_unique( $errors ) as $error_message ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1226,7 +1226,7 @@ class AMP_Validated_URL_Post_Type {
 
 			$validity = AMP_Validation_Manager::validate_url( $url );
 			if ( is_wp_error( $validity ) ) {
-				$errors[] = $validity->get_error_code();
+				$errors[] = AMP_Validation_Manager::get_validate_url_error_message( $validity->get_error_code(), $validity->get_error_message() );
 				continue;
 			}
 
@@ -1254,13 +1254,13 @@ class AMP_Validated_URL_Post_Type {
 			self::URLS_TESTED => count( $items ),
 		];
 		if ( ! empty( $errors ) ) {
-			$args['amp_validate_error'] = $errors;
+			$args['amp_validate_error'] = AMP_Validation_Manager::serialize_validation_error_messages( $errors );
 		} else {
 			$args[ self::REMAINING_ERRORS ] = count( $remaining_invalid_urls );
 		}
 
 		$redirect = remove_query_arg( wp_removable_query_args(), $redirect );
-		return add_query_arg( $args, $redirect );
+		return add_query_arg( rawurlencode_deep( $args ), $redirect );
 	}
 
 	/**
@@ -1273,14 +1273,23 @@ class AMP_Validated_URL_Post_Type {
 			return;
 		}
 
-		if ( isset( $_GET['amp_validate_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$error_codes = array_unique( array_map( 'sanitize_key', (array) $_GET['amp_validate_error'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			foreach ( $error_codes as $error_code ) {
-				printf(
-					'<div class="notice is-dismissible error"><p>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
-					esc_html( AMP_Validation_Manager::get_validate_url_error_message( $error_code ) ),
-					esc_html__( 'Dismiss this notice.', 'amp' )
-				);
+		if ( isset( $_GET['amp_validate_error'] ) && is_string( $_GET['amp_validate_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// Note: The input var is validated by the deserialize_validation_error_messages method.
+			$errors = AMP_Validation_Manager::unserialize_validation_error_messages( wp_unslash( $_GET['amp_validate_error'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			if ( $errors ) {
+				foreach ( array_unique( $errors ) as $error_message ) {
+					printf(
+						'<div class="notice is-dismissible error"><p>%s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+						wp_kses(
+							$error_message,
+							[
+								'a'    => array_fill_keys( [ 'href', 'target' ], true ),
+								'code' => [],
+							]
+						),
+						esc_html__( 'Dismiss this notice.', 'amp' )
+					);
+				}
 			}
 		}
 
@@ -1482,7 +1491,7 @@ class AMP_Validated_URL_Post_Type {
 
 			$validity = AMP_Validation_Manager::validate_url( $url );
 			if ( is_wp_error( $validity ) ) {
-				throw new Exception( esc_html( $validity->get_error_code() ) );
+				throw new Exception( AMP_Validation_Manager::get_validate_url_error_message( $validity->get_error_code(), $validity->get_error_message() ) );
 			}
 
 			$errors = wp_list_pluck( $validity['results'], 'error' );
@@ -1497,7 +1506,7 @@ class AMP_Validated_URL_Post_Type {
 				)
 			);
 			if ( is_wp_error( $stored ) ) {
-				throw new Exception( esc_html( $stored->get_error_code() ) );
+				throw new Exception( AMP_Validation_Manager::get_validate_url_error_message( $stored->get_error_code(), $stored->get_error_message() ) );
 			}
 			$redirect = get_edit_post_link( $stored, 'raw' );
 
@@ -1513,7 +1522,9 @@ class AMP_Validated_URL_Post_Type {
 			$args[ self::URLS_TESTED ]      = '1';
 			$args[ self::REMAINING_ERRORS ] = $error_count;
 		} catch ( Exception $e ) {
-			$args['amp_validate_error'] = $e->getMessage();
+			$args['amp_validate_error'] = AMP_Validation_Manager::serialize_validation_error_messages(
+				[ $e->getMessage() ]
+			);
 			$args[ self::URLS_TESTED ]  = '0';
 
 			if ( $post && self::POST_TYPE_SLUG === $post->post_type ) {
@@ -1528,7 +1539,7 @@ class AMP_Validated_URL_Post_Type {
 			}
 		}
 
-		wp_safe_redirect( add_query_arg( $args, $redirect ) );
+		wp_safe_redirect( add_query_arg( rawurlencode_deep( $args ), $redirect ) );
 		exit();
 	}
 

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -631,17 +631,13 @@ class AMP_Validated_URL_Post_Type {
 	/**
 	 * Normalize a URL for storage.
 	 *
-	 * This ensures that query vars like utm_* and the like will not cause duplicates.
 	 * The AMP query param is removed to facilitate switching between standard and transitional.
 	 * The URL scheme is also normalized to HTTPS to help with transition from HTTP to HTTPS.
 	 *
 	 * @param string $url URL.
 	 * @return string Normalized URL.
-	 * @global WP $wp
 	 */
 	protected static function normalize_url_for_storage( $url ) {
-		global $wp;
-
 		// Only ever store the canonical version.
 		$url = amp_remove_endpoint( $url );
 
@@ -651,12 +647,11 @@ class AMP_Validated_URL_Post_Type {
 		// Normalize query args, removing all that are not recognized or which are removable.
 		$url_parts = explode( '?', $url, 2 );
 		if ( 2 === count( $url_parts ) ) {
-			parse_str( $url_parts[1], $args );
+			$args = wp_parse_args( $url_parts[1] );
 			foreach ( wp_removable_query_args() as $removable_query_arg ) {
 				unset( $args[ $removable_query_arg ] );
 			}
-			$args = wp_array_slice_assoc( $args, $wp->public_query_vars );
-			$url  = $url_parts[0];
+			$url = $url_parts[0];
 			if ( ! empty( $args ) ) {
 				$url = $url_parts[0] . '?' . build_query( $args );
 			}

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1943,7 +1943,7 @@ class AMP_Validation_Manager {
 		}
 
 		$support_forum_message = ' ' . sprintf(
-			/* translators: 1: Link to support forum. 2: Link to new topic form in support forum. */
+			/* translators: %1$s: Link to support forum. %2$s: Link to new topic form in support forum. */
 			__( 'If you are stuck, please search the <a href="%1$s">support forum</a> for possible related topics, or otherwise start a <a href="%2$s">new support topic</a> including the error message, the URL to your site, and your active theme/plugins.', 'amp' ),
 			esc_url( 'https://wordpress.org/support/plugin/amp/' ),
 			esc_url( 'https://wordpress.org/support/plugin/amp/#new-topic-0' )
@@ -1967,7 +1967,7 @@ class AMP_Validation_Manager {
 			case 'http_request_failed':
 				return __( 'Failed to fetch URL to validate.', 'amp' ) . $error_message . $site_health_message . $support_forum_message;
 			case 'white_screen_of_death':
-				return __( 'Unable to validate URL. Encountered a white screen of death likely due to PHP a fatal error.', 'amp' ) . $error_message . $check_error_log . $support_forum_message;
+				return __( 'Unable to validate URL. Encountered a white screen of death likely due to a PHP fatal error.', 'amp' ) . $error_message . $check_error_log . $support_forum_message;
 			case '404':
 				return __( 'The fetched URL was not found. It may have been deleted. If so, you can trash this.', 'amp' ) . $error_message . $support_forum_message;
 			case '500':

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1874,17 +1874,14 @@ class AMP_Validation_Manager {
 
 		$response = wp_remote_retrieve_body( $r );
 		if ( trim( $response ) === '' ) {
-			$error_code = 'white_screen_of_death';
-			return new WP_Error( $error_code, self::get_validate_url_error_message( $error_code ) );
+			return new WP_Error( 'white_screen_of_death' );
 		}
 		if ( ! preg_match( '#</body>.*?<!--\s*AMP_VALIDATION\s*:\s*(\{.*?\})\s*-->#s', $response, $matches ) ) {
-			$error_code = 'response_comment_absent';
-			return new WP_Error( $error_code, self::get_validate_url_error_message( $error_code ) );
+			return new WP_Error( 'response_comment_absent' );
 		}
 		$validation = json_decode( $matches[1], true );
 		if ( json_last_error() || ! isset( $validation['results'] ) || ! is_array( $validation['results'] ) ) {
-			$error_code = 'malformed_json_validation_errors';
-			return new WP_Error( $error_code, self::get_validate_url_error_message( $error_code ) );
+			return new WP_Error( 'malformed_json_validation_errors' );
 		}
 
 		return array_merge(
@@ -1894,37 +1891,104 @@ class AMP_Validation_Manager {
 	}
 
 	/**
+	 * Serialize validation error messages.
+	 *
+	 * In order to safely pass validation error messages through redirects with query parameters, they must be serialized
+	 * with a HMAC for security. The messages contain markup so the HMAC prevents tampering.
+	 *
+	 * @since 1.4.2
+	 * @see AMP_Validation_Manager::unserialize_validation_error_messages()
+	 *
+	 * @param string[] $messages Messages.
+	 * @return string Serialized.
+	 */
+	public static function serialize_validation_error_messages( $messages ) {
+		$encoded_messages = base64_encode( wp_json_encode( array_unique( $messages ) ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		return wp_hash( $encoded_messages ) . ':' . $encoded_messages;
+	}
+
+	/**
+	 * Unserialize validation error messages.
+	 *
+	 * @since 1.4.2
+	 * @see AMP_Validation_Manager::serialize_validation_error_messages()
+	 *
+	 * @param string $serialized Serialized messages.
+	 * @return string[]|null
+	 */
+	public static function unserialize_validation_error_messages( $serialized ) {
+		$parts = explode( ':', $serialized, 2 );
+		if ( count( $parts ) !== 2 || wp_hash( $parts[1] ) !== $parts[0] ) {
+			return null;
+		}
+		return json_decode( base64_decode( $parts[1] ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+	}
+
+	/**
 	 * Get error message for a validate URL failure.
 	 *
-	 * @param string $error_code Error code.
-	 * @return string Error message.
+	 * @param string $error_code    Error code.
+	 * @param string $error_message Error message, typically technical such as from HTTP status text or cURL error message.
+	 * @return string Error message with HTML markup.
 	 */
-	public static function get_validate_url_error_message( $error_code ) {
-		$check_error_log = __( 'Please check your server\'s PHP error logs; to do this you may need to enable WP_DEBUG_LOG.', 'amp' );
+	public static function get_validate_url_error_message( $error_code, $error_message = '' ) {
+		$check_error_log = sprintf(
+			/* translators: %s is link to Debugging in WordPress */
+			' ' . __( 'Please check your server PHP error logs; to do this you may need to <a href="%s" target="_blank">enable</a> <code>WP_DEBUG_LOG</code>.', 'amp' ),
+			esc_url( 'https://wordpress.org/support/article/debugging-in-wordpress/' )
+		);
+
+		if ( $error_message ) {
+			$error_message = ' ' . rtrim( $error_message, '.' ) . '.';
+		}
+
+		$support_forum_message = ' ' . sprintf(
+			/* translators: 1: Link to support forum. 2: Link to new topic form in support forum. */
+			__( 'If you are stuck, please search the <a href="%1$s">support forum</a> for possible related topics, or otherwise start a <a href="%2$s">new support topic</a> including the error message, the URL to your site, and your active theme/plugins.', 'amp' ),
+			esc_url( 'https://wordpress.org/support/plugin/amp/' ),
+			esc_url( 'https://wordpress.org/support/plugin/amp/#new-topic-0' )
+		);
+
+		$site_health_message = '';
+		if ( version_compare( get_bloginfo( 'version' ), '5.2', '>=' ) ) {
+			$site_health_message .= ' ' . sprintf(
+				/* translators: %s is link to Site Health */
+				__( 'Please check your <a href="%s">Site Health</a> to verify it can perform loopback requests.', 'amp' ),
+				esc_url( admin_url( 'site-health.php' ) )
+			);
+			$support_forum_message .= ' ' . sprintf(
+				/* translators: %s is the URL to Site Health Info. */
+				__( 'Please include your <a href="%s">Site Health Info</a>.', 'amp' ),
+				esc_url( admin_url( 'site-health.php?tab=debug' ) )
+			);
+		}
+
 		switch ( $error_code ) {
 			case 'http_request_failed':
-				return __( 'Failed to fetch URL(s) to validate. This may be due to a request timeout.', 'amp' ) . ' ' . $check_error_log;
+				return __( 'Failed to fetch URL to validate.', 'amp' ) . $error_message . $site_health_message . $support_forum_message;
 			case 'white_screen_of_death':
-				return __( 'Unable to validate URL. Encountered a white screen of death likely due to a fatal error.', 'amp' ) . ' ' . $check_error_log;
+				return __( 'Unable to validate URL. Encountered a white screen of death likely due to PHP a fatal error.', 'amp' ) . $error_message . $check_error_log . $support_forum_message;
 			case '404':
-				return __( 'The fetched URL was not found. It may have been deleted. If so, you can trash this.', 'amp' );
+				return __( 'The fetched URL was not found. It may have been deleted. If so, you can trash this.', 'amp' ) . $error_message . $support_forum_message;
 			case '500':
-				return __( 'An internal server error occurred when fetching the URL for validation.', 'amp' ) . ' ' . $check_error_log;
+				return __( 'An internal server error occurred when fetching the URL for validation.', 'amp' ) . $error_message . $check_error_log . $support_forum_message;
 			case 'response_comment_absent':
 				return sprintf(
-					/* translators: %s: AMP_VALIDATION */
-					__( 'URL validation failed to due to the absence of the expected JSON-containing %s comment after the body. This is often due to a PHP fatal error occurring.', 'amp' ),
-					'AMP_VALIDATION'
-				) . ' ' . $check_error_log;
+					/* translators: %1$s: AMP_VALIDATION, %2$s: </body> */
+					__( 'URL validation failed to due to the absence of the expected JSON-containing %1$s HTML comment after %2$s. This is often due to a PHP fatal error occurring.', 'amp' ),
+					'<code>AMP_VALIDATION</code>',
+					'<code>&lt;/body&gt;</code>'
+				) . $error_message . $check_error_log . $support_forum_message;
 			case 'malformed_json_validation_errors':
 				return sprintf(
-					/* translators: %s: AMP_VALIDATION */
-					__( 'URL validation failed to due to unexpected JSON in the %s comment after the body.', 'amp' ),
-					'AMP_VALIDATION'
-				);
+					/* translators: %1$s: AMP_VALIDATION, %2$s: </body> */
+					__( 'URL validation failed to due to unexpected JSON in the %1$s HTML comment after %2$s.', 'amp' ),
+					'<code>AMP_VALIDATION</code>',
+					'<code>&lt;/body&gt;</code>'
+				) . $error_message . $support_forum_message;
 			default:
 				/* translators: %s is error code */
-				return sprintf( __( 'URL validation failed. Error code: %s.', 'amp' ), $error_code ); // Note that $error_code has been sanitized with sanitize_key(); will be escaped below as well.
+				return sprintf( __( 'URL validation failed. Error code: %s.', 'amp' ), $error_code ) . $error_message . $support_forum_message;
 		}
 	}
 

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -808,14 +808,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 				];
 			}
 		);
-		$this->assertEquals(
-			add_query_arg(
-				[
-					AMP_Validated_URL_Post_Type::URLS_TESTED => $urls_tested,
-					'amp_validate_error' => [ 'response_comment_absent' ],
-				],
-				$initial_redirect
-			),
+		$this->assertContains(
+			'amp_validate_error=',
 			AMP_Validated_URL_Post_Type::handle_bulk_action( $initial_redirect, AMP_Validated_URL_Post_Type::BULK_VALIDATE_ACTION, $items )
 		);
 	}
@@ -824,6 +818,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 	 * Test for print_admin_notice()
 	 *
 	 * @covers \AMP_Validated_URL_Post_Type::print_admin_notice()
+	 * @covers \AMP_Validation_Manager::serialize_validation_error_messages()
+	 * @covers \AMP_Validation_Manager::unserialize_validation_error_messages()
 	 */
 	public function test_print_admin_notice() {
 		add_theme_support( AMP_Theme_Support::SLUG );
@@ -856,9 +852,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
 		$this->assertContains( 'The rechecked URL is free of non-removed invalid markup.', $output );
 
-		$_GET['amp_validate_error'] = [ 'http_request_failed' ];
+		$error_message              = 'Something <code>bad</code> happened!';
+		$_GET['amp_validate_error'] = AMP_Validation_Manager::serialize_validation_error_messages( [ $error_message ] );
 		$output                     = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
-		$this->assertContains( 'Failed to fetch URL(s) to validate', $output );
+		$this->assertContains( $error_message, $output );
 
 		unset( $GLOBALS['current_screen'] );
 	}
@@ -929,8 +926,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertStringEndsWith(
-			'/edit.php?post_type=amp_validated_url&amp_validate_error=missing_url&amp_urls_tested=0',
+		$this->assertContains(
+			'/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
 		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -940,8 +937,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception    = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertStringEndsWith(
-			'/edit.php?post_type=amp_validated_url&amp_validate_error=invalid_post&amp_urls_tested=0',
+		$this->assertContains(
+			'/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
 		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -951,8 +948,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception    = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertStringEndsWith(
-			'/edit.php?post_type=amp_validated_url&amp_validate_error=invalid_post&amp_urls_tested=0',
+		$this->assertContains(
+			'/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
 		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -962,8 +959,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception    = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertStringEndsWith(
-			sprintf( 'post.php?post=%s&action=edit&amp_urls_tested=1&amp_remaining_errors=2', $post_id ),
+		$this->assertContains(
+			sprintf( 'post.php?post=%s&action=edit&amp_urls_tested=', $post_id ),
 			$exception->getMessage()
 		);
 		unset( $_GET['post'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -993,8 +990,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception   = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertStringEndsWith(
-			'wp-admin/edit.php?post_type=amp_validated_url&amp_validate_error=illegal_url&amp_urls_tested=0',
+		$this->assertContains(
+			'wp-admin/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
 	}

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -265,7 +265,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		// Test normalized.
 		$args = [ 'normalize' => false ];
-		$url  = add_query_arg( 'utm_foo', 'bar', get_permalink( $post ) . '#baz' );
+		$url  = add_query_arg(
+			array_fill_keys( wp_removable_query_args(), 'true' ),
+			get_permalink( $post ) . '#baz'
+		);
 		$url  = set_url_scheme( $url, 'http' );
 		$this->assertNull( AMP_Validated_URL_Post_Type::get_invalid_url_post( $url, $args ) );
 		$args = [ 'normalize' => true ];


### PR DESCRIPTION
## Summary

This PR addresses something I noticed when troubleshooting a [support topic](https://wordpress.org/support/topic/links-and-buttons-are-disabled/#post-12146493), namely that when a validation request fails the error message is too generic and not provide enough context for why the problem is happening and how it can be resolved. This includes direction to check Site Health and how to find the support forum and submit topics.

For testing, there is a [plugin](https://gist.github.com/westonruter/d34f49b6288ed52604f7e9b6926810a9) which allows you to (re-)validate URLs with particular query vars to trigger various error scenarios, for example:

* `?amp_simulate_validate_request_error=response_comment_absent`
* `?amp_simulate_validate_request_error=wsod`
* `?amp_simulate_validate_request_error=bad_host`
* `?amp_simulate_validate_request_error=timeout`

This PR also addresses an issue discovered where query params added to the original URLs are normalized-away in the resulting URL that is used for the `amp_validated_url` post type. It also fixes encoding query params in URLs that are added to links in the admin bar.

### Before

<img width="1101" alt="Screen Shot 2019-11-18 at 21 51 25" src="https://user-images.githubusercontent.com/134745/69120755-42f0e880-0a4f-11ea-9313-2c07065a3aca.png">

### After

<img width="1101" alt="Screen Shot 2019-11-18 at 21 50 33" src="https://user-images.githubusercontent.com/134745/69120768-47b59c80-0a4f-11ea-863b-d884140a9183.png">

Relates to #3789 and #1371 and #2199.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
