### PR TITLE
Fix handling of gallery carousels in paragraphs and fix no-JS fallbacks

### DIFF
--- a/includes/embeds/class-amp-gallery-embed.php
+++ b/includes/embeds/class-amp-gallery-embed.php
@@ -236,7 +236,7 @@ class AMP_Gallery_Embed_Handler extends AMP_Base_Embed_Handler {
 			}
 			$image = AMP_DOM_Utils::create_node(
 				$dom,
-				'amp-img',
+				'img',
 				$image_atts
 			);
 

--- a/src/Component/Carousel.php
+++ b/src/Component/Carousel.php
@@ -84,15 +84,15 @@ final class Carousel {
 			$caption         = $slide instanceof HasCaption ? $slide->get_caption() : null;
 			$slide_container = AMP_DOM_Utils::create_node(
 				$this->dom,
-				'div',
+				'span', // This cannot be a <div> because if the gallery is inside of a <p>, then the DOM will break.
 				[ 'class' => 'slide' ]
 			);
 
 			// Ensure an image fills the entire <amp-carousel>, so the possible caption looks right.
-			if ( 'amp-img' === $slide_node->tagName ) {
+			if ( $this->is_image_element( $slide_node ) ) {
 				$slide_node->setAttribute( 'layout', 'fill' );
 				$slide_node->setAttribute( 'object-fit', 'cover' );
-			} elseif ( isset( $slide_node->firstChild->tagName ) && 'amp-img' === $slide_node->firstChild->tagName ) {
+			} elseif ( $slide_node->firstChild instanceof DOMElement && $this->is_image_element( $slide_node->firstChild ) ) {
 				// If the <amp-img> is wrapped in an <a>.
 				$slide_node->firstChild->setAttribute( 'layout', 'fill' );
 				$slide_node->firstChild->setAttribute( 'object-fit', 'cover' );
@@ -100,11 +100,11 @@ final class Carousel {
 
 			$slide_container->appendChild( $slide_node );
 
-			// If there's a caption, wrap it in a <div> and <span>, and append it to the slide.
+			// If there's a caption, wrap it and append it to the slide.
 			if ( $caption ) {
 				$caption_wrapper = AMP_DOM_Utils::create_node(
 					$this->dom,
-					'div',
+					'span', // This cannot be a <div> because if the gallery is inside of a <p>, then the DOM will break.
 					[ 'class' => 'amp-wp-gallery-caption' ]
 				);
 				$caption_span    = AMP_DOM_Utils::create_node( $this->dom, 'span', [] );
@@ -146,7 +146,7 @@ final class Carousel {
 		foreach ( $this->slides as $slide ) {
 			$slide_node = $slide instanceof HasCaption ? $slide->get_slide_node() : $slide;
 			// Account for an <amp-img> that's wrapped in an <a>.
-			if ( 'amp-img' !== $slide_node->tagName && isset( $slide_node->firstChild->tagName ) && 'amp-img' === $slide_node->firstChild->tagName ) {
+			if ( ! $this->is_image_element( $slide_node ) && $slide_node->firstChild instanceof DOMElement && $this->is_image_element( $slide_node->firstChild ) ) {
 				$slide_node = $slide_node->firstChild;
 			}
 
@@ -174,5 +174,15 @@ final class Carousel {
 		}
 
 		return [ $carousel_width, $carousel_height ];
+	}
+
+	/**
+	 * Determine whether an element is an image (either an <amp-img> or an <img>).
+	 *
+	 * @param DOMElement $element Element.
+	 * @return bool If it is an image.
+	 */
+	private function is_image_element( DOMElement $element ) {
+		return 'amp-img' === $element->tagName || 'img' === $element->tagName;
 	}
 }

--- a/tests/php/test-amp-carousel.php
+++ b/tests/php/test-amp-carousel.php
@@ -40,12 +40,12 @@ class Test_Carousel extends \WP_UnitTestCase {
 			'image_without_caption' => [
 				( new ElementList() )->add( $image, '' ),
 				$dom,
-				'<amp-carousel width="' . $width . '" height="' . $height . '" type="slides" layout="responsive"><div class="slide"><amp-img src="' . $src . '" width="' . $width . '" height="' . $height . '" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
+				'<amp-carousel width="' . $width . '" height="' . $height . '" type="slides" layout="responsive"><span class="slide"><amp-img src="' . $src . '" width="' . $width . '" height="' . $height . '" layout="fill" object-fit="cover"></amp-img></span></amp-carousel>',
 			],
 			'image_with_caption'    => [
 				( new ElementList() )->add( $image, $caption ),
 				$dom,
-				'<amp-carousel width="' . $width . '" height="' . $height . '" type="slides" layout="responsive"><div class="slide"><amp-img src="' . $src . '" width="' . $width . '" height="' . $height . '" layout="fill" object-fit="cover"></amp-img><div class="amp-wp-gallery-caption"><span>' . $caption . '</span></div></div></amp-carousel>',
+				'<amp-carousel width="' . $width . '" height="' . $height . '" type="slides" layout="responsive"><span class="slide"><amp-img src="' . $src . '" width="' . $width . '" height="' . $height . '" layout="fill" object-fit="cover"></amp-img><span class="amp-wp-gallery-caption"><span>' . $caption . '</span></span></span></amp-carousel>',
 			],
 		];
 	}

--- a/tests/php/test-amp-gallery-embed.php
+++ b/tests/php/test-amp-gallery-embed.php
@@ -30,7 +30,7 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 	 * @return array[]
 	 */
 	public function get_conversion_data() {
-		$amp_carousel_caption = '<div class="amp-wp-gallery-caption"><span>' . self::CAPTION_TEXT . '</span></div>';
+		$amp_carousel_caption = '<span class="amp-wp-gallery-caption"><span>' . self::CAPTION_TEXT . '</span></span>';
 
 		return [
 			'shortcode_with_invalid_id'               => [
@@ -39,38 +39,38 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 			],
 			'shortcode_with_valid_id'                 => [
 				'[gallery ids={{id1}}]',
-				'<amp-carousel width="50" height="50" type="slides" layout="responsive"><div class="slide"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></amp-img>' . $amp_carousel_caption . '</div></amp-carousel>',
+				'<amp-carousel width="50" height="50" type="slides" layout="responsive"><span class="slide"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover">' . $amp_carousel_caption . '</span></amp-carousel>',
 			],
 			'shortcode_with_multiple_ids'             => [
 				'[gallery ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<div class="slide"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></amp-img>' . $amp_carousel_caption . '</div>' .
-					'<div class="slide"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></amp-img></div>' .
-					'<div class="slide"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></amp-img></div>' .
+					'<span class="slide"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover">' . $amp_carousel_caption . '</span>' .
+					'<span class="slide"><img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></span>' .
+					'<span class="slide"><img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></span>' .
 				'</amp-carousel>',
 			],
 			'shortcode_linking_to_file'               => [
 				'[gallery link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<div class="slide"><a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></amp-img></a>' . $amp_carousel_caption . '</div>' .
-					'<div class="slide"><a href="{{file2}}.jpg"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></amp-img></a></div>' .
-					'<div class="slide"><a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></amp-img></a></div>' .
+					'<span class="slide"><a href="{{file1}}.jpg"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></a>' . $amp_carousel_caption . '</span>' .
+					'<span class="slide"><a href="{{file2}}.jpg"><img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></a></span>' .
+					'<span class="slide"><a href="{{file3}}.jpg"><img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></a></span>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_carousel'                 => [
 				'[gallery amp-lightbox=false amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<div class="slide"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></amp-img>' . $amp_carousel_caption . '</div>' .
-					'<div class="slide"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></amp-img></div>' .
-					'<div class="slide"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></amp-img></div>' .
+					'<span class="slide"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover">' . $amp_carousel_caption . '</span>' .
+					'<span class="slide"><img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></span>' .
+					'<span class="slide"><img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></span>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=false amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<div class="slide"><a href="{{file1}}.jpg"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></amp-img></a>' . $amp_carousel_caption . '</div>' .
-					'<div class="slide"><a href="{{file2}}.jpg"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></amp-img></a></div>' .
-					'<div class="slide"><a href="{{file3}}.jpg"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></amp-img></a></div>' .
+					'<span class="slide"><a href="{{file1}}.jpg"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" object-fit="cover"></a>' . $amp_carousel_caption . '</span>' .
+					'<span class="slide"><a href="{{file2}}.jpg"><img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" object-fit="cover"></a></span>' .
+					'<span class="slide"><a href="{{file3}}.jpg"><img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" object-fit="cover"></a></span>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_lightbox'                 => [
@@ -108,17 +108,17 @@ class AMP_Gallery_Embed_Test extends WP_UnitTestCase {
 			'shortcode_with_lightbox_and_carousel'    => [
 				'[gallery amp-lightbox=true amp-carousel=true ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<div class="slide"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" lightbox="" object-fit="cover"></amp-img>' . $amp_carousel_caption . '</div>' .
-					'<div class="slide"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" lightbox="" object-fit="cover"></amp-img></div>' .
-					'<div class="slide"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" lightbox="" object-fit="cover"></amp-img></div>' .
+					'<span class="slide"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" lightbox="" object-fit="cover">' . $amp_carousel_caption . '</span>' .
+					'<span class="slide"><img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" lightbox="" object-fit="cover"></span>' .
+					'<span class="slide"><img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" lightbox="" object-fit="cover"></span>' .
 				'</amp-carousel>',
 			],
 			'shortcode_with_lightbox_and_carousel_linking_to_file' => [
 				'[gallery amp-lightbox=true amp-carousel=true link="file" ids={{id1}},{{id2}},{{id3}}]',
 				'<amp-carousel width="600" height="450" type="slides" layout="responsive">' .
-					'<div class="slide"><amp-img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" lightbox="" object-fit="cover"></amp-img>' . $amp_carousel_caption . '</div>' .
-					'<div class="slide"><amp-img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" lightbox="" object-fit="cover"></amp-img></div>' .
-					'<div class="slide"><amp-img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" lightbox="" object-fit="cover"></amp-img></div>' .
+					'<span class="slide"><img src="{{file1}}.jpg" width="50" height="50" layout="fill" alt="Alt text" lightbox="" object-fit="cover">' . $amp_carousel_caption . '</span>' .
+					'<span class="slide"><img src="{{file2}}.jpg" width="600" height="450" layout="fill" alt="Alt text" srcset="{{file2}}.jpg 640w, {{file2}}-300x225.jpg 300w" lightbox="" object-fit="cover"></span>' .
+					'<span class="slide"><img src="{{file3}}.jpg" width="100" height="100" layout="fill" alt="Alt text" lightbox="" object-fit="cover"></span>' .
 				'</amp-carousel>',
 			],
 		];

--- a/tests/php/test-class-amp-gallery-block-sanitizer.php
+++ b/tests/php/test-class-amp-gallery-block-sanitizer.php
@@ -39,18 +39,18 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_carousel_and_link'     => [
 				'<ul class="wp-block-gallery" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img></a></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img></a></span></amp-carousel>',
 			],
 
 			'data_amp_with_carousel_and_caption'  => [
 				'<ul class="wp-block-gallery" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img><figcaption>This is a caption</figcaption></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img><div class="amp-wp-gallery-caption"><span>This is a caption</span></div></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img><span class="amp-wp-gallery-caption"><span>This is a caption</span></span></span></amp-carousel>',
 			],
 
 			// WordPress 5.3 changed the markup for the Gallery block, wrapping it in a <figure>.
 			'data_amp_with_carousel_caption_5_3'  => [
 				'<figure class="wp-block-gallery" data-amp-carousel="true"><ul><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img><figcaption>This is a caption</figcaption></figure></li></ul></figure>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img><div class="amp-wp-gallery-caption"><span>This is a caption</span></div></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img><span class="amp-wp-gallery-caption"><span>This is a caption</span></span></span></amp-carousel>',
 			],
 
 			'data_amp_with_lightbox'              => [
@@ -75,12 +75,12 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_lightbox_and_carousel' => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="1234" height="567"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
+				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" lightbox="" layout="fill" object-fit="cover"></amp-img></span></amp-carousel>',
 			],
 
 			'data_amp_with_lightbox_carousel_5_3' => [
 				'<figure class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><ul><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="1234" height="567"></amp-img></a></figure></li></ul></figure>',
-				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
+				'<amp-carousel width="1234" height="567" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="1234" height="567" lightbox="" layout="fill" object-fit="cover"></amp-img></span></amp-carousel>',
 			],
 		];
 	}
@@ -124,22 +124,22 @@ class AMP_Gallery_Block_Sanitizer_Test extends WP_UnitTestCase {
 
 			'data_amp_with_carousel_and_caption'  => [
 				'<ul class="wp-block-gallery" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a><figcaption>Here is a caption</figcaption></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img></a><div class="amp-wp-gallery-caption"><span>Here is a caption</span></div></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400" layout="fill" object-fit="cover"></amp-img></a><span class="amp-wp-gallery-caption"><span>Here is a caption</span></span></span></amp-carousel>',
 			],
 
 			'data_amp_with_lightbox'              => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></span></amp-carousel>',
 			],
 
 			'data_amp_with_lightbox_and_link'     => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></span></amp-carousel>',
 			],
 
 			'data_amp_lightbox_carousel_and_link' => [
 				'<ul class="wp-block-gallery" data-amp-lightbox="true" data-amp-carousel="true"><li class="blocks-gallery-item"><figure><a href="http://example.com"><amp-img src="http://example.com/img.png" width="600" height="400"></amp-img></a></figure></li></ul>',
-				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><div class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></div></amp-carousel>',
+				'<amp-carousel width="600" height="400" type="slides" layout="responsive"><span class="slide"><amp-img src="http://example.com/img.png" width="600" height="400" lightbox="" layout="fill" object-fit="cover"></amp-img></span></amp-carousel>',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

I found that when a gallery carousel is displayed inside of a paragraph (that is, an `<amp-carousel>` inside of a `<p>`), it completely breaks because the use of `<div>` inside of the `<amp-carousel>` causes it to break out the `<p>` (since block level elements can't appear inside of paragraphs).

Given this gallery on a non-AMP page:

![image](https://user-images.githubusercontent.com/134745/71400685-5eb25600-25dc-11ea-9798-2a1d1ec73e79.png)

Where the underlying `post_content` is:

```html
<p>Gallery: [gallery amp-carousel=true size="large" ids="2436,2435,2434"]</p>
```

The expected rendered gallery is:

![image](https://user-images.githubusercontent.com/134745/71400733-80134200-25dc-11ea-8f2b-e954d49545c6.png)

But the actual gallery appears as:

![image](https://user-images.githubusercontent.com/134745/71400795-a89b3c00-25dc-11ea-85db-f8b24f23ad39.png)

By looking at the DOM tree, the issue of the slide divs breaking out of the `amp-carousel` can be clearly seen:

![image](https://user-images.githubusercontent.com/134745/71400844-d1bbcc80-25dc-11ea-9c3a-1c2faeff05a9.png)

After the fix in this PR, the DOM appears properly nested:

![image](https://user-images.githubusercontent.com/134745/71401050-8229d080-25dd-11ea-8e9b-89bd41ad155e.png)

### No-JS Fallbacks

Additionally, I also found that when JS is turned off in the browser, the carousel images do not display at all. This is because the gallery embed handler was creating an `amp-img`, when it should have been creating an `img` so that the image sanitizer would create the necessary `amp-img` with the `noscript > img` fallback content.

Before:

![image](https://user-images.githubusercontent.com/134745/71400916-10ea1d80-25dd-11ea-8755-009f616ae607.png)

After:

![image](https://user-images.githubusercontent.com/134745/71400948-2c552880-25dd-11ea-9fd0-b2ca6374adc0.png)

Amends #3659. See #3658.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
