### PR TITLE
Fix conversion of forms with relative action URLs

### DIFF
--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -67,9 +67,21 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 				$action_url = esc_url_raw( '//' . $_SERVER['HTTP_HOST'] . wp_unslash( $_SERVER['REQUEST_URI'] ) );
 			} else {
 				$action_url = $node->getAttribute( 'action' );
-				// Check if action_url is a relative path and add the host to it.
+
+				// Handle relative URLs.
 				if ( ! preg_match( '#^(https?:)?//#', $action_url ) ) {
-					$action_url = esc_url_raw( '//' . $_SERVER['HTTP_HOST'] . $action_url );
+					$schemeless_host = '//' . $_SERVER['HTTP_HOST'];
+					if ( '?' === $action_url[0] || '#' === $action_url[0] ) {
+						// For actions consisting of only a query or URL fragment, include the schemeless-host and the REQUEST URI of the current page.
+						$action_url = '//' . $_SERVER['HTTP_HOST'] . wp_unslash( $_SERVER['REQUEST_URI'] ) . $action_url;
+					} elseif ( '.' === $action_url[0] ) {
+						// For actions consisting of relative paths (e.g. '../'), prepend the schemeless-host and a trailing-slashed REQUEST URI.
+						$action_url = '//' . $_SERVER['HTTP_HOST'] . trailingslashit( wp_unslash( $_SERVER['REQUEST_URI'] ) ) . $action_url;
+					} else {
+						// Otherwise, when the action URL includes an absolute path, just append it to the schemeless-host.
+						$action_url = $schemeless_host . $action_url;
+					}
+					$action_url = esc_url_raw( $action_url );
 				}
 			}
 			$xhr_action = $node->getAttribute( 'action-xhr' );

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -73,10 +73,10 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 					$schemeless_host = '//' . $_SERVER['HTTP_HOST'];
 					if ( '?' === $action_url[0] || '#' === $action_url[0] ) {
 						// For actions consisting of only a query or URL fragment, include the schemeless-host and the REQUEST URI of the current page.
-						$action_url = '//' . $_SERVER['HTTP_HOST'] . wp_unslash( $_SERVER['REQUEST_URI'] ) . $action_url;
+						$action_url = $schemeless_host . wp_unslash( $_SERVER['REQUEST_URI'] ) . $action_url;
 					} elseif ( '.' === $action_url[0] ) {
 						// For actions consisting of relative paths (e.g. '../'), prepend the schemeless-host and a trailing-slashed REQUEST URI.
-						$action_url = '//' . $_SERVER['HTTP_HOST'] . trailingslashit( wp_unslash( $_SERVER['REQUEST_URI'] ) ) . $action_url;
+						$action_url = $schemeless_host . trailingslashit( wp_unslash( $_SERVER['REQUEST_URI'] ) ) . $action_url;
 					} else {
 						// Otherwise, when the action URL includes an absolute path, just append it to the schemeless-host.
 						$action_url = $schemeless_host . $action_url;

--- a/tests/php/test-amp-form-sanitizer.php
+++ b/tests/php/test-amp-form-sanitizer.php
@@ -93,7 +93,18 @@ class AMP_Form_Sanitizer_Test extends WP_UnitTestCase {
 				'<form method="post" action="/login/"></form>',
 				'#' . preg_quote( '<form method="post" action-xhr="//example.org/login/?_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
 			],
-
+			'form_with_relative_path_action_url' => [
+				'<form method="post" action="../"></form>',
+				'#' . preg_quote( '<form method="post" action-xhr="//example.org/current-page/../?_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
+			],
+			'form_with_relative_query_action_url' => [
+				'<form method="post" action="?foo=bar"></form>',
+				'#' . preg_quote( '<form method="post" action-xhr="//example.org/current-page/?foo=bar&amp;_wp_amp_action_xhr_converted=1" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
+			],
+			'form_with_relative_fragment_action_url' => [
+				'<form method="post" action="#foo"></form>',
+				'#' . preg_quote( '<form method="post" action-xhr="//example.org/current-page/?_wp_amp_action_xhr_converted=1#foo" target="_top">', '#' ) . $form_template_pattern . '</form>#s',
+			],
 			'test_with_dev_mode' => [
 				'<form data-ampdevmode="" action="javascript:"></form>',
 				null, // No change.


### PR DESCRIPTION
## Summary

The subscription `form` in Jetpack [uses](https://github.com/Automattic/jetpack/blob/e67bea661ea10a2396bf6efd3a484e9c274a1e2a/modules/subscriptions/views.php#L329) an `action` of `#`:

```html
<form action="#" method="post" accept-charset="utf-8" id="subscribe-blog-blog_subscription-2">
```

When the form is being displayed on a URL like `https://example.org/about/` it is getting converted by the form sanitizer as:

```html
<form action-xhr="//example.org?_wp_amp_action_xhr_converted=1#" method="post" accept-charset="utf-8" id="subscribe-blog-blog_subscription-2" target="_top">
```

This is wrong. It should instead be:

```html
<form action-xhr="//example.org/about/?_wp_amp_action_xhr_converted=1#" method="post" accept-charset="utf-8" id="subscribe-blog-blog_subscription-2" target="_top">
```

This PR fixes the sanitization of `action` attribute containing values such as:

* `../`
* `?foo=bar`
* `#foo`

Issue discovered in a [WordPress.org support topic](https://wordpress.org/support/topic/jetpack-subscribe-to-blog-widget-not-working/#post-12259691).

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
