### PR TITLE
Create a separate layer for all Moveable instances

### DIFF
--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -12,9 +12,10 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStory } from '../../app';
+import SelectionMovable from '../selection';
+import MovableLayer from '../movable/movableLayer';
 import useCanvas from './useCanvas';
 import Element from './element';
-import Movable from './../movable';
 
 const Background = styled.div.attrs( { className: 'container' } )`
 	background-color: ${ ( { theme } ) => theme.colors.fg.v1 };
@@ -63,29 +64,31 @@ function Page() {
 
 	return (
 		<Background>
-			{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
-				const isSelected = Boolean( selectedElement && selectedElement.id === id );
+			<MovableLayer>
+				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
+					const isSelected = Boolean( selectedElement && selectedElement.id === id );
 
-				return (
-					<Element
-						key={ id }
-						setNodeForElement={ setNodeForElement }
-						isEditing={ editingElement === id }
-						element={ { id, ...rest } }
-						isSelected={ isSelected }
-						handleSelectElement={ handleSelectElement }
-						forwardedRef={ isSelected ? setTargetEl : null }
+					return (
+						<Element
+							key={ id }
+							setNodeForElement={ setNodeForElement }
+							isEditing={ editingElement === id }
+							element={ { id, ...rest } }
+							isSelected={ isSelected }
+							handleSelectElement={ handleSelectElement }
+							forwardedRef={ isSelected ? setTargetEl : null }
+						/>
+					);
+				} ) }
+
+				{ selectedElement && targetEl && (
+					<SelectionMovable
+						selectedElement={ selectedElement }
+						targetEl={ targetEl }
+						pushEvent={ pushEvent }
 					/>
-				);
-			} ) }
-
-			{ selectedElement && targetEl && (
-				<Movable
-					selectedElement={ selectedElement }
-					targetEl={ targetEl }
-					pushEvent={ pushEvent }
-				/>
-			) }
+				) }
+			</MovableLayer>
 		</Background>
 	);
 }

--- a/assets/src/edit-story/components/movable/context.js
+++ b/assets/src/edit-story/components/movable/context.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+export default createContext( { container: null, layer: null } );

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -3,154 +3,46 @@
  */
 import Moveable from 'react-moveable';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useState } from '@wordpress/element';
+import { forwardRef, useContext, createPortal } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { useStory } from '../../app';
+import Context from './context';
 
-const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
+const Wrapper = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+  zIndex: ${ ( { zIndex } ) => `${ zIndex }` };
+`;
 
-function Movable( {
-	selectedElement,
-	targetEl,
-	pushEvent,
-} ) {
-	const moveable = useRef();
-	const [ keepRatioMode, setKeepRatioMode ] = useState( true );
-
-	const {
-		actions: { setPropertiesOnSelectedElements },
-	} = useStory();
-
-	const latestEvent = useRef();
-
-	useEffect( () => {
-		latestEvent.current = pushEvent;
-	}, [ pushEvent ] );
-
-	useEffect( () => {
-		if ( moveable.current ) {
-			// If we have persistent event then let's use that, ensuring the targets match.
-			if ( latestEvent.current && targetEl.contains( latestEvent.current.target ) ) {
-				moveable.current.moveable.dragStart( latestEvent.current );
-			}
-			moveable.current.updateRect();
-		}
-	}, [ targetEl, moveable ] );
-
-	// Update moveable with whatever properties could be updated outside moveable
-	// itself.
-	useEffect( () => {
-		if ( moveable.current ) {
-			moveable.current.updateRect();
-		}
-	} );
-
-	const frame = {
-		translate: [ 0, 0 ],
-		rotate: selectedElement.rotationAngle,
-	};
-
-	const setTransformStyle = ( target ) => {
-		target.style.transform = `translate(${ frame.translate[ 0 ] }px, ${ frame.translate[ 1 ] }px) rotate(${ frame.rotate }deg)`;
-	};
-
-	/**
-	 * Resets Movable once the action is done, sets the initial values.
-	 *
-	 * @param {Object} target Target element.
-	 */
-	const resetMoveable = ( target ) => {
-		frame.translate = [ 0, 0 ];
-		// Inline start resetting has to be done very carefully here to avoid
-		// conflicts with stylesheets. See #3951.
-		target.style.transform = '';
-		target.style.width = '';
-		target.style.height = '';
-		setKeepRatioMode( true );
-		if ( moveable.current ) {
-			moveable.current.updateRect();
-		}
-	};
-
-	return (
-		<Moveable
-			ref={ moveable }
-			target={ targetEl }
-			draggable={ ! selectedElement.isFullbleed }
-			resizable={ ! selectedElement.isFullbleed }
-			rotatable={ ! selectedElement.isFullbleed }
-			onDrag={ ( { target, beforeTranslate } ) => {
-				frame.translate = beforeTranslate;
-				setTransformStyle( target );
-			} }
-			throttleDrag={ 0 }
-			onDragStart={ ( { set } ) => {
-				set( frame.translate );
-			} }
-			onDragEnd={ ( { target } ) => {
-				// When dragging finishes, set the new properties based on the original + what moved meanwhile.
-				const newProps = { x: selectedElement.x + frame.translate[ 0 ], y: selectedElement.y + frame.translate[ 1 ] };
-				setPropertiesOnSelectedElements( newProps );
-				resetMoveable( target );
-			} }
-			onResizeStart={ ( { setOrigin, dragStart, direction } ) => {
-				setOrigin( [ '%', '%' ] );
-				if ( dragStart ) {
-					dragStart.set( frame.translate );
-				}
-				// Lock ratio for diagonal directions (nw, ne, sw, se). Both
-				// `direction[]` values for diagonals are either 1 or -1. Non-diagonal
-				// directions have 0s.
-				const newKeepRatioMode = direction[ 0 ] !== 0 && direction[ 1 ] !== 0;
-				if ( keepRatioMode !== newKeepRatioMode ) {
-					setKeepRatioMode( newKeepRatioMode );
-				}
-			} }
-			onResize={ ( { target, width, height, drag } ) => {
-				target.style.width = `${ width }px`;
-				target.style.height = `${ height }px`;
-				frame.translate = drag.beforeTranslate;
-				setTransformStyle( target );
-			} }
-			onResizeEnd={ ( { target } ) => {
-				setPropertiesOnSelectedElements( {
-					width: parseInt( target.style.width ),
-					height: parseInt( target.style.height ),
-					x: selectedElement.x + frame.translate[ 0 ],
-					y: selectedElement.y + frame.translate[ 1 ],
-				} );
-				resetMoveable( target );
-			} }
-			onRotateStart={ ( { set } ) => {
-				set( frame.rotate );
-			} }
-			onRotate={ ( { target, beforeRotate } ) => {
-				frame.rotate = beforeRotate;
-				setTransformStyle( target );
-			} }
-			onRotateEnd={ ( { target } ) => {
-				setPropertiesOnSelectedElements( { rotationAngle: frame.rotate } );
-				resetMoveable( target );
-			} }
-			origin={ false }
-			pinchable={ true }
-			keepRatio={ 'image' === selectedElement.type && keepRatioMode }
-			renderDirections={ ALL_HANDLES }
-		/>
+function MovableWithRef( { zIndex, ...moveableProps }, ref ) {
+	const { container, layer } = useContext( Context );
+	if ( ! container || ! layer ) {
+		return null;
+	}
+	const slot = (
+		<Wrapper zIndex={ zIndex }>
+			<Moveable
+				ref={ ref }
+				container={ container }
+				{ ...moveableProps }
+			/>
+		</Wrapper>
 	);
+	return createPortal( slot, layer );
 }
 
+const Movable = forwardRef( MovableWithRef );
+
 Movable.propTypes = {
-	selectedElement: PropTypes.object,
-	targetEl: PropTypes.object.isRequired,
-	pushEvent: PropTypes.object,
+	zIndex: PropTypes.number.isRequired,
 };
 
 export default Movable;

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -15,11 +15,13 @@ import { forwardRef, useContext, createPortal } from '@wordpress/element';
  */
 import Context from './context';
 
+const DEFAULT_Z_INDEX = 10;
+
 const Wrapper = styled.div`
   position: absolute;
   top: 0;
   left: 0;
-  zIndex: ${ ( { zIndex } ) => `${ zIndex }` };
+  z-index: ${ ( { zIndex } ) => `${ zIndex }` };
 `;
 
 function MovableWithRef( { zIndex, ...moveableProps }, ref ) {
@@ -28,7 +30,7 @@ function MovableWithRef( { zIndex, ...moveableProps }, ref ) {
 		return null;
 	}
 	const slot = (
-		<Wrapper zIndex={ zIndex }>
+		<Wrapper zIndex={ zIndex || DEFAULT_Z_INDEX }>
 			<Moveable
 				ref={ ref }
 				container={ container }
@@ -39,10 +41,14 @@ function MovableWithRef( { zIndex, ...moveableProps }, ref ) {
 	return createPortal( slot, layer );
 }
 
-const Movable = forwardRef( MovableWithRef );
-
-Movable.propTypes = {
-	zIndex: PropTypes.number.isRequired,
+MovableWithRef.propTypes = {
+	zIndex: PropTypes.number,
 };
+
+MovableWithRef.defaultProps = {
+	zIndex: DEFAULT_Z_INDEX,
+};
+
+const Movable = forwardRef( MovableWithRef );
 
 export default Movable;

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import Moveable from 'react-moveable';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -40,14 +39,6 @@ function MovableWithRef( { zIndex, ...moveableProps }, ref ) {
 	);
 	return createPortal( slot, layer );
 }
-
-MovableWithRef.propTypes = {
-	zIndex: PropTypes.number,
-};
-
-MovableWithRef.defaultProps = {
-	zIndex: DEFAULT_Z_INDEX,
-};
 
 const Movable = forwardRef( MovableWithRef );
 

--- a/assets/src/edit-story/components/movable/movableLayer.js
+++ b/assets/src/edit-story/components/movable/movableLayer.js
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+const Container = styled.div`
+  position: absolute;
+  inset: 0;
+`;
+
+const Layer = styled.div`
+  position: absolute;
+  top: 0;
+  left: 0;
+`;
+
+// @todo: consider making this more generic tool: a set of tools layered on top
+// of the editor, with the tool order controlled via zIndex.
+function MovableLayer( { children } ) {
+	const [ layer, setLayer ] = useState( null );
+	const [ container, setContainer ] = useState( null );
+	return (
+		<Container ref={ setContainer }>
+			<Context.Provider value={ { container, layer } }>
+				{ children }
+
+				<Layer ref={ setLayer } />
+			</Context.Provider>
+		</Container>
+	);
+}
+
+MovableLayer.propTypes = {
+	children: PropTypes.oneOfType( [
+		PropTypes.arrayOf( PropTypes.node ),
+		PropTypes.node,
+	] ).isRequired,
+};
+
+export default MovableLayer;

--- a/assets/src/edit-story/components/selection/index.js
+++ b/assets/src/edit-story/components/selection/index.js
@@ -1,0 +1,146 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useStory } from '../../app';
+import Movable from '../movable';
+
+const CORNER_HANDLES = [ 'nw', 'ne', 'sw', 'se' ];
+const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
+
+function SelectionMovable( {
+	selectedElement,
+	targetEl,
+	pushEvent,
+} ) {
+	const moveable = useRef();
+
+	const {
+		actions: { setPropertiesOnSelectedElements },
+	} = useStory();
+
+	const latestEvent = useRef();
+
+	useEffect( () => {
+		latestEvent.current = pushEvent;
+	}, [ pushEvent ] );
+
+	useEffect( () => {
+		if ( moveable.current ) {
+			// If we have persistent event then let's use that, ensuring the targets match.
+			if ( latestEvent.current && targetEl.contains( latestEvent.current.target ) ) {
+				moveable.current.moveable.dragStart( latestEvent.current );
+			}
+			moveable.current.updateRect();
+		}
+	}, [ targetEl, moveable ] );
+
+	// Update moveable with whatever properties could be updated outside moveable
+	// itself.
+	useEffect( () => {
+		if ( moveable.current ) {
+			moveable.current.updateRect();
+		}
+	} );
+
+	const frame = {
+		translate: [ 0, 0 ],
+		rotate: selectedElement.rotationAngle,
+	};
+
+	const setStyle = ( target ) => {
+		target.style.transform = `translate(${ frame.translate[ 0 ] }px, ${ frame.translate[ 1 ] }px) rotate(${ frame.rotate }deg)`;
+	};
+
+	/**
+  * Resets SelectionMovable once the action is done, sets the initial values.
+  *
+  * @param {Object} target Target element.
+  */
+	const resetMoveable = ( target ) => {
+		frame.translate = [ 0, 0 ];
+		setStyle( target );
+		target.style.width = '';
+		target.style.height = '';
+		if ( moveable.current ) {
+			moveable.current.updateRect();
+		}
+	};
+
+	return (
+		<Movable
+			ref={ moveable }
+			zIndex={ 0 }
+			target={ targetEl }
+			draggable={ ! selectedElement.isFullbleed }
+			resizable={ ! selectedElement.isFullbleed }
+			rotatable={ ! selectedElement.isFullbleed }
+			onDrag={ ( { target, beforeTranslate } ) => {
+				frame.translate = beforeTranslate;
+				setStyle( target );
+			} }
+			throttleDrag={ 0 }
+			onDragStart={ ( { set } ) => {
+				set( frame.translate );
+			} }
+			onDragEnd={ ( { target } ) => {
+				// When dragging finishes, set the new properties based on the original + what moved meanwhile.
+				const newProps = { x: selectedElement.x + frame.translate[ 0 ], y: selectedElement.y + frame.translate[ 1 ] };
+				setPropertiesOnSelectedElements( newProps );
+				resetMoveable( target );
+			} }
+			onResizeStart={ ( { setOrigin, dragStart } ) => {
+				setOrigin( [ '%', '%' ] );
+				if ( dragStart ) {
+					dragStart.set( frame.translate );
+				}
+			} }
+			onResize={ ( { target, width, height, drag } ) => {
+				target.style.width = `${ width }px`;
+				target.style.height = `${ height }px`;
+				frame.translate = drag.beforeTranslate;
+				setStyle( target );
+			} }
+			onResizeEnd={ ( { target } ) => {
+				setPropertiesOnSelectedElements( {
+					width: parseInt( target.style.width ),
+					height: parseInt( target.style.height ),
+					x: selectedElement.x + frame.translate[ 0 ],
+					y: selectedElement.y + frame.translate[ 1 ],
+				} );
+				resetMoveable( target );
+			} }
+			onRotateStart={ ( { set } ) => {
+				set( frame.rotate );
+			} }
+			onRotate={ ( { target, beforeRotate } ) => {
+				frame.rotate = beforeRotate;
+				setStyle( target );
+			} }
+			onRotateEnd={ () => {
+				setPropertiesOnSelectedElements( { rotationAngle: frame.rotate } );
+			} }
+			origin={ false }
+			pinchable={ true }
+			keepRatio={ 'image' === selectedElement.type } // @†odo Even image doesn't always keep ratio, consider moving to element's model.
+			renderDirections={ 'image' === selectedElement.type ? CORNER_HANDLES : ALL_HANDLES }
+		/>
+	);
+}
+
+SelectionMovable.propTypes = {
+	selectedElement: PropTypes.object,
+	targetEl: PropTypes.object.isRequired,
+	pushEvent: PropTypes.object,
+};
+
+export default SelectionMovable;

--- a/assets/src/edit-story/components/selection/index.js
+++ b/assets/src/edit-story/components/selection/index.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,7 +14,6 @@ import { useRef, useEffect } from '@wordpress/element';
 import { useStory } from '../../app';
 import Movable from '../movable';
 
-const CORNER_HANDLES = [ 'nw', 'ne', 'sw', 'se' ];
 const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
 
 function SelectionMovable( {
@@ -23,6 +22,7 @@ function SelectionMovable( {
 	pushEvent,
 } ) {
 	const moveable = useRef();
+	const [ keepRatioMode, setKeepRatioMode ] = useState( true );
 
 	const {
 		actions: { setPropertiesOnSelectedElements },
@@ -57,20 +57,23 @@ function SelectionMovable( {
 		rotate: selectedElement.rotationAngle,
 	};
 
-	const setStyle = ( target ) => {
+	const setTransformStyle = ( target ) => {
 		target.style.transform = `translate(${ frame.translate[ 0 ] }px, ${ frame.translate[ 1 ] }px) rotate(${ frame.rotate }deg)`;
 	};
 
 	/**
-  * Resets SelectionMovable once the action is done, sets the initial values.
-  *
-  * @param {Object} target Target element.
-  */
+	 * Resets Movable once the action is done, sets the initial values.
+	 *
+	 * @param {Object} target Target element.
+	 */
 	const resetMoveable = ( target ) => {
 		frame.translate = [ 0, 0 ];
-		setStyle( target );
+		// Inline start resetting has to be done very carefully here to avoid
+		// conflicts with stylesheets. See #3951.
+		target.style.transform = '';
 		target.style.width = '';
 		target.style.height = '';
+		setKeepRatioMode( true );
 		if ( moveable.current ) {
 			moveable.current.updateRect();
 		}
@@ -78,15 +81,15 @@ function SelectionMovable( {
 
 	return (
 		<Movable
-			ref={ moveable }
 			zIndex={ 0 }
+			ref={ moveable }
 			target={ targetEl }
 			draggable={ ! selectedElement.isFullbleed }
 			resizable={ ! selectedElement.isFullbleed }
 			rotatable={ ! selectedElement.isFullbleed }
 			onDrag={ ( { target, beforeTranslate } ) => {
 				frame.translate = beforeTranslate;
-				setStyle( target );
+				setTransformStyle( target );
 			} }
 			throttleDrag={ 0 }
 			onDragStart={ ( { set } ) => {
@@ -98,17 +101,24 @@ function SelectionMovable( {
 				setPropertiesOnSelectedElements( newProps );
 				resetMoveable( target );
 			} }
-			onResizeStart={ ( { setOrigin, dragStart } ) => {
+			onResizeStart={ ( { setOrigin, dragStart, direction } ) => {
 				setOrigin( [ '%', '%' ] );
 				if ( dragStart ) {
 					dragStart.set( frame.translate );
+				}
+				// Lock ratio for diagonal directions (nw, ne, sw, se). Both
+				// `direction[]` values for diagonals are either 1 or -1. Non-diagonal
+				// directions have 0s.
+				const newKeepRatioMode = direction[ 0 ] !== 0 && direction[ 1 ] !== 0;
+				if ( keepRatioMode !== newKeepRatioMode ) {
+					setKeepRatioMode( newKeepRatioMode );
 				}
 			} }
 			onResize={ ( { target, width, height, drag } ) => {
 				target.style.width = `${ width }px`;
 				target.style.height = `${ height }px`;
 				frame.translate = drag.beforeTranslate;
-				setStyle( target );
+				setTransformStyle( target );
 			} }
 			onResizeEnd={ ( { target } ) => {
 				setPropertiesOnSelectedElements( {
@@ -124,15 +134,16 @@ function SelectionMovable( {
 			} }
 			onRotate={ ( { target, beforeRotate } ) => {
 				frame.rotate = beforeRotate;
-				setStyle( target );
+				setTransformStyle( target );
 			} }
-			onRotateEnd={ () => {
+			onRotateEnd={ ( { target } ) => {
 				setPropertiesOnSelectedElements( { rotationAngle: frame.rotate } );
+				resetMoveable( target );
 			} }
 			origin={ false }
 			pinchable={ true }
-			keepRatio={ 'image' === selectedElement.type } // @†odo Even image doesn't always keep ratio, consider moving to element's model.
-			renderDirections={ 'image' === selectedElement.type ? CORNER_HANDLES : ALL_HANDLES }
+			keepRatio={ 'image' === selectedElement.type && keepRatioMode }
+			renderDirections={ ALL_HANDLES }
 		/>
 	);
 }


### PR DESCRIPTION
## Summary

Partial for #3895

Based on the prototype in #3895, it appears that:

1. It will be fairly hard to reuse the selection moveable for cropping. So an additional 2 moveable instances are needed.
2. It's much easier to keep all moveables in the same place in DOM: for coordinate system, but also because in some cases their `z-index` order is important.

The proposal thus creates a portal inside the `Background` and all moveables are hoisted into it. This seems to work pretty well and would allow us to keep moveable instances inside the `Edit` components. We could even further try to make this a generic approach to host other overlaying tools.


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
