### PR TITLE
Improve compatibility of legacy stories editor with Gutenberg plugin

### DIFF
--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.css
@@ -1,4 +1,4 @@
-.editor-block-list__layout div[data-type="amp/amp-story-cta"] {
+.block-editor-block-list__layout div[data-type="amp/amp-story-cta"] {
 	top: 80%;
 	left: 0;
 	width: 100%;
@@ -9,7 +9,7 @@
 	margin-top: 0;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-cta"] img {
+.block-editor-block-list__layout div[data-type="amp/amp-story-cta"] img {
 
 	/* Remove the top/bottom padding from the available space. */
 	max-height: calc(110px - 24px);
@@ -34,7 +34,7 @@ div[data-type="amp/amp-story-cta"] .amp-overlay {
 	bottom: 0;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-cta"] .editor-block-mover {
+.block-editor-block-list__layout div[data-type="amp/amp-story-cta"] .editor-block-mover {
 	display: none;
 }
 

--- a/assets/src/stories-editor/blocks/amp-story-cta/edit.js
+++ b/assets/src/stories-editor/blocks/amp-story-cta/edit.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
  */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
-import { Dashicon, IconButton } from '@wordpress/components';
+import { Dashicon, Button } from '@wordpress/components';
 import { URLInput, RichText } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 
@@ -168,7 +168,7 @@ const CallToActionEdit = ( {
 						onChange={ ( value ) => setAttributes( { url: value } ) }
 						autoFocus={ false /* eslint-disable-line jsx-a11y/no-autofocus */ }
 					/>
-					<IconButton icon="editor-break" label={ __( 'Apply', 'amp' ) } type="submit" />
+					<Button icon="editor-break" label={ __( 'Apply', 'amp' ) } type="submit" />
 				</form>
 			) }
 		</div>

--- a/assets/src/stories-editor/blocks/amp-story-page-attachment/attachment-content.js
+++ b/assets/src/stories-editor/blocks/amp-story-page-attachment/attachment-content.js
@@ -123,7 +123,7 @@ const AttachmentContent = ( props ) => {
 		<div className="attachment-container">
 			<div className="attachment-wrapper">
 				<div className="attachment-header">
-					{ /* This does not use an IconButton as it replicates the close button on the frontend */ }
+					{ /* This does not use a Button as it replicates the close button on the frontend */ }
 					<span
 						tabIndex="0"
 						className="amp-story-page-attachment-close-button"

--- a/assets/src/stories-editor/blocks/amp-story-page-attachment/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page-attachment/edit.css
@@ -13,7 +13,7 @@ div[data-type="amp/amp-story-page-attachment"] .components-notice.is-warning {
 	position: absolute;
 }
 
-div[data-type="amp/amp-story-page-attachment"] .editor-block-list__block-edit.block-editor-block-list__block-edit,
+div[data-type="amp/amp-story-page-attachment"] .block-editor-block-list__block-edit.block-editor-block-list__block-edit,
 div[data-type="amp/amp-story-page-attachment"] .attachment-wrapper {
 	width: 100%;
 	height: 100%;

--- a/assets/src/stories-editor/blocks/amp-story-page/animation-settings.js
+++ b/assets/src/stories-editor/blocks/amp-story-page/animation-settings.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { sprintf, __, _n } from '@wordpress/i18n';
 import {
 	PanelBody,
-	IconButton,
+	Button,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -67,13 +67,13 @@ const AnimationSettings = ( { clientId } ) => {
 		<PanelBody
 			title={ __( 'Animation', 'amp' ) }
 		>
-			<IconButton
+			<Button
 				icon={ isPlayingAnimation ? stopIcon( { width: 20, height: 20 } ) : 'controls-play' }
 				className="is-button is-default"
 				onClick={ isPlayingAnimation ? onAnimationStop : onAnimationStart }
 			>
 				{ buttonLabel }
-			</IconButton>
+			</Button>
 		</PanelBody>
 	);
 };

--- a/assets/src/stories-editor/blocks/amp-story-page/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-page/edit.css
@@ -15,10 +15,10 @@
 }
 
 /*
- * Disable the block mover at all times for page blocks.
+ * Disable the block mover at all times.
  */
 
-[data-type="amp/amp-story-page"] > .editor-block-list__block-edit > .editor-block-mover {
+.block-editor-block-toolbar .block-editor-block-mover {
 	display: none !important;
 }
 
@@ -26,14 +26,14 @@
  * Fix the page editor size to the ratio of the stories.
  */
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"] {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"] {
 	padding: 0;
 	margin: 60px 30px 0;
 }
 
 @media (min-width: 600px) {
 
-	div[data-type="amp/amp-story-page"] .editor-block-list__block {
+	div[data-type="amp/amp-story-page"] .block-editor-block-list__block {
 		margin: 0;
 		padding: 0;
 	}
@@ -44,44 +44,44 @@
 }
 
 #amp-story-editor .wp-block[data-type="amp/amp-story-page"],
-#amp-story-editor .wp-block[data-type="amp/amp-story-page"] .editor-inner-blocks .editor-block-list__layout:first-of-type {
+#amp-story-editor .wp-block[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-block-list__layout:first-of-type {
 	width: 100%;
 	max-width: 328px;
 	height: 553px;
 	position: relative;
 }
 
-#amp-story-editor .wp-block[data-type="amp/amp-story-page"] .editor-block-list__layout > .block-list-appender {
+#amp-story-editor .wp-block[data-type="amp/amp-story-page"] .block-editor-block-list__layout > .block-list-appender {
 	width: 316px;
 	margin: 0 auto;
 	display: none;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"].editor-block-list__block .editor-block-list__block-edit,
-.editor-block-list__layout .editor-block-list__layout .editor-block-list__block .editor-block-list__block-edit {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"].block-editor-block-list__block .block-editor-block-list__block-edit,
+.block-editor-block-list__layout .block-editor-block-list__layout .block-editor-block-list__block .block-editor-block-list__block-edit {
 	margin: 0;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"] {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"] {
 	flex: 0 0 auto;
 	position: relative;
 	transition: border 300ms linear;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"] + div[data-type="amp/amp-story-page"] {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"] + div[data-type="amp/amp-story-page"] {
 	margin-left: 20px;
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-inactive {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-inactive {
 	opacity: .5;
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover {
 	opacity: 1;
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-droppable::before,
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::before {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-droppable::before,
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::before {
 	display: block;
 	content: "";
 	position: absolute;
@@ -93,12 +93,12 @@
 	z-index: 10;
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::before {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::before {
 	top: calc(80% - 2px);
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-undroppable::after,
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::after {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-undroppable::after,
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::after {
 	display: block;
 	content: "";
 	position: absolute;
@@ -111,15 +111,15 @@
 	z-index: 10;
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::after {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-draggable-hover-amp-amp-story-cta.amp-page-draggable-hover-droppable::after {
 	bottom: calc(20% + 2px);
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-inactive > div {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"].amp-page-inactive > div {
 	pointer-events: none;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number {
 	position: absolute;
 	top: -3em;
 	text-transform: uppercase;
@@ -129,7 +129,7 @@
 	letter-spacing: 1px;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div .editor-inner-blocks.block-editor-inner-blocks {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"] .amp-story-page-number + div .block-editor-inner-blocks.block-editor-inner-blocks {
 	height: 553px;
 }
 
@@ -178,23 +178,23 @@
 /*
  * Make all the inner blocks positioned with absolute.
  */
-div[data-type="amp/amp-story-page"] .editor-inner-blocks .amp-page-child-block {
+div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .amp-page-child-block {
 	z-index: 10;
 }
 
-div[data-type="amp/amp-story-page"] .editor-inner-blocks .amp-page-child-block:not([data-type="amp/amp-story-cta"]) {
+div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .amp-page-child-block:not([data-type="amp/amp-story-cta"]) {
 	position: absolute;
 }
 
-div[data-type="amp/amp-story-page"] .editor-inner-blocks .amp-page-child-block[data-type="amp/amp-story-cta"] {
+div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .amp-page-child-block[data-type="amp/amp-story-cta"] {
 	height: 100%;
 }
 
-.editor-block-list__block .editor-block-list__layout {
+.block-editor-block-list__block .block-editor-block-list__layout {
 	margin: 0;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"][data-amp-selected="parent"] .editor-block-drop-zone {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"][data-amp-selected="parent"] .editor-block-drop-zone {
 	height: 603px;
 	--dropzone-padding: 400px;
 	--page-width: 328px;
@@ -206,7 +206,7 @@ div[data-type="amp/amp-story-page"] .editor-inner-blocks .amp-page-child-block[d
 	background: transparent;
 }
 
-.editor-block-list__layout div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > .editor-block-drop-zone .components-drop-zone__content {
+.block-editor-block-list__layout div[data-type="amp/amp-story-page"][data-amp-selected="parent"] > .editor-block-drop-zone .components-drop-zone__content {
 	display: none;
 }
 
@@ -289,11 +289,11 @@ div[data-type="amp/amp-story-page"] .wp-block-image {
 
 /* Block Validation Warnings */
 
-.editor-block-list__layout [data-type="amp/amp-story-page"] .block-editor-block-list__block .block-editor-warning {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"] .block-editor-block-list__block .block-editor-warning {
 	transform: none;
 }
 
-.editor-block-list__layout [data-type="amp/amp-story-page"] .block-editor-block-list__block.is-selected .block-editor-warning {
+.block-editor-block-list__layout [data-type="amp/amp-story-page"] .block-editor-block-list__block.is-selected .block-editor-warning {
 	border: none;
 }
 

--- a/assets/src/stories-editor/blocks/amp-story-text/edit.css
+++ b/assets/src/stories-editor/blocks/amp-story-text/edit.css
@@ -63,7 +63,7 @@ div[data-type="amp/amp-story-page"] .block-editor-inner-blocks .block-editor-blo
 	position: absolute !important;
 }
 
-.editor-block-list__layout .wp-block[data-type="amp/amp-story-text"] .editor-block-list__block-edit::before {
+.block-editor-block-list__layout .wp-block[data-type="amp/amp-story-text"] .block-editor-block-list__block-edit::before {
 	position: absolute;
 }
 

--- a/assets/src/stories-editor/components/animation-controls/index.js
+++ b/assets/src/stories-editor/components/animation-controls/index.js
@@ -7,7 +7,7 @@ import { ReactElement } from 'react';
 /**
  * WordPress dependencies
  */
-import { RangeControl, SelectControl, IconButton } from '@wordpress/components';
+import { RangeControl, SelectControl, Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -106,13 +106,13 @@ const AnimationControls = ( {
 						options={ animatedBlocks() }
 						onChange={ onAnimationAfterChange }
 					/>
-					<IconButton
+					<Button
 						icon={ isPlayingAnimation ? stopIcon( { width: 20, height: 20 } ) : 'controls-play' }
 						className="is-button is-default"
 						onClick={ isPlayingAnimation ? onAnimationStop : onAnimationStart }
 					>
 						{ isPlayingAnimation ? __( 'Stop Animation', 'amp' ) : __( 'Play Animation', 'amp' ) }
-					</IconButton>
+					</Button>
 				</>
 			) }
 		</>

--- a/assets/src/stories-editor/components/autocomplete/index.js
+++ b/assets/src/stories-editor/components/autocomplete/index.js
@@ -6,7 +6,7 @@ import OriginalAutocomplete from 'accessible-autocomplete/react';
  * WordPress dependencies
  */
 import {
-	IconButton,
+	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -123,7 +123,7 @@ class Autocomplete extends OriginalAutocomplete {
 				/>
 				{ query && ! menuOpen && queryLongEnough && (
 
-					<IconButton
+					<Button
 						icon="no"
 						label={ __( 'Clear Font', 'amp' ) }
 						onClick={ ( event ) => this.handleClearClick( event ) }

--- a/assets/src/stories-editor/components/block-navigation/edit.css
+++ b/assets/src/stories-editor/components/block-navigation/edit.css
@@ -5,7 +5,7 @@
 	top: 75px;
 	width: 300px;
 	min-width: 115px;
-	z-index: 80;
+	z-index: 25;
 	list-style-type: none;
 	padding: 0;
 	margin: 0;
@@ -20,7 +20,7 @@
 
 @media (min-width: 1001px) and (max-width: 1100px) {
 
-	.is-sidebar-opened .editor-block-list__layout {
+	.is-sidebar-opened .block-editor-block-list__layout {
 		margin-right: -100px;
 	}
 }

--- a/assets/src/stories-editor/components/custom-video-block-edit.js
+++ b/assets/src/stories-editor/components/custom-video-block-edit.js
@@ -13,7 +13,6 @@ import { useRef, useState, useEffect } from '@wordpress/element';
 import {
 	BaseControl,
 	Button,
-	IconButton,
 	Notice,
 	PanelBody,
 	Path,
@@ -280,7 +279,7 @@ const CustomVideoBlockEdit = ( { instanceId, isSelected, className, attributes, 
 		<>
 			<BlockControls>
 				<Toolbar>
-					<IconButton
+					<Button
 						className="components-icon-button components-toolbar__control"
 						label={ __( 'Edit video', 'amp' ) }
 						onClick={ switchToEditing }

--- a/assets/src/stories-editor/components/editor-carousel/edit.css
+++ b/assets/src/stories-editor/components/editor-carousel/edit.css
@@ -14,7 +14,7 @@
 	overflow: hidden;
 }
 
-#amp-story-editor > .editor-block-list__layout {
+#amp-story-editor > .block-editor-block-list__layout {
 	padding-left: 0;
 	padding-right: 0;
 	display: flex;
@@ -23,7 +23,7 @@
 	transition: transform 300ms ease-in-out;
 }
 
-#amp-story-editor > .editor-block-list__layout .block-list-appender {
+#amp-story-editor > .block-editor-block-list__layout .block-list-appender {
 	display: none;
 }
 

--- a/assets/src/stories-editor/components/editor-carousel/index.js
+++ b/assets/src/stories-editor/components/editor-carousel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { DropZoneProvider, IconButton } from '@wordpress/components';
+import { DropZoneProvider, Button } from '@wordpress/components';
 import { useEffect, useRef } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -84,7 +84,7 @@ const EditorCarousel = () => {
 	return (
 		<DropZoneProvider>
 			<div className="amp-story-editor-carousel-navigation">
-				<IconButton
+				<Button
 					icon={ isRTL ? 'arrow-right-alt2' : 'arrow-left-alt2' }
 					label={ __( 'Previous Page', 'amp' ) }
 					onClick={ ( e ) => {
@@ -98,7 +98,7 @@ const EditorCarousel = () => {
 					currentPage={ currentPage }
 					onClick={ goToPage }
 				/>
-				<IconButton
+				<Button
 					icon={ isRTL ? 'arrow-left-alt2' : 'arrow-right-alt2' }
 					label={ __( 'Next Page', 'amp' ) }
 					onClick={ ( e ) => {

--- a/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
+++ b/assets/src/stories-editor/components/higher-order/with-amp-story-settings.js
@@ -13,7 +13,7 @@ import { getBlockType } from '@wordpress/blocks';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import {
-	IconButton,
+	Button,
 	PanelBody,
 	RangeControl,
 	SelectControl,
@@ -348,7 +348,7 @@ export default createHigherOrderComponent(
 								title={ __( 'Block Position', 'amp' ) }
 							>
 								<div className="amp-story-order-controls-wrap">
-									<IconButton
+									<Button
 										className="amp-story-controls-bring-front"
 										onClick={ moveFront }
 										icon={ bringFrontIcon( { width: 24, height: 24 } ) }
@@ -357,8 +357,8 @@ export default createHigherOrderComponent(
 										aria-disabled={ isLast }
 									>
 										{ __( 'Front', 'amp' ) }
-									</IconButton>
-									<IconButton
+									</Button>
+									<Button
 										className="amp-story-controls-bring-forward"
 										onClick={ bringForward }
 										icon={ bringForwardIcon( { width: 24, height: 24 } ) }
@@ -367,8 +367,8 @@ export default createHigherOrderComponent(
 										aria-disabled={ isLast }
 									>
 										{ __( 'Forward', 'amp' ) }
-									</IconButton>
-									<IconButton
+									</Button>
+									<Button
 										className="amp-story-controls-send-backwards"
 										onClick={ sendBackward }
 										icon={ sendBackwardIcon( { width: 24, height: 24 } ) }
@@ -377,8 +377,8 @@ export default createHigherOrderComponent(
 										aria-disabled={ isFirst }
 									>
 										{ __( 'Backward', 'amp' ) }
-									</IconButton>
-									<IconButton
+									</Button>
+									<Button
 										className="amp-story-controls-send-back"
 										onClick={ moveBack }
 										icon={ sendBackIcon( { width: 24, height: 24 } ) }
@@ -387,7 +387,7 @@ export default createHigherOrderComponent(
 										aria-disabled={ isFirst }
 									>
 										{ __( 'Back', 'amp' ) }
-									</IconButton>
+									</Button>
 								</div>
 								<span className="amp-story-controls-description" id={ `amp-story-controls-bring-front-description-${ clientId }` }>
 									{

--- a/assets/src/stories-editor/components/inserter-list-item/index.js
+++ b/assets/src/stories-editor/components/inserter-list-item/index.js
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { BlockIcon } from '@wordpress/block-editor';
+import { Button } from '@wordpress/components';
 
 function InserterListItem( {
 	icon,
@@ -34,14 +35,14 @@ function InserterListItem( {
 	} : {};
 
 	return (
-		<li className="editor-block-types-list__list-item block-editor-block-types-list__list-item">
-			<button
+		<li className="block-editor-block-types-list__list-item">
+			<Button
 				className={
 					classnames(
-						'editor-block-types-list__item block-editor-block-types-list__item',
+						'block-editor-block-types-list__item',
 						className,
 						{
-							'editor-block-types-list__item-has-children block-editor-block-types-list__item-has-children':
+							'block-editor-block-types-list__item-has-children':
 								hasChildBlocksWithInserterSupport,
 						},
 					)
@@ -55,21 +56,21 @@ function InserterListItem( {
 				{ ...props }
 			>
 				<span
-					className="editor-block-types-list__item-icon block-editor-block-types-list__item-icon"
+					className="block-editor-block-types-list__item-icon"
 					style={ itemIconStyle }
 				>
 					<BlockIcon icon={ icon } showColors />
 					{ hasChildBlocksWithInserterSupport &&
 						<span
-							className="editor-block-types-list__item-icon-stack block-editor-block-types-list__item-icon-stack"
+							className="block-editor-block-types-list__item-icon-stack"
 							style={ itemIconStackStyle }
 						/>
 					}
 				</span>
-				<span className="editor-block-types-list__item-title block-editor-block-types-list__item-title">
+				<span className="block-editor-block-types-list__item-title">
 					{ title }
 				</span>
-			</button>
+			</Button>
 		</li>
 	);
 }

--- a/assets/src/stories-editor/components/inserter/index.js
+++ b/assets/src/stories-editor/components/inserter/index.js
@@ -17,7 +17,7 @@ import { ReactElement } from 'react';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -27,12 +27,12 @@ import InserterMenu from './menu'; // eslint-disable-line import/no-named-as-def
 import './edit.css';
 
 const defaultRenderToggle = ( { onToggle, disabled, isOpen } ) => (
-	<IconButton
+	<Button
 		icon="insert"
 		label={ __( 'Add element', 'amp' ) }
-		labelPosition="bottom"
+		tooltipPosition="bottom"
 		onClick={ onToggle }
-		className="editor-inserter__toggle block-editor-inserter__toggle"
+		className="block-editor-inserter__toggle"
 		aria-haspopup="true"
 		aria-expanded={ isOpen }
 		disabled={ disabled }
@@ -99,8 +99,8 @@ const Inserter = ( props ) => {
 
 	return (
 		<Dropdown
-			className="editor-inserter block-editor-inserter"
-			contentClassName="editor-inserter__popover block-editor-inserter__popover"
+			className="block-editor-inserter"
+			contentClassName="block-editor-inserter__popover"
 			position={ position }
 			onToggle={ onToggle }
 			expandOnMobile

--- a/assets/src/stories-editor/components/media-inserter/index.js
+++ b/assets/src/stories-editor/components/media-inserter/index.js
@@ -114,7 +114,7 @@ const MediaInserter = () => {
 			hasArrowIndicator={ true }
 			popoverProps={ POPOVER_PROPS }
 			toggleProps={
-				{ labelPosition: 'bottom' }
+				{ tooltipPosition: 'bottom' }
 			}
 		/>
 	);

--- a/assets/src/stories-editor/components/page-inserter/index.js
+++ b/assets/src/stories-editor/components/page-inserter/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
@@ -20,7 +20,7 @@ function PageInserter() {
 
 	return (
 		<div className="block-editor-inserter">
-			<IconButton
+			<Button
 				icon={ addTemplateIcon( { width: 16, height: 16 } ) }
 				label={ __( 'Insert Blank Page', 'amp' ) }
 				onClick={ onClick }

--- a/assets/src/stories-editor/components/reorderer/edit.css
+++ b/assets/src/stories-editor/components/reorderer/edit.css
@@ -26,8 +26,8 @@
 	padding: 0;
 }
 
-.amp-story-reorderer .editor-block-list__layout.block-editor-block-list__layout,
-.amp-story-reorderer .editor-inner-blocks.block-editor-inner-blocks {
+.amp-story-reorderer .block-editor-block-list__layout.block-editor-block-list__layout,
+.amp-story-reorderer .block-editor-inner-blocks.block-editor-inner-blocks {
 	height: 100%;
 	padding: 0;
 }
@@ -116,7 +116,7 @@
 	height: 260px;
 }
 
-.amp-story-reorderer .amp-story-page-preview .editor-block-list__layout {
+.amp-story-reorderer .amp-story-page-preview .block-editor-block-list__layout {
 	padding: 0;
 }
 

--- a/assets/src/stories-editor/components/rotatable-box/edit.css
+++ b/assets/src/stories-editor/components/rotatable-box/edit.css
@@ -8,9 +8,9 @@
 	opacity: 0;
 }
 
-.editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__insertion-point,
-.editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__breadcrumb,
-.editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-contextual-toolbar {
+.block-editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__insertion-point,
+.block-editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-list__breadcrumb,
+.block-editor-inner-blocks .block-editor-block-list__block.is-rotating .block-editor-block-contextual-toolbar {
 	display: none !important;
 }
 

--- a/assets/src/stories-editor/components/shortcuts/index.js
+++ b/assets/src/stories-editor/components/shortcuts/index.js
@@ -4,7 +4,7 @@
 import { getBlockType, createBlock } from '@wordpress/blocks';
 import { BlockIcon } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { IconButton } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -56,12 +56,12 @@ const Shortcuts = () => {
 			const blockType = getBlockType( block );
 
 			return (
-				<IconButton
+				<Button
 					key={ block }
 					icon={ <BlockIcon icon={ blockType.icon } /> }
 					onClick={ () => onClick( block ) }
 					label={ blockType.title }
-					labelPosition="bottom"
+					tooltipPosition="bottom"
 				/>
 			);
 		} )

--- a/assets/src/stories-editor/components/story-block-drop-zone.js
+++ b/assets/src/stories-editor/components/story-block-drop-zone.js
@@ -23,7 +23,7 @@ import {
 	STORY_PAGE_INNER_HEIGHT_FOR_CTA,
 } from '../constants';
 
-const wrapperElSelector = 'div[data-amp-selected="parent"] .editor-inner-blocks';
+const wrapperElSelector = 'div[data-amp-selected="parent"] .block-editor-inner-blocks';
 
 const BlockDropZone = ( { srcBlockName, srcClientId } ) => {
 	const blockIsCTA = isCTABlock( srcBlockName );
@@ -45,7 +45,7 @@ const BlockDropZone = ( { srcBlockName, srcClientId } ) => {
 		if ( blockIsCTA ) {
 			elementId = `amp-story-cta-button-${ srcClientId }`;
 			cloneElementId = `clone-amp-story-cta-button-${ srcClientId }`;
-			const btnWrapperSelector = `#block-${ srcClientId } .editor-block-list__block-edit`;
+			const btnWrapperSelector = `#block-${ srcClientId } .block-editor-block-list__block-edit`;
 
 			// Get the editor wrapper element for calculating the width and height.
 			wrapperEl = document.querySelector( btnWrapperSelector );

--- a/assets/src/stories-editor/components/story-controls/index.js
+++ b/assets/src/stories-editor/components/story-controls/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { IconButton, Button } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -33,13 +33,13 @@ function StoryControls() {
 	if ( isReordering ) {
 		return (
 			<>
-				<IconButton
+				<Button
 					className="amp-story-controls-reorder-cancel"
 					onClick={ () => resetOrder( blockOrder ) }
 					icon="no-alt"
 				>
 					{ __( 'Cancel', 'amp' ) }
-				</IconButton>
+				</Button>
 				<Button
 					className="amp-story-controls-reorder-save"
 					onClick={ saveOrder }
@@ -55,7 +55,7 @@ function StoryControls() {
 	return (
 		<>
 			<PageInserter />
-			<IconButton
+			<Button
 				className="amp-story-controls-reorder"
 				icon={ reorderIcon( { width: 24, height: 19 } ) }
 				label={ __( 'Reorder Pages', 'amp' ) }

--- a/assets/src/stories-editor/components/template-inserter/edit.css
+++ b/assets/src/stories-editor/components/template-inserter/edit.css
@@ -148,7 +148,7 @@
 
 .amp-stories__editor-inserter__results .components-disabled,
 .amp-stories__editor-inserter__results .components-disabled div:first-of-type,
-.amp-stories__editor-inserter__results .components-disabled .editor-inner-blocks {
+.amp-stories__editor-inserter__results .components-disabled .block-editor-inner-blocks {
 	padding: 0;
 	height: 268px;
 }

--- a/assets/src/stories-editor/components/template-inserter/index.js
+++ b/assets/src/stories-editor/components/template-inserter/index.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Dropdown, IconButton } from '@wordpress/components';
+import { Dropdown, Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
@@ -77,7 +77,7 @@ const TemplateInserter = ( props ) => {
 			onToggle={ onToggle }
 			expandOnMobile
 			renderToggle={ ( { onToggle: onClick, isOpen } ) => (
-				<IconButton
+				<Button
 					icon={ addTemplateIcon( { width: 16, height: 16 } ) }
 					label={ __( 'Insert Template', 'amp' ) }
 					onClick={ onClick }
@@ -104,7 +104,7 @@ const TemplateInserter = ( props ) => {
 						>
 							<div role="list" className="editor-block-types-list block-editor-block-types-list">
 								<div className="editor-block-preview block-editor-block-preview">
-									<IconButton
+									<Button
 										icon={ pageIcon( { width: 86, height: 96 } ) }
 										label={ __( 'Blank Page', 'amp' ) }
 										onClick={ () => {

--- a/assets/src/stories-editor/formats/background-color/edit.js
+++ b/assets/src/stories-editor/formats/background-color/edit.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, ColorPalette } from '@wordpress/block-editor';
-import { Toolbar, Dropdown, IconButton } from '@wordpress/components';
+import { Toolbar, Dropdown, Button } from '@wordpress/components';
 import { getActiveFormat, applyFormat, removeFormat } from '@wordpress/rich-text';
 
 /**
@@ -33,7 +33,7 @@ const FormatEdit = ( { isActive, value, onChange } ) => {
 				<Dropdown
 					position="bottom right"
 					renderToggle={ ( { isOpen, onToggle } ) => (
-						<IconButton
+						<Button
 							icon={ markerIcon( { width: 16, height: 16, viewBox: '0 0 24 24' } ) }
 							tooltip={ __( 'Highlight Color', 'amp' ) }
 							onClick={ onToggle }
@@ -45,7 +45,7 @@ const FormatEdit = ( { isActive, value, onChange } ) => {
 									backgroundColor: activeColor,
 								} }
 							/>
-						</IconButton>
+						</Button>
 					) }
 					renderContent={ () => (
 						<div className="components-background-color-popover-content">

--- a/assets/src/stories-editor/formats/text-color/edit.js
+++ b/assets/src/stories-editor/formats/text-color/edit.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
  */
 import { __ } from '@wordpress/i18n';
 import { BlockControls, ColorPalette } from '@wordpress/block-editor';
-import { Toolbar, Dropdown, IconButton } from '@wordpress/components';
+import { Toolbar, Dropdown, Button } from '@wordpress/components';
 import { getActiveFormat, applyFormat, removeFormat } from '@wordpress/rich-text';
 
 /**
@@ -32,7 +32,7 @@ const FormatEdit = ( { isActive, value, onChange } ) => {
 				<Dropdown
 					position="bottom right"
 					renderToggle={ ( { isOpen, onToggle } ) => (
-						<IconButton
+						<Button
 							icon="editor-textcolor"
 							tooltip={ __( 'Text Color', 'amp' ) }
 							onClick={ onToggle }
@@ -44,7 +44,7 @@ const FormatEdit = ( { isActive, value, onChange } ) => {
 									backgroundColor: activeColor,
 								} }
 							/>
-						</IconButton>
+						</Button>
 					) }
 					renderContent={ () => (
 						<div className="components-text-color-popover-content">

--- a/assets/src/stories-editor/helpers/renderStoryComponents.js
+++ b/assets/src/stories-editor/helpers/renderStoryComponents.js
@@ -12,8 +12,8 @@ import { BlockNavigation, EditorCarousel, Inserter, MediaInserter, Shortcuts, St
  * Add some additional elements needed to render our custom UI controls.
  */
 const renderStoryComponents = () => {
-	const editorBlockList = document.querySelector( '.editor-block-list__layout' );
-	const editorBlockNavigation = document.querySelector( '.editor-block-navigation' );
+	const editorBlockList = document.querySelector( '.block-editor-block-list__layout' );
+	const editorBlockNavigation = document.querySelector( '.block-editor-block-navigation' );
 
 	if ( editorBlockList && ! document.getElementById( 'amp-story-editor' ) ) {
 		const ampStoryWrapper = document.createElement( 'div' );
@@ -96,13 +96,14 @@ const renderStoryComponents = () => {
 		const customInserter = document.createElement( 'div' );
 		customInserter.id = 'amp-story-inserter';
 
-		const inserterWrapper = editorBlockNavigation.parentNode.parentNode.querySelector( '.block-editor-inserter' ).parentNode;
-		inserterWrapper.parentNode.replaceChild( customInserter, inserterWrapper );
+		editorBlockNavigation.parentNode.parentNode.replaceChild( customInserter, editorBlockNavigation.parentNode.parentNode.firstChild );
 
 		render(
 			<Inserter position="bottom right" />,
 			customInserter,
 		);
+
+		editorBlockNavigation.remove();
 	}
 
 	// Prevent WritingFlow component from focusing on last text field when clicking below the carousel.

--- a/assets/src/stories-editor/style.css
+++ b/assets/src/stories-editor/style.css
@@ -194,11 +194,11 @@
  * Fixes Gutenberg bug where an extra wrapping div is causing no pointer events on the notice layer.
  */
 
-.editor-block-list__layout .block-editor-block-list__block.has-warning .block-editor-block-list__block-edit > :not(.editor-warning) {
+.block-editor-block-list__layout .block-editor-block-list__block.has-warning .block-editor-block-list__block-edit > :not(.editor-warning) {
 	pointer-events: all;
 }
 
-.editor-block-list__layout .block-editor-block-list__block.has-warning .block-editor-block-list__block-edit > div > div:not(.editor-warning) {
+.block-editor-block-list__layout .block-editor-block-list__block.has-warning .block-editor-block-list__block-edit > div > div:not(.editor-warning) {
 	pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary

Addresses https://wordpress.org/support/topic/new-version-of-gutenberg-breaks-stories-layout/

* Updates obsolete class names in CSS
* Fixes selectors used for DOM manipulation
* Replace usage of deprecated `IconButton` with `Button`
* Hides some newly added elements from the UI

This way it works better with the Gutenberg plugin active, but doesn't fully work with WordPress 5.3 at the moment. Don't think it's worth trying to make it work for both.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
