### PR TITLE
Show plugin name when listing incompatible plugins

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2024,7 +2024,7 @@ class AMP_Validation_Manager {
 				foreach ( $invalid_plugins as $plugin_slug ) {
 					$plugin_data        = AMP_Validation_Error_Taxonomy::get_plugin_from_slug( $plugin_slug );
 					$plugin_name        = is_array( $plugin_data ) ? $plugin_data['data']['Name'] : $plugin_slug;
-					$reported_plugins[] = sprintf( '<code>%s</code>', esc_html( $plugin_name ) );
+					$reported_plugins[] = $plugin_name;
 				}
 
 				$more_details_link = sprintf(
@@ -2040,9 +2040,19 @@ class AMP_Validation_Manager {
 				);
 
 				printf(
-					'<div class="notice notice-warning is-dismissible"><p>%s %s %s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
-					esc_html( _n( 'Warning: The following plugin may be incompatible with AMP:', 'Warning: The following plugins may be incompatible with AMP:', count( $invalid_plugins ), 'amp' ) ),
-					implode( ', ', $reported_plugins ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					'<div class="notice notice-warning is-dismissible"><p>%s %s</p><button type="button" class="notice-dismiss"><span class="screen-reader-text">%s</span></button></div>',
+					esc_html(
+						sprintf(
+							/* translators: %s is comma-separated list of one or more plugins */
+							_n(
+								'Warning: The following plugin may be incompatible with AMP: %s.',
+								'Warning: The following plugins may be incompatible with AMP: %s.',
+								count( $invalid_plugins ),
+								'amp'
+							),
+							implode( ', ', $reported_plugins ) // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						)
+					),
 					$more_details_link, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					esc_html__( 'Dismiss this notice.', 'amp' )
 				);

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2021,8 +2021,10 @@ class AMP_Validation_Manager {
 			$invalid_plugins = isset( $errors[ AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT ]['plugin'] ) ? array_unique( $errors[ AMP_Validation_Error_Taxonomy::SOURCES_INVALID_OUTPUT ]['plugin'] ) : null;
 			if ( isset( $invalid_plugins ) ) {
 				$reported_plugins = [];
-				foreach ( $invalid_plugins as $plugin ) {
-					$reported_plugins[] = sprintf( '<code>%s</code>', esc_html( $plugin ) );
+				foreach ( $invalid_plugins as $plugin_slug ) {
+					$plugin_data        = AMP_Validation_Error_Taxonomy::get_plugin_from_slug( $plugin_slug );
+					$plugin_name        = is_array( $plugin_data ) ? $plugin_data['data']['Name'] : $plugin_slug;
+					$reported_plugins[] = sprintf( '<code>%s</code>', esc_html( $plugin_name ) );
 				}
 
 				$more_details_link = sprintf(

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -1718,6 +1718,18 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$pagenow          = 'plugins.php';
 		$_GET['activate'] = 'true';
 
+		$cache_plugins_backup = wp_cache_get( 'plugins', 'plugins' );
+
+		$plugins = [
+			'' => [
+				$this->plugin_name => [
+					'Name' => 'Foo Bar',
+				],
+			],
+		];
+
+		wp_cache_set( 'plugins', $plugins, 'plugins' );
+
 		set_transient(
 			AMP_Validation_Manager::PLUGIN_ACTIVATION_VALIDATION_ERRORS_TRANSIENT_KEY,
 			[
@@ -1734,9 +1746,13 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		);
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_plugin_notice' ] );
 		$this->assertContains( 'Warning: The following plugin may be incompatible with AMP', $output );
-		$this->assertContains( $this->plugin_name, $output );
+		$this->assertContains( 'Foo Bar', $output );
 		$this->assertContains( 'More details', $output );
 		$this->assertContains( admin_url( 'edit.php' ), $output );
+
+		if ( $cache_plugins_backup ) {
+			wp_cache_set( 'plugins', $cache_plugins_backup, 'plugins' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Upon the activation of a plugin, a check is made to find plugins which may be incompatible with AMP. If such is found, a notice is displayed listing them:

![image](https://user-images.githubusercontent.com/16200219/70156365-cfbbb900-1681-11ea-8939-7ac15a702919.png)

As shown above, the plugin's slug is being displayed instead of its name. The plugin may not always be identifiable by its slug, and can lead to scenarios where the user may not know which plugin to examine.


This PR fixes this by instead showing the plugin's name:

![image](https://user-images.githubusercontent.com/16200219/70156749-6e481a00-1682-11ea-8d62-1f13bb1e3ac0.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
