### PR TITLE
Refactor generated spec data to facilitate looking up by spec name

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -101,6 +101,7 @@ def GeneratePHP(out_dir):
 	expected_spec_names = (
 		'style amp-custom',
 		'style[amp-keyframes]',
+		'link rel=stylesheet for fonts',
 	)
 	for expected_spec_name in expected_spec_names:
 		if expected_spec_name not in seen_spec_names:
@@ -250,12 +251,26 @@ def GenerateFooterPHP(out):
 	 * Get the rules for a single tag so that the entire data structure needn't be passed around.
 	 *
 	 * @since 0.7
-	 * @param string $node_name Tag name.
+	 *
+	 * @param string      $node_name Tag name.
+	 * @param string|null $spec_name Spec name.
 	 * @return array|null Allowed tag, or null if the tag does not exist.
 	 */
-	public static function get_allowed_tag( $node_name ) {
+	public static function get_allowed_tag( $node_name, $spec_name = null ) {
 		if ( isset( self::$allowed_tags[ $node_name ] ) ) {
-			return self::$allowed_tags[ $node_name ];
+			$rule_specs = self::$allowed_tags[ $node_name ];
+			if ( empty( $spec_name ) ) {
+				return $rule_specs;
+			}
+			foreach ( $rule_specs as $rule_spec ) {
+				if (
+					( ! isset( $rule_spec['tag_spec']['spec_name'] ) && $node_name === $spec_name )
+					||
+					( isset( $rule_spec['tag_spec']['spec_name'] ) && $rule_spec['tag_spec']['spec_name'] === $spec_name )
+				) {
+					return $rule_spec;
+				}
+			}
 		}
 		return null;
 	}
@@ -501,6 +516,10 @@ def GetTagSpec(tag_spec, attr_lists):
 		if spec_name in seen_spec_names:
 			raise Exception( 'Already seen spec_name: %s' % spec_name )
 		seen_spec_names.add( spec_name )
+
+		# Add the spec_name to the tag spec if it isn't the same as the tag name.
+		if spec_name != tag_spec.tag_name.lower():
+			tag_spec_dict['tag_spec']['spec_name'] = spec_name
 
 	return tag_spec_dict
 

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -593,10 +593,6 @@ def GetTagRules(tag_spec):
 		versions.remove( 'latest' )
 		extension_spec['version'] = sorted( versions, key=lambda version: map(int, version.split('.') ) )
 
-		# Unused since amp_filter_script_loader_tag() and \AMP_Tag_And_Attribute_Sanitizer::get_rule_spec_list_to_validate() just hard-codes the check for amp-mustache.
-		if 'extension_type' in extension_spec:
-			del extension_spec['extension_type']
-
 		if 'deprecated_version' in extension_spec:
 			del extension_spec['deprecated_version']
 

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13602,6 +13602,7 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'extension_spec' => array(
+						'extension_type' => 2,
 						'name' => 'amp-mustache',
 						'requires_usage' => true,
 						'version' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -11554,6 +11554,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-3d-gltf]',
 				),
 			),
 			array(
@@ -11579,6 +11580,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-3q-player]',
 				),
 			),
 			array(
@@ -11608,6 +11610,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-access',
 					),
+					'spec_name' => 'script [custom-element=amp-access-laterpay]',
 				),
 			),
 			array(
@@ -11636,6 +11639,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-access',
 					),
+					'spec_name' => 'script [custom-element=amp-access-poool]',
 				),
 			),
 			array(
@@ -11664,6 +11668,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-access',
 					),
+					'spec_name' => 'script [custom-element=amp-access-scroll]',
 				),
 			),
 			array(
@@ -11689,6 +11694,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-access]',
 				),
 			),
 			array(
@@ -11746,6 +11752,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-accordion]',
 				),
 			),
 			array(
@@ -11771,6 +11778,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-action-macro]',
 				),
 			),
 			array(
@@ -11848,6 +11856,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-addthis]',
 				),
 			),
 			array(
@@ -11873,6 +11882,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-analytics]',
 				),
 			),
 			array(
@@ -11924,6 +11934,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-anim]',
 				),
 			),
 			array(
@@ -11949,6 +11960,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-animation]',
 				),
 			),
 			array(
@@ -11999,6 +12011,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-apester-media]',
 				),
 			),
 			array(
@@ -12024,6 +12037,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-app-banner]',
 				),
 			),
 			array(
@@ -12049,6 +12063,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-audio]',
 				),
 			),
 			array(
@@ -12074,6 +12089,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-auto-ads]',
 				),
 			),
 			array(
@@ -12099,6 +12115,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-autocomplete]',
 				),
 			),
 			array(
@@ -12149,6 +12166,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-base-carousel]',
 				),
 			),
 			array(
@@ -12174,6 +12192,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-beopinion]',
 				),
 			),
 			array(
@@ -12199,6 +12218,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-bind]',
 				),
 			),
 			array(
@@ -12252,6 +12272,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-bodymovin-animation]',
 				),
 			),
 			array(
@@ -12277,6 +12298,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-brid-player]',
 				),
 			),
 			array(
@@ -12302,6 +12324,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-brightcove]',
 				),
 			),
 			array(
@@ -12327,6 +12350,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-byside-content]',
 				),
 			),
 			array(
@@ -12352,6 +12376,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-call-tracking]',
 				),
 			),
 			array(
@@ -12378,6 +12403,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.2',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-carousel]',
 				),
 			),
 			array(
@@ -12403,6 +12429,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-connatix-player]',
 				),
 			),
 			array(
@@ -12428,6 +12455,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-consent]',
 				),
 			),
 			array(
@@ -12479,6 +12507,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-dailymotion]',
 				),
 			),
 			array(
@@ -12504,6 +12533,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-date-countdown]',
 				),
 			),
 			array(
@@ -12529,6 +12559,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-date-display]',
 				),
 			),
 			array(
@@ -12554,6 +12585,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-date-picker]',
 				),
 			),
 			array(
@@ -12579,6 +12611,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-delight-player]',
 				),
 			),
 			array(
@@ -12604,6 +12637,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-dynamic-css-classes]',
 				),
 			),
 			array(
@@ -12629,6 +12663,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-embedly-card]',
 				),
 			),
 			array(
@@ -12655,6 +12690,7 @@ class AMP_Allowed_Tags_Generated {
 							'1.0',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-experiment]',
 				),
 			),
 			array(
@@ -12705,6 +12741,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-facebook-comments]',
 				),
 			),
 			array(
@@ -12730,6 +12767,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-facebook-like]',
 				),
 			),
 			array(
@@ -12755,6 +12793,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-facebook-page]',
 				),
 			),
 			array(
@@ -12780,6 +12819,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-facebook]',
 				),
 			),
 			array(
@@ -12805,6 +12845,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-fit-text]',
 				),
 			),
 			array(
@@ -12830,6 +12871,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-font]',
 				),
 			),
 			array(
@@ -12855,6 +12897,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-form]',
 				),
 			),
 			array(
@@ -12880,6 +12923,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-fx-collection]',
 				),
 			),
 			array(
@@ -12905,6 +12949,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-fx-flying-carpet]',
 				),
 			),
 			array(
@@ -12930,6 +12975,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-geo]',
 				),
 			),
 			array(
@@ -12981,6 +13027,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-gfycat]',
 				),
 			),
 			array(
@@ -13006,6 +13053,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-gist]',
 				),
 			),
 			array(
@@ -13031,6 +13079,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-google-document-embed]',
 				),
 			),
 			array(
@@ -13056,6 +13105,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-hulu]',
 				),
 			),
 			array(
@@ -13081,6 +13131,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-iframe]',
 				),
 			),
 			array(
@@ -13106,6 +13157,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-ima-video]',
 				),
 			),
 			array(
@@ -13131,6 +13183,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-image-lightbox]',
 				),
 			),
 			array(
@@ -13156,6 +13209,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-image-slider]',
 				),
 			),
 			array(
@@ -13181,6 +13235,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-imgur]',
 				),
 			),
 			array(
@@ -13206,6 +13261,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-inputmask]',
 				),
 			),
 			array(
@@ -13231,6 +13287,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-instagram]',
 				),
 			),
 			array(
@@ -13256,6 +13313,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-install-serviceworker]',
 				),
 			),
 			array(
@@ -13281,6 +13339,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-izlesene]',
 				),
 			),
 			array(
@@ -13306,6 +13365,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-jwplayer]',
 				),
 			),
 			array(
@@ -13331,6 +13391,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-kaltura-player]',
 				),
 			),
 			array(
@@ -13356,6 +13417,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-lightbox-gallery]',
 				),
 			),
 			array(
@@ -13381,6 +13443,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-lightbox]',
 				),
 			),
 			array(
@@ -13406,6 +13469,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-link-rewriter]',
 				),
 			),
 			array(
@@ -13456,6 +13520,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-list]',
 				),
 			),
 			array(
@@ -13482,6 +13547,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'mandatory_parent' => 'head',
+					'spec_name' => 'script [custom-element=amp-live-list]',
 					'unique_warning' => true,
 				),
 			),
@@ -13508,6 +13574,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-mathml]',
 				),
 			),
 			array(
@@ -13533,6 +13600,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-megaphone]',
 				),
 			),
 			array(
@@ -13558,6 +13626,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-minute-media-player]',
 				),
 			),
 			array(
@@ -13583,6 +13652,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-mowplayer]',
 				),
 			),
 			array(
@@ -13610,6 +13680,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.2',
 						),
 					),
+					'spec_name' => 'script [custom-template=amp-mustache]',
 				),
 			),
 			array(
@@ -13673,6 +13744,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-next-page]',
 				),
 			),
 			array(
@@ -13717,6 +13789,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-nexxtv-player]',
 				),
 			),
 			array(
@@ -13742,6 +13815,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-o2-player]',
 				),
 			),
 			array(
@@ -13767,6 +13841,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-ooyala-player]',
 				),
 			),
 			array(
@@ -13792,6 +13867,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-orientation-observer]',
 				),
 			),
 			array(
@@ -13817,6 +13893,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-pan-zoom]',
 				),
 			),
 			array(
@@ -13842,6 +13919,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-pinterest]',
 				),
 			),
 			array(
@@ -13867,6 +13945,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-playbuzz]',
 				),
 			),
 			array(
@@ -13892,6 +13971,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-position-observer]',
 				),
 			),
 			array(
@@ -13917,6 +13997,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-powr-player]',
 				),
 			),
 			array(
@@ -13942,6 +14023,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-reach-player]',
 				),
 			),
 			array(
@@ -13967,6 +14049,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-recaptcha-input]',
 				),
 			),
 			array(
@@ -13992,6 +14075,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-reddit]',
 				),
 			),
 			array(
@@ -14017,6 +14101,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-riddle-quiz]',
 				),
 			),
 			array(
@@ -14042,6 +14127,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-script]',
 				),
 			),
 			array(
@@ -14104,6 +14190,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-selector]',
 				),
 			),
 			array(
@@ -14129,6 +14216,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-sidebar]',
 				),
 			),
 			array(
@@ -14154,6 +14242,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-skimlinks]',
 				),
 			),
 			array(
@@ -14179,6 +14268,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-smartlinks]',
 				),
 			),
 			array(
@@ -14204,6 +14294,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-social-share]',
 				),
 			),
 			array(
@@ -14229,6 +14320,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-soundcloud]',
 				),
 			),
 			array(
@@ -14254,6 +14346,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-springboard-player]',
 				),
 			),
 			array(
@@ -14280,6 +14373,7 @@ class AMP_Allowed_Tags_Generated {
 							'1.0',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-sticky-ad]',
 				),
 			),
 			array(
@@ -14305,6 +14399,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-story-auto-ads]',
 				),
 			),
 			array(
@@ -14356,6 +14451,7 @@ class AMP_Allowed_Tags_Generated {
 							'1.0',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-story]',
 				),
 			),
 			array(
@@ -14452,6 +14548,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-subscriptions]',
 				),
 			),
 			array(
@@ -14512,6 +14609,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-subscriptions',
 					),
+					'spec_name' => 'script [custom-element=amp-subscriptions-google]',
 				),
 			),
 			array(
@@ -14537,6 +14635,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-timeago]',
 				),
 			),
 			array(
@@ -14562,6 +14661,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-truncate-text]',
 				),
 			),
 			array(
@@ -14587,6 +14687,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-twitter]',
 				),
 			),
 			array(
@@ -14612,6 +14713,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-user-location]',
 				),
 			),
 			array(
@@ -14663,6 +14765,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-user-notification]',
 				),
 			),
 			array(
@@ -14714,6 +14817,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-video-iframe]',
 				),
 			),
 			array(
@@ -14765,6 +14869,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-vimeo]',
 				),
 			),
 			array(
@@ -14790,6 +14895,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-vine]',
 				),
 			),
 			array(
@@ -14815,6 +14921,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-viqeo-player]',
 				),
 			),
 			array(
@@ -14840,6 +14947,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-vk]',
 				),
 			),
 			array(
@@ -14865,6 +14973,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-web-push]',
 				),
 			),
 			array(
@@ -14890,6 +14999,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-wistia-player]',
 				),
 			),
 			array(
@@ -14915,6 +15025,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-yotpo]',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo',
 				),
 			),
@@ -14941,6 +15052,7 @@ class AMP_Allowed_Tags_Generated {
 							'0.1',
 						),
 					),
+					'spec_name' => 'script [custom-element=amp-youtube]',
 				),
 			),
 		),
@@ -17625,12 +17737,26 @@ class AMP_Allowed_Tags_Generated {
 	 * Get the rules for a single tag so that the entire data structure needn't be passed around.
 	 *
 	 * @since 0.7
-	 * @param string $node_name Tag name.
+	 *
+	 * @param string      $node_name Tag name.
+	 * @param string|null $spec_name Spec name.
 	 * @return array|null Allowed tag, or null if the tag does not exist.
 	 */
-	public static function get_allowed_tag( $node_name ) {
+	public static function get_allowed_tag( $node_name, $spec_name = null ) {
 		if ( isset( self::$allowed_tags[ $node_name ] ) ) {
-			return self::$allowed_tags[ $node_name ];
+			$rule_specs = self::$allowed_tags[ $node_name ];
+			if ( empty( $spec_name ) ) {
+				return $rule_specs;
+			}
+			foreach ( $rule_specs as $rule_spec ) {
+				if (
+					( ! isset( $rule_spec['tag_spec']['spec_name'] ) && $node_name === $spec_name )
+					||
+					( isset( $rule_spec['tag_spec']['spec_name'] ) && $rule_spec['tag_spec']['spec_name'] === $spec_name )
+				) {
+					return $rule_spec;
+				}
+			}
 		}
 		return null;
 	}

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -11533,172 +11533,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-3d-gltf',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-3d-gltf]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-3q-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-3q-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-access-laterpay',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-							'0.2',
-						),
-					),
-					'requires_extension' => array(
-						'amp-access',
-					),
-					'spec_name' => 'script [custom-element=amp-access-laterpay]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-access-poool',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'requires_extension' => array(
-						'amp-access',
-					),
-					'spec_name' => 'script [custom-element=amp-access-poool]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-access-scroll',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'requires_extension' => array(
-						'amp-access',
-					),
-					'spec_name' => 'script [custom-element=amp-access-scroll]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-access',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-access]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'id' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
@@ -11731,162 +11565,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-accordion',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-accordion]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-action-macro',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-action-macro]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-ad-custom',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'amp-ad-custom extension .js script',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-ad',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'amp-ad extension .js script',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-addthis',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-addthis]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-analytics',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-analytics]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -11909,58 +11587,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-analytics extension .json script',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-analytics',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-anim',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-anim]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-animation',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-animation]',
 				),
 			),
 			array(
@@ -11990,136 +11616,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-apester-media',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-apester-media]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-app-banner',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-app-banner]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-audio',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-audio]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-auto-ads',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-auto-ads]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-autocomplete',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-autocomplete]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -12141,84 +11637,6 @@ class AMP_Allowed_Tags_Generated {
 						'amp-autocomplete',
 					),
 					'spec_name' => 'amp-autocomplete JSON',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-base-carousel',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-base-carousel]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-beopinion',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-beopinion]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-bind',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-bind]',
 				),
 			),
 			array(
@@ -12251,215 +11669,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-bodymovin-animation',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-bodymovin-animation]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-brid-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-brid-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-brightcove',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-brightcove]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-byside-content',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-byside-content]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-call-tracking',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-call-tracking]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-carousel',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-							'0.2',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-carousel]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-connatix-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-connatix-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-consent',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-consent]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -12486,215 +11695,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-dailymotion',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-dailymotion]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-date-countdown',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-date-countdown]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-date-display',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-date-display]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-date-picker',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-date-picker]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-delight-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-delight-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-dynamic-css-classes',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-dynamic-css-classes]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-embedly-card',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-embedly-card]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-experiment',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-							'1.0',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-experiment]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -12716,266 +11716,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'amp-experiment',
 					'spec_name' => 'amp-experiment extension .json script',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-experiment',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-facebook-comments',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-facebook-comments]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-facebook-like',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-facebook-like]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-facebook-page',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-facebook-page]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-facebook',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-facebook]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-fit-text',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-fit-text]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-font',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-font]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-form',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-form]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-fx-collection',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-fx-collection]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-fx-flying-carpet',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-fx-flying-carpet]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-geo',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-geo]',
 				),
 			),
 			array(
@@ -13006,474 +11746,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-gfycat',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-gfycat]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-gist',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-gist]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-google-document-embed',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-google-document-embed]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-hulu',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-hulu]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-iframe',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-iframe]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-ima-video',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-ima-video]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-image-lightbox',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-image-lightbox]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-image-slider',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-image-slider]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-imgur',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-imgur]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-inputmask',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-inputmask]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-instagram',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-instagram]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-install-serviceworker',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-install-serviceworker]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-izlesene',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-izlesene]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-jwplayer',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-jwplayer]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-kaltura-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-kaltura-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-lightbox-gallery',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-lightbox-gallery]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-lightbox',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-lightbox]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-link-rewriter',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-link-rewriter]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -13495,192 +11767,6 @@ class AMP_Allowed_Tags_Generated {
 						'amp-link-rewriter',
 					),
 					'spec_name' => 'amp-link-rewriter extension .json script',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-list',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-list]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-live-list',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'mandatory_parent' => 'head',
-					'spec_name' => 'script [custom-element=amp-live-list]',
-					'unique_warning' => true,
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-mathml',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-mathml]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-megaphone',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-megaphone]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-minute-media-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-minute-media-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-mowplayer',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-mowplayer]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'extension_type' => 2,
-						'name' => 'amp-mustache',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-							'0.2',
-						),
-					),
-					'spec_name' => 'script [custom-template=amp-mustache]',
 				),
 			),
 			array(
@@ -13723,32 +11809,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-next-page',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-next-page]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'type' => array(
 						'dispatch_key' => 3,
 						'mandatory' => true,
@@ -13764,370 +11824,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-next-page extension .json configuration',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-nexxtv-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-nexxtv-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-o2-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-o2-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-ooyala-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-ooyala-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-orientation-observer',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-orientation-observer]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-pan-zoom',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-pan-zoom]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-pinterest',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-pinterest]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-playbuzz',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-playbuzz]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-position-observer',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-position-observer]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-powr-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-powr-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-reach-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-reach-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-recaptcha-input',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-recaptcha-input]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-reddit',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-reddit]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-riddle-quiz',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-riddle-quiz]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-script',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-script]',
 				),
 			),
 			array(
@@ -14169,241 +11865,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-selector',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-selector]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-sidebar',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-sidebar]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-skimlinks',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-skimlinks]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-smartlinks',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-smartlinks]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-social-share',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-social-share]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-soundcloud',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-soundcloud]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-springboard-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-springboard-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-sticky-ad',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-							'1.0',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-sticky-ad]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-story-auto-ads',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-story-auto-ads]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -14426,32 +11887,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-story-auto-ads config script',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-story-auto-ads',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-story',
-						'requires_usage' => true,
-						'version' => array(
-							'1.0',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-story]',
 				),
 			),
 			array(
@@ -14527,32 +11962,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-subscriptions',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-subscriptions]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'id' => array(
 						'dispatch_key' => 2,
 						'mandatory' => true,
@@ -14585,139 +11994,6 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-subscriptions-google',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'requires_extension' => array(
-						'amp-subscriptions',
-					),
-					'spec_name' => 'script [custom-element=amp-subscriptions-google]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-timeago',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-timeago]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-truncate-text',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-truncate-text]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-twitter',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-twitter]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-user-location',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-user-location]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'nonce' => array(),
 					'type' => array(
 						'dispatch_key' => 3,
@@ -14740,319 +12016,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'spec_name' => 'amp-user-location extension .json script',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-user-notification',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-user-notification]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-video-docking',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'amp-video-docking',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-video-iframe',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-video-iframe]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-video',
-						'requires_usage' => false,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'amp-video extension .js script',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-vimeo',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-vimeo]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-vine',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-vine]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-viqeo-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-viqeo-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-vk',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-vk]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-web-push',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-web-push]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-wistia-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-wistia-player]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-yotpo',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-yotpo]',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-yotpo',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-youtube',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-					'spec_name' => 'script [custom-element=amp-youtube]',
 				),
 			),
 		),
@@ -17698,6 +14661,712 @@ class AMP_Allowed_Tags_Generated {
 	);
 
 
+	private static $extension_specs = array(
+		'amp-3d-gltf' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-3q-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-access' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-access-laterpay' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+				'0.2',
+			),
+		),
+		'amp-access-poool' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-access-scroll' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-accordion' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-action-macro' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-ad' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-ad-custom' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-addthis' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-analytics' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-anim' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-animation' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-apester-media' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-app-banner' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-audio' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-auto-ads' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-autocomplete' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-base-carousel' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-beopinion' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-bind' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-bodymovin-animation' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-brid-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-brightcove' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-byside-content' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-call-tracking' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-carousel' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+				'0.2',
+			),
+		),
+		'amp-connatix-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-consent' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-dailymotion' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-date-countdown' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-date-display' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-date-picker' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-delight-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-dynamic-css-classes' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-embedly-card' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-experiment' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+				'1.0',
+			),
+		),
+		'amp-facebook' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-facebook-comments' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-facebook-like' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-facebook-page' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-fit-text' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-font' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-form' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-fx-collection' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-fx-flying-carpet' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-geo' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-gfycat' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-gist' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-google-document-embed' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-hulu' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-iframe' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-ima-video' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-image-lightbox' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-image-slider' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-imgur' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-inputmask' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-instagram' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-install-serviceworker' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-izlesene' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-jwplayer' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-kaltura-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-lightbox' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-lightbox-gallery' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-link-rewriter' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-list' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-live-list' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-mathml' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-megaphone' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-minute-media-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-mowplayer' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-mustache' => array(
+			'extension_type' => 2,
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+				'0.2',
+			),
+		),
+		'amp-next-page' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-nexxtv-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-o2-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-ooyala-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-orientation-observer' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-pan-zoom' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-pinterest' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-playbuzz' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-position-observer' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-powr-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-reach-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-recaptcha-input' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-reddit' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-riddle-quiz' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-script' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-selector' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-sidebar' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-skimlinks' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-smartlinks' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-social-share' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-soundcloud' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-springboard-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-sticky-ad' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+				'1.0',
+			),
+		),
+		'amp-story' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'1.0',
+			),
+		),
+		'amp-story-auto-ads' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-subscriptions' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-subscriptions-google' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-timeago' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-truncate-text' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-twitter' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-user-location' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-user-notification' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-video' => array(
+			'requires_usage' => false,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-video-docking' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-video-iframe' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-vimeo' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-vine' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-viqeo-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-vk' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-web-push' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-wistia-player' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-yotpo' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+		'amp-youtube' => array(
+			'requires_usage' => true,
+			'version' => array(
+				'0.1',
+			),
+		),
+	);
+
+
 	/**
 	 * Get allowed tags.
 	 *
@@ -17713,22 +15382,27 @@ class AMP_Allowed_Tags_Generated {
 	 *
 	 * @since 1.5
 	 * @internal
+	 *
 	 * @return array Extension specs, keyed by extension name.
 	 */
 	public static function get_extension_specs() {
-		static $extension_specs = [];
+		return self::$extension_specs;
+	}
 
-		if ( ! empty( $extension_specs ) ) {
-			return $extension_specs;
+	/**
+	 * Get extension specs.
+	 *
+	 * @since 1.5
+	 * @internal
+	 *
+	 * @param string $name Extension name.
+	 * @return array Extension specs, keyed by extension name.
+	 */
+	public static function get_extension_spec( $name ) {
+		if ( isset( self::$extension_specs[ $name ] ) ) {
+			return self::$extension_specs[ $name ];
 		}
-
-		foreach ( self::get_allowed_tag( 'script' ) as $script_spec ) {
-			if ( isset( $script_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec'] ) ) {
-				$extension_specs[ $script_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec']['name'] ] = $script_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec'];
-			}
-		}
-
-		return $extension_specs;
+		return null;
 	}
 
 	/**
@@ -17738,23 +15412,23 @@ class AMP_Allowed_Tags_Generated {
 	 *
 	 * @since 0.7
 	 *
-	 * @param string      $node_name Tag name.
+	 * @param string      $tag_name  Tag name.
 	 * @param string|null $spec_name Spec name.
-	 * @return array|null Allowed tag, or null if the tag does not exist.
+	 * @return array[]|array|null Allowed tags, allowed tag spec, or null if the tag does not exist.
 	 */
-	public static function get_allowed_tag( $node_name, $spec_name = null ) {
-		if ( isset( self::$allowed_tags[ $node_name ] ) ) {
-			$rule_specs = self::$allowed_tags[ $node_name ];
+	public static function get_allowed_tag( $tag_name, $spec_name = null ) {
+		if ( isset( self::$allowed_tags[ $tag_name ] ) ) {
+			$rule_specs = self::$allowed_tags[ $tag_name ];
 			if ( empty( $spec_name ) ) {
 				return $rule_specs;
 			}
 			foreach ( $rule_specs as $rule_spec ) {
 				if (
-					( ! isset( $rule_spec['tag_spec']['spec_name'] ) && $node_name === $spec_name )
+					( ! isset( $rule_spec['tag_spec']['spec_name'] ) && $tag_name === $spec_name )
 					||
 					( isset( $rule_spec['tag_spec']['spec_name'] ) && $rule_spec['tag_spec']['spec_name'] === $spec_name )
 				) {
-					return $rule_spec;
+					return array_merge( compact( 'tag_name' ), $rule_spec );
 				}
 			}
 		}

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -144,18 +144,4 @@ abstract class AMP_Rule_Spec {
 		'typemustmatch',
 		'visible',
 	];
-
-	/**
-	 * Additional allowed tags.
-	 *
-	 * @var array
-	 */
-	public static $additional_allowed_tags = [
-
-		// An experimental tag with no protoascii.
-		'amp-share-tracking' => [
-			'attr_spec_list' => [],
-			'tag_spec'       => [],
-		],
-	];
 }

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -388,24 +388,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	public function __construct( $dom, array $args = [] ) {
 		parent::__construct( $dom, $args );
 
-		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'style' ) as $spec_rule ) {
-			if ( ! isset( $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) ) {
-				continue;
-			}
-			if ( self::STYLE_AMP_KEYFRAMES_SPEC_NAME === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
-				$this->style_keyframes_cdata_spec = $spec_rule[ AMP_Rule_Spec::CDATA ];
-			} elseif ( self::STYLE_AMP_CUSTOM_SPEC_NAME === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
-				$this->style_custom_cdata_spec = $spec_rule[ AMP_Rule_Spec::CDATA ];
-			}
-		}
+		$style_custom_rule_spec        = AMP_Allowed_Tags_Generated::get_allowed_tag( 'style', self::STYLE_AMP_CUSTOM_SPEC_NAME );
+		$this->style_custom_cdata_spec = $style_custom_rule_spec[ AMP_Rule_Spec::CDATA ];
 
-		$spec_name = 'link rel=stylesheet for fonts'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		foreach ( AMP_Allowed_Tags_Generated::get_allowed_tag( 'link' ) as $spec_rule ) {
-			if ( isset( $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) && $spec_name === $spec_rule[ AMP_Rule_Spec::TAG_SPEC ]['spec_name'] ) {
-				$this->allowed_font_src_regex = '@^(' . $spec_rule[ AMP_Rule_Spec::ATTR_SPEC_LIST ]['href']['value_regex'] . ')$@';
-				break;
-			}
-		}
+		$style_keyframes_rule_spec        = AMP_Allowed_Tags_Generated::get_allowed_tag( 'style', self::STYLE_AMP_KEYFRAMES_SPEC_NAME );
+		$this->style_keyframes_cdata_spec = $style_keyframes_rule_spec[ AMP_Rule_Spec::CDATA ];
+
+		$font_stylesheet_tag_spec     = AMP_Allowed_Tags_Generated::get_allowed_tag( 'link', 'link rel=stylesheet for fonts' ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->allowed_font_src_regex = '@^(' . $font_stylesheet_tag_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ]['href']['value_regex'] . ')$@';
 
 		$guessurl = site_url();
 		if ( ! $guessurl ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -152,28 +152,25 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array    $args Args.
 	 */
 	public function __construct( $dom, $args = [] ) {
-		// @todo It is pointless to have this DEFAULT_ARGS copying the array values. We should only get the data from AMP_Allowed_Tags_Generated.
-		$this->DEFAULT_ARGS = [
-			'amp_allowed_tags'                => AMP_Allowed_Tags_Generated::get_allowed_tags(),
-			'amp_globally_allowed_attributes' => AMP_Allowed_Tags_Generated::get_allowed_attributes(),
-			'amp_layout_allowed_attributes'   => AMP_Allowed_Tags_Generated::get_layout_attributes(),
-		];
-
 		parent::__construct( $dom, $args );
+
+		$this->allowed_tags                = AMP_Allowed_Tags_Generated::get_allowed_tags();
+		$this->globally_allowed_attributes = AMP_Allowed_Tags_Generated::get_allowed_attributes();
+		$this->layout_allowed_attributes   = AMP_Allowed_Tags_Generated::get_layout_attributes();
 
 		// @todo AMP dev mode should eventually be used instead of allow_dirty_styles.
 		if ( ! empty( $this->args['allow_dirty_styles'] ) ) {
 
 			// Allow style attribute on all elements.
-			$this->args['amp_globally_allowed_attributes']['style'] = [];
+			$this->globally_allowed_attributes['style'] = [];
 
 			// Remove restrictions on use of !important.
-			foreach ( $this->args['amp_allowed_tags']['style'] as &$style ) {
+			foreach ( $this->allowed_tags['style'] as &$style ) {
 				$style['cdata'] = [];
 			}
 
 			// Allow style elements.
-			$this->args['amp_allowed_tags']['style'][] = [
+			$this->allowed_tags['style'][] = [
 				'attr_spec_list' => [
 					'type' => [
 						'value_casei' => 'text/css',
@@ -186,7 +183,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			];
 
 			// Allow stylesheet links.
-			$this->args['amp_allowed_tags']['link'][] = [
+			$this->allowed_tags['link'][] = [
 				'attr_spec_list' => [
 					'async'       => [],
 					'crossorigin' => [],
@@ -213,7 +210,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		// @todo AMP dev mode should eventually be used instead of allow_dirty_scripts.
 		// Allow scripts if requested.
 		if ( ! empty( $this->args['allow_dirty_scripts'] ) ) {
-			$this->args['amp_allowed_tags']['script'][] = [
+			$this->allowed_tags['script'][] = [
 				'attr_spec_list' => [
 					'type'  => [],
 					'src'   => [],
@@ -228,7 +225,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		// Prepare whitelists.
-		$this->allowed_tags = $this->args['amp_allowed_tags'];
 		foreach ( AMP_Rule_Spec::$additional_allowed_tags as $tag_name => $tag_rule_spec ) {
 			$this->allowed_tags[ $tag_name ][] = $tag_rule_spec;
 		}
@@ -254,8 +250,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 		unset( $tag_specs );
 
-		$this->globally_allowed_attributes = $this->process_alternate_names( $this->args['amp_globally_allowed_attributes'] );
-		$this->layout_allowed_attributes   = $this->process_alternate_names( $this->args['amp_layout_allowed_attributes'] );
+		$this->globally_allowed_attributes = $this->process_alternate_names( $this->globally_allowed_attributes );
+		$this->layout_allowed_attributes   = $this->process_alternate_names( $this->layout_allowed_attributes );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -380,8 +380,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $rule_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec'] ) ) {
 			$extension_spec = $rule_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec'];
 
-			// This could also be derived from the extension_type in the extension_spec.
-			$custom_attr = 'amp-mustache' === $extension_spec['name'] ? 'custom-template' : 'custom-element';
+			if ( isset( $rule_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec']['extension_type'] ) && 2 === $rule_spec[ AMP_Rule_Spec::TAG_SPEC ]['extension_spec']['extension_type'] ) {
+				$custom_attr = 'custom-template';
+			} else {
+				$custom_attr = 'custom-element';
+			}
 
 			$rule_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ][ $custom_attr ] = [
 				AMP_Rule_Spec::VALUE     => $extension_spec['name'],
@@ -1056,7 +1059,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		} elseif ( isset( $tag_spec['extension_spec']['name'] ) ) {
 			return sprintf(
 				'script[%s=%s]',
-				'amp-mustache' === $tag_spec['extension_spec']['name'] ? 'custom-template' : 'custom-element',
+				isset( $tag_spec['extension_spec']['extension_type'] ) && 2 === $tag_spec['extension_spec']['extension_type'] ? 'custom-template' : 'custom-element',
 				strtolower( $tag_spec['extension_spec']['name'] )
 			);
 		} else {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -224,17 +224,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			];
 		}
 
-		// Prepare whitelists.
-		foreach ( AMP_Rule_Spec::$additional_allowed_tags as $tag_name => $tag_rule_spec ) {
-			$this->allowed_tags[ $tag_name ][] = $tag_rule_spec;
-		}
-
 		// @todo Do the same for body when !use_document_element?
 		if ( ! empty( $this->args['use_document_element'] ) ) {
 			foreach ( $this->allowed_tags['html'] as &$rule_spec ) {
 				unset( $rule_spec[ AMP_Rule_Spec::TAG_SPEC ][ AMP_Rule_Spec::MANDATORY_PARENT ] );
 			}
-
 			unset( $rule_spec );
 		}
 
@@ -244,10 +238,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					$tag_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ] = $this->process_alternate_names( $tag_spec[ AMP_Rule_Spec::ATTR_SPEC_LIST ] );
 				}
 			}
-
 			unset( $tag_spec );
 		}
-
 		unset( $tag_specs );
 
 		$this->globally_allowed_attributes = $this->process_alternate_names( $this->globally_allowed_attributes );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -39,6 +39,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the specs required by the constructor are present.
+	 */
+	public function test_constructor_dependencies() {
+		$this->assertInternalType( 'array', AMP_Allowed_Tags_Generated::get_allowed_tag( 'style', AMP_Style_Sanitizer::STYLE_AMP_CUSTOM_SPEC_NAME )[ AMP_Rule_Spec::CDATA ] );
+		$this->assertInternalType( 'array', AMP_Allowed_Tags_Generated::get_allowed_tag( 'style', AMP_Style_Sanitizer::STYLE_AMP_KEYFRAMES_SPEC_NAME )[ AMP_Rule_Spec::CDATA ] );
+		$this->assertInternalType( 'string', AMP_Allowed_Tags_Generated::get_allowed_tag( 'link', 'link rel=stylesheet for fonts' )[ AMP_Rule_Spec::ATTR_SPEC_LIST ]['href']['value_regex'] ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+	}
+
+	/**
 	 * Get data for tests.
 	 *
 	 * @return array


### PR DESCRIPTION
## Summary

Fixes #4597.

### Todo

- [ ] There should be an efficient way to look up a spec by a spec name regardless of the tag it occurs in.
- [ ] Instead of looping over the tag specs to find the one with the matching spec name, it would be better if the spec name was the array key.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
