### PR TITLE
Keep ratio property: edit panels and moveable

### DIFF
--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -7,14 +7,13 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { useStory } from '../../app';
 
-const CORNER_HANDLES = [ 'nw', 'ne', 'sw', 'se' ];
 const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
 
 function Movable( {
@@ -23,6 +22,7 @@ function Movable( {
 	pushEvent,
 } ) {
 	const moveable = useRef();
+	const [ keepRatioMode, setKeepRatioMode ] = useState( true );
 
 	const {
 		actions: { setPropertiesOnSelectedElements },
@@ -71,6 +71,7 @@ function Movable( {
 		setStyle( target );
 		target.style.width = '';
 		target.style.height = '';
+		setKeepRatioMode( true );
 		if ( moveable.current ) {
 			moveable.current.updateRect();
 		}
@@ -97,10 +98,14 @@ function Movable( {
 				setPropertiesOnSelectedElements( newProps );
 				resetMoveable( target );
 			} }
-			onResizeStart={ ( { setOrigin, dragStart } ) => {
+			onResizeStart={ ( { setOrigin, dragStart, direction } ) => {
 				setOrigin( [ '%', '%' ] );
 				if ( dragStart ) {
 					dragStart.set( frame.translate );
+				}
+				const newKeepRatioMode = direction[ 0 ] !== 0 && direction[ 1 ] !== 0;
+				if ( keepRatioMode !== newKeepRatioMode ) {
+					setKeepRatioMode( newKeepRatioMode );
 				}
 			} }
 			onResize={ ( { target, width, height, drag } ) => {
@@ -130,8 +135,8 @@ function Movable( {
 			} }
 			origin={ false }
 			pinchable={ true }
-			keepRatio={ selectedElement.keepRatio || false }
-			renderDirections={ selectedElement.keepRatio ? CORNER_HANDLES : ALL_HANDLES }
+			keepRatio={ 'image' === selectedElement.type && keepRatioMode }
+			renderDirections={ ALL_HANDLES }
 		/>
 	);
 }

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -130,8 +130,8 @@ function Movable( {
 			} }
 			origin={ false }
 			pinchable={ true }
-			keepRatio={ 'image' === selectedElement.type } // @†odo Even image doesn't always keep ratio, consider moving to element's model.
-			renderDirections={ 'image' === selectedElement.type ? CORNER_HANDLES : ALL_HANDLES }
+			keepRatio={ selectedElement.keepRatio || false }
+			renderDirections={ selectedElement.keepRatio ? CORNER_HANDLES : ALL_HANDLES }
 		/>
 	);
 }

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -103,6 +103,9 @@ function Movable( {
 				if ( dragStart ) {
 					dragStart.set( frame.translate );
 				}
+				// Lock ratio for diagonal directions (nw, ne, sw, se). Both
+				// `direction[]` values for diagonals are either 1 or -1. Non-diagonal
+				// directions have 0s.
 				const newKeepRatioMode = direction[ 0 ] !== 0 && direction[ 1 ] !== 0;
 				if ( keepRatioMode !== newKeepRatioMode ) {
 					setKeepRatioMode( newKeepRatioMode );

--- a/assets/src/edit-story/elements/image/edit.js
+++ b/assets/src/edit-story/elements/image/edit.js
@@ -51,9 +51,9 @@ function ImageEdit( { src, origRatio, width, height, x, y, scale, focalX, focalY
 	const imgProps = getImgProps( elementProps.width, elementProps.height, scale, focalX, focalY, origRatio );
 	return (
 		<Element { ...elementProps }>
-			<FadedImg src={ src } { ...imgProps } />
+			<FadedImg draggable={ false } src={ src } { ...imgProps } />
 			<ActualBox>
-				<ActualImg src={ src } { ...imgProps } />
+				<ActualImg draggable={ false } src={ src } { ...imgProps } />
 			</ActualBox>
 		</Element>
 	);

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -6,7 +6,6 @@ export { default as Display } from './display';
 export { default as Edit } from './edit';
 
 export const defaultAttributes = {
-	keepRatio: true,
 };
 
 export const hasEditMode = true;

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -6,6 +6,7 @@ export { default as Display } from './display';
 export { default as Edit } from './edit';
 
 export const defaultAttributes = {
+	keepRatio: true,
 };
 
 export const hasEditMode = true;

--- a/assets/src/edit-story/panels/shared.js
+++ b/assets/src/edit-story/panels/shared.js
@@ -58,7 +58,7 @@ function InputGroup( { type, label, value, isMultiple, onChange, postfix, disabl
 				onChange={ ( evt ) => onChange( isCheckbox ? evt.target.checked : evt.target.value, evt ) }
 				onBlur={ ( evt ) => evt.target.form.dispatchEvent( new window.Event( 'submit' ) ) }
 				placeholder={ placeholder }
-				value={ isCheckbox ? null : value }
+				value={ isCheckbox ? '' : value }
 				checked={ isCheckbox ? value : null }
 			/>
 			{ postfix }

--- a/assets/src/edit-story/panels/shared.js
+++ b/assets/src/edit-story/panels/shared.js
@@ -44,19 +44,22 @@ export const ActionButton = styled.button`
 	font-size: 11px;
 `;
 
-function InputGroup( { label, value, isMultiple, onChange, postfix, disabled } ) {
+function InputGroup( { type, label, value, isMultiple, onChange, postfix, disabled } ) {
 	const placeholder = isMultiple ? '( multiple )' : '';
+	const isCheckbox = type === 'checkbox';
 	return (
 		<Group disabled={ disabled }>
 			<Label>
 				{ label }
 			</Label>
 			<Input
+				type={ type || 'text' }
 				disabled={ disabled }
-				onChange={ ( evt ) => onChange( evt.target.value, evt ) }
+				onChange={ ( evt ) => onChange( isCheckbox ? evt.target.checked : evt.target.value, evt ) }
 				onBlur={ ( evt ) => evt.target.form.dispatchEvent( new window.Event( 'submit' ) ) }
 				placeholder={ placeholder }
-				value={ value }
+				value={ isCheckbox ? null : value }
+				checked={ isCheckbox ? value : null }
 			/>
 			{ postfix }
 		</Group>
@@ -64,6 +67,7 @@ function InputGroup( { label, value, isMultiple, onChange, postfix, disabled } )
 }
 
 InputGroup.propTypes = {
+	type: PropTypes.string,
 	label: PropTypes.string.isRequired,
 	value: PropTypes.any.isRequired,
 	isMultiple: PropTypes.bool.isRequired,

--- a/assets/src/edit-story/panels/shared.js
+++ b/assets/src/edit-story/panels/shared.js
@@ -53,7 +53,7 @@ function InputGroup( { type, label, value, isMultiple, onChange, postfix, disabl
 				{ label }
 			</Label>
 			<Input
-				type={ type || 'text' }
+				type={ type || 'number' }
 				disabled={ disabled }
 				onChange={ ( evt ) => onChange( isCheckbox ? evt.target.checked : evt.target.value, evt ) }
 				onBlur={ ( evt ) => evt.target.form.dispatchEvent( new window.Event( 'submit' ) ) }
@@ -77,6 +77,7 @@ InputGroup.propTypes = {
 };
 
 InputGroup.defaultProps = {
+	type: 'number',
 	postfix: '',
 };
 

--- a/assets/src/edit-story/panels/size.js
+++ b/assets/src/edit-story/panels/size.js
@@ -33,7 +33,6 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 				{ 'Size' }
 			</Title>
 			<InputGroup
-				type="number"
 				label="Width"
 				value={ state.width }
 				isMultiple={ width === '' }
@@ -51,7 +50,6 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 				disabled={ isFullbleed }
 			/>
 			<InputGroup
-				type="number"
 				label="Height"
 				value={ state.height }
 				isMultiple={ height === '' }

--- a/assets/src/edit-story/panels/size.js
+++ b/assets/src/edit-story/panels/size.js
@@ -16,13 +16,12 @@ import { Panel, Title, InputGroup, getCommonValue } from './shared';
 function SizePanel( { selectedElements, onSetProperties } ) {
 	const width = getCommonValue( selectedElements, 'width' );
 	const height = getCommonValue( selectedElements, 'height' );
-	const keepRatio = getCommonValue( selectedElements, 'keepRatio' );
-	const origRatio = getCommonValue( selectedElements, 'origRatio' );
 	const isFullbleed = getCommonValue( selectedElements, 'isFullbleed' );
-	const [ state, setState ] = useState( { width, height, keepRatio } );
+	const [ state, setState ] = useState( { width, height } );
+	const [ lockRatio, setLockRatio ] = useState( true );
 	useEffect( () => {
-		setState( { width, height, keepRatio } );
-	}, [ width, height, keepRatio ] );
+		setState( { width, height } );
+	}, [ width, height ] );
 	const handleSubmit = ( evt ) => {
 		onSetProperties( state );
 		evt.preventDefault();
@@ -37,13 +36,12 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 				value={ state.width }
 				isMultiple={ width === '' }
 				onChange={ ( value ) => {
+					const ratio = width / height;
 					const newWidth = isNaN( value ) || value === '' ? '' : parseFloat( value );
 					setState( {
 						...state,
 						width: newWidth,
-						// @todo: Move to the reducer once available. This is especially critical
-						// because different elements have different aspect ratios.
-						height: typeof newWidth === 'number' && keepRatio && typeof origRatio === 'number' ? newWidth / origRatio : height,
+						height: typeof newWidth === 'number' && lockRatio ? newWidth / ratio : height,
 					} );
 				} }
 				postfix="px"
@@ -54,13 +52,12 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 				value={ state.height }
 				isMultiple={ height === '' }
 				onChange={ ( value ) => {
+					const ratio = width / height;
 					const newHeight = isNaN( value ) || value === '' ? '' : parseFloat( value );
 					setState( {
 						...state,
 						height: newHeight,
-						// @todo: Move to the reducer once available. This is especially critical
-						// because different elements have different aspect ratios.
-						width: typeof newHeight === 'number' && keepRatio && typeof origRatio === 'number' ? newHeight * origRatio : width,
+						width: typeof newHeight === 'number' && lockRatio ? newHeight * ratio : width,
 					} );
 				} }
 				postfix="px"
@@ -69,20 +66,10 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 			<InputGroup
 				type="checkbox"
 				label="Keep ratio"
-				value={ state.keepRatio }
-				isMultiple={ keepRatio === '' }
+				value={ lockRatio }
+				isMultiple={ false }
 				onChange={ ( value ) => {
-					if ( value && typeof origRatio === 'number' ) {
-						onSetProperties( {
-							keepRatio: true,
-							// @todo: Move to the reducer once available. This is especially critical
-							// because different elements have different aspect ratios.
-							width,
-							height: width / origRatio,
-						} );
-					} else {
-						onSetProperties( { keepRatio: false } );
-					}
+					setLockRatio( value );
 				} }
 				disabled={ isFullbleed }
 			/>


### PR DESCRIPTION
## Summary

Partial for #3895

`keepRatio: boolean` property has been introduced. Size edit panel and moveable transformers have been modified to use it.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
