### PR TITLE
Reset edit state when a new element is selected to avoid nested loop

### DIFF
--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -33,7 +33,7 @@ function Page() {
 
 	const {
 		state: { editingElement },
-		actions: { setBackgroundClickHandler, setNodeForElement },
+		actions: { setBackgroundClickHandler, setNodeForElement, clearEditing },
 	} = useCanvas();
 
 	const [ pushEvent, setPushEvent ] = useState( null );
@@ -43,6 +43,9 @@ function Page() {
 	}, [ setBackgroundClickHandler, clearSelection ] );
 
 	const handleSelectElement = useCallback( ( elId, evt ) => {
+		if ( editingElement && elId !== editingElement ) {
+			clearEditing();
+		}
 		if ( evt.metaKey ) {
 			toggleElementIdInSelection( elId );
 		} else {
@@ -54,7 +57,7 @@ function Page() {
 			evt.persist();
 			setPushEvent( evt );
 		}
-	}, [ toggleElementIdInSelection, selectElementById ] );
+	}, [ editingElement, clearEditing, toggleElementIdInSelection, selectElementById ] );
 
 	const selectedElement = selectedElements.length === 1 ? selectedElements[ 0 ] : null;
 


### PR DESCRIPTION
## Summary

A small fix for a problem that makes testing very hard. To repro:

1. Add two text blocks on the page.
2. Select and click to enter the edit mode on one text block.
3. Click on the other text block.

Expected: the other text block is selected. 
Observed: max-nested-loop React error. The editor is hanging.


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
