### PR TITLE
Use white-space:pre-wrap on pre tags to prevent overflowing container

### DIFF
--- a/assets/css/src/amp-validation-single-error-url.css
+++ b/assets/css/src/amp-validation-single-error-url.css
@@ -63,6 +63,10 @@ table.striped > tbody > tr.even {
 	font-weight: 600;
 }
 
+.detailed pre {
+	white-space: pre-wrap;
+}
+
 .column-status select {
 	vertical-align: top;
 }


### PR DESCRIPTION
## Summary

When there is an invalid inline `script` or `style` that has minified source, expanding the text content can cause the `pre` to overflow the container. This can be fixed by applying `white-space:pre-wrap` to the element.

### Before

<img width="1287" alt="Screen Shot 2019-11-20 at 11 19 44" src="https://user-images.githubusercontent.com/134745/69270565-07a60500-0b88-11ea-8de1-2b728965ee7d.png">

### After

<img width="1288" alt="Screen Shot 2019-11-20 at 11 20 14" src="https://user-images.githubusercontent.com/134745/69270582-0e347c80-0b88-11ea-8841-bdabcd760a94.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
