### PR TITLE
For a Gallery block with a lightbox, allow viewing multiple images in the lightbox

### DIFF
--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -20,15 +20,6 @@ abstract class AMP_Base_Sanitizer {
 	const FALLBACK_HEIGHT = 400;
 
 	/**
-	 * Value for <amp-image-lightbox> ID.
-	 *
-	 * @since 1.0
-	 *
-	 * @const string
-	 */
-	const AMP_IMAGE_LIGHTBOX_ID = 'amp-image-lightbox';
-
-	/**
 	 * Placeholder for default args, to be set in child classes.
 	 *
 	 * @since 0.2
@@ -685,33 +676,6 @@ abstract class AMP_Base_Sanitizer {
 		}
 
 		return $new_attributes;
-	}
-
-	/**
-	 * Add <amp-image-lightbox> element to body tag if it doesn't exist yet.
-	 */
-	public function maybe_add_amp_image_lightbox_node() {
-
-		$nodes = $this->dom->getElementById( self::AMP_IMAGE_LIGHTBOX_ID );
-		if ( null !== $nodes ) {
-			return;
-		}
-
-		$nodes = $this->dom->getElementsByTagName( 'body' );
-		if ( ! $nodes->length ) {
-			return;
-		}
-		$body_node          = $nodes->item( 0 );
-		$amp_image_lightbox = AMP_DOM_Utils::create_node(
-			$this->dom,
-			'amp-image-lightbox',
-			[
-				'id'                           => self::AMP_IMAGE_LIGHTBOX_ID,
-				'layout'                       => 'nodisplay',
-				'data-close-button-aria-label' => __( 'Close', 'amp' ),
-			]
-		);
-		$body_node->appendChild( $amp_image_lightbox );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-gallery-block-sanitizer.php
+++ b/includes/sanitizers/class-amp-gallery-block-sanitizer.php
@@ -99,7 +99,6 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 			// If lightbox is set, we should add lightbox feature to the gallery images.
 			if ( $is_amp_lightbox ) {
 				$this->add_lightbox_attributes_to_image_nodes( $node );
-				$this->maybe_add_amp_image_lightbox_node();
 			}
 
 			// If amp-carousel is not set, nothing else to do here.
@@ -145,18 +144,10 @@ class AMP_Gallery_Block_Sanitizer extends AMP_Base_Sanitizer {
 		if ( 0 === $num_images ) {
 			return;
 		}
-		$attributes = [
-			'data-amp-lightbox' => '',
-			'on'                => 'tap:' . self::AMP_IMAGE_LIGHTBOX_ID,
-			'role'              => 'button',
-			'tabindex'          => 0,
-		];
 
 		for ( $j = $num_images - 1; $j >= 0; $j-- ) {
 			$image_node = $images->item( $j );
-			foreach ( $attributes as $att => $value ) {
-				$image_node->setAttribute( $att, $value );
-			}
+			$image_node->setAttribute( 'lightbox', '' );
 		}
 	}
 

--- a/tests/php/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/php/test-class-amp-gallery-block-sanitizer.php
@@ -55,32 +55,32 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_lightbox'              => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></figure></li></ul>',
-				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></figure></li></ul><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400" lightbox=""></amp-img></figure></li></ul>',
 			],
 
 			'data_amp_with_lightbox_and_link'     => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></a></figure></li></ul><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox=""></amp-img></a></figure></li></ul>',
 			],
 
 			'data_amp_with_lightbox_5_3'          => [
 				'<figure class="wp-block-gallery" data-amp-lightbox="true"><ul><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></figure></li></ul></figure>',
-				'<figure class="wp-block-gallery" data-amp-lightbox="true"><ul><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></figure></li></ul></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure class="wp-block-gallery" data-amp-lightbox="true"><ul><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400" lightbox=""></amp-img></figure></li></ul></figure>',
 			],
 
 			'data_amp_with_lightbox_and_link_5_3' => [
 				'<figure class="wp-block-gallery" data-amp-lightbox="true"><ul><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul></figure>',
-				'<figure class="wp-block-gallery" data-amp-lightbox="true"><ul><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0"></amp-img></a></figure></li></ul></figure><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<figure class="wp-block-gallery" data-amp-lightbox="true"><ul><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox=""></amp-img></a></figure></li></ul></figure>',
 			],
 
 			'data_amp_with_lightbox_and_carousel' => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="1234" height="567"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0" layout="fill" object-fit="cover"></amp-img></div></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
 			],
 
 			'data_amp_with_lightbox_carousel_5_3' => [
 				'<figure class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><ul><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="1234" height="567"></amp-img></a></figure></li></ul></figure>',
-				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0" layout="fill" object-fit="cover"></amp-img></div></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
 			],
 		];
 	}
@@ -129,17 +129,17 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_lightbox'              => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0" layout="fill" object-fit="cover"></amp-img></div></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
 			],
 
 			'data_amp_with_lightbox_and_link'     => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0" layout="fill" object-fit="cover"></amp-img></div></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
 			],
 
 			'data_amp_lightbox_carousel_and_link' => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" data-amp-lightbox="" on="tap:amp-image-lightbox" role="button" tabindex="0" layout="fill" object-fit="cover"></amp-img></div></amp-carousel><amp-image-lightbox id="amp-image-lightbox" layout="nodisplay" data-close-button-aria-label="Close"></amp-image-lightbox>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

In a Gallery block with a lightbox, this enables viewing multiple images in the lightbox:

![gallery-li](https://user-images.githubusercontent.com/4063887/69674048-4f81cc00-1061-11ea-9021-f83fd6a8685a.gif)

To do this, it uses the [amp-lightbox-gallery](https://github.com/ampproject/amphtml/issues/25021#issuecomment-541846264) instead of `amp-image-lightbox`.

This is a similar change to that in the [gallery shortcode](https://github.com/ampproject/amp-wp/pull/3659/files#r340341137).

Fixes #2849

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
