### PR TITLE
Ignore Story editor tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,6 @@ jobs:
     # PHP unit tests (7.4, WordPress trunk)
     - env: WP_VERSION=trunk  DEV_LIB_ONLY=phpunit                               INSTALL_PWA_PLUGIN=1
       php: 7.4snapshot
-    # E2E tests, since flaky.
-    - env: WP_VERSION=latest DEV_LIB_SKIP=phpcs,eslint,xmllint,phpsyntax,phpunit PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=
   include:
     - stage: lint
       name: Lint (PHP, JavaScript, and configuration files)

--- a/bin/local-env/run-e2e-tests.js
+++ b/bin/local-env/run-e2e-tests.js
@@ -24,7 +24,7 @@ prc.stdout.on( 'data', ( data ) => {
 
 	const testsToIgnore = [];
 
-	if ( semver.gte( '5.3.0', semver.coerce( wpVersion ) ) ) {
+	if ( semver.gte( semver.clean( wpVersion ), '5.3.0' ) ) {
 		// Ignore tests that are not to be run in WP >= 5.3.0.
 		testsToIgnore.push( 'AMP Settings Screen should not allow AMP Stories to be enabled when Gutenberg is not active' );
 	}

--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -14,6 +14,8 @@ module.exports = {
 	testPathIgnorePatterns: [
 		'.git',
 		'node_modules',
+		'tests/e2e/specs/block-editor',
+		'tests/e2e/specs/stories-editor',
 	],
 	reporters: [ [ 'jest-silent-reporter', { useDots: true } ] ],
 };

--- a/tests/e2e/jest.config.js
+++ b/tests/e2e/jest.config.js
@@ -14,7 +14,6 @@ module.exports = {
 	testPathIgnorePatterns: [
 		'.git',
 		'node_modules',
-		'tests/e2e/specs/block-editor',
 		'tests/e2e/specs/stories-editor',
 	],
 	reporters: [ [ 'jest-silent-reporter', { useDots: true } ] ],

--- a/tests/e2e/specs/block-editor/featured-image-notice.js
+++ b/tests/e2e/specs/block-editor/featured-image-notice.js
@@ -22,7 +22,7 @@ describe( 'Featured Image Notice', () => {
 	beforeEach( async () => {
 		await createNewPost( { postType: 'post' } );
 		await clickButton( 'Document' );
-		await clickButton( 'Featured Image' );
+		await clickButton( 'Featured image' );
 		await clickButton( 'Set featured image' );
 	} );
 


### PR DESCRIPTION
## Summary

This PR ignores the Stories Editor E2E tests due to their flakiness.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
