### PR TITLE
Discovery: simple draft of the masks system

### DIFF
--- a/assets/src/edit-story/components/canvas/element.js
+++ b/assets/src/edit-story/components/canvas/element.js
@@ -15,12 +15,16 @@ import { useLayoutEffect, useRef } from '@wordpress/element';
 import { getDefinitionForType } from '../../elements';
 import { useStory } from '../../app';
 import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { WithElementMask } from '../../masks';
 import useCanvas from './useCanvas';
 
+// Pointer events are disabled in the display mode to ensure that selection
+// can be limited to the mask.
 const Wrapper = styled.div`
 	${ ElementWithPosition }
 	${ ElementWithSize }
 	${ ElementWithRotation }
+	pointer-events: ${ ( { isEditing } ) => isEditing ? 'initial' : 'none' };
 `;
 
 function Element( {
@@ -62,6 +66,7 @@ function Element( {
 		<Wrapper
 			ref={ element }
 			{ ...box }
+			isEditing={ isEditing }
 			onMouseDown={ ( evt ) => {
 				if ( ! isSelected ) {
 					handleSelectElement( id, evt );
@@ -71,7 +76,11 @@ function Element( {
 		>
 			{ isEditing ?
 				( <Edit { ...props } /> ) :
-				( <Display { ...props } /> ) }
+				(
+					<WithElementMask type={ type } { ...rest } >
+						<Display { ...props } />
+					</WithElementMask>
+				) }
 		</Wrapper>
 	);
 }

--- a/assets/src/edit-story/elements/image/edit.js
+++ b/assets/src/edit-story/elements/image/edit.js
@@ -14,6 +14,7 @@ import { useCallback, useState } from '@wordpress/element';
  */
 import { ElementFillContent } from '../shared';
 import { useStory } from '../../app';
+import { WithElementMask } from '../../masks';
 import EditPanMovable from './editPanMovable';
 import EditCropMovable from './editCropMovable';
 import { getImgProps, ImageWithScale } from './util';
@@ -53,7 +54,7 @@ const CropImg = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed } ) {
+function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed, type, ...rest } ) {
 	const [ fullImage, setFullImage ] = useState( null );
 	const [ croppedImage, setCroppedImage ] = useState( null );
 	const [ cropBox, setCropBox ] = useState( null );
@@ -69,7 +70,9 @@ function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, fo
 		<Element>
 			<FadedImg ref={ setFullImage } draggable={ false } src={ src } { ...imgProps } />
 			<CropBox ref={ setCropBox }>
-				<CropImg ref={ setCroppedImage } draggable={ false } src={ src } { ...imgProps } />
+				<WithElementMask type={ type } { ...rest } >
+					<CropImg ref={ setCroppedImage } draggable={ false } src={ src } { ...imgProps } />
+				</WithElementMask>
 			</CropBox>
 
 			{ ! isFullbleed && cropBox && croppedImage && (
@@ -108,6 +111,7 @@ function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, fo
 
 ImageEdit.propTypes = {
 	id: PropTypes.string.isRequired,
+	type: PropTypes.string.isRequired,
 	src: PropTypes.string.isRequired,
 	origRatio: PropTypes.number.isRequired,
 	width: PropTypes.number.isRequired,

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -17,4 +17,5 @@ export const panels = [
 	PanelTypes.SCALE,
 	PanelTypes.ROTATION_ANGLE,
 	PanelTypes.FULLBLEED,
+	PanelTypes.MASK,
 ];

--- a/assets/src/edit-story/masks/index.js
+++ b/assets/src/edit-story/masks/index.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import styled, { css } from 'styled-components';
+import PropTypes from 'prop-types';
+import uuid from 'uuid/v4';
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ElementFillContent } from '../elements/shared';
+
+const MaskIds = {
+	HEART: 'heart',
+	STAR: 'star',
+};
+
+const CLIP_PATHS = {
+	// @todo: This is a very bad heart.
+	[ MaskIds.HEART ]: 'M 0.5,1 C 0.5,1,0,0.7,0,0.3 A 0.25,0.25,1,1,1,0.5,0.3 A 0.25,0.25,1,1,1,1,0.3 C 1,0.7,0.5,1,0.5,1 Z',
+	// @todo: This is a horrible star.
+	[ MaskIds.STAR ]: 'M .5,0 L .8,1 L 0,.4 L 1,.4 L .2,1 Z',
+};
+
+export const MASKS = [
+	{
+		type: MaskIds.HEART,
+		name: 'Heart',
+		path: CLIP_PATHS[ MaskIds.HEART ],
+	},
+	{
+		type: MaskIds.STAR,
+		name: 'Star',
+		path: CLIP_PATHS[ MaskIds.STAR ],
+	},
+];
+
+// Pointer events have to be restored to ensure that selection works, but
+// limited to the mask.
+const MaskCss = css`
+  ${ ElementFillContent }
+  pointer-events: initial;
+`;
+
+const NoMask = styled.div`
+  ${ MaskCss }
+`;
+
+const ClipPathMask = styled.div`
+  ${ MaskCss }
+  clip-path: url(#${ ( { maskId } ) => maskId });
+`;
+
+export function WithElementMask( { children, ...elementProps } ) {
+	const mask = getElementMaskProperties( elementProps );
+	return (
+		<WithtMask { ...mask }>
+			{ children }
+		</WithtMask>
+	);
+}
+
+WithElementMask.propTypes = {
+	children: PropTypes.oneOfType( [
+		PropTypes.arrayOf( PropTypes.node ),
+		PropTypes.node,
+	] ).isRequired,
+};
+
+function WithtMask( { children, type, ...mask } ) {
+	const maskId = useMemo( () => type + '-' + uuid(), [ type ] );
+	if ( type ) {
+		// @todo: Chrome cannot do inline clip-path using data: URLs.
+		// See https://bugs.chromium.org/p/chromium/issues/detail?id=1041024.
+		return (
+			<ClipPathMask maskId={ maskId } { ...mask }>
+				<svg width={ 0 } height={ 0 }>
+					<defs>
+						<clipPath id={ maskId } clipPathUnits="objectBoundingBox">
+							<path d={ CLIP_PATHS[ type ] } />
+						</clipPath>
+					</defs>
+				</svg>
+				{ children }
+			</ClipPathMask>
+		);
+	}
+	return (
+		<NoMask>
+			{ children }
+		</NoMask>
+	);
+}
+
+WithtMask.propTypes = {
+	type: PropTypes.string.isRequired,
+	children: PropTypes.oneOfType( [
+		PropTypes.arrayOf( PropTypes.node ),
+		PropTypes.node,
+	] ).isRequired,
+};
+
+function getElementMaskProperties( { type, mask, ...rest } ) {
+	if ( mask ) {
+		return mask;
+	}
+	return getDefaultElementMaskProperties( { type, ...rest } );
+}
+
+function getDefaultElementMaskProperties( { } ) {
+	// @todo: mask-based shapes (square, circle, etc) automatically assume masks.
+	return null;
+}

--- a/assets/src/edit-story/panels/index.js
+++ b/assets/src/edit-story/panels/index.js
@@ -7,6 +7,7 @@ import ColorPanel from './color';
 import BackgroundColorPanel from './backgroundColor';
 import FullbleedPanel from './fullbleed';
 import FontPanel from './font';
+import MaskPanel from './mask';
 import RotationPanel from './rotationAngle';
 import SizePanel from './size';
 import PositionPanel from './position';
@@ -23,6 +24,7 @@ const SIZE = 'size';
 const POSITION = 'position';
 const FULLBLEED = 'fullbleed';
 const BACKGROUND_COLOR = 'backgroundColor';
+const MASK = 'mask';
 
 export const PanelTypes = {
 	ACTIONS,
@@ -35,6 +37,7 @@ export const PanelTypes = {
 	TEXT,
 	ROTATION_ANGLE,
 	FULLBLEED,
+	MASK,
 };
 
 const ALL = Object.values( PanelTypes );
@@ -67,6 +70,7 @@ export function getPanels( elements ) {
 				case COLOR: return { type, Panel: ColorPanel };
 				case FONT: return { type, Panel: FontPanel };
 				case TEXT: return { type, Panel: TextPanel };
+				case MASK: return { type, Panel: MaskPanel };
 				default: throw new Error( `Unknown panel: ${ type }` );
 			}
 		} );

--- a/assets/src/edit-story/panels/mask.js
+++ b/assets/src/edit-story/panels/mask.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import { MASKS } from '../masks';
+import { Panel, Title, getCommonValue } from './shared';
+
+/* eslint-disable jsx-a11y/no-onchange */
+function MaskPanel( { selectedElements, onSetProperties } ) {
+	const masks = selectedElements.map( ( { mask } ) => mask );
+	const type = masks.includes( undefined ) ? '' : getCommonValue( masks, 'type' );
+	const mask = MASKS.find( ( aMask ) => aMask.type === type );
+
+	const onTypeChanged = ( evt ) => {
+		const newType = evt.target.value;
+		if ( newType === '' ) {
+			onSetProperties( { mask: null } );
+		} else {
+			const newMask = MASKS.find( ( aMask ) => aMask.type === newType );
+			onSetProperties( {
+				mask: {
+					type: newType,
+					...newMask.defaultProps,
+				},
+			} );
+		}
+	};
+
+	return (
+		<Panel onSubmit={ ( event ) => event.preventDefault() }>
+			<Title>
+				{ 'Mask' }
+			</Title>
+			<select value={ type } onChange={ onTypeChanged }>
+				<option key={ 'none' } value={ '' }>
+					{ 'None' }
+				</option>
+				{ MASKS.map( ( { type: aType, name } ) => (
+					<option key={ aType } value={ aType }>
+						{ name }
+					</option>
+				) ) }
+			</select>
+			<div>
+				{ mask && (
+					<svg width={ 50 } height={ 50 } viewBox="0 0 1 1">
+						<g transform="scale(0.8)" transform-origin="50% 50%">
+							<path
+								d={ mask.path }
+								fill="none"
+								stroke="blue"
+								strokeWidth={ 2 / 50 } />
+						</g>
+					</svg>
+				) }
+			</div>
+		</Panel>
+	);
+}
+/* eslint-enable jsx-a11y/no-onchange */
+
+MaskPanel.propTypes = {
+	selectedElements: PropTypes.array.isRequired,
+	onSetProperties: PropTypes.func.isRequired,
+};
+
+export default MaskPanel;


### PR DESCRIPTION
## Summary

No issue available yet. In design phase. But PR is meant to instruct some technicals.

Some implementation nuances:

1. The mask is applied to all elements in the display mode, right in between the `Wrapper` and the `Display`.
2. The `Edit` mode is different and the elements are expected to apply the mask themselves. This is because the edit mode is pretty nuanced and requires different specialized layouts.
3. The `Wrapper` is set to `pointer-events: none`. This is so that clicking within the total rectangle but outside the max (see the "heart" in the demo), the content seen behind the mask is selected.
4. The nuances of editing the mask on the right side (or any other) is still WIP by @samitron7, so this is a very preliminary debugging stuff.

See demo: 
![ezgif-5-9d0358b6baf8](https://user-images.githubusercontent.com/726049/72229781-109ecb80-3566-11ea-92d4-61e2fe1fe981.gif)




## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
