### PR TITLE
Return allowed KSES tags if not an array

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -684,8 +684,8 @@ class AMP_Story_Post_Type {
 	/**
 	 * Filter the allowed tags for KSES to allow for amp-story children.
 	 *
-	 * @param array $allowed_tags Allowed tags.
-	 * @return array Allowed tags.
+	 * @param array|string $allowed_tags Allowed tags.
+	 * @return array|string Allowed tags.
 	 */
 	public static function filter_kses_allowed_html( $allowed_tags ) {
 		if ( ! is_array( $allowed_tags ) ) {

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -688,6 +688,10 @@ class AMP_Story_Post_Type {
 	 * @return array Allowed tags.
 	 */
 	public static function filter_kses_allowed_html( $allowed_tags ) {
+		if ( ! is_array( $allowed_tags ) ) {
+			return $allowed_tags;
+		}
+
 		$story_components = [
 			'amp-story-page',
 			'amp-story-grid-layer',


### PR DESCRIPTION
## Summary

As discovered on the [support forums](https://wordpress.org/support/topic/php-error-with-stories/),  [wp_kses_allowed_html](https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/) does accept string values. If such a value is received from the `wp_kses_allowed_html` filter hook it should be returned immediately as it would be for a different context we do not handle.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
