### PR TITLE
Make video in cover block fill the container

### DIFF
--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -197,6 +197,13 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 	protected function filter_video_dimensions( $new_attributes, $src ) {
 		if ( empty( $new_attributes['width'] ) || empty( $new_attributes['height'] ) ) {
 
+			// @todo This is not the right placement. It should perhaps even go into AMP_Core_Block_Handler as a new method specifically for fixing up the cover block.
+			if ( isset( $new_attributes['class'] ) && false !== strpos( $new_attributes['class'], 'wp-block-cover__video-background' ) ) {
+				$new_attributes['layout']     = 'fill';
+				$new_attributes['object-fit'] = 'cover';
+				return $new_attributes;
+			}
+
 			// Get the width and height from the file.
 			$path = wp_parse_url( $src, PHP_URL_PATH );
 			$ext  = pathinfo( $path, PATHINFO_EXTENSION );


### PR DESCRIPTION
## Summary

I found out that the cover block fails to display the video with a `fill` layout. This can be seen in the “Block: Cover” post imported in the theme unit test data. 

The approach in this PR is a quick fix that needs further refinement. Namely, it should go into `AMP_Core_Block_Handler` somehow like this:

```diff
--- a/includes/embeds/class-amp-core-block-handler.php
+++ b/includes/embeds/class-amp-core-block-handler.php
@@ -21,6 +21,7 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 		'core/categories' => 'ampify_categories_block',
 		'core/archives'   => 'ampify_archives_block',
 		'core/video'      => 'ampify_video_block',
+		'core/cover'      => 'ampify_cover_block',
 	];
 
 	/**
@@ -155,4 +156,12 @@ class AMP_Core_Block_Handler extends AMP_Base_Embed_Handler {
 
 		return $block_content;
 	}
+
+	/**
+	 * ...
+	 */
+	public function ampify_cover_block( $block_content, $block ) {
+		// ...
+		return $block_content;
+	}
 }
```

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
