### PR TITLE
SPA with amp shadow DOM extras

### DIFF
--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -112,6 +112,9 @@
 	 */
 	function isHeaderVisible() {
 		const element = document.querySelector( '.site-branding' );
+		if ( ! element ) { 
+			return;
+		} 
 		const clientRect = element.getBoundingClientRect();
 		return clientRect.height + clientRect.top >= 0;
 	}
@@ -124,7 +127,8 @@
 	 */
 	function fetchShadowDocResponse( url ) {
 		const ampUrl = new URL( url );
-		ampUrl.searchParams.set( ampAppShell.componentQueryVar, 'inner' );
+		const pathSuffix = '_' + ampAppShell.componentQueryVar + '_inner';
+		ampUrl.pathname = ampUrl.pathname + pathSuffix;
 
 		return fetch( ampUrl.toString(), {
 			method: 'GET',

--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -240,8 +240,14 @@
 					}
 
 					if ( scrollIntoView && ! isHeaderVisible() ) {
+						const siteContent = document.querySelector( '.site-content-contain' );
+
+						if ( ! siteContent ) {
+							return;
+						}
+
 						// @todo The scroll position is not correct when admin bar is used. Consider scrolling to Y coordinate smoothly instead.
-						document.querySelector( '.site-content-contain' ).scrollIntoView( {
+						siteContent.scrollIntoView( {
 							block: 'start',
 							inline: 'start',
 							behavior: 'smooth'

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -462,7 +462,7 @@ function amp_register_default_scripts( $wp_scripts ) {
 		$handle,
 		sprintf(
 			'if ( ! Element.prototype.attachShadow ) { const script = document.createElement( "script" ); script.src = %s; script.async = true; document.head.appendChild( script ); }',
-			wp_json_encode( 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.3.3/webcomponents-sd-ce.js' )
+			wp_json_encode( 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.4.0/webcomponents-bundle.js' )
 		),
 		'after'
 	);

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -462,7 +462,7 @@ function amp_register_default_scripts( $wp_scripts ) {
 		$handle,
 		sprintf(
 			'if ( ! Element.prototype.attachShadow ) { const script = document.createElement( "script" ); script.src = %s; script.async = true; document.head.appendChild( script ); }',
-			wp_json_encode( 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.4.0/webcomponents-bundle.js' )
+			wp_json_encode( 'https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.4.1/webcomponents-bundle.js' )
 		),
 		'after'
 	);

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2033,7 +2033,7 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_output_buffering( $response ) {
 		self::$is_output_buffering = false;
-		return apply_filters( 'amp_document_output', self::prepare_response( $response ) );
+		return self::prepare_response( $response );
 	}
 
 	/**

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2033,7 +2033,7 @@ class AMP_Theme_Support {
 	 */
 	public static function finish_output_buffering( $response ) {
 		self::$is_output_buffering = false;
-		return self::prepare_response( $response );
+		return apply_filters( 'amp_document_output', self::prepare_response( $response ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Issued it against the branch part of this PR: #1519

This contains some improvements to amp-wp-app-shell.js contributed by Jonathan Barnett ( @indieisaconcept ). Consent was [already provided](https://github.com/ampproject/amp-wp/pull/3931#issuecomment-572302342). 

Ensure .site-content-contain element exists

Rationale
A prior change introduced an early return for isHeaderVisible should the
site-branding element not be found in the document. However this early
return caused code to trigger elsewhere related to scrolling.

Changes

Ensure .site-content-contain document lookup is also guarded to prevent
calling scrollIntoView on a non-existing dom element.
Rationale
Due to caching restrictions with WPengine the use of a query-string parameter to
denote an inner shell request is problematic as it prevents the request from
being cached independently. The request needs to be distinctly different from
the outer shell in-order for it to be treated as a seperate cache item.

Changes

Query string parameter is now appended to the path instead of
Fixed bug where code was always expecting a .site-branding element to exist

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
