### PR TITLE
Ensure Stories preview in e2e tests meets minimum viewport requirements.

### DIFF
--- a/tests/e2e/utils/open-preview-page.js
+++ b/tests/e2e/utils/open-preview-page.js
@@ -22,6 +22,15 @@ export async function openPreviewPage( editorPage, selector ) {
 	}
 
 	const previewPage = last( openTabs );
+
+	// Ensure that Story preview page meets AMP desktop viewport requirements.
+	if ( 'amp-story' === selector ) {
+		await previewPage.setViewport( {
+			width: 1024,
+			height: 550,
+		} );
+	}
+
 	// Wait for the preview to load. We can't do interstitial detection here,
 	// because it might load too quickly for us to pick up, so we wait for
 	// the preview to load by waiting for the title to appear.


### PR DESCRIPTION
When running the e2e tests interactively, there was a consistent failure of the `amp-story` preview page which seems to be causing an issue with the testing suite. 

In short, when AMP detects that the screen is of a specific larger size, it uses the desktop version of Stories, which requires a minimum width of 1024px and height of 550px. When this viewport requirement is not met, AMP displays an notice to the user to adjust the size of the viewport, which may have been causing those errors.

This pull request sets the Stories preview to the minimum AMP requirements (for desktop).