### PR TITLE
Switch click and pointerdown to mousedown and prevent unselection

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { CENTRAL_RIGHT_PADDING, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+import useCanvas from './useCanvas';
 import Page from './page';
 import Meta from './meta';
 import Carrousel from './carrousel';
@@ -35,8 +36,9 @@ const Area = styled.div`
 `;
 
 function CanvasLayout() {
+	const { state: { backgroundMouseDownHandler } } = useCanvas();
 	return (
-		<Background>
+		<Background onMouseDown={ backgroundMouseDownHandler }>
 			<Area area="page">
 				<Page />
 			</Area>

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -7,7 +7,6 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { CENTRAL_RIGHT_PADDING, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
-import useCanvas from './useCanvas';
 import Page from './page';
 import Meta from './meta';
 import Carrousel from './carrousel';
@@ -36,9 +35,8 @@ const Area = styled.div`
 `;
 
 function CanvasLayout() {
-	const { state: { backgroundClickHandler } } = useCanvas();
 	return (
-		<Background onClick={ backgroundClickHandler }>
+		<Background>
 			<Area area="page">
 				<Page />
 			</Area>

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -21,9 +21,9 @@ function CanvasProvider( { children } ) {
 	} = useEditingElement();
 
 	const [
-		backgroundClickHandler,
-		setBackgroundClickHandler,
-		clearBackgroundClickHandler,
+		backgroundMouseDownHandler,
+		setBackgroundMouseDownHandler,
+		clearBackgroundMouseDownHandler,
 	] = useFunctionState();
 
 	const state = {
@@ -31,12 +31,12 @@ function CanvasProvider( { children } ) {
 			editingElement,
 			editingElementState,
 			isEditing: Boolean( editingElement ),
-			backgroundClickHandler,
+			backgroundMouseDownHandler,
 		},
 		actions: {
 			setNodeForElement,
-			setBackgroundClickHandler,
-			clearBackgroundClickHandler,
+			setBackgroundMouseDownHandler,
+			clearBackgroundMouseDownHandler,
 			setEditingElement: setEditingElementWithoutState,
 			setEditingElementWithState,
 			clearEditing,

--- a/assets/src/edit-story/components/canvas/element.js
+++ b/assets/src/edit-story/components/canvas/element.js
@@ -52,17 +52,16 @@ function Element( {
 
 	return (
 		<Wrapper
-			onClick={ ( evt ) => handleSelectElement( id, evt ) }
+			onMouseDown={ ( evt ) => {
+				if ( ! isSelected ) {
+					handleSelectElement( id, evt );
+				}
+				evt.stopPropagation();
+			} }
 			ref={ element }
 		>
 			<Display
 				{ ...props }
-				onMouseDown={ ( evt ) => {
-					if ( ! isSelected ) {
-						handleSelectElement( id, evt );
-					}
-					evt.stopPropagation();
-				} }
 				forwardedRef={ forwardedRef }
 			/>
 		</Wrapper>

--- a/assets/src/edit-story/components/canvas/element.js
+++ b/assets/src/edit-story/components/canvas/element.js
@@ -41,6 +41,9 @@ function Element( {
 		return (
 			<Wrapper
 				ref={ element }
+				onMouseDown={ ( evt ) => {
+					evt.stopPropagation();
+				} }
 			>
 				<Edit { ...props } />
 			</Wrapper>
@@ -54,10 +57,11 @@ function Element( {
 		>
 			<Display
 				{ ...props }
-				onPointerDown={ ( evt ) => {
+				onMouseDown={ ( evt ) => {
 					if ( ! isSelected ) {
 						handleSelectElement( id, evt );
 					}
+					evt.stopPropagation();
 				} }
 				forwardedRef={ forwardedRef }
 			/>

--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -33,7 +33,7 @@ function Page() {
 	} = useStory();
 
 	const {
-		state: { backgroundMouseDownHandler, editingElement },
+		state: { editingElement },
 		actions: { setBackgroundMouseDownHandler, setNodeForElement },
 	} = useCanvas();
 
@@ -51,7 +51,7 @@ function Page() {
 		}
 		evt.stopPropagation();
 
-		if ( 'pointerdown' === evt.type ) {
+		if ( 'mousedown' === evt.type ) {
 			evt.persist();
 			setPushEvent( evt );
 		}
@@ -60,7 +60,7 @@ function Page() {
 	const selectedElement = selectedElements.length === 1 ? selectedElements[ 0 ] : null;
 
 	return (
-		<Background onMouseDown={ backgroundMouseDownHandler }>
+		<Background>
 			<MovableLayer>
 				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
 					const isSelected = Boolean( selectedElement && selectedElement.id === id );

--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -33,15 +33,15 @@ function Page() {
 	} = useStory();
 
 	const {
-		state: { editingElement },
-		actions: { setBackgroundClickHandler, setNodeForElement },
+		state: { backgroundMouseDownHandler, editingElement },
+		actions: { setBackgroundMouseDownHandler, setNodeForElement },
 	} = useCanvas();
 
 	const [ pushEvent, setPushEvent ] = useState( null );
 
 	useEffect( () => {
-		setBackgroundClickHandler( () => clearSelection() );
-	}, [ setBackgroundClickHandler, clearSelection ] );
+		setBackgroundMouseDownHandler( () => clearSelection() );
+	}, [ setBackgroundMouseDownHandler, clearSelection ] );
 
 	const handleSelectElement = useCallback( ( elId, evt ) => {
 		if ( evt.metaKey ) {
@@ -60,7 +60,7 @@ function Page() {
 	const selectedElement = selectedElements.length === 1 ? selectedElements[ 0 ] : null;
 
 	return (
-		<Background>
+		<Background onMouseDown={ backgroundMouseDownHandler }>
 			<MovableLayer>
 				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
 					const isSelected = Boolean( selectedElement && selectedElement.id === id );

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -30,7 +30,9 @@ function MovableWithRef( { zIndex, ...moveableProps }, ref ) {
 		return null;
 	}
 	const slot = (
-		<Wrapper zIndex={ zIndex || DEFAULT_Z_INDEX }>
+		<Wrapper
+			zIndex={ zIndex || DEFAULT_Z_INDEX }
+			onMouseDown={ ( evt ) => evt.stopPropagation() }>
 			<Moveable
 				ref={ ref }
 				container={ container }

--- a/assets/src/edit-story/elements/image/display.js
+++ b/assets/src/edit-story/elements/image/display.js
@@ -29,11 +29,10 @@ const Img = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageDisplay( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed, forwardedRef, onMouseDown } ) {
+function ImageDisplay( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed, forwardedRef } ) {
 	const elementProps = {
 		...getBox( { x, y, width, height, rotationAngle, isFullbleed } ),
 		ref: forwardedRef,
-		onMouseDown,
 	};
 	const imgProps = getImgProps( elementProps.width, elementProps.height, scale, focalX, focalY, origRatio );
 	const {
@@ -66,7 +65,6 @@ ImageDisplay.propTypes = {
 		PropTypes.object,
 		PropTypes.func,
 	] ),
-	onMouseDown: PropTypes.func,
 };
 
 ImageDisplay.defaultProps = {

--- a/assets/src/edit-story/elements/image/display.js
+++ b/assets/src/edit-story/elements/image/display.js
@@ -29,11 +29,11 @@ const Img = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageDisplay( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed, forwardedRef, onPointerDown } ) {
+function ImageDisplay( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed, forwardedRef, onMouseDown } ) {
 	const elementProps = {
 		...getBox( { x, y, width, height, rotationAngle, isFullbleed } ),
 		ref: forwardedRef,
-		onPointerDown,
+		onMouseDown,
 	};
 	const imgProps = getImgProps( elementProps.width, elementProps.height, scale, focalX, focalY, origRatio );
 	const {
@@ -66,7 +66,7 @@ ImageDisplay.propTypes = {
 		PropTypes.object,
 		PropTypes.func,
 	] ),
-	onPointerDown: PropTypes.func,
+	onMouseDown: PropTypes.func,
 };
 
 ImageDisplay.defaultProps = {

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -41,7 +41,7 @@ const Element = styled.p`
 	}
 `;
 
-function TextDisplay( { id, content, color, backgroundColor, width, height, x, y, fontFamily, fontSize, fontWeight, fontStyle, rotationAngle, forwardedRef, onMouseDown } ) {
+function TextDisplay( { id, content, color, backgroundColor, width, height, x, y, fontFamily, fontSize, fontWeight, fontStyle, rotationAngle, forwardedRef } ) {
 	const props = {
 		color,
 		backgroundColor,
@@ -54,7 +54,6 @@ function TextDisplay( { id, content, color, backgroundColor, width, height, x, y
 		x,
 		y,
 		rotationAngle,
-		onMouseDown,
 	};
 	const {
 		state: { selectedElementIds },
@@ -157,7 +156,6 @@ TextDisplay.propTypes = {
 		PropTypes.object,
 		PropTypes.func,
 	] ),
-	onMouseDown: PropTypes.func,
 };
 
 export default TextDisplay;

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -41,7 +41,7 @@ const Element = styled.p`
 	}
 `;
 
-function TextDisplay( { id, content, color, backgroundColor, width, height, x, y, fontFamily, fontSize, fontWeight, fontStyle, rotationAngle, forwardedRef, onPointerDown } ) {
+function TextDisplay( { id, content, color, backgroundColor, width, height, x, y, fontFamily, fontSize, fontWeight, fontStyle, rotationAngle, forwardedRef, onMouseDown } ) {
 	const props = {
 		color,
 		backgroundColor,
@@ -54,7 +54,7 @@ function TextDisplay( { id, content, color, backgroundColor, width, height, x, y
 		x,
 		y,
 		rotationAngle,
-		onPointerDown,
+		onMouseDown,
 	};
 	const {
 		state: { selectedElementIds },
@@ -157,7 +157,7 @@ TextDisplay.propTypes = {
 		PropTypes.object,
 		PropTypes.func,
 	] ),
-	onPointerDown: PropTypes.func,
+	onMouseDown: PropTypes.func,
 };
 
 export default TextDisplay;


### PR DESCRIPTION
## Summary

Partial for #3895

This PR builds on #3957. I think this is the easiest way to reduce collisions between our mouse handlers and those of `Moveable`. I had to switch to `mousedown` because that's what `Moveable` is using. Since `pointerdown` arrives before `mousedown` that makes it very hard to control. `touchdown` should be automatically handled this way as well.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
