### PR TITLE
Restrict paired browsing to when dev mode is enabled

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2516,6 +2516,11 @@ class AMP_Theme_Support {
 			return;
 		}
 
+		// Paired browsing requires a custom script which in turn requires dev mode.
+		if ( ! amp_is_dev_mode() ) {
+			return;
+		}
+
 		$asset_file   = AMP__DIR__ . '/assets/js/amp-paired-browsing-client.asset.php';
 		$asset        = require $asset_file;
 		$dependencies = $asset['dependencies'];
@@ -2528,10 +2533,6 @@ class AMP_Theme_Support {
 			$version,
 			true
 		);
-
-		// Force dev mode to be enabled. This ensures that the enqueued script and its dependencies
-		// will be present when the admin bar is not showing.
-		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 
 		// Whitelist enqueued script for AMP dev mdoe so that it is not removed.
 		// @todo Revisit with <https://github.com/google/site-kit-wp/pull/505#discussion_r348683617>.
@@ -2599,6 +2600,14 @@ class AMP_Theme_Support {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! isset( $_GET[ self::PAIRED_BROWSING_QUERY_VAR ] ) ) {
 			return $template;
+		}
+
+		if ( ! amp_is_dev_mode() ) {
+			wp_die(
+				esc_html__( 'Paired browsing is only available when AMP dev mode is enabled (e.g. when logged-in and admin bar is showing).', 'amp' ),
+				esc_html__( 'AMP Paired Browsing Unavailable', 'amp' ),
+				[ 'response' => 403 ]
+			);
 		}
 
 		wp_enqueue_style(

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2540,7 +2540,8 @@ class AMP_Theme_Support {
 			'script_loader_tag',
 			static function( $tag, $handle ) {
 				if ( self::has_dependency( wp_scripts(), 'amp-paired-browsing-client', $handle ) ) {
-					$tag = preg_replace( '/(?<=<script)(?=\s|>)/i', ' ' . AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, $tag );
+					$attrs = [ AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, 'async' ];
+					$tag   = preg_replace( '/(?<=<script)(?=\s|>)/i', ' ' . implode( ' ', $attrs ), $tag );
 				}
 				return $tag;
 			},

--- a/includes/templates/amp-paired-browsing.php
+++ b/includes/templates/amp-paired-browsing.php
@@ -38,7 +38,7 @@ $amp_url = add_query_arg( amp_get_slug(), '1', $url );
 
 					<div class="dialog-text">
 						<span class="general">
-							<?php esc_html_e( 'The navigated URL is not available for paired browsing. Would you like to go back or exit to continue to that URL?', 'amp' ); ?>
+							<?php esc_html_e( 'The navigated URL is not available for paired browsing.', 'amp' ); ?>
 						</span>
 
 						<span class="invalid-amp">

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -493,7 +493,7 @@ class AMP_Validation_Manager {
 			$wp_admin_bar->add_node( $link_item );
 		}
 
-		if ( AMP_Theme_Support::is_paired_available() && $error_count <= 0 ) {
+		if ( AMP_Theme_Support::is_paired_available() && $error_count <= 0 && amp_is_dev_mode() ) {
 			// Construct admin bar item to link to paired browsing experience.
 			$paired_browsing_item = [
 				'parent' => 'amp',

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -315,6 +315,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
 
 		// Admin bar item available in paired mode.
+		add_filter( 'amp_dev_mode_enabled', '__return_true' );
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		$admin_bar = new WP_Admin_Bar();
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );


### PR DESCRIPTION
## Summary

See https://github.com/ampproject/amp-wp/pull/3656/files#r352310999:

> I just realized that this makes every page invalid AMP, because every page is forced to be in dev mode and the custom script is enqueued. Two options I see:
> 
> 1. Short-circuit this function if an user is not logged-in (or rather, if `amp_is_dev_mode()` returns `false`). Since search crawlers will never be logged-in, they will never then see an invalid AMP page. This would also require entire paired browsing app should `wp_die()` if the user is not logged in.
> 2. Go back to only including this JS if the admin bar is showing. Accessing paired browsing here would still need to include the `wp_die()` if `! amp_is_dev_mode()`.

This PR implements the former. This allows a site to continue to allow paired browsing for unauthenticated users by adding plugin code that does `add_filter( 'amp_dev_mode_enabled', '__return_true' );`, though naturally they'd want to use some other condition (e.g. setting a cookie).

See #3365. Amends #3656.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
