### PR TITLE
For images, don't raise a validation error for loading="lazy" or decoding="async"

### DIFF
--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -197,8 +197,19 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 				// Skip directly copying new web platform attributes from img to amp-img which are largely handled by AMP already.
 				case 'importance': // Not supported by AMP.
-				case 'loading': // Lazy-loading handled by amp-img natively.
 				case 'intrinsicsize': // Responsive images handled by amp-img directly.
+					break;
+
+				case 'loading': // Lazy-loading handled by amp-img natively.
+					if ( 'lazy' !== strtolower( $value ) ) {
+						$out[ $name ] = $value;
+					}
+					break;
+
+				case 'decoding': // Async decoding handled by AMP.
+					if ( 'async' !== strtolower( $value ) ) {
+						$out[ $name ] = $value;
+					}
 					break;
 
 				default:

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -65,6 +65,31 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
+			'image_with_decoding_attribute_of_async'   => [
+				'<img src="https://placehold.it/150x300" width="150" height="300" decoding="async">',
+				'<amp-img src="https://placehold.it/150x300" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/150x300" width="150" height="300" decoding="async"></noscript></amp-img>',
+				[
+					'add_noscript_fallback' => true,
+				],
+			],
+
+			'image_with_loading_attribute_of_lazy'     => [
+				'<img src="https://placehold.it/150x300" width="150" height="300" loading="lazy">',
+				'<amp-img src="https://placehold.it/150x300" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/150x300" width="150" height="300" loading="lazy"></noscript></amp-img>',
+				[
+					'add_noscript_fallback' => true,
+				],
+			],
+
+			'image_with_wrong_decoding_and_loading'    => [
+				'<img src="https://placehold.it/150x300" width="150" height="300" decoding="sync" loading="eager">',
+				'<amp-img src="https://placehold.it/150x300" width="150" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"><noscript><img src="https://placehold.it/150x300" width="150" height="300" decoding="sync" loading="eager"></noscript></amp-img>',
+				[
+					'add_noscript_fallback' => true,
+				],
+				array_fill( 0, 2, AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_ATTR )
+			],
+
 			'simple_image_without_noscript'            => [
 				'<p><img src="http://placehold.it/300x300" width="300" height="300" /></p>',
 				'<p><amp-img src="http://placehold.it/300x300" width="300" height="300" class="amp-wp-enforced-sizes" layout="intrinsic"></amp-img></p>',

--- a/tests/php/test-amp-img-sanitizer.php
+++ b/tests/php/test-amp-img-sanitizer.php
@@ -87,7 +87,7 @@ class AMP_Img_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'add_noscript_fallback' => true,
 				],
-				array_fill( 0, 2, AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_ATTR )
+				array_fill( 0, 2, AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_ATTR ),
 			],
 
 			'simple_image_without_noscript'            => [


### PR DESCRIPTION
## Summary
For images, this prevents validation errors if `loading="lazy"` or `decoding="async"`, but raises an error for any other value. Uses Weston's snippet in https://github.com/ampproject/amp-wp/issues/3938#issue-538636912.
<!-- Please reference the issue this PR addresses. -->
Fixes #3938

Using Weston's testing snippet in a Custom HTML block:

```html
<img decoding="async" loading="eager" src="https://blog.amp.dev/wp-content/uploads/2019/12/AdobeStock_163856462-e1574813805126-1024x448.jpeg" alt="" class="wp-image-3003" width="1024" height="448">
```

...there is now only a validation error for `loading="eager"`, not `decoding="async"`:

<img width="966" alt="valid-ealo" src="https://user-images.githubusercontent.com/4063887/70952232-37cbb100-202b-11ea-8e53-c3b259f725ed.png">

And there's no validation error for `<img decoding="async" loading="lazy" ...>`, though those aren't copied into the `<amp-img>`:

<img width="750" alt="error-async" src="https://user-images.githubusercontent.com/4063887/70952282-62b60500-202b-11ea-88e1-3040c40d2f44.png">


## Sanitization behavior

| `<img>` attribute  |  value |  Validation error? | Copied into `<amp-img>`? |
|---|---|---|---|
| `loading`  | `lazy`  | no  | no |
|  `loading` |  anything other than `lazy`, like `eager` |  yes | no |
| `decoding`  | `async`  | no  | no |
| `decoding` |  anything other than `async`, like `sync` |  yes | no |

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
