### PR TITLE
DRAFT/Discovery: render elements to 2d canvas

### DIFF
--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -11,6 +11,7 @@ import Header from '../../components/header';
 import Inspector from '../../components/inspector';
 import Library from '../../components/library';
 import Canvas from '../../components/canvas';
+import BitmapRenderer from '../../components/bitmapRenderer';
 import { LIBRARY_WIDTH, INSPECTOR_WIDTH, HEADER_HEIGHT } from '../../constants';
 
 const Editor = styled.div`
@@ -34,6 +35,13 @@ const Area = styled.div`
   position: relative;
 `;
 
+const Fixed = styled.div`
+  position: fixed;
+  bottom: 10px;
+  right: 10px;
+  z-index: 1000;
+`;
+
 function Layout() {
 	return (
 		<Editor>
@@ -49,6 +57,9 @@ function Layout() {
 			<Area area="insp">
 				<Inspector />
 			</Area>
+			<Fixed>
+				<BitmapRenderer />
+			</Fixed>
 		</Editor>
 	);
 }

--- a/assets/src/edit-story/components/bitmapRenderer/index.js
+++ b/assets/src/edit-story/components/bitmapRenderer/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+import { useStory } from '../../app';
+import { getDefinitionForType } from '../../elements';
+import useEffectSinglePath from '../../utils/useEffectSinglePath';
+
+const WIDTH = 200;
+const HEIGHT = Math.round( WIDTH * 16 / 9 );
+
+const Container = styled.div`
+  background: #fff;
+  width: ${ WIDTH + 2 }px;
+  height: ${ HEIGHT + 2 }px;
+  border: 1px solid lightgray;
+`;
+
+function BitmapRenderer( {} ) {
+	const canvasRef = useRef( null );
+	const { state: { currentPage } } = useStory();
+
+	useEffectSinglePath( () => {
+		const canvas = canvasRef.current;
+		const context = canvas.getContext( '2d' );
+		context.resetTransform();
+		context.scale( WIDTH / PAGE_WIDTH, HEIGHT / PAGE_HEIGHT );
+		context.clearRect( 0, 0, PAGE_WIDTH, PAGE_HEIGHT );
+
+		if ( ! currentPage ) {
+			return null;
+		}
+
+		let promise = Promise.resolve();
+		currentPage.elements.forEach( ( element ) => {
+			promise = promise.then( () => {
+				const { type, x, y, width, height } = element;
+				const { Render } = getDefinitionForType( type );
+				if ( Render ) {
+					return Render( context, element );
+				}
+
+				// Show that a renderer is absent for debugging for now.
+				context.lineWidth = 0.5;
+				context.strokeStyle = 'red';
+				context.strokeRect( x, y, width, height );
+				return null;
+			} );
+		} );
+
+		return promise;
+	} );
+
+	return (
+		<Container>
+			<canvas ref={ canvasRef } width={ WIDTH } height={ HEIGHT } />
+		</Container>
+	);
+}
+
+export default BitmapRenderer;

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -5,6 +5,7 @@ import { PanelTypes } from '../../panels';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Save } from './save';
+export { default as Render } from './render';
 
 export const defaultAttributes = {
 };

--- a/assets/src/edit-story/elements/image/render.js
+++ b/assets/src/edit-story/elements/image/render.js
@@ -1,0 +1,35 @@
+
+/**
+ * Internal dependencies
+ */
+import { getBox } from '../shared';
+import { getImgProps } from './util';
+
+function ImageRender( context, { src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed } ) {
+	return loadImage( src ).then( ( image ) => {
+		const { naturalWidth } = image;
+		const elementProps = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
+		const imgProps = getImgProps( elementProps.width, elementProps.height, scale, focalX, focalY, origRatio );
+		const naturalScale = naturalWidth / imgProps.width;
+		const sx = imgProps.offsetX * naturalScale;
+		const sy = imgProps.offsetY * naturalScale;
+		const sw = elementProps.width * naturalScale;
+		const sh = elementProps.height * naturalScale;
+		context.drawImage(
+			image,
+			sx, sy, sw, sh,
+			elementProps.x, elementProps.y, elementProps.width, elementProps.height,
+		);
+	} );
+}
+
+function loadImage( src ) {
+	return new Promise( ( resolve, reject ) => {
+		const image = new window.Image();
+		image.onload = () => resolve( image );
+		image.onerror = ( reason ) => reject( reason );
+		image.src = src;
+	} );
+}
+
+export default ImageRender;

--- a/assets/src/edit-story/elements/image/render.js
+++ b/assets/src/edit-story/elements/image/render.js
@@ -2,23 +2,21 @@
 /**
  * Internal dependencies
  */
-import { getBox } from '../shared';
 import { getImgProps } from './util';
 
-function ImageRender( context, { src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed } ) {
+function ImageRender( context, { src, origRatio, width, height, scale, focalX, focalY } ) {
 	return loadImage( src ).then( ( image ) => {
 		const { naturalWidth } = image;
-		const elementProps = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
-		const imgProps = getImgProps( elementProps.width, elementProps.height, scale, focalX, focalY, origRatio );
+		const imgProps = getImgProps( width, height, scale, focalX, focalY, origRatio );
 		const naturalScale = naturalWidth / imgProps.width;
 		const sx = imgProps.offsetX * naturalScale;
 		const sy = imgProps.offsetY * naturalScale;
-		const sw = elementProps.width * naturalScale;
-		const sh = elementProps.height * naturalScale;
+		const sw = width * naturalScale;
+		const sh = height * naturalScale;
 		context.drawImage(
 			image,
 			sx, sy, sw, sh,
-			elementProps.x, elementProps.y, elementProps.width, elementProps.height,
+			0, 0, width, height,
 		);
 	} );
 }

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -5,6 +5,7 @@ import { PanelTypes } from '../../panels';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Save } from './save';
+export { default as Render } from './render';
 
 export const defaultAttributes = {
 	fontFamily: 'Arial',

--- a/assets/src/edit-story/elements/text/render.js
+++ b/assets/src/edit-story/elements/text/render.js
@@ -1,0 +1,9 @@
+
+function TextRender( context, { content, width, x, y } ) {
+	// @todo: load font.
+	// @todo: strip HTML or redraw text with bold, etc.
+	context.fillStyle = 'black';
+	context.fillText( content, x, y, width );
+}
+
+export default TextRender;

--- a/assets/src/edit-story/elements/text/render.js
+++ b/assets/src/edit-story/elements/text/render.js
@@ -1,9 +1,17 @@
 
-function TextRender( context, { content, width, x, y } ) {
-	// @todo: load font.
-	// @todo: strip HTML or redraw text with bold, etc.
-	context.fillStyle = 'black';
-	context.fillText( content, x, y, width );
+function TextRender( context, { content, color, fontFamily, fontSize, fontWeight, width } ) {
+	// @todo: come up with something A LOT more efficient.
+	// @todo: align and wrap text.
+	const plainTextDiv = document.createElement( 'div' );
+	plainTextDiv.innerHTML = content;
+	const plainText = plainTextDiv.textContent;
+
+	// @todo: wait for the font to load.
+	// @todo: why is fontSize not a number?
+	context.font = `${ fontWeight || 'normal' } ${ fontSize && fontSize !== 'auto' ? fontSize : '10px' } "${ fontFamily || 'sans-serif' }"`;
+
+	context.fillStyle = color || 'black';
+	context.fillText( plainText, 0, 0, width );
 }
 
 export default TextRender;

--- a/assets/src/edit-story/utils/useEffectSinglePath.js
+++ b/assets/src/edit-story/utils/useEffectSinglePath.js
@@ -1,0 +1,38 @@
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect } from '@wordpress/element';
+
+function useEffectSinglePath( callback, deps = undefined ) {
+	const scheduledRef = useRef( null );
+	const lastRef = useRef( null );
+
+	/* eslint-disable react-hooks/exhaustive-deps */
+	useEffect( () => {
+		const wasScheduled = Boolean( scheduledRef.current );
+		// Always use the latest callback scheduled.
+		scheduledRef.current = callback;
+
+		if ( wasScheduled ) {
+			return;
+		}
+
+		const promise = Promise.resolve( lastRef.current )
+			.then( () => {
+				const { current } = scheduledRef;
+				scheduledRef.current = null;
+				return current();
+			} )
+			.catch( ( reason ) => {
+				// Rethrow asynchronously and ignore the error to avoid blocking
+				// the queue.
+				setTimeout( () => {
+					throw reason;
+				} );
+			} );
+		lastRef.current = promise;
+	}, deps );
+/* eslint-enable react-hooks/exhaustive-deps */
+}
+
+export default useEffectSinglePath;


### PR DESCRIPTION
## Summary

Partial for #3803

A quick exploration for 2d rendering for editor elements. The main goal is the contrast detection, but could also be useful for page thumbnail generation.

There's not much unexpected here. The only smallish caveats:

1. Everything should always be untainted. We should get this for free for fonts and for all media coming from media library.
1. We always have to wait for media and fonts to load before rendering. So, the rendering is a single-critical-path queue.
1. Rendering of wrapped/centered/tokenized HTML with correct line height is will be a headache. So it depends on how "perfect" we need the rendered canvas to be comparing to HTML version. For contrast detection and even thumbnails, arguably, we need only a good approximate quality.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
