### PR TITLE
Add missing src directory to build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,7 @@ module.exports = function( grunt ) {
 		'back-compat',
 		'includes',
 		'readme.txt',
+		'src',
 		'templates',
 		'vendor',
 	];


### PR DESCRIPTION
When deploying the ZIP to a site, I was seeing errors like this:

```
Fatal error: Uncaught Error: Class 'Amp\AmpWP\Component\DOMElementList' not found in /srv/bindings/842e702ecb134f309437791560d11313/code/wp-content/plugins/amp/includes/sanitizers/class-amp-gallery-block-sanitizer.php:109
Stack trace:
#0 /srv/bindings/842e702ecb134f309437791560d11313/code/wp-content/plugins/amp/includes/templates/class-amp-content-sanitizer.php(117): AMP_Gallery_Block_Sanitizer->sanitize()
#1 /srv/bindings/842e702ecb134f309437791560d11313/code/wp-content/plugins/amp/includes/class-amp-theme-support.php(2315): AMP_Content_Sanitizer::sanitize_document(Object(DOMDocument), Array, Array)
#2 /srv/bindings/842e702ecb134f309437791560d11313/code/wp-content/plugins/amp/includes/class-amp-theme-support.php(2003): AMP_Theme_Support::prepare_response('<!DOCTYPE html>...')
#3 [internal function]: AMP_Theme_Support::finish_output_buffering('<!DOCTYPE html>...', 9)
#4 /srv/bindings/842e702ecb134f309437791560d11313/code/wp-includes/functions.php(4469): ob_end_flush()
#5 /srv/bindings/842e702ecb134f309437791560d11313/code in /srv/bindings/842e702ecb134f309437791560d11313/code/wp-content/plugins/amp/includes/sanitizers/class-amp-gallery-block-sanitizer.php on line 109
```

The reason is the `src` directory was not flagged for being included in the build ZIP after #3659.