### PR TITLE
Pull the built `block-libray` package from Gutenberg SVN

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -12,6 +12,11 @@ function after_wp_install {
 		echo -n "Installing Gutenberg..."
 		gutenberg_plugin_svn_url=https://plugins.svn.wordpress.org/gutenberg/trunk/
 		svn export -q "$gutenberg_plugin_svn_url" "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
+
+		if [ ! -s "$WP_CORE_DIR/src/wp-includes/css/dist/block-library/style.css" ]; then
+			svn export -q --force https://plugins.svn.wordpress.org/gutenberg/trunk/build/block-library/ "$WP_CORE_DIR/src/wp-includes/css/dist/block-library"
+		fi
+
 		echo "done"
 	fi
 


### PR DESCRIPTION
## Summary

The test `AMP_Style_Sanitizer_Test::test_prioritized_stylesheets` has been failing for some time now in the PHPUnit test jobs on Travis that test against WP versions 5.0 and 5.1 (see [here](https://travis-ci.org/ampproject/amp-wp/jobs/618793087) and [here](https://travis-ci.org/ampproject/amp-wp/jobs/618793088) for example).

Upon further investigation, these tests were failing because the CSS file `<WP_CORE_DIR>/wp-includes/css/dist/block-library/style.css` was missing due to WP Core styles not being built. This issue is only now surfacing as the Gutenberg plugin has been providing this file all this time, but since v7.0.0, this is no longer happening as the minimum WP version required to run the plugin has been bumped from 5.0 to 5.2, making the built CSS files no longer available in WP < 5.2.

This PR fixes this issue by pulling the built `block-library` package from Gutenberg's SVN repo, which will include the built CSS files needed to run the test successfully.