### PR TITLE
Fix ability to update the status of a validation error

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1907,6 +1907,7 @@ class AMP_Validated_URL_Post_Type {
 			postId = <?php echo wp_json_encode( $post->ID ); ?>;
 			$( '#preview_validation_errors' ).on( 'click', function() {
 				var params = {}, validatePreviewUrl = validateUrl;
+				params.preview = '1';
 				$( '.amp-validation-error-status' ).each( function() {
 					if ( this.value && ! this.options[ this.selectedIndex ].defaultSelected ) {
 						params[ this.name ] = this.value;

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -241,7 +241,7 @@ class AMP_Validation_Manager {
 			add_action( 'admin_bar_menu', [ __CLASS__, 'add_admin_bar_menu_items' ], 101 );
 		}
 
-		self::override_validation_error_statuses();
+		add_action( 'wp', [ __CLASS__, 'override_validation_error_statuses' ] );
 
 		if ( self::$is_validate_request ) {
 			self::add_validation_error_sourcing();
@@ -548,6 +548,8 @@ class AMP_Validation_Manager {
 	 */
 	public static function override_validation_error_statuses() {
 		$override_validation_error_statuses = (
+			isset( $_REQUEST['preview'] )
+			&&
 			isset( $_REQUEST[ self::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			&&
 			is_array( $_REQUEST[ self::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -366,6 +366,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertEmpty( AMP_Validation_Manager::$validation_error_status_overrides );
 		$validation_error_term_1 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( [ 'test' => 1 ] );
 		$validation_error_term_2 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( [ 'test' => 2 ] );
+		$_REQUEST['preview']  = '1';
 		$_REQUEST['_wpnonce'] = wp_create_nonce( AMP_Validation_Manager::MARKUP_STATUS_PREVIEW_ACTION );
 		$_REQUEST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = [
 			$validation_error_term_1['slug'] => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
@@ -383,6 +384,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_override_validation_error_statuses_with_bad_nonce() {
 		$validation_error_term_1 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( [ 'test' => 1 ] );
+		$_REQUEST['preview']  = '1';
 		$_REQUEST['_wpnonce'] = 'bad';
 		$_REQUEST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = [
 			$validation_error_term_1['slug'] => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
@@ -398,6 +400,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 	 */
 	public function test_override_validation_error_statuses_with_no_nonce() {
 		$validation_error_term_1 = AMP_Validation_Error_Taxonomy::prepare_validation_error_taxonomy_term( [ 'test' => 1 ] );
+		$_REQUEST['preview']     = '1';
 		$_REQUEST[ AMP_Validation_Manager::VALIDATION_ERROR_TERM_STATUS_QUERY_VAR ] = [
 			$validation_error_term_1['slug'] => AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS,
 		];


### PR DESCRIPTION
## Summary

This fixes a regression I introduced in https://github.com/ampproject/amp-wp/pull/3898, where there was no longer an ability to update the status of validation errors. Instead, the user would see this error:

<img width="807" alt="Screen Shot 2020-01-08 at 17 07 43" src="https://user-images.githubusercontent.com/134745/72029021-6e1adb80-3239-11ea-9d0b-139ca693f95f.png">

After the changes here, the user is again able to both preview and update changes to the removed/kept status of a validation error.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
