### PR TITLE
Try: Use portals instead of iframes in paired browsing, when available

### DIFF
--- a/assets/src/admin/paired-browsing/app.css
+++ b/assets/src/admin/paired-browsing/app.css
@@ -86,7 +86,8 @@ body * {
 	height: 100%;
 }
 
-iframe {
+iframe,
+portal {
 	width: 100%;
 	height: 100%;
 	border: 0;

--- a/assets/src/admin/paired-browsing/app.js
+++ b/assets/src/admin/paired-browsing/app.js
@@ -71,7 +71,7 @@ class PairedBrowsingApp {
 		this.addDisconnectButtonListeners();
 
 		// Load clients.
-		Promise.all( this.initializeFrames() );
+		this.initializeFrames();
 	}
 
 	/**

--- a/assets/src/admin/paired-browsing/client.js
+++ b/assets/src/admin/paired-browsing/client.js
@@ -1,35 +1,91 @@
 /**
  * WordPress dependencies
  */
-import domReady from '@wordpress/dom-ready';
+// import domReady from '@wordpress/dom-ready';
+
+function domReady( callback ) {
+	if (
+		document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+		document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+	) {
+		return callback();
+	} // DOMContentLoaded has not fired yet, delay callback until then.
+
+	document.addEventListener( 'DOMContentLoaded', callback );
+	return null;
+}
 
 const { parent } = window;
 
-if ( parent.pairedBrowsingApp ) {
-	window.ampPairedBrowsingClient = true;
-	const app = parent.pairedBrowsingApp;
-
-	app.registerClientWindow( window );
-
-	domReady( () => {
-		if ( app.documentIsAmp( document ) ) {
-			// Hide the paired browsing menu item.
-			const pairedBrowsingMenuItem = document.getElementById( 'wp-admin-bar-amp-paired-browsing' );
-			if ( pairedBrowsingMenuItem ) {
-				pairedBrowsingMenuItem.remove();
-			}
-
-			// Hide menu item to view non-AMP version.
-			const ampViewBrowsingItem = document.getElementById( 'wp-admin-bar-amp-view' );
-			if ( ampViewBrowsingItem ) {
-				ampViewBrowsingItem.remove();
-			}
-		} else {
-			/**
-			 * No need to show the AMP menu in the Non-AMP window.
-			 */
-			const ampMenuItem = document.getElementById( 'wp-admin-bar-amp' );
-			ampMenuItem.remove();
-		}
-	} );
+function documentIsAmp() {
+	return Boolean( document.querySelector( 'head > script[src="https://cdn.ampproject.org/v0.js"]' ) );
 }
+
+function isEmbedded() {
+	return parent && parent.pairedBrowsingApp; // @todo Also consider window.portalHost.
+}
+
+function checkWhetherClient() {
+	if ( parent.pairedBrowsingApp ) { // @todo This is always false! Portals can't access their parent window currently. May need to use message passing?
+		window.ampPairedBrowsingClient = true;
+		parent.registerClientWindow( window );
+	} else {
+		window.ampPairedBrowsingClient = false;
+	}
+	updateAdminBarLinks();
+}
+
+checkWhetherClient();
+window.addEventListener( 'portalactivate', checkWhetherClient );
+window.addEventListener( 'message', ( event ) => {
+	if ( 'ampPairedBrowsingEmbedded' === event.data ) {
+		checkWhetherClient();
+	}
+} );
+
+function updateAdminBarLinks() {
+	if ( documentIsAmp() ) {
+		// Hide the paired browsing menu item.
+		const pairedBrowsingMenuItem = document.getElementById( 'wp-admin-bar-amp-paired-browsing' );
+		if ( pairedBrowsingMenuItem ) {
+			pairedBrowsingMenuItem.hidden = isEmbedded();
+		}
+
+		// Hide menu item to view non-AMP version.
+		const ampViewBrowsingItem = document.getElementById( 'wp-admin-bar-amp-view' );
+		if ( ampViewBrowsingItem ) {
+			ampViewBrowsingItem.hidden = isEmbedded();
+		}
+	} else {
+		/**
+		 * No need to show the AMP menu in the Non-AMP window.
+		 */
+		const ampMenuItem = document.getElementById( 'wp-admin-bar-amp' );
+		ampMenuItem.hidden = isEmbedded();
+	}
+}
+
+domReady( () => {
+	updateAdminBarLinks();
+
+	const pairedBrowsingLink = document.querySelector( '#wp-admin-bar-amp-paired-browsing > a' );
+
+	// If portals are available, let clicking the link open the portal.
+	if ( pairedBrowsingLink && 'HTMLPortalElement' in window ) {
+		pairedBrowsingLink.addEventListener( 'click', ( event ) => {
+			event.preventDefault();
+
+			const portal = document.createElement( 'portal' );
+			portal.src = pairedBrowsingLink.href;
+			document.body.appendChild( portal );
+
+			portal.addEventListener( 'load', () => {
+				portal.activate( {
+					data: {
+						isAmp: documentIsAmp(),
+					},
+				} );
+			} );
+		} );
+	}
+} );

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2641,6 +2641,8 @@ class AMP_Theme_Support {
 				'ampPairedBrowsingQueryVar'   => self::PAIRED_BROWSING_QUERY_VAR,
 				'ampValidationErrorsQueryVar' => AMP_Validation_Manager::VALIDATION_ERRORS_QUERY_VAR,
 				'documentTitlePrefix'         => __( 'AMP Paired Browsing:', 'amp' ),
+				'ampFrameTitle'               => __( 'AMP version', 'amp' ),
+				'nonAmpFrameTitle'            => __( 'Non-AMP version', 'amp' ),
 			]
 		);
 

--- a/includes/templates/amp-paired-browsing.php
+++ b/includes/templates/amp-paired-browsing.php
@@ -57,21 +57,8 @@ $amp_url = add_query_arg( amp_get_slug(), '1', $url );
 				</div>
 			</div>
 
-			<div id="non-amp">
-				<iframe
-					src="<?php echo esc_url( $url ); ?>"
-					sandbox="allow-forms allow-scripts allow-same-origin allow-popups"
-					title="<?php esc_attr__( 'Non-AMP version', 'amp' ); ?>"
-				></iframe>
-			</div>
-
-			<div id="amp">
-				<iframe
-					src="<?php echo esc_url( $amp_url ); ?>"
-					sandbox="allow-forms allow-scripts allow-same-origin allow-popups"
-					title="<?php esc_attr__( 'AMP version', 'amp' ); ?>"
-				></iframe>
-			</div>
+			<div id="non-amp"></div>
+			<div id="amp"></div>
 		</div>
 
 		<?php print_footer_scripts(); ?>


### PR DESCRIPTION
## Summary

As noted in https://github.com/ampproject/amp-wp/pull/3656#issuecomment-559910535:

> You know what paired browsing will eventually be able to make excellent use of? Instead of iframes it could use [portals](https://web.dev/hands-on-portals/), when they become available. This would allow seamlessly exiting the paired browsing context without having to reload the page. I think this will also work when _entering_ paired browsing as well:
> 
> 1. Clicking the “Start paired browsing” link on in the admin bar could create a portal that contains the paired browsing interface.
> 2. The paired browsing interface can be activated.
> 3. The previous window could then be adopted as a portal _inside_ the paired browsing window and displayed as either the AMP or non-AMP frame, depending on if the user started from an AMP or non-AMP page.
> 4. And a second portal can then be created to contain the corresponding window (non-AMP for AMP, and vice versa), and this portal could likewise be used for exiting paired browsing.
> 
> This brings something to light. A user could actually exit to _either_ the AMP or non-AMP window when they are done with paired browsing. At the moment it forces the user to go to the non-AMP version (see https://github.com/ampproject/amp-wp/pull/3656/files#r352265423) but eventually they could be directed to either. There's no need to implement this now, but once portals become an option, this could be a nice touch.

See #3365.

### Outstanding Issues

- [ ] When a window is loaded in a `portal`, it cannot access its `parent` like an `iframe` can; nor can the portal host access `contentWindow` on the portals in the page. Is this by design? If so, we may need to refactor the app to make use of message passing exclusively rather than direct cross-window calls.
- [ ] Windows embedded in portals are not scrollable; in fact, they are completely non-interactive, at least in Chrome Canary 80.0.3981.0. See [tweet question](https://twitter.com/westonruter/status/1201083296362323968).

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
