### PR TITLE
Try/ini aspect ratio

### DIFF
--- a/assets/src/edit-story/components/library/mediaLibrary.js
+++ b/assets/src/edit-story/components/library/mediaLibrary.js
@@ -134,20 +134,6 @@ function MediaLibrary( { onInsert } ) {
 	};
 
 	/**
-	 * Generate height based on ratio of original height / width.
-	 *
-	 * @param {number} oWidth Original element width.
-	 * @param {number} oHeight Original element height.
-	 * @param {number} width Desired width.
-	 * @return {number} Relative height compared to height.
-	 */
-	const getRelativeHeight = ( oWidth, oHeight, width ) => {
-		const ratio = oWidth / width;
-		const height = Math.round( oHeight / ratio );
-		return height;
-	};
-
-	/**
 	 * Handle search term changes.
 	 *
 	 * @param {Object} evt Doc Event
@@ -196,8 +182,8 @@ function MediaLibrary( { onInsert } ) {
 	 */
 	const insertMediaElement = ( attachment, width ) => {
 		const { src, mimeType, oWidth, oHeight } = attachment;
-		const height = getRelativeHeight( oWidth, oHeight, width );
-		const origRatio = oWidth / width;
+		const origRatio = oWidth / oHeight;
+		const height = width / origRatio;
 		if ( SUPPORTED_IMAGE_TYPES.includes( mimeType ) ) {
 			return onInsert( 'image', {
 				src,
@@ -207,6 +193,8 @@ function MediaLibrary( { onInsert } ) {
 				y: 5,
 				rotationAngle: 0,
 				origRatio,
+				origWidth: oWidth,
+				origHeight: oHeight,
 			} );
 		} else if ( SUPPORTED_VIDEO_TYPES.includes( mimeType ) ) {
 			return onInsert( 'video', {
@@ -217,6 +205,8 @@ function MediaLibrary( { onInsert } ) {
 				y: 5,
 				rotationAngle: 0,
 				origRatio,
+				origWidth: oWidth,
+				origHeight: oHeight,
 				mimeType,
 			} );
 		}
@@ -232,7 +222,8 @@ function MediaLibrary( { onInsert } ) {
 	 */
 	const getMediaElement = ( mediaEl, width ) => {
 		const { src, oWidth, oHeight, mimeType } = mediaEl;
-		const height = getRelativeHeight( oWidth, oHeight, width );
+		const origRatio = oWidth / oHeight;
+		const height = width / origRatio;
 		if ( SUPPORTED_IMAGE_TYPES.includes( mimeType ) ) {
 			return ( <Image
 				key={ src }


### PR DESCRIPTION
## Summary

This fixes a tiny bug with how `origRatio` and consequently initial width and height are calculated. Reported initially by @miina: 
![stretched-image](https://user-images.githubusercontent.com/726049/71034274-ecb6aa00-20cd-11ea-91af-704ba9402b64.gif)


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
