### PR TITLE
Copy/paste for selected elements inside the canvas

### DIFF
--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -7,7 +7,6 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { CENTRAL_RIGHT_PADDING, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
-import useCanvas from './useCanvas';
 import Page from './page';
 import Meta from './meta';
 import Carrousel from './carrousel';

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -7,6 +7,7 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { CENTRAL_RIGHT_PADDING, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+import useCanvas from './useCanvas';
 import Page from './page';
 import Meta from './meta';
 import Carrousel from './carrousel';

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
  */
 import { useStory } from '../../app';
 import useEditingElement from './useEditingElement';
+import useCanvasSelectionCopyPaste from './useCanvasSelectionCopyPaste';
 import Context from './context';
 
 function CanvasProvider( { children } ) {
@@ -76,6 +77,8 @@ function CanvasProvider( { children } ) {
 			clearEditing();
 		}
 	}, [ editingElement, selectedElementIds, clearEditing ] );
+
+	useCanvasSelectionCopyPaste( pageContainer );
 
 	const state = {
 		state: {

--- a/assets/src/edit-story/components/canvas/useCanvasSelectionCopyPaste.js
+++ b/assets/src/edit-story/components/canvas/useCanvasSelectionCopyPaste.js
@@ -1,0 +1,126 @@
+/**
+ * External dependencies
+ */
+import uuid from 'uuid/v4';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback, renderToString } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useStory } from '../../app';
+import useClipboardHandlers from '../../utils/useClipboardHandlers';
+import { getDefinitionForType } from '../../elements';
+
+const DOUBLE_DASH_ESCAPE = '_DOUBLEDASH_';
+
+/**
+ * @param {?Element} container
+ */
+function useCanvasSelectionCopyPaste( container ) {
+	const {
+		state: { currentPage, selectedElements },
+		actions: { appendElementToCurrentPage, deleteSelectedElements },
+	} = useStory();
+
+	const copyCutHandler = useCallback(
+		( evt ) => {
+			const { type: eventType, clipboardData } = evt;
+
+			if ( selectedElements.length === 0 ) {
+				return;
+			}
+
+			const payload = {
+				sentinel: 'story-elements',
+				// @todo: Ensure that there's no unserializable data here. The easiest
+				// would be to keep all serializable data together and all non-serializable
+				// in a separate property.
+				items: selectedElements.map( ( element ) => ( {
+					...element,
+					basedOn: element.id,
+					id: undefined,
+				} ) ),
+			};
+			const serializedPayload = JSON.stringify( payload ).replace( /\-\-/g, DOUBLE_DASH_ESCAPE );
+
+			const textContent = selectedElements
+				.map( ( { type, ...rest } ) => {
+					const { TextContent } = getDefinitionForType( type );
+					if ( TextContent ) {
+						return TextContent( { ...rest } );
+					}
+					return type;
+				} )
+				.join( '\n' );
+
+			const htmlContent = selectedElements
+				.map( ( { type, ...rest } ) => {
+					// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+					const { Save } = getDefinitionForType( type );
+					return renderToString( <Save { ...rest } /> );
+				} )
+				.join( '\n' );
+
+			clipboardData.setData( 'text/plain', textContent );
+			clipboardData.setData( 'text/html', `<!-- ${ serializedPayload } -->${ htmlContent }` );
+
+			if ( eventType === 'cut' ) {
+				deleteSelectedElements();
+			}
+
+			evt.preventDefault();
+		},
+		[ deleteSelectedElements, selectedElements ],
+	);
+
+	const pasteHandler = useCallback(
+		( evt ) => {
+			const { clipboardData } = evt;
+
+			try {
+				const html = clipboardData.getData( 'text/html' );
+				if ( html ) {
+					const template = document.createElement( 'template' );
+					template.innerHTML = html;
+					for ( let n = template.content.firstChild; n; n = n.nextSibling ) {
+						if ( n.nodeType === /* COMMENT */ 8 ) {
+							const payload = JSON.parse( n.nodeValue.replace( new RegExp( DOUBLE_DASH_ESCAPE, 'g' ), '--' ) );
+							if ( payload.sentinel === 'story-elements' ) {
+								payload.items.forEach( ( { x, y, basedOn, ...rest } ) => {
+									currentPage.elements.forEach( ( element ) => {
+										if ( element.id === basedOn || element.basedOn === basedOn ) {
+											x = Math.max( x, element.x + 20 );
+											y = Math.max( y, element.y + 20 );
+										}
+									} );
+									const element = {
+										...rest,
+										basedOn,
+										id: uuid(),
+										x,
+										y,
+									};
+									appendElementToCurrentPage( element );
+								} );
+								evt.preventDefault();
+							}
+						}
+					}
+				}
+			} catch ( e ) {
+				// Ignore.
+			}
+		},
+		[ appendElementToCurrentPage, currentPage ],
+	);
+
+	useClipboardHandlers( container, copyCutHandler, pasteHandler );
+
+	// @todo: return copy/cut/pasteAction that can be used in the context menus.
+}
+
+export default useCanvasSelectionCopyPaste;

--- a/assets/src/edit-story/components/canvas/useCanvasSelectionCopyPaste.js
+++ b/assets/src/edit-story/components/canvas/useCanvasSelectionCopyPaste.js
@@ -87,28 +87,30 @@ function useCanvasSelectionCopyPaste( container ) {
 					const template = document.createElement( 'template' );
 					template.innerHTML = html;
 					for ( let n = template.content.firstChild; n; n = n.nextSibling ) {
-						if ( n.nodeType === /* COMMENT */ 8 ) {
-							const payload = JSON.parse( n.nodeValue.replace( new RegExp( DOUBLE_DASH_ESCAPE, 'g' ), '--' ) );
-							if ( payload.sentinel === 'story-elements' ) {
-								payload.items.forEach( ( { x, y, basedOn, ...rest } ) => {
-									currentPage.elements.forEach( ( element ) => {
-										if ( element.id === basedOn || element.basedOn === basedOn ) {
-											x = Math.max( x, element.x + 20 );
-											y = Math.max( y, element.y + 20 );
-										}
-									} );
-									const element = {
-										...rest,
-										basedOn,
-										id: uuid(),
-										x,
-										y,
-									};
-									appendElementToCurrentPage( element );
-								} );
-								evt.preventDefault();
-							}
+						if ( n.nodeType !== /* COMMENT */ 8 ) {
+							continue;
 						}
+						const payload = JSON.parse( n.nodeValue.replace( new RegExp( DOUBLE_DASH_ESCAPE, 'g' ), '--' ) );
+						if ( payload.sentinel !== 'story-elements' ) {
+							continue;
+						}
+						payload.items.forEach( ( { x, y, basedOn, ...rest } ) => {
+							currentPage.elements.forEach( ( element ) => {
+								if ( element.id === basedOn || element.basedOn === basedOn ) {
+									x = Math.max( x, element.x + 20 );
+									y = Math.max( y, element.y + 20 );
+								}
+							} );
+							const element = {
+								...rest,
+								basedOn,
+								id: uuid(),
+								x,
+								y,
+							};
+							appendElementToCurrentPage( element );
+						} );
+						evt.preventDefault();
 					}
 				}
 			} catch ( e ) {

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -5,6 +5,7 @@ import { PanelTypes } from '../../panels';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Save } from './save';
+export { default as TextContent } from './textContent';
 
 export const defaultAttributes = {
 };

--- a/assets/src/edit-story/elements/image/textContent.js
+++ b/assets/src/edit-story/elements/image/textContent.js
@@ -1,0 +1,6 @@
+
+function TextContent( { src } ) {
+	return `image: ${ src }`;
+}
+
+export default TextContent;

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -5,6 +5,7 @@ import { PanelTypes } from '../../panels';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Save } from './save';
+export { default as TextContent } from './textContent';
 
 export const defaultAttributes = {
 	fontFamily: 'Arial',

--- a/assets/src/edit-story/elements/text/textContent.js
+++ b/assets/src/edit-story/elements/text/textContent.js
@@ -1,0 +1,9 @@
+
+function TextContent( { content } ) {
+	// @todo: implement a cheaper way to strip markup.
+	const buffer = document.createElement( 'div' );
+	buffer.innerHTML = content;
+	return buffer.textContent;
+}
+
+export default TextContent;

--- a/assets/src/edit-story/utils/useClipboardHandlers.js
+++ b/assets/src/edit-story/utils/useClipboardHandlers.js
@@ -1,0 +1,73 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+const BLACKLIST_CLIPBOARD_ELEMENTS = [ 'INPUT', 'TEXTAREA' ];
+
+/**
+ * @param {?Element} container
+ * @param {function(!ClipboardEvent)} copyCutHandler
+ * @param {function(!ClipboardEvent)} pasteHandler
+ */
+function useClipboardHandlers( container, copyCutHandler, pasteHandler ) {
+	useEffect( () => {
+		if ( ! container ) {
+			return undefined;
+		}
+
+		const copyCutHandlerWrapper = ( evt ) => {
+			const { target, clipboardData } = evt;
+
+			// Elements that either handle their own clipboard or use platform.
+			if ( ! target ||
+          BLACKLIST_CLIPBOARD_ELEMENTS.includes( target.tagName ) ||
+          target.closest( '[contenteditable="true"]' ) ) {
+				return;
+			}
+
+			// A target can be anywhere in the container's full subtree, but not
+			// in its siblings.
+			if ( ! container.contains( target ) && ! target.contains( container ) ) {
+				return;
+			}
+
+			// Someone has already put something in the clipboard. Do not override.
+			if ( clipboardData.types.length !== 0 ) {
+				return;
+			}
+
+			copyCutHandler( evt );
+		};
+
+		const pasteHandlerWrapper = ( evt ) => {
+			const { target } = evt;
+
+			// Elements that either handle their own clipboard or use platform.
+			if ( ! target ||
+          BLACKLIST_CLIPBOARD_ELEMENTS.includes( target.tagName ) ||
+          target.closest( '[contenteditable="true"]' ) ) {
+				return;
+			}
+
+			// A target can be anywhere in the container's full subtree, but not
+			// in its siblings.
+			if ( ! container.contains( target ) && ! target.contains( container ) ) {
+				return;
+			}
+
+			pasteHandler( evt );
+		};
+
+		document.addEventListener( 'copy', copyCutHandlerWrapper );
+		document.addEventListener( 'cut', copyCutHandlerWrapper );
+		document.addEventListener( 'paste', pasteHandlerWrapper );
+		return () => {
+			document.removeEventListener( 'copy', copyCutHandlerWrapper );
+			document.removeEventListener( 'cut', copyCutHandlerWrapper );
+			document.removeEventListener( 'paste', pasteHandlerWrapper );
+		};
+	}, [ container, copyCutHandler, pasteHandler ] );
+}
+
+export default useClipboardHandlers;

--- a/assets/src/edit-story/utils/useClipboardHandlers.js
+++ b/assets/src/edit-story/utils/useClipboardHandlers.js
@@ -3,7 +3,7 @@
  */
 import { useEffect } from '@wordpress/element';
 
-const BLACKLIST_CLIPBOARD_ELEMENTS = [ 'INPUT', 'TEXTAREA' ];
+const BLACKLIST_CLIPBOARD_ELEMENTS = [ 'INPUT', 'TEXTAREA', 'BUTTON' ];
 
 /**
  * @param {?Element} container
@@ -20,9 +20,7 @@ function useClipboardHandlers( container, copyCutHandler, pasteHandler ) {
 			const { target, clipboardData } = evt;
 
 			// Elements that either handle their own clipboard or use platform.
-			if ( ! target ||
-          BLACKLIST_CLIPBOARD_ELEMENTS.includes( target.tagName ) ||
-          target.closest( '[contenteditable="true"]' ) ) {
+			if ( ! isCopyPasteTarget( target ) ) {
 				return;
 			}
 
@@ -44,9 +42,7 @@ function useClipboardHandlers( container, copyCutHandler, pasteHandler ) {
 			const { target } = evt;
 
 			// Elements that either handle their own clipboard or use platform.
-			if ( ! target ||
-          BLACKLIST_CLIPBOARD_ELEMENTS.includes( target.tagName ) ||
-          target.closest( '[contenteditable="true"]' ) ) {
+			if ( ! isCopyPasteTarget( target ) ) {
 				return;
 			}
 
@@ -68,6 +64,14 @@ function useClipboardHandlers( container, copyCutHandler, pasteHandler ) {
 			document.removeEventListener( 'paste', pasteHandlerWrapper );
 		};
 	}, [ container, copyCutHandler, pasteHandler ] );
+}
+
+/**
+ * @param {?Element} target
+ * @return {boolean}
+ */
+function isCopyPasteTarget( target ) {
+	return ( target && ! BLACKLIST_CLIPBOARD_ELEMENTS.includes( target.tagName ) && ! target.closest( '[contenteditable="true"]' ) );
 }
 
 export default useClipboardHandlers;


### PR DESCRIPTION
## Summary

Partial for #3779.

Blocked by #4018.

This doesn't deal with all aspects of shortcuts and popup menus. Just focus on the selected element copy/paste using platform events. 

Some nuances:

* The focus state of elements is currently ignored. Even if we decide to support it, we can't rely on this because the focus in this kind of editor is relatively fragile and also because we need to support multi-select.
* The implementation intercepts document-level copy/cut/paste events and sets the payload.
* The document-level events part is important. Copy/paste target outside of inputs and selection ranges is most likely will be `document.body` element.
* This PR uses a pre-existing `Save()` template, but adds a new `TextContent` template to support both: in-editor and out-of-editor copy/paste.
* The HTML payloads that are not packaged by our editor could also be processed. E.g. `<img>` and other could be imported this way. However, that requires a deeper media library integration to reupload resources. Thus I'm skipping it in this PR.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
