### PR TITLE
Optimize is_amp_allowed_attribute checking for reference points

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1693,18 +1693,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		 * https://github.com/ampproject/amphtml/blob/1526498116488/extensions/amp-selector/validator-amp-selector.protoascii#L81-L91
 		 */
 		$descendant_reference_points = [
-			'amp-selector'         => AMP_Allowed_Tags_Generated::get_reference_point_spec( 'AMP-SELECTOR option' ),
-			'amp-story-grid-layer' => AMP_Allowed_Tags_Generated::get_reference_point_spec( 'AMP-STORY-GRID-LAYER default' ), // @todo Consider the more restrictive 'AMP-STORY-GRID-LAYER animate-in'.
+			'amp-selector'         => 'AMP-SELECTOR option',
+			'amp-story-grid-layer' => 'AMP-STORY-GRID-LAYER default', // @todo Consider the more restrictive 'AMP-STORY-GRID-LAYER animate-in'.
 		];
-		foreach ( $descendant_reference_points as $ancestor_name => $reference_point_spec ) {
+		foreach ( $descendant_reference_points as $ancestor_name => $reference_point_spec_name ) {
+			if ( empty( $this->open_elements[ $ancestor_name ] ) ) {
+				continue;
+			}
+			$reference_point_spec = AMP_Allowed_Tags_Generated::get_reference_point_spec( $reference_point_spec_name );
 			if ( isset( $reference_point_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ][ $attr_name ] ) ) {
-				$parent = $attr_node->parentNode;
-				while ( $parent ) {
-					if ( $ancestor_name === $parent->nodeName ) {
-						return true;
-					}
-					$parent = $parent->parentNode;
-				}
+				return true;
 			}
 		}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1124,6 +1124,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-selector', 'amp-form', 'amp-carousel' ],
 			],
 
+			'reference-point-descendant-attr-outside-parent' => [
+				'<div option="foo">Foo!</div>',
+				'<div>Foo!</div>',
+				[],
+			],
+
 			'amp_live_list_sort'                           => [
 				'<amp-live-list sort="ascending" data-poll-interval="15000" data-max-items-per-page="5" id="amp-live-list-insert-blog"><button update on="tap:amp-live-list-insert-blog.update" class="ampstart-btn ml1 caps">You have updates</button><div items><div id="A green landscape with trees." data-sort-time="20180317225019">Hello</div></div></amp-live-list>',
 				null, // No change.


### PR DESCRIPTION
Following up on #3243 we can now optimize `\AMP_Tag_And_Attribute_Sanitizer::is_amp_allowed_attribute()` by looking at the currently-open elements rather than traversing all the ancestor nodes to see whether an element is open. This PR implements that optimization.