### PR TITLE
Catch unfiltered requests when testing Crowsignal embed

### DIFF
--- a/tests/php/test-amp-crowdsignal-embed-handler.php
+++ b/tests/php/test-amp-crowdsignal-embed-handler.php
@@ -82,7 +82,7 @@ class AMP_Crowdsignal_Embed_Test extends WP_UnitTestCase {
 		add_filter(
 			'pre_http_request',
 			static function ( $pre, $r, $request_url ) use ( $oembed_response ) {
-				if ( false === strpos( $request_url, 'crowdsignal' ) ) {
+				if ( ! preg_match( '/crowdsignal|polldaddy/', $request_url ) ) {
 					return $pre;
 				}
 


### PR DESCRIPTION
## Summary

HTTP requests for the Crowdsignal tests were not being mocked on WP < 5.1.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
