### PR TITLE
Prioritize twentytwenty inline CSS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,5 +49,10 @@
     "psr-4": {
       "Amp\\AmpWP\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Amp\\AmpWP\\Tests\\": "tests/php/src/"
+    }
   }
 }

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -89,6 +89,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *      @type string   $parsed_cache_variant       Additional value by which to vary parsed cache.
 	 *      @type string   $include_manifest_comment   Whether to show the manifest HTML comment in the response before the style[amp-custom] element. Can be 'always', 'never', or 'when_excessive'.
 	 *      @type string[] $focus_within_classes       Class names in selectors that should be replaced with :focus-within pseudo classes.
+	 *      @type string[] $low_priority_plugins       Plugin slugs of the plugins to deprioritize when hitting the CSS limit.
 	 * }
 	 */
 	protected $args;
@@ -110,6 +111,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		'parsed_cache_variant'      => null,
 		'include_manifest_comment'  => 'always',
 		'focus_within_classes'      => [ 'focus' ],
+		'low_priority_plugins'      => [ 'query-monitor' ],
 	];
 
 	/**
@@ -931,9 +933,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				'wp-mediaelement',
 				'thickbox',
 			];
-			$low_priority_plugins  = [
-				'query-monitor',
-			];
 
 			if ( in_array( $style_handle, $non_amp_handles, true ) ) {
 				// Styles are for non-AMP JS only so not be used in AMP at all.
@@ -955,7 +954,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$priority = 20;
 			} elseif ( $plugin ) {
 				// Styles from plugins are next-highest priority, unless they are in the list of low-priority plugins.
-				$priority = in_array( $plugin, $low_priority_plugins, true ) ? 150 : 30;
+				$priority = in_array( $plugin, $this->args['low_priority_plugins'], true ) ? 150 : 30;
 			} elseif ( 0 === strpos( $schemeless_href, $remove_url_scheme( includes_url() ) ) ) {
 				// Other styles from wp-includes come next.
 				$priority = 40;

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -967,19 +967,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$priority += $print_priority_base;
 			}
 		} elseif ( $node instanceof DOMElement && 'style' === $node->nodeName && $node->hasAttribute( 'id' ) ) {
-			$id = $node->getAttribute( 'id' );
-			if (
-				preg_match( '/^(?<handle>.+)-inline-css$/', $id, $matches ) &&
-				wp_style_is( $matches['handle'], 'registered' ) &&
-				0 === strpos( wp_styles()->registered[ $matches['handle'] ]->src, get_template_directory_uri() )
-			) {
+			$id                  = $node->getAttribute( 'id' );
+			$is_theme_inline_css = preg_match( '/^(?<handle>.+)-inline-css$/', $id, $matches ) && wp_style_is( $matches['handle'], 'registered' );
+			if ( $is_theme_inline_css && 0 === strpos( wp_styles()->registered[ $matches['handle'] ]->src, get_template_directory_uri() ) ) {
 				// Parent theme inline style.
 				$priority = 2;
-			} elseif (
-				preg_match( '/^(?<handle>.+)-inline-css$/', $id, $matches ) &&
-				wp_style_is( $matches['handle'], 'registered' ) &&
-				0 === strpos( wp_styles()->registered[ $matches['handle'] ]->src, get_stylesheet_directory_uri() )
-			) {
+			} elseif ( $is_theme_inline_css && get_stylesheet() !== get_template() && 0 === strpos( wp_styles()->registered[ $matches['handle'] ]->src, get_stylesheet_directory_uri() ) ) {
 				// Child theme inline style.
 				$priority = 12;
 			} elseif ( 'admin-bar-inline-css' === $id ) {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -3140,45 +3140,46 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		unset( $pending_stylesheet );
 
-		// Sort stylesheets by their priority.
+		// Determine which stylesheets are included based on their priorities.
+		$pending_stylesheet_indices = array_keys( $this->pending_stylesheets );
 		usort(
-			$this->pending_stylesheets,
-			static function ( $a, $b ) {
-				return $a['priority'] - $b['priority'];
+			$pending_stylesheet_indices,
+			function ( $a, $b ) {
+				return $this->pending_stylesheets[ $a ]['priority'] - $this->pending_stylesheets[ $b ]['priority'];
 			}
 		);
 
 		$current_concatenated_size = 0;
-		foreach ( $this->pending_stylesheets as $index => $pending_stylesheet ) {
-			if ( $group !== $pending_stylesheet['group'] ) {
+		foreach ( $pending_stylesheet_indices as $i ) {
+			if ( $group !== $this->pending_stylesheets[ $i ]['group'] ) {
 				continue;
 			}
 
 			// Skip duplicates.
-			if ( false === $pending_stylesheet['included'] ) {
+			if ( false === $this->pending_stylesheets[ $i ]['included'] ) {
 				continue;
 			}
 
 			// Report validation error if size is now too big.
-			if ( $current_concatenated_size + $pending_stylesheet['size'] > $max_bytes ) {
+			if ( $current_concatenated_size + $this->pending_stylesheets[ $i ]['size'] > $max_bytes ) {
 				$validation_error = [
 					'code' => 'excessive_css',
 					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
 				];
-				if ( isset( $pending_stylesheet['sources'] ) ) {
-					$validation_error['sources'] = $pending_stylesheet['sources'];
+				if ( isset( $this->pending_stylesheets[ $i ]['sources'] ) ) {
+					$validation_error['sources'] = $this->pending_stylesheets[ $i ]['sources'];
 				}
 
-				if ( $this->should_sanitize_validation_error( $validation_error, wp_array_slice_assoc( $pending_stylesheet, [ 'node' ] ) ) ) {
-					$this->pending_stylesheets[ $index ]['included'] = false;
+				if ( $this->should_sanitize_validation_error( $validation_error, wp_array_slice_assoc( $this->pending_stylesheets[ $i ], [ 'node' ] ) ) ) {
+					$this->pending_stylesheets[ $i ]['included'] = false;
 					continue; // Skip to the next stylesheet.
 				}
 			}
 
-			if ( ! isset( $pending_stylesheet['included'] ) ) {
-				$this->pending_stylesheets[ $index ]['included'] = true;
+			if ( ! isset( $this->pending_stylesheets[ $i ]['included'] ) ) {
+				$this->pending_stylesheets[ $i ]['included'] = true;
 				$included_count++;
-				$current_concatenated_size += $pending_stylesheet['size'];
+				$current_concatenated_size += $this->pending_stylesheets[ $i ]['size'];
 			}
 		}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -904,9 +904,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$element_id      = (string) $node->getAttribute( 'id' );
 			$schemeless_href = $remove_url_scheme( $node->getAttribute( 'href' ) );
 			$is_plugin_asset = (
-				0 === strpos( $schemeless_href, $remove_url_scheme( trailingslashit( plugins_url( WP_PLUGIN_DIR ) ) ) )
+				0 === strpos( $schemeless_href, $remove_url_scheme( trailingslashit( WP_PLUGIN_URL ) ) )
 				||
-				0 === strpos( $schemeless_href, $remove_url_scheme( trailingslashit( plugins_url( WPMU_PLUGIN_URL ) ) ) )
+				0 === strpos( $schemeless_href, $remove_url_scheme( trailingslashit( WPMU_PLUGIN_URL ) ) )
 			);
 			$style_handle    = null;
 			if ( preg_match( '/^(.+)-css$/', $element_id, $matches ) ) {
@@ -956,15 +956,22 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$priority += $print_priority_base;
 			}
 		} elseif ( $node instanceof DOMElement && 'style' === $node->nodeName ) {
-			$element_id = (string) $node->getAttribute( 'id' );
-			if ( 'admin-bar-inline-css' === $element_id ) {
-				$priority = $admin_bar_priority;
-			} elseif ( 'wp-custom-css' === $element_id ) {
-				// Additional CSS from Customizer.
-				$priority = 60;
-			} else {
-				// Other style elements, including from Recent Comments widget.
-				$priority = 70;
+			switch ( (string) $node->getAttribute( 'id' ) ) {
+				case 'twentytwenty-style-inline-css':
+					// @todo The core theme sanitizer should be able to provide this instead of hardcoding it here.
+					// Not easily implementable right now, we'll wait for the middleware make-over.
+					$priority = 2;
+					break;
+				case 'admin-bar-inline-css':
+					$priority = $admin_bar_priority;
+					break;
+				case 'wp-custom-css':
+					// Additional CSS from Customizer.
+					$priority = 60;
+					break;
+				default:
+					// Other style elements, including from Recent Comments widget.
+					$priority = 70;
 			}
 
 			if ( 'print' === $node->getAttribute( 'media' ) ) {

--- a/tests/php/src/PrivateAccess.php
+++ b/tests/php/src/PrivateAccess.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Trait PrivateAccess.
+ *
+ * @package Amp\AmpWP
+ */
+
+namespace Amp\AmpWP\Tests;
+
+use ReflectionClass;
+use ReflectionException;
+
+/**
+ * Trait PrivateAccess.
+ *
+ * Allows accessing private methods and properties for testing.
+ *
+ * @internal
+ * @since 1.5.0
+ */
+trait PrivateAccess {
+
+	/**
+	 * Call a private method as if it was public.
+	 *
+	 * @param object|string $object      Object instance or class string to call the method of.
+	 * @param string        $method_name Name of the method to call.
+	 * @param array         $args        Optional. Array of arguments to pass to the method.
+	 * @return mixed Return value of the method call.
+	 * @throws ReflectionException If the object could not be reflected upon.
+	 */
+	private function call_private_method( $object, $method_name, $args = [] ) {
+		$method = ( new ReflectionClass( $object ) )->getMethod( $method_name );
+		$method->setAccessible( true );
+		return $method->invokeArgs( $object, $args );
+	}
+
+	/**
+	 * Set a private property as if it was public.
+	 *
+	 * @param object|string $object        Object instance or class string to set the property of.
+	 * @param string        $property_name Name of the property to set.
+	 * @param mixed         $value         Value to set the property to.
+	 * @throws ReflectionException If the object could not be reflected upon.
+	 */
+	private function set_private_property( $object, $property_name, $value ) {
+		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
+		$property->setAccessible( true );
+		$property->setValue( $object, $value );
+	}
+
+	/**
+	 * Get a private property as if it was public.
+	 *
+	 * @param object|string $object        Object instance or class string to get the property of.
+	 * @param string        $property_name Name of the property to get.
+	 * @return mixed Return value of the property.
+	 * @throws ReflectionException If the object could not be reflected upon.
+	 */
+	private function get_private_property( $object, $property_name ) {
+		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
+		$property->setAccessible( true );
+		return $property->getValue( $object );
+	}
+}

--- a/tests/php/test-amp-carousel.php
+++ b/tests/php/test-amp-carousel.php
@@ -7,6 +7,7 @@
 
 use Amp\AmpWP\Component\Carousel;
 use Amp\AmpWP\Component\DOMElementList;
+use Amp\AmpWP\Tests\PrivateAccess;
 
 /**
  * Tests for Carousel class.
@@ -14,6 +15,8 @@ use Amp\AmpWP\Component\DOMElementList;
  * @covers \Amp\AmpWP\Component\Carousel
  */
 class Test_Carousel extends \WP_UnitTestCase {
+
+	use PrivateAccess;
 
 	/**
 	 * Gets the data to test the carousel.
@@ -147,16 +150,13 @@ class Test_Carousel extends \WP_UnitTestCase {
 	 *
 	 * @param DOMElementList $slides   The slides to get the dimensions from.
 	 * @param array          $expected The expected return value of the tested function.
-	 * @throws ReflectionException If invoking the method reflection fails.
 	 */
 	public function test_get_dimensions( $slides, $expected ) {
-		$carousel       = new Carousel( new DOMDocument(), $slides );
-		$get_dimensions = new ReflectionMethod( $carousel, 'get_dimensions' );
-		$get_dimensions->setAccessible( true );
+		$carousel = new Carousel( new DOMDocument(), $slides );
 
 		$this->assertEquals(
 			$expected,
-			$get_dimensions->invoke( $carousel )
+			$this->call_private_method( $carousel, 'get_dimensions' )
 		);
 	}
 }

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+use Amp\AmpWP\Tests\PrivateAccess;
+
 /**
  * Class AMP_Img_Sanitizer_Test
  *
@@ -517,16 +519,13 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @param string $source The source markup to test.
 	 * @param string $expected The expected return of the tested function, using the source markup.
-	 * @throws ReflectionException If invoking the private method fails.
 	 */
 	public function test_does_node_have_block_class( $source, $expected ) {
 		$dom       = AMP_DOM_Utils::get_dom_from_content( $source );
 		$sanitizer = new AMP_Img_Sanitizer( $dom );
 		$figures   = $dom->getElementsByTagName( 'figure' );
-		$method    = new ReflectionMethod( $sanitizer, 'does_node_have_block_class' );
 
-		$method->setAccessible( true );
-		$this->assertEquals( $expected, $method->invoke( $sanitizer, $figures->item( 0 ) ) );
+		$this->assertEquals( $expected, $this->call_private_method( $sanitizer, 'does_node_have_block_class', [ $figures->item( 0 ) ] ) );
 	}
 
 	/**

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -14,6 +14,8 @@ use Amp\AmpWP\Tests\PrivateAccess;
  */
 class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 
+	use PrivateAccess;
+
 	/**
 	 * Set up.
 	 */

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2429,13 +2429,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			// Dashicons handle.
 			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'dashicons-css' ] ), 90 ],
 			// Parent theme styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/parent-theme/' ] ), 1 ],
+			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/parent-theme/style.css' ] ), 1 ],
 			// Child theme styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/child-theme/' ] ), 10 ],
+			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/child-theme/style.css' ] ), 10 ],
 			// Core frontend handle.
 			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'wp-block-library-css' ] ), 20 ],
 			// Plugin asset.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/plugins/some-plugin' ] ), 30 ],
+			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/plugins/some-plugin/style.css' ] ), 30 ],
+			// Query monitor plugin asset.
+			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/plugins/query-monitor/style.css' ] ), 150 ],
 			// Other styles from wp-includes.
 			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-includes/' ] ), 40 ],
 			// All other links.
@@ -2490,7 +2492,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$dom,
 					'link',
 					[
-						'href' => '//example.org/wp-content/themes/parent-theme/',
+						'href' => '//example.org/wp-content/themes/parent-theme/style.css',
 						'media' => 'print',
 					]
 				),
@@ -2502,7 +2504,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$dom,
 					'link',
 					[
-						'href' => '//example.org/wp-content/themes/child-theme/',
+						'href' => '//example.org/wp-content/themes/child-theme/style.css',
 						'media' => 'print',
 					]
 				),
@@ -2526,11 +2528,23 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					$dom,
 					'link',
 					[
-						'href' => '//example.org/wp-content/plugins/some-plugin',
+						'href' => '//example.org/wp-content/plugins/some-plugin/style.css',
 						'media' => 'print',
 					]
 				),
 				130,
+			],
+			// Query monitor plugin asset for print.
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'href' => '//example.org/wp-content/plugins/query-monitor/style.css',
+						'media' => 'print',
+					]
+				),
+				250,
 			],
 			// Other styles from wp-includes for print.
 			[

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2428,17 +2428,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			// Dashicons handle.
 			[ [ 'link', [ 'id' => 'dashicons-css' ] ], 90 ],
 			// Parent theme styles.
-			[ [ 'link', [ 'href' => '//example.org/wp-content/themes/parent-theme/style.css' ] ], 1 ],
+			[ [ 'link', [ 'href' => get_theme_root_uri() . '/parent-theme/style.css' ] ], 1 ],
 			// Child theme styles.
-			[ [ 'link', [ 'href' => '//example.org/wp-content/themes/child-theme/style.css' ] ], 10 ],
+			[ [ 'link', [ 'href' => get_theme_root_uri() . '/child-theme/style.css' ] ], 10 ],
 			// Core frontend handle.
 			[ [ 'link', [ 'id' => 'wp-block-library-css' ] ], 20 ],
 			// Plugin asset.
-			[ [ 'link', [ 'href' => '//example.org/wp-content/plugins/some-plugin/style.css' ] ], 30 ],
+			[ [ 'link', [ 'href' => plugins_url() . '/some-plugin/style.css' ] ], 30 ],
 			// Query monitor plugin asset.
-			[ [ 'link', [ 'href' => '//example.org/wp-content/plugins/query-monitor/style.css' ] ], 150 ],
+			[ [ 'link', [ 'href' => plugins_url() . '/query-monitor/style.css' ] ], 150 ],
 			// Other styles from wp-includes.
-			[ [ 'link', [ 'href' => '//example.org/wp-includes/' ] ], 40 ],
+			[ [ 'link', [ 'href' => includes_url() ] ], 40 ],
 			// All other links.
 			[ [ 'link', [ 'id' => 'something-else' ] ], 50 ],
 			// Parent theme inline styles.
@@ -2489,7 +2489,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'link',
 					[
-						'href' => '//example.org/wp-content/themes/parent-theme/style.css',
+						'href' => get_theme_root_uri() . '/parent-theme/style.css',
 						'media' => 'print',
 					],
 				],
@@ -2500,7 +2500,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'link',
 					[
-						'href' => '//example.org/wp-content/themes/child-theme/style.css',
+						'href' => get_theme_root_uri() . '/child-theme/style.css',
 						'media' => 'print',
 					],
 				],
@@ -2522,7 +2522,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'link',
 					[
-						'href' => '//example.org/wp-content/plugins/some-plugin/style.css',
+						'href' => plugins_url() . '/some-plugin/style.css',
 						'media' => 'print',
 					],
 				],
@@ -2533,7 +2533,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'link',
 					[
-						'href' => '//example.org/wp-content/plugins/query-monitor/style.css',
+						'href' => plugins_url() . '/query-monitor/style.css',
 						'media' => 'print',
 					],
 				],
@@ -2544,7 +2544,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'link',
 					[
-						'href' => '//example.org/wp-includes/',
+						'href' => includes_url(),
 						'media' => 'print',
 					],
 				],
@@ -2586,7 +2586,6 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			// Admin bar inline styles for print.
 			[
 				[
-					$dom,
 					'style',
 					[
 						'id' => 'admin-bar-inline-css',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -1380,9 +1380,9 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$comment = $style->previousSibling;
 		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
 		$this->assertNotContains( 'The following stylesheets are too large to be included', $comment->nodeValue );
-		$this->assertContains( '15 B: style.body', $comment->nodeValue );
-		$this->assertNotContains( '17 B: style.foo1', $comment->nodeValue );
-		$this->assertContains( '0 B: style.bard', $comment->nodeValue );
+		$this->assertRegExp( '/15 B\s*:\s*style.body/', $comment->nodeValue );
+		$this->assertNotRegExp( '/17 B\s*:\s*style.foo1/', $comment->nodeValue );
+		$this->assertRegExp( '/0 B\s*:\s*style.bard/', $comment->nodeValue );
 		$this->assertNotContains( 'style.foo2', $comment->nodeValue );
 		$this->assertContains( 'style.foo3', $comment->nodeValue );
 		$this->assertContains( 'Total included size: 32 bytes (72% of 44 total after tree shaking)', $comment->nodeValue );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2449,31 +2449,161 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			// Other inline styles.
 			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'something-else' ] ), 70 ],
 			// Non-AMP handle for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'mediaelement-css', 'media' => 'print' ] ), 1100 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'id' => 'mediaelement-css',
+						'media' => 'print',
+					]
+				),
+				1100,
+			],
 			// Admin bar handle for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'admin-bar-css', 'media' => 'print' ] ), 300 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'id' => 'admin-bar-css',
+						'media' => 'print',
+					]
+				),
+				300,
+			],
 			// Dashicons handle for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'dashicons-css', 'media' => 'print' ] ), 190 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'id' => 'dashicons-css',
+						'media' => 'print',
+					]
+				),
+				190,
+			],
 			// Parent theme styles for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/parent-theme/', 'media' => 'print' ] ), 101 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'href' => '//example.org/wp-content/themes/parent-theme/',
+						'media' => 'print',
+					]
+				),
+				101,
+			],
 			// Child theme styles for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/child-theme/', 'media' => 'print' ] ), 110 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'href' => '//example.org/wp-content/themes/child-theme/',
+						'media' => 'print',
+					]
+				),
+				110,
+			],
 			// Core frontend handle for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'wp-block-library-css', 'media' => 'print' ] ), 120 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'id' => 'wp-block-library-css',
+						'media' => 'print',
+					]
+				),
+				120,
+			],
 			// Plugin asset for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/plugins/some-plugin', 'media' => 'print' ] ), 130 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'href' => '//example.org/wp-content/plugins/some-plugin',
+						'media' => 'print',
+					]
+				),
+				130,
+			],
 			// Other styles from wp-includes for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-includes/', 'media' => 'print' ] ), 140 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'href' => '//example.org/wp-includes/',
+						'media' => 'print',
+					]
+				),
+				140,
+			],
 			// All other links for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'something-else', 'media' => 'print' ] ), 150 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'link',
+					[
+						'id' => 'something-else',
+						'media' => 'print',
+					]
+				),
+				150,
+			],
 			// Twentytwenty inline styles for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'twentytwenty-style-inline-css', 'media' => 'print' ] ), 102 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'style',
+					[
+						'id' => 'twentytwenty-style-inline-css',
+						'media' => 'print',
+					]
+				),
+				102,
+			],
 			// Admin bar inline styles for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'admin-bar-inline-css', 'media' => 'print' ] ), 300 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'style',
+					[
+						'id' => 'admin-bar-inline-css',
+						'media' => 'print',
+					]
+				),
+				300,
+			],
 			// Customizer inline styles for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'wp-custom-css', 'media' => 'print' ] ), 160 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'style',
+					[
+						'id' => 'wp-custom-css',
+						'media' => 'print',
+					]
+				),
+				160,
+			],
 			// Other inline styles for print.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'something-else', 'media' => 'print' ] ), 170 ],
+			[
+				AMP_DOM_Utils::create_node(
+					$dom,
+					'style',
+					[
+						'id' => 'something-else',
+						'media' => 'print',
+					]
+				),
+				170,
+			],
 			// Style attribute.
 			[ $dom->createAttribute( 'something' ), 70 ],
 		];
@@ -2490,10 +2620,14 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @param int    $expected Expected priority.
 	 */
 	public function test_get_stylesheet_priority( $node, $expected ) {
-		$dom = new DOMDocument();
-		$sanitizer = new AMP_Style_Sanitizer( $dom );
-		$parent_theme_filter = static function () { return 'parent-theme'; };
-		$child_theme_filter = static function () { return 'child-theme'; };
+		$dom                 = new DOMDocument();
+		$sanitizer           = new AMP_Style_Sanitizer( $dom );
+		$parent_theme_filter = static function () {
+			return 'parent-theme';
+		};
+		$child_theme_filter  = static function () {
+			return 'child-theme';
+		};
 		add_filter( 'template', $parent_theme_filter );
 		add_filter( 'stylesheet', $child_theme_filter );
 		$this->assertEquals( $expected, $this->call_private_method( $sanitizer, 'get_stylesheet_priority', [ $node ] ) );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2419,40 +2419,24 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @return array[] Array of test data.
 	 */
-	public function get_get_stylesheet_priority_data() {
+	public function get_stylesheet_priority_data() {
 		return [
-			// Non-AMP handle.
-			[ [ 'link', [ 'id' => 'mediaelement-css' ] ], 1000 ],
-			// Admin bar handle.
-			[ [ 'link', [ 'id' => 'admin-bar-css' ] ], 200 ],
-			// Dashicons handle.
-			[ [ 'link', [ 'id' => 'dashicons-css' ] ], 90 ],
-			// Parent theme styles.
-			[ [ 'link', [ 'href' => get_theme_root_uri() . '/parent-theme/style.css' ] ], 1 ],
-			// Child theme styles.
-			[ [ 'link', [ 'href' => get_theme_root_uri() . '/child-theme/style.css' ] ], 10 ],
-			// Core frontend handle.
-			[ [ 'link', [ 'id' => 'wp-block-library-css' ] ], 20 ],
-			// Plugin asset.
-			[ [ 'link', [ 'href' => plugins_url() . '/some-plugin/style.css' ] ], 30 ],
-			// Query monitor plugin asset.
-			[ [ 'link', [ 'href' => plugins_url() . '/query-monitor/style.css' ] ], 150 ],
-			// Other styles from wp-includes.
-			[ [ 'link', [ 'href' => includes_url() ] ], 40 ],
-			// All other links.
-			[ [ 'link', [ 'id' => 'something-else' ] ], 50 ],
-			// Parent theme inline styles.
-			[ [ 'style', [ 'id' => 'parent-theme-inline-css' ] ], 2 ],
-			// Child theme inline styles.
-			[ [ 'style', [ 'id' => 'child-theme-inline-css' ] ], 12 ],
-			// Admin bar inline styles.
-			[ [ 'style', [ 'id' => 'admin-bar-inline-css' ] ], 200 ],
-			// Customizer inline styles.
-			[ [ 'style', [ 'id' => 'wp-custom-css' ] ], 60 ],
-			// Other inline styles.
-			[ [ 'style', [ 'id' => 'something-else' ] ], 70 ],
-			// Non-AMP handle for print.
-			[
+			'Non-AMP handle' => [ [ 'link', [ 'id' => 'mediaelement-css' ] ], 1000 ],
+			'Admin bar handle' => [ [ 'link', [ 'id' => 'admin-bar-css' ] ], 200 ],
+			'Dashicons handle' => [ [ 'link', [ 'id' => 'dashicons-css' ] ], 90 ],
+			'Parent theme styles' => [ [ 'link', [ 'href' => get_theme_root_uri() . '/parent-theme/style.css' ] ], 1 ],
+			'Child theme styles' => [ [ 'link', [ 'href' => get_theme_root_uri() . '/child-theme/style.css' ] ], 10 ],
+			'Core frontend handle' => [ [ 'link', [ 'id' => 'wp-block-library-css' ] ], 20 ],
+			'Plugin asset' => [ [ 'link', [ 'href' => plugins_url() . '/some-plugin/style.css' ] ], 30 ],
+			'Query monitor plugin asset' => [ [ 'link', [ 'href' => plugins_url() . '/query-monitor/style.css' ] ], 150 ],
+			'Other styles from wp-includes' => [ [ 'link', [ 'href' => includes_url() ] ], 40 ],
+			'All other links' => [ [ 'link', [ 'id' => 'something-else' ] ], 50 ],
+			'Parent theme inline styles' => [ [ 'style', [ 'id' => 'parent-theme-inline-css' ] ], 2 ],
+			'Child theme inline styles' => [ [ 'style', [ 'id' => 'child-theme-inline-css' ] ], 12 ],
+			'Admin bar inline styles' => [ [ 'style', [ 'id' => 'admin-bar-inline-css' ] ], 200 ],
+			'Customizer inline styles' => [ [ 'style', [ 'id' => 'wp-custom-css' ] ], 60 ],
+			'Other inline styles' => [ [ 'style', [ 'id' => 'something-else' ] ], 70 ],
+			'Non-AMP handle for print' => [
 				[
 					'link',
 					[
@@ -2462,8 +2446,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				1100,
 			],
-			// Admin bar handle for print.
-			[
+			'Admin bar handle for print' => [
 				[
 					'link',
 					[
@@ -2473,8 +2456,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				300,
 			],
-			// Dashicons handle for print.
-			[
+			'Dashicons handle for print' => [
 				[
 					'link',
 					[
@@ -2484,8 +2466,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				190,
 			],
-			// Parent theme styles for print.
-			[
+			'Parent theme styles for print' => [
 				[
 					'link',
 					[
@@ -2495,8 +2476,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				101,
 			],
-			// Child theme styles for print.
-			[
+			'Child theme styles for print' => [
 				[
 					'link',
 					[
@@ -2506,8 +2486,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				110,
 			],
-			// Core frontend handle for print.
-			[
+			'Core frontend handle for print' => [
 				[
 					'link',
 					[
@@ -2517,8 +2496,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				120,
 			],
-			// Plugin asset for print.
-			[
+			'Plugin asset for print' => [
 				[
 					'link',
 					[
@@ -2528,8 +2506,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				130,
 			],
-			// Query monitor plugin asset for print.
-			[
+			'Query monitor plugin asset for print' => [
 				[
 					'link',
 					[
@@ -2539,8 +2516,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				250,
 			],
-			// Other styles from wp-includes for print.
-			[
+			'Other styles from wp-includes for print' => [
 				[
 					'link',
 					[
@@ -2550,8 +2526,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				140,
 			],
-			// All other links for print.
-			[
+			'All other links for print' => [
 				[
 					'link',
 					[
@@ -2561,8 +2536,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				150,
 			],
-			// Parent theme inline styles for print.
-			[
+			'Parent theme inline styles for print' => [
 				[
 					'style',
 					[
@@ -2572,8 +2546,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				102,
 			],
-			// Child theme inline styles for print.
-			[
+			'Child theme inline styles for print' => [
 				[
 					'style',
 					[
@@ -2583,8 +2556,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				112,
 			],
-			// Admin bar inline styles for print.
-			[
+			'Admin bar inline styles for print' => [
 				[
 					'style',
 					[
@@ -2594,8 +2566,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				300,
 			],
-			// Customizer inline styles for print.
-			[
+			'Customizer inline styles for print' => [
 				[
 					'style',
 					[
@@ -2605,8 +2576,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				160,
 			],
-			// Other inline styles for print.
-			[
+			'Other inline styles for print' => [
 				[
 					'style',
 					[
@@ -2616,8 +2586,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				170,
 			],
-			// Style attribute.
-			[ [ null, [ 'something' ] ], 70 ],
+			'Style attribute' => [ [ null, [ 'something' ] ], 70 ],
 		];
 	}
 
@@ -2626,7 +2595,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @covers       \AMP_Style_Sanitizer::get_stylesheet_priority()
 	 *
-	 * @dataProvider get_get_stylesheet_priority_data
+	 * @dataProvider get_stylesheet_priority_data
 	 *
 	 * @param array $node_data Node to check the priority of.
 	 * @param int   $expected  Expected priority.

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2420,220 +2420,205 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @return array[] Array of test data.
 	 */
 	public function get_get_stylesheet_priority_data() {
-		$dom = new DOMDocument();
 		return [
 			// Non-AMP handle.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'mediaelement-css' ] ), 1000 ],
+			[ [ 'link', [ 'id' => 'mediaelement-css' ] ], 1000 ],
 			// Admin bar handle.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'admin-bar-css' ] ), 200 ],
+			[ [ 'link', [ 'id' => 'admin-bar-css' ] ], 200 ],
 			// Dashicons handle.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'dashicons-css' ] ), 90 ],
+			[ [ 'link', [ 'id' => 'dashicons-css' ] ], 90 ],
 			// Parent theme styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/parent-theme/style.css' ] ), 1 ],
+			[ [ 'link', [ 'href' => '//example.org/wp-content/themes/parent-theme/style.css' ] ], 1 ],
 			// Child theme styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/themes/child-theme/style.css' ] ), 10 ],
+			[ [ 'link', [ 'href' => '//example.org/wp-content/themes/child-theme/style.css' ] ], 10 ],
 			// Core frontend handle.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'wp-block-library-css' ] ), 20 ],
+			[ [ 'link', [ 'id' => 'wp-block-library-css' ] ], 20 ],
 			// Plugin asset.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/plugins/some-plugin/style.css' ] ), 30 ],
+			[ [ 'link', [ 'href' => '//example.org/wp-content/plugins/some-plugin/style.css' ] ], 30 ],
 			// Query monitor plugin asset.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-content/plugins/query-monitor/style.css' ] ), 150 ],
+			[ [ 'link', [ 'href' => '//example.org/wp-content/plugins/query-monitor/style.css' ] ], 150 ],
 			// Other styles from wp-includes.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'href' => '//example.org/wp-includes/' ] ), 40 ],
+			[ [ 'link', [ 'href' => '//example.org/wp-includes/' ] ], 40 ],
 			// All other links.
-			[ AMP_DOM_Utils::create_node( $dom, 'link', [ 'id' => 'something-else' ] ), 50 ],
+			[ [ 'link', [ 'id' => 'something-else' ] ], 50 ],
 			// Parent theme inline styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'parent-theme-inline-css' ] ), 2 ],
+			[ [ 'style', [ 'id' => 'parent-theme-inline-css' ] ], 2 ],
 			// Child theme inline styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'child-theme-inline-css' ] ), 12 ],
+			[ [ 'style', [ 'id' => 'child-theme-inline-css' ] ], 12 ],
 			// Admin bar inline styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'admin-bar-inline-css' ] ), 200 ],
+			[ [ 'style', [ 'id' => 'admin-bar-inline-css' ] ], 200 ],
 			// Customizer inline styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'wp-custom-css' ] ), 60 ],
+			[ [ 'style', [ 'id' => 'wp-custom-css' ] ], 60 ],
 			// Other inline styles.
-			[ AMP_DOM_Utils::create_node( $dom, 'style', [ 'id' => 'something-else' ] ), 70 ],
+			[ [ 'style', [ 'id' => 'something-else' ] ], 70 ],
 			// Non-AMP handle for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'id' => 'mediaelement-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				1100,
 			],
 			// Admin bar handle for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'id' => 'admin-bar-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				300,
 			],
 			// Dashicons handle for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'id' => 'dashicons-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				190,
 			],
 			// Parent theme styles for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'href' => '//example.org/wp-content/themes/parent-theme/style.css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				101,
 			],
 			// Child theme styles for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'href' => '//example.org/wp-content/themes/child-theme/style.css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				110,
 			],
 			// Core frontend handle for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'id' => 'wp-block-library-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				120,
 			],
 			// Plugin asset for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'href' => '//example.org/wp-content/plugins/some-plugin/style.css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				130,
 			],
 			// Query monitor plugin asset for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'href' => '//example.org/wp-content/plugins/query-monitor/style.css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				250,
 			],
 			// Other styles from wp-includes for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'href' => '//example.org/wp-includes/',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				140,
 			],
 			// All other links for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'link',
 					[
 						'id' => 'something-else',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				150,
 			],
 			// Parent theme inline styles for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'style',
 					[
 						'id' => 'parent-theme-inline-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				102,
 			],
 			// Child theme inline styles for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'style',
 					[
 						'id' => 'child-theme-inline-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				112,
 			],
 			// Admin bar inline styles for print.
 			[
-				AMP_DOM_Utils::create_node(
+				[
 					$dom,
 					'style',
 					[
 						'id' => 'admin-bar-inline-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				300,
 			],
 			// Customizer inline styles for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'style',
 					[
 						'id' => 'wp-custom-css',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				160,
 			],
 			// Other inline styles for print.
 			[
-				AMP_DOM_Utils::create_node(
-					$dom,
+				[
 					'style',
 					[
 						'id' => 'something-else',
 						'media' => 'print',
-					]
-				),
+					],
+				],
 				170,
 			],
 			// Style attribute.
-			[ $dom->createAttribute( 'something' ), 70 ],
+			[ [ null, [ 'something' ] ], 70 ],
 		];
 	}
 
@@ -2644,10 +2629,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_get_stylesheet_priority_data
 	 *
-	 * @param string $node     Node to check the priority of.
-	 * @param int    $expected Expected priority.
+	 * @param array $node_data Node to check the priority of.
+	 * @param int   $expected  Expected priority.
 	 */
-	public function test_get_stylesheet_priority( $node, $expected ) {
+	public function test_get_stylesheet_priority( $node_data, $expected ) {
 		global $wp_styles;
 		$wp_styles = new WP_Styles();
 
@@ -2658,14 +2643,25 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			return 'child-theme';
 		};
 
-		$dom       = new DOMDocument();
+		$dom = new DOMDocument();
+
+		if ( isset( $node_data[0] ) ) {
+			$node = AMP_DOM_Utils::create_node( $dom, $node_data[0], $node_data[1] );
+		} else {
+			$node = $dom->createAttribute( $node_data[1][0] );
+		}
+
 		$sanitizer = new AMP_Style_Sanitizer( $dom );
 
 		add_filter( 'template', $parent_theme_filter );
 		add_filter( 'stylesheet', $child_theme_filter );
 		$wp_styles->add( 'parent-theme', get_template_directory_uri() . '/style.css' );
 		$wp_styles->add( 'child-theme', get_stylesheet_directory_uri() . '/style.css' );
-		$this->assertEquals( $expected, $this->call_private_method( $sanitizer, 'get_stylesheet_priority', [ $node ] ) );
+		$this->assertEquals(
+			$expected,
+			$this->call_private_method( $sanitizer, 'get_stylesheet_priority', [ $node ] ),
+			'Node data: ' . wp_json_encode( $node_data, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT )
+		);
 		remove_filter( 'stylesheet', $child_theme_filter );
 		remove_filter( 'template', $parent_theme_filter );
 	}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -1399,13 +1399,13 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$comment = $style->previousSibling;
 		$this->assertContains( 'The style[amp-custom] element is populated with', $comment->nodeValue );
 		$this->assertContains( 'The following stylesheets are too large to be included', $comment->nodeValue );
-		$this->assertContains( '15 B: style.body', $comment->nodeValue );
-		$this->assertNotContains( '17 B: style.foo1', $comment->nodeValue );
-		$this->assertContains( '0 B: style.bard', $comment->nodeValue );
+		$this->assertRegExp( '/15 B\s*:\s*style.body/', $comment->nodeValue );
+		$this->assertNotRegExp( '/17 B\s*:\s*style.foo1/', $comment->nodeValue );
+		$this->assertRegExp( '/0 B\s*:\s*style.bard/', $comment->nodeValue );
 		$this->assertNotContains( 'style.foo2', $comment->nodeValue );
 		$this->assertContains( 'style.foo3', $comment->nodeValue );
 		$this->assertContains( 'Total included size: 32 bytes (72% of 44 total after tree shaking)', $comment->nodeValue );
-		$this->assertContains( '50024 B: style.excessive', $comment->nodeValue );
+		$this->assertRegExp( '/50024 B\s*:\s*style.excessive/', $comment->nodeValue );
 		$this->assertContains( 'Total excluded size: 50,024 bytes (100% of 50,024 total after tree shaking)', $comment->nodeValue );
 		$this->assertContains( 'Total combined size: 50,056 bytes (99% of 50,068 total after tree shaking)', $comment->nodeValue );
 	}

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -3,7 +3,11 @@
 // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_var_dump
 // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 
+use Amp\AmpWP\Tests\PrivateAccess;
+
 class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCase {
+
+	use PrivateAccess;
 
 	protected $allowed_tags;
 	protected $globally_allowed_attrs;
@@ -398,7 +402,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 
-		$got = $this->invoke_method( $sanitizer, $data['func_name'], [ $node, $data['attribute_name'], $attr_spec_rule ] );
+		$got = $this->call_private_method( $sanitizer, $data['func_name'], [ $node, $data['attribute_name'], $attr_spec_rule ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $source, wp_json_encode( $data ) ) );
 	}
@@ -554,7 +558,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 		$attr      = $node->getAttributeNode( $data['attribute_name'] );
 
-		$got = $this->invoke_method( $sanitizer, $data['func_name'], [ $attr, $attr_spec_list ] );
+		$got = $this->call_private_method( $sanitizer, $data['func_name'], [ $attr, $attr_spec_list ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $source, wp_json_encode( $data ) ) );
 	}
@@ -643,7 +647,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 
-		$this->invoke_method( $sanitizer, 'remove_node', [ $node ] );
+		$this->call_private_method( $sanitizer, 'remove_node', [ $node ] );
 
 		$got = AMP_DOM_Utils::get_content_from_dom( $dom );
 
@@ -784,7 +788,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['tag_name'] )->item( 0 );
 
-		$this->invoke_method( $sanitizer, 'replace_node_with_children', [ $node ] );
+		$this->call_private_method( $sanitizer, 'replace_node_with_children', [ $node ] );
 
 		$got = AMP_DOM_Utils::get_content_from_dom( $dom );
 		$got = preg_replace( '/(?<=>)\s+(?=<)/', '', $got );
@@ -854,7 +858,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			$ancestor_node = null;
 		}
 
-		$got = $this->invoke_method( $sanitizer, 'get_ancestor_with_matching_spec_name', [ $node, $data['ancestor_tag_name'] ] );
+		$got = $this->call_private_method( $sanitizer, 'get_ancestor_with_matching_spec_name', [ $node, $data['ancestor_tag_name'] ] );
 
 		$this->assertEquals( $ancestor_node, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1060,7 +1064,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 
-		$got = $this->invoke_method( $sanitizer, 'validate_attr_spec_list_for_node', [ $node, $data['attr_spec_list'] ] );
+		$got = $this->call_private_method( $sanitizer, 'validate_attr_spec_list_for_node', [ $node, $data['attr_spec_list'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1182,7 +1186,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_value', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
+		$got = $this->call_private_method( $sanitizer, 'check_attr_spec_rule_value', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1329,7 +1333,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_value_casei', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
+		$got = $this->call_private_method( $sanitizer, 'check_attr_spec_rule_value_casei', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1418,7 +1422,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_blacklisted_value_regex', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
+		$got = $this->call_private_method( $sanitizer, 'check_attr_spec_rule_blacklisted_value_regex', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1548,7 +1552,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_allowed_protocol', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
+		$got = $this->call_private_method( $sanitizer, 'check_attr_spec_rule_allowed_protocol', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
@@ -1692,26 +1696,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$node      = $dom->getElementsByTagName( $data['node_tag_name'] )->item( 0 );
 		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 
-		$got = $this->invoke_method( $sanitizer, 'check_attr_spec_rule_disallowed_relative', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
+		$got = $this->call_private_method( $sanitizer, 'check_attr_spec_rule_disallowed_relative', [ $node, $data['attr_name'], $data['attr_spec_rule'] ] );
 
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
-
-	/**
-	 * Use this to call private methods.
-	 *
-	 * @param object $object      Object.
-	 * @param string $method_name Method name.
-	 * @param array  $parameters  Parameters.
-	 * @return mixed Result.
-	 */
-	public function invoke_method( &$object, $method_name, array $parameters = [] ) {
-		$reflection = new ReflectionClass( get_class( $object ) );
-
-		$method = $reflection->getMethod( $method_name );
-		$method->setAccessible( true );
-
-		return $method->invokeArgs( $object, $parameters );
-	}
-
 }

--- a/tests/php/test-class-amp-cli-validation-command.php
+++ b/tests/php/test-class-amp-cli-validation-command.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use Amp\AmpWP\Tests\PrivateAccess;
+
 /**
  * Tests for Test_AMP_CLI_Validation_Command class.
  *
  * @since 1.0
  */
 class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
+
+	use PrivateAccess;
 
 	/**
 	 * Store a reference to the validation command object.
@@ -30,29 +34,6 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'add_comment' ] );
 		$this->validation->include_conditionals      = [];
 		$this->validation->limit_type_validate_count = 100;
-	}
-
-	/**
-	 * Call a private method as if it was public.
-	 *
-	 * This is currently being used to test the internals of the validation
-	 * command.
-	 *
-	 * The command should be refactored to rely on abstractions, instead of
-	 * having so much of its own logic. This would then make testing the
-	 * internals unnecessary.
-	 * See: https://github.com/ampproject/amp-wp/issues/3077
-	 *
-	 * @param object $object      Object instance to call the method on.
-	 * @param string $method_name Name of the method to call.
-	 * @param array  $args        Optional. Array of arguments to pass to the method.
-	 * @return mixed Return value of the method call.
-	 * @throws ReflectionException If the object could not be reflected upon.
-	 */
-	private function call_private_method( $object, $method_name, $args = [] ) {
-		$method = ( new ReflectionClass( $object ) )->getMethod( $method_name );
-		$method->setAccessible( true );
-		return $method->invokeArgs( $object, $args );
 	}
 
 	/**

--- a/tests/php/test-class-amp-comments-sanitizer.php
+++ b/tests/php/test-class-amp-comments-sanitizer.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use Amp\AmpWP\Tests\PrivateAccess;
+
 /**
  * Tests for AMP_Comments_Sanitizer class.
  *
  * @since 0.7
  */
 class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
+
+	use PrivateAccess;
 
 	/**
 	 * Representation of the DOM.
@@ -75,11 +79,9 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 	public function test_process_comment_form() {
 		$instance = new AMP_Comments_Sanitizer( $this->dom );
 
-		$form          = $this->create_form( '/wp-comments-post.php' );
-		$reflection    = new ReflectionObject( $instance );
-		$tested_method = $reflection->getMethod( 'process_comment_form' );
-		$tested_method->setAccessible( true );
-		$tested_method->invoke( $instance, $form );
+		$form = $this->create_form( '/wp-comments-post.php' );
+		$this->call_private_method( $instance, 'process_comment_form', [ $form ] );
+
 		$on        = $form->getAttribute( 'on' );
 		$amp_state = $this->dom->getElementsByTagName( 'amp-state' )->item( 0 );
 

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -5,39 +5,14 @@
  * @package AMP
  */
 
+use Amp\AmpWP\Tests\PrivateAccess;
+
 /**
  * Class AMP_Core_Theme_Sanitizer_Test
  */
 class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 
-	/**
-	 * Call a private method as if it was public.
-	 *
-	 * @param object $object      Object instance to call the method on.
-	 * @param string $method_name Name of the method to call.
-	 * @param array  $args        Optional. Array of arguments to pass to the method.
-	 * @return mixed Return value of the method call.
-	 * @throws ReflectionException If the object could not be reflected upon.
-	 */
-	private function call_private_method( $object, $method_name, $args = [] ) {
-		$method = ( new ReflectionClass( $object ) )->getMethod( $method_name );
-		$method->setAccessible( true );
-		return $method->invokeArgs( $object, $args );
-	}
-
-	/**
-	 * Set a private property as if it was public.
-	 *
-	 * @param object $object        Object instance to the property of.
-	 * @param string $property_name Name of the property to set.
-	 * @param mixed  $value         Value to set the property to.
-	 * @throws ReflectionException If the object could not be reflected upon.
-	 */
-	private function set_private_property( $object, $property_name, $value ) {
-		$property = ( new ReflectionClass( $object ) )->getProperty( $property_name );
-		$property->setAccessible( true );
-		$property->setValue( $object, $value );
-	}
+	use PrivateAccess;
 
 	public function get_xpath_from_css_selector_data() {
 		return [

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -7,6 +7,7 @@
  */
 
 use org\bovigo\vfs;
+use Amp\AmpWP\Tests\PrivateAccess;
 
 /**
  * Tests for Theme Support.
@@ -14,6 +15,8 @@ use org\bovigo\vfs;
  * @covers AMP_Theme_Support
  */
 class Test_AMP_Theme_Support extends WP_UnitTestCase {
+
+	use PrivateAccess;
 
 	/**
 	 * The name of the tested class.
@@ -521,10 +524,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	 * @covers AMP_Theme_Support::add_amp_template_filters()
 	 */
 	public function test_add_amp_template_filters() {
-		$reflection = new ReflectionClass( 'AMP_Theme_Support' );
-		$property   = $reflection->getProperty( 'template_types' );
-		$property->setAccessible( true );
-		$template_types = $property->getValue();
+		$template_types = $this->get_private_property( 'AMP_Theme_Support', 'template_types' );
 
 		AMP_Theme_Support::add_amp_template_filters();
 
@@ -1055,10 +1055,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$embed_handlers = AMP_Theme_Support::register_content_embed_handlers();
 		foreach ( $embed_handlers as $embed_handler ) {
 			$this->assertTrue( is_subclass_of( $embed_handler, 'AMP_Base_Embed_Handler' ) );
-			$reflection = new ReflectionObject( $embed_handler );
-			$args       = $reflection->getProperty( 'args' );
-			$args->setAccessible( true );
-			$property = $args->getValue( $embed_handler );
+			$property = $this->get_private_property( $embed_handler, 'args' );
 			$this->assertEquals( $content_width, $property['content_max_width'] );
 		}
 	}


### PR DESCRIPTION
## Summary

This PR adds the following:
- prioritization of Twentytwenty inline CSS (at priority 2)
- unit test for `AMP_Style_Sanitizer::get_stylesheet_priority()`
- bugfix for plugin CSS bug detected through the new tests
- deprioritization of dev plugins like Query Monitor
- `Amp\AmpWP\Tests\PrivateAccess` trait to access private/protected methods and properties
- `Amp\AmpWP\Tests` development autoloader
- add priorities to CSS manifest
- improve CSS manifest alignment

Related #3869 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
