### PR TITLE
Tiny fix: refocus the editor when the wrapper is clicked

### DIFF
--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -115,6 +115,7 @@ function TextEdit( { content, color, backgroundColor, width, height, x, y, fontF
 	// Make sure to allow the user to click in the text box while working on the text.
 	const onClick = ( evt ) => {
 		const editor = editorRef.current;
+		// Refocus the editor if the container outside it is clicked.
 		if ( ! editor.editorContainer.contains( evt.target ) ) {
 			editor.focus();
 		}

--- a/assets/src/edit-story/elements/text/edit.js
+++ b/assets/src/edit-story/elements/text/edit.js
@@ -63,6 +63,7 @@ function TextEdit( { content, color, backgroundColor, width, height, x, y, fontF
 		y,
 		rotationAngle,
 	};
+	const editorRef = useRef( null );
 	const { actions: { setPropertiesOnSelectedElements } } = useStory();
 	const { state: { editingElementState } } = useCanvas();
 	const { offset, clearContent } = editingElementState || {};
@@ -112,21 +113,26 @@ function TextEdit( { content, color, backgroundColor, width, height, x, y, fontF
 	}, [ setPropertiesOnSelectedElements ] );
 
 	// Make sure to allow the user to click in the text box while working on the text.
-	const onClick = ( evt ) => evt.stopPropagation();
+	const onClick = ( evt ) => {
+		const editor = editorRef.current;
+		if ( ! editor.editorContainer.contains( evt.target ) ) {
+			editor.focus();
+		}
+		evt.stopPropagation();
+	};
 
 	// Handle basic key commands such as bold, italic and underscore.
 	const handleKeyCommand = getHandleKeyCommand( setEditorState );
 
 	// Set focus when initially rendered
-	const editor = useRef( null );
 	useLayoutEffect( () => {
-		editor.current.focus();
+		editorRef.current.focus();
 	}, [] );
 
 	return (
 		<Element { ...props } onClick={ onClick }>
 			<Editor
-				ref={ editor }
+				ref={ editorRef }
 				onChange={ updateEditorState }
 				editorState={ editorState }
 				handleKeyCommand={ handleKeyCommand }


### PR DESCRIPTION
## Summary

This is a tiny fix to make manual testing easier. Alternative solution would be to size the RTE itself to fill the wrapper. Either way should be fine for this problem. Mostly depends on whether we want "auto-resize-on-more-text" kind of feature.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
