### PR TITLE
Prevent `wpautop()` from modifying Twitter embed

### DIFF
--- a/includes/embeds/class-amp-twitter-embed-handler.php
+++ b/includes/embeds/class-amp-twitter-embed-handler.php
@@ -59,38 +59,6 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	}
 
 	/**
-	 * Filter oEmbed HTML for Twitter to prepare it for AMP.
-	 *
-	 * @param string $cache Cache for oEmbed.
-	 * @param string $url   Embed URL.
-	 * @return string Embed.
-	 */
-	public function filter_embed_oembed_html( $cache, $url ) {
-		$parsed_url = wp_parse_url( $url );
-		if ( false === strpos( $parsed_url['host'], 'twitter.com' ) ) {
-			return $cache;
-		}
-
-		if ( ! preg_match( '#^https?://twitter.com/.+/status/(\d+)#', $url, $matches ) ) {
-			return $cache;
-		}
-		$tweet_id = $matches[1];
-
-		$cache = preg_replace(
-			'#(<blockquote[^>]+?twitter-tweet[^>]+)(>[^\r]+)<script.*$#',
-			sprintf(
-				'<amp-twitter width="%d" height="%d" layout="responsive" data-tweetid="%s">$1 placeholder $2</amp-twitter>',
-				esc_attr( $this->DEFAULT_WIDTH ),
-				esc_attr( $this->DEFAULT_HEIGHT ),
-				esc_attr( $tweet_id )
-			),
-			$cache
-		);
-
-		return $cache;
-	}
-
-	/**
 	 * Gets AMP-compliant markup for the Twitter shortcode.
 	 *
 	 * Note that this shortcode is is defined in Jetpack.
@@ -141,7 +109,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Render oEmbed.
 	 *
 	 * @deprecated Since 1.1 as now the sanitize_raw_embeds() is used exclusively, allowing the
-	 * original oEmbed response to be wrapped with `amp-twitter`.
+	 *             original oEmbed response to be wrapped with `amp-twitter`.
 	 *
 	 * @see \WP_Embed::shortcode()
 	 *
@@ -331,7 +299,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Removes Twitter's embed <script> tag.
 	 *
-	 * @param DOMElement $node The DOMNode to whose sibling is the instagram script.
+	 * @param DOMElement $node The DOMNode to whose sibling is the Twitter script.
 	 */
 	private function sanitize_embed_script( $node ) {
 		$next_element_sibling = $node->nextSibling;

--- a/includes/embeds/class-amp-twitter-embed-handler.php
+++ b/includes/embeds/class-amp-twitter-embed-handler.php
@@ -46,7 +46,6 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers embed.
 	 */
 	public function register_embed() {
-		add_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ], 10, 2 );
 		add_shortcode( 'tweet', [ $this, 'shortcode' ] ); // Note: This is a Jetpack shortcode.
 		wp_embed_register_handler( 'amp-twitter-timeline', self::URL_PATTERN_TIMELINE, [ $this, 'oembed_timeline' ], -1 );
 	}
@@ -55,7 +54,6 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Unregisters embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'embed_oembed_html', [ $this, 'filter_embed_oembed_html' ] );
 		remove_shortcode( 'tweet' ); // Note: This is a Jetpack shortcode.
 		wp_embed_unregister_handler( 'amp-twitter-timeline', -1 );
 	}
@@ -88,6 +86,7 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 			),
 			$cache
 		);
+
 		return $cache;
 	}
 
@@ -141,7 +140,9 @@ class AMP_Twitter_Embed_Handler extends AMP_Base_Embed_Handler {
 	/**
 	 * Render oEmbed.
 	 *
-	 * @deprecated Since 1.1 as now the sanitize_raw_embeds() is used exclusively, allowing the original oEmbed response to be rapped by amp-twitter.
+	 * @deprecated Since 1.1 as now the sanitize_raw_embeds() is used exclusively, allowing the
+	 * original oEmbed response to be wrapped with `amp-twitter`.
+	 *
 	 * @see \WP_Embed::shortcode()
 	 *
 	 * @param array $matches URL pattern matches.

--- a/tests/php/test-amp-twitter-embed.php
+++ b/tests/php/test-amp-twitter-embed.php
@@ -91,34 +91,28 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 			],
 			'url_simple'                           => [
 				'https://twitter.com/wordpress/status/987437752164737025' . PHP_EOL,
-				'<p><amp-twitter width="600" height="480" layout="responsive" data-tweetid="987437752164737025">',
-				"</amp-twitter></p>\n",
+				"<amp-twitter width=\"600\" height=\"480\" layout=\"responsive\" data-tweetid=\"987437752164737025\" class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\"><blockquote class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\" placeholder=\"\">\n<p lang=\"en\" dir=\"ltr\">Celebrate the WordPress 15th Anniversary on May 27 <a href=\"https://t.co/jv62WkI9lr\">https://t.co/jv62WkI9lr</a> <a href=\"https://t.co/4ZECodSK78\">pic.twitter.com/4ZECodSK78</a></p>\n<p>— WordPress (@WordPress) <a href=\"https://twitter.com/WordPress/status/987437752164737025?ref_src=twsrc%5Etfw\">April 20, 2018</a></p></blockquote></amp-twitter>\n\n",
 			],
 			'url_with_big_tweet_id'                => [
 				'https://twitter.com/wordpress/status/705219971425574912' . PHP_EOL,
-				'<p><amp-twitter width="600" height="480" layout="responsive" data-tweetid="705219971425574912">',
-				"</amp-twitter></p>\n",
+				"<amp-twitter width=\"600\" height=\"480\" layout=\"responsive\" data-tweetid=\"705219971425574912\" class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\"><blockquote class=\"twitter-tweet\" data-width=\"500\" data-dnt=\"true\" placeholder=\"\">\n<p lang=\"en\" dir=\"ltr\">On our way to the <a href=\"https://twitter.com/hashtag/GoogleDance?src=hash&amp;ref_src=twsrc%5Etfw\">#GoogleDance</a>! <a href=\"https://twitter.com/hashtag/SMX?src=hash&amp;ref_src=twsrc%5Etfw\">#SMX</a> 💃🏻 <a href=\"https://t.co/N8kZ9M3eN4\">pic.twitter.com/N8kZ9M3eN4</a></p>\n<p>— Search Engine Land (@sengineland) <a href=\"https://twitter.com/sengineland/status/705219971425574912?ref_src=twsrc%5Etfw\">March 3, 2016</a></p></blockquote></amp-twitter>\n\n",
 			],
 
 			'timeline_url_with_profile'            => [
 				'https://twitter.com/wordpress' . PHP_EOL,
-				'<p><amp-twitter data-timeline-source-type="profile" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480">',
-				"</amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"profile\" data-timeline-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
 			],
 			'timeline_url_with_likes'              => [
 				'https://twitter.com/wordpress/likes' . PHP_EOL,
-				'<p><amp-twitter data-timeline-source-type="likes" data-timeline-screen-name="wordpress" layout="responsive" width="600" height="480">',
-				"</amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"likes\" data-timeline-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
 			],
 			'timeline_url_with_list'               => [
 				'https://twitter.com/wordpress/lists/random_list' . PHP_EOL,
-				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="random_list" data-timeline-owner-screen-name="wordpress" layout="responsive" width="600" height="480">',
-				"</amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"list\" data-timeline-slug=\"random_list\" data-timeline-owner-screen-name=\"wordpress\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
 			],
 			'timeline_url_with_list2'              => [
 				'https://twitter.com/robertnyman/lists/web-gdes' . PHP_EOL,
-				'<p><amp-twitter data-timeline-source-type="list" data-timeline-slug="web-gdes" data-timeline-owner-screen-name="robertnyman" layout="responsive" width="600" height="480">',
-				"</amp-twitter></p>\n",
+				"<p><amp-twitter data-timeline-source-type=\"list\" data-timeline-slug=\"web-gdes\" data-timeline-owner-screen-name=\"robertnyman\" layout=\"responsive\" width=\"600\" height=\"480\"></amp-twitter></p>\n",
 			],
 
 			'shortcode_without_id'                 => [
@@ -127,28 +121,24 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 			],
 			'shortcode_simple'                     => [
 				'[tweet 987437752164737025]' . PHP_EOL,
-				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480">',
+				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>',
 				"</amp-twitter>\n",
 			],
 			'shortcode_with_tweet_attribute'       => [
 				'[tweet tweet=987437752164737025]' . PHP_EOL,
-				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480">',
-				"</amp-twitter>\n",
+				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>',
 			],
 			'shortcode_with_big_tweet_id'          => [
 				'[tweet 705219971425574912]' . PHP_EOL,
-				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480">',
-				"</amp-twitter>\n",
+				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>',
 			],
 			'shortcode_with_url'                   => [
 				'[tweet https://twitter.com/wordpress/status/987437752164737025]' . PHP_EOL,
-				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480">',
-				"</amp-twitter>\n",
+				'<amp-twitter data-tweetid="987437752164737025" layout="responsive" width="600" height="480"></amp-twitter>',
 			],
 			'shortcode_with_url_with_big_tweet_id' => [
 				'[tweet https://twitter.com/wordpress/status/705219971425574912]' . PHP_EOL,
-				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480">',
-				"</amp-twitter>\n",
+				'<amp-twitter data-tweetid="705219971425574912" layout="responsive" width="600" height="480"></amp-twitter>',
 			],
 			'shortcode_with_non_numeric_tweet_id'  => [
 				'[tweet abcd]' . PHP_EOL,
@@ -162,18 +152,19 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_conversion_data
 	 * @param string $source   Source.
-	 * @param string $expected_start Expected start.
-	 * @param string $expected_end   Expected end.
+	 * @param string $expected Expected content.
 	 */
-	public function test__conversion( $source, $expected_start, $expected_end = null ) {
+	public function test__conversion( $source, $expected ) {
 		$embed = new AMP_Twitter_Embed_Handler();
 		$embed->register_embed();
-		$filtered_content = apply_filters( 'the_content', $source );
 
-		$this->assertStringStartsWith( $expected_start, $filtered_content );
-		if ( $expected_end ) {
-			$this->assertStringEndsWith( $expected_end, $filtered_content );
-		}
+		$filtered_content = apply_filters( 'the_content', $source );
+		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
+		$embed->sanitize_raw_embeds( $dom );
+
+		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
+
+		$this->assertEquals( $content, $expected );
 	}
 
 	public function get_scripts_data() {
@@ -200,10 +191,12 @@ class AMP_Twitter_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Twitter_Embed_Handler();
 		$embed->register_embed();
-		$source = apply_filters( 'the_content', $source );
-		$source = preg_replace( '#(<amp-twitter.+?>).*?(</amp-twitter>)#s', '$1$2', $source );
 
-		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$filtered_content = apply_filters( 'the_content', $source );
+		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
+		$embed->sanitize_raw_embeds( $dom );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$whitelist_sanitizer->sanitize();
 
 		$scripts = array_merge(


### PR DESCRIPTION
## Summary

The cause of the duplication was due to `wpautop()` mucking with the content, wrapping tags it deems as "block-level" with a `<p>` which causes the `blockquote` tag to be placed outside the AMP component. Once outside, the `blockquote` is santitized as a raw embed and another Twitter AMP component would be rendered.

Removing the HTML oEmbed filter in `AMP_Twitter_Embed_Handler` will allow for `wpautop` to process the original HTML, and allows the raw embed sanitizer within the class to convert it into an AMP component, without any interference.

<!-- Please reference the issue this PR addresses. -->
Fixes #3865.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
