### PR TITLE
DRAFT/PoC: animations and replay mode

### DIFF
--- a/assets/src/edit-story/app/designMode.js
+++ b/assets/src/edit-story/app/designMode.js
@@ -1,0 +1,7 @@
+
+const DesignMode = {
+	DESIGN: 'design',
+	REPLAY: 'replay',
+};
+
+export default DesignMode;

--- a/assets/src/edit-story/app/index.js
+++ b/assets/src/edit-story/app/index.js
@@ -17,6 +17,7 @@ import {
  * Internal dependencies
  */
 import theme, { GlobalStyle } from '../theme';
+import DesignMode from './designMode';
 import { useHistory, HistoryProvider } from './history';
 import { useAPI, APIProvider } from './api';
 import { useConfig, ConfigProvider } from './config';
@@ -51,6 +52,7 @@ App.propTypes = {
 export default App;
 
 export {
+	DesignMode,
 	useHistory,
 	useAPI,
 	useStory,

--- a/assets/src/edit-story/app/story/storyProvider.js
+++ b/assets/src/edit-story/app/story/storyProvider.js
@@ -11,6 +11,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import DesignMode from '../designMode';
 import Context from './context';
 
 import useLoadStory from './effects/useLoadStory';
@@ -35,6 +36,7 @@ function StoryProvider( { storyId, children } ) {
 	// Story state is stored in these three immutable variables only!
 	// Don't update 1 of these in an effect based off another base variable.
 	// Only update these directly as a response to user or api interactions.
+	const [ designMode, setDesignMode ] = useState( DesignMode.DESIGN );
 	const [ pages, setPages ] = useState( [] );
 	const [ title, setTitle ] = useState( '' );
 	const [ link, setLink ] = useState( '' );
@@ -73,6 +75,7 @@ function StoryProvider( { storyId, children } ) {
 
 	const state = {
 		state: {
+			designMode,
 			pages,
 			currentPageIndex,
 			currentPageNumber,
@@ -86,6 +89,7 @@ function StoryProvider( { storyId, children } ) {
 			link,
 		},
 		actions: {
+			setDesignMode,
 			setCurrentPageByIndex,
 			addBlankPage,
 			clearSelection,

--- a/assets/src/edit-story/components/animations/animationPlayer.js
+++ b/assets/src/edit-story/components/animations/animationPlayer.js
@@ -1,0 +1,84 @@
+
+/**
+ * Rouhgly follows `Animation` API.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Animation.
+ */
+class AnimationPlayer {
+	constructor( animations ) {
+		this.animations = animations;
+		this.playState = 'pending';
+		this.pendingCount = 0;
+		this.onPlayStateChange = null;
+
+		this.players = animations.map( ( { target, keyframes, timing } ) => {
+			const player = target.animate( keyframes, timing );
+			player.pause();
+			return player;
+		} );
+	}
+
+	updatePlayState( playState ) {
+		if ( this.playState !== playState ) {
+			this.playState = playState;
+			if ( this.onPlayStateChange ) {
+				this.onPlayStateChange();
+			}
+		}
+	}
+
+	play() {
+		if ( this.playState === 'pending' ) {
+			this.pendingCount = this.players.length;
+			this.players.forEach( ( player ) => {
+				player.onfinish = () => {
+					this.pendingCount--;
+					if ( this.pendingCount <= 0 ) {
+						// When all finished, finish the combined animation.
+						this.finish();
+					}
+				};
+				player.oncancel = () => {
+					// If one fails: cancel all others.
+					this.cancel();
+				};
+				player.play();
+			} );
+			this.updatePlayState( 'running' );
+		} else if ( this.playState === 'paused' ) {
+			this.players.forEach( ( player ) => player.play() );
+			this.updatePlayState( 'running' );
+		}
+	}
+
+	pause() {
+		if ( this.playState !== 'running' ) {
+			return;
+		}
+		this.players.forEach( ( player ) => {
+			player.pause();
+		} );
+		this.updatePlayState( 'paused' );
+	}
+
+	finish() {
+		if ( this.playState !== 'running' && this.playState !== 'paused' ) {
+			return;
+		}
+		this.players.forEach( ( player ) => {
+			player.finish();
+		} );
+		this.updatePlayState( 'finished' );
+	}
+
+	cancel() {
+		if ( this.playState !== 'running' && this.playState !== 'paused' ) {
+			return;
+		}
+		this.players.forEach( ( player ) => {
+			player.cancel();
+		} );
+		this.updatePlayState( 'canceled' );
+	}
+}
+
+export default AnimationPlayer;

--- a/assets/src/edit-story/components/animations/animationPresets.js
+++ b/assets/src/edit-story/components/animations/animationPresets.js
@@ -1,0 +1,37 @@
+
+// See https://github.com/ampproject/amphtml/blob/master/extensions/amp-story/1.0/animation-presets.js
+// todo@: Try to repro/reuse the presets as much as possible.
+
+// First keyframe will always be considered offset: 0 and will be applied to the
+// element as the first frame before animation starts.
+function getPresetDef( name ) {
+	switch ( name ) {
+		case 'fade-in':
+			return {
+				duration: 400,
+				easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+				keyframes: [
+					{ opacity: 0 },
+					{ opacity: 1 },
+				],
+			};
+		case 'fly-in-top':
+			return {
+				duration: 400,
+				easing: 'cubic-bezier(0.0, 0.0, 0.2, 1)',
+				keyframes: [
+					{ transform: 'translateY(-300px)' },
+					{ transform: 'translateY(0px)' },
+				],
+			};
+		default:
+			return null;
+	}
+}
+
+function getAnimation( { preset, timing } ) {
+	const { keyframes, ...presetTiming } = getPresetDef( preset );
+	return { keyframes, timing: { ...presetTiming, ...timing } };
+}
+
+export default getAnimation;

--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { useStory } from '../../app';
+import { DesignMode, useStory } from '../../app';
 import useCanvas from './useCanvas';
 import Element from './element';
 import Movable from './../movable';
@@ -27,8 +27,8 @@ function Page() {
 	const [ targetEl, setTargetEl ] = useState( null );
 
 	const {
-		state: { currentPage, selectedElements },
-		actions: { clearSelection, selectElementById, toggleElementIdInSelection },
+		state: { designMode, currentPage, selectedElements },
+		actions: { setDesignMode, clearSelection, selectElementById, toggleElementIdInSelection },
 	} = useStory();
 
 	const {
@@ -39,8 +39,14 @@ function Page() {
 	const [ pushEvent, setPushEvent ] = useState( null );
 
 	useEffect( () => {
-		setBackgroundClickHandler( () => clearSelection() );
-	}, [ setBackgroundClickHandler, clearSelection ] );
+		setBackgroundClickHandler( () => {
+			if ( designMode === DesignMode.REPLAY ) {
+				setDesignMode( DesignMode.DESIGN );
+				return;
+			}
+			clearSelection();
+		} );
+	}, [ designMode, setBackgroundClickHandler, clearSelection, setDesignMode ] );
 
 	const handleSelectElement = useCallback( ( elId, evt ) => {
 		if ( evt.metaKey ) {
@@ -76,7 +82,7 @@ function Page() {
 				);
 			} ) }
 
-			{ selectedElement && targetEl && (
+			{ designMode === DesignMode.DESIGN && selectedElement && targetEl && (
 				<Movable
 					selectedElement={ selectedElement }
 					targetEl={ targetEl }

--- a/assets/src/edit-story/panels/animations.js
+++ b/assets/src/edit-story/panels/animations.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import uuid from 'uuid/v4';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DesignMode, useStory } from '../app';
+import AnimationPlayer from '../components/animations/animationPlayer';
+import getAnimation from '../components/animations/animationPresets';
+import useDelayEffect from '../utils/useDelayEffect';
+import { ActionButton, Panel, Title, getCommonValue } from './shared';
+
+const Delete = styled.a`
+  cursor: pointer;
+`;
+
+function AnimationsPanel( { selectedElements, onSetProperties } ) {
+	const animations = getCommonValue( selectedElements, 'animations' ) || [];
+
+	const { state: { designMode }, actions: { setDesignMode } } = useStory();
+
+	const playerRef = useRef( null );
+	const [ playState, setPlayState ] = useState( null );
+
+	// An effect for designMode change.
+	useDelayEffect(
+		() => {
+			if ( designMode !== DesignMode.REPLAY || animations.length === 0 ) {
+				return null;
+			}
+
+			// When we enter a "replay" mode and we have an animation pending.
+			const player = new AnimationPlayer( animations.map( ( { id, ...rest } ) => {
+				// @todo: a smarter way to lookup nodes. At least limitted to the
+				// selected elements.
+				const target = document.querySelector( `[data-animation-id="${ id }"]` );
+				const { keyframes, timing } = getAnimation( rest );
+				return { target, keyframes, timing };
+			} ) );
+			playerRef.current = player;
+			player.onPlayStateChange = () => {
+				if ( player.playState === 'finished' || player.playState === 'canceled' ) {
+					// Reset everything.
+					playerRef.current = null;
+					setPlayState( null );
+					setDesignMode( DesignMode.DESIGN );
+				} else {
+					setPlayState( player.playState );
+				}
+			};
+			player.play();
+			return () => {
+				// Interrupt animation when the editor exits "replay" mode for any
+				// reason.
+				player.cancel();
+			};
+		},
+		[ designMode, animations, setPlayState ] );
+
+	const handleAddAnimation = () => {
+		// @todo: construct animation based on the selected preset from the dropdown
+		// in the side-panel.
+		const animation = {
+			id: uuid(),
+			preset: animations.length === 0 ? 'fade-in' : 'fly-in-top',
+			timing: {
+				duration: 1000,
+				iterations: 1,
+			},
+		};
+		onSetProperties( {
+			animations: animations.concat( animation ),
+		} );
+	};
+
+	const handleDeleteAnimation = ( toDelete ) => {
+		onSetProperties( {
+			animations: animations.filter( ( animation ) => animation.id !== toDelete.id ),
+		} );
+	};
+
+	const handlePlayAnimation = () => {
+		const player = playerRef.current;
+		if ( player && playState === 'paused' ) {
+			player.play();
+		} else {
+			// Switch to replay mode. The animation will start automatically.
+			setDesignMode( DesignMode.REPLAY );
+		}
+	};
+
+	const handlePauseAnimation = () => {
+		const player = playerRef.current;
+		if ( player ) {
+			player.pause();
+		}
+	};
+
+	const handleStopAnimation = () => {
+		const player = playerRef.current;
+		if ( player ) {
+			player.cancel();
+		}
+	};
+
+	return (
+		<Panel onSubmit={ ( event ) => event.preventDefault() }>
+			<Title>
+				{ 'Animations' }
+			</Title>
+
+			<div>
+				{ animations.map( ( animation, index ) => (
+					<div key={ animation.id } >
+						{ `Animation ${ index + 1 }` }
+						<Delete onClick={ () => handleDeleteAnimation( animation ) }>
+							{ 'Delete' }
+						</Delete>
+					</div>
+				) ) }
+			</div>
+
+			<ActionButton onClick={ handleAddAnimation }>
+				{ 'Add animation' }
+			</ActionButton>
+
+			{ animations.length !== 0 && playState !== 'running' && (
+				<ActionButton onClick={ handlePlayAnimation }>
+					{ 'Play' }
+				</ActionButton>
+			) }
+
+			{ playState === 'running' && (
+				<ActionButton onClick={ handlePauseAnimation }>
+					{ 'Pause' }
+				</ActionButton>
+			) }
+
+			{ playState !== null && (
+				<ActionButton onClick={ handleStopAnimation }>
+					{ 'Stop' }
+				</ActionButton>
+			) }
+		</Panel>
+	);
+}
+
+AnimationsPanel.propTypes = {
+	selectedElements: PropTypes.array.isRequired,
+	onSetProperties: PropTypes.func.isRequired,
+};
+
+export default AnimationsPanel;

--- a/assets/src/edit-story/panels/index.js
+++ b/assets/src/edit-story/panels/index.js
@@ -3,6 +3,7 @@
  */
 import { elementTypes } from '../elements';
 import ActionsPanel from './actions';
+import AnimationsPanel from './animations';
 import ColorPanel from './color';
 import BackgroundColorPanel from './backgroundColor';
 import FullbleedPanel from './fullbleed';
@@ -14,6 +15,7 @@ import ScalePanel from './scale';
 import TextPanel from './text';
 
 const ACTIONS = 'actions';
+const ANIMATIONS = 'animations';
 const COLOR = 'color';
 const SCALE = 'scale';
 const FONT = 'font';
@@ -26,6 +28,7 @@ const BACKGROUND_COLOR = 'backgroundColor';
 
 export const PanelTypes = {
 	ACTIONS,
+	ANIMATIONS,
 	POSITION,
 	SIZE,
 	SCALE,
@@ -51,6 +54,7 @@ export function getPanels( elements ) {
 	// Panels to always display, independent of the selected element.
 	const sharedPanels = [
 		{ type: ACTIONS, Panel: ActionsPanel },
+		{ type: ANIMATIONS, Panel: AnimationsPanel },
 	];
 	// Find which panels all the selected elements have in common
 	const selectionPanels = elements

--- a/assets/src/edit-story/utils/useDelayEffect.js
+++ b/assets/src/edit-story/utils/useDelayEffect.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+function useDelayEffect( callback, deps = undefined ) {
+	/* eslint-disable react-hooks/exhaustive-deps */
+	useEffect(
+		() => {
+			const callbackPromise = new Promise( ( resolve ) => {
+				setTimeout( () => {
+					resolve( callback() );
+				}, 0 );
+			} );
+			return () => {
+				callbackPromise.then( ( unsubscribe ) => {
+					if ( unsubscribe ) {
+						unsubscribe();
+					}
+				} );
+			};
+		},
+		deps,
+	);
+	/* eslint-enable react-hooks/exhaustive-deps */
+}
+
+export default useDelayEffect;


### PR DESCRIPTION
## Summary

Partial for #3801

Notes:

1. I introduced `DesignMode={design, replay}`. The `replay` mode servers to main functions: disabling parts of the editor that obscure or complicated animations replay. For instance, selection really gets in a way of the replay, so it's completely disabled. Second reason: intermediary animated `divs` are inserted for animation that are otherwise not needed (and possibly harmful) for editing itself.
2. Design mode is currently canceled when clicking on the background. We will certainly also add <kbd>esc</kbd> canceling, and cancelling if any part of the model has been updated.
3. I think we might be able to adopt AMP animation presets more or less exactly with a small transformation of the code. But for now I just forked couple of presets for PoC/demo purposes only.
4. The element wrapper ideally would be already defining positioning, size, and rotation (see #4018). For now the status-quo works, but it feels rather fragile.


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
