### PR TITLE
Handle sanitization of security, marginwidth & marginheight iframe attributes

### DIFF
--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -239,6 +239,21 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 					}
 					break;
 
+				case 'security':
+					/*
+					 * Omit the `security` attribute as it now been superseded by the `sandbox` attribute. It is
+					 * (apparently) only supported by IE <https://stackoverflow.com/a/20071528>.
+					 */
+					break;
+
+				case 'marginwidth':
+				case 'marginheight':
+					// These attributes have been obsolete since HTML5. If they have the value `0` they can be omitted.
+					if ( '0' !== $value ) {
+						$out[ $name ] = $value;
+					}
+					break;
+
 				default:
 					$out[ $name ] = $value;
 					break;

--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -430,6 +430,26 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>',
 			],
+
+			'iframe_with_security_attr' => [
+				'<iframe security="restricted" src="https://example.com" width="320" height="640"></iframe>',
+				'
+					<amp-iframe src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>',
+			],
+
+			'iframe_with_marginheight_and_marginwidth_attrs' => [
+				'<iframe marginwidth="0" marginheight="0" src="https://example.com" width="320" height="640"></iframe>',
+				'
+					<amp-iframe src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<noscript>
+							<iframe src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

When sanitizing iframes:

- Remove the obsolete `security` attribute
- Remove the obsolete `marginwidth` and `marginheight` attributes if their values are `0`.

<!-- Please reference the issue this PR addresses. -->
Fixes #3950.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
