### PR TITLE
Preserve styles applied via [style] attribute selectors

### DIFF
--- a/tests/php/test-amp-audio-converter.php
+++ b/tests/php/test-amp-audio-converter.php
@@ -169,11 +169,11 @@ class AMP_Audio_Converter_Test extends WP_UnitTestCase {
 					</figure>
 
 					<!--[if lt IE 9]><script>document.createElement(\'audio\');</script><![endif]-->
-					<amp-audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls" width="auto">
+					<amp-audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls" width="auto" data-amp-original-style="width: 100%;">
 						<source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
 						<a href="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3" fallback="">https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3</a>
 						<noscript>
-							<audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls">
+							<audio class="wp-audio-shortcode amp-wp-199b6f0" id="audio-87-1" preload="none" controls="controls" data-amp-original-style="width: 100%;">
 								<source type="audio/mpeg" src="https://wordpressdev.lndo.site/content/uploads/2019/02/do-you-know-I-am-batman.mp3?_=1">
 							</audio>
 						</noscript>

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -113,6 +113,6 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertRegExp( '/<!-- Google Tag Manager -->\s*<!-- End Google Tag Manager -->/', $content );
 		$this->assertContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
 		$this->assertContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
-		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
+		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" data-amp-original-style="display:none;visibility:hidden" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" data-amp-original-style="display:none;visibility:hidden" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
 	}
 }

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -53,7 +53,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style' => [
 				'<span style="color: #00ff00;">This is green.</span>',
-				'<span class="amp-wp-bb01159">This is green.</span>',
+				'<span data-amp-original-style="color: #00ff00;" class="amp-wp-bb01159">This is green.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0}',
 				],
@@ -61,7 +61,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_one_style_bad_format' => [
 				'<span style="color  :   #00ff00">This is green.</span>',
-				'<span class="amp-wp-0837823">This is green.</span>',
+				'<span data-amp-original-style="color  :   #00ff00" class="amp-wp-0837823">This is green.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-0837823{color:#0f0}',
 				],
@@ -69,7 +69,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_two_styles_reversed' => [
 				'<span style="color: #00ff00; background-color: #000; ">This is green.</span>',
-				'<span class="amp-wp-c71affe">This is green.</span>',
+				'<span data-amp-original-style="color: #00ff00; background-color: #000; " class="amp-wp-c71affe">This is green.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c71affe{color:#0f0;background-color:#000}',
 				],
@@ -77,7 +77,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'span_display_none' => [
 				'<span style="display: none;">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
-				'<span class="amp-wp-224b51a">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
+				'<span data-amp-original-style="display: none;" class="amp-wp-224b51a">Kses-banned properties are allowed since Kses will have already applied if user does not have unfiltered_html.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none}',
 				],
@@ -85,7 +85,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'!important_is_ok' => [
 				'<span style="padding:1px; margin: 2px !important; outline: 3px;">!important is converted.</span>',
-				'<span class="amp-wp-6a75598">!important is converted.</span>',
+				'<span data-amp-original-style="padding:1px; margin: 2px !important; outline: 3px;" class="amp-wp-6a75598">!important is converted.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{padding:1px;outline:3px}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-6a75598{margin:2px}',
 				],
@@ -93,7 +93,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'!important_with_spaces_also_converted' => [
 				'<span style="color: red  !  important;">!important is converted.</span>',
-				'<span class="amp-wp-952600b">!important is converted.</span>',
+				'<span data-amp-original-style="color: red  !  important;" class="amp-wp-952600b">!important is converted.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-952600b{color:red}',
 				],
@@ -101,7 +101,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'!important_multiple_is_converted' => [
 				'<span style="color: red !important; background: blue!important;">!important is converted.</span>',
-				'<span class="amp-wp-1e2bfaa">!important is converted.</span>',
+				'<span data-amp-original-style="color: red !important; background: blue!important;" class="amp-wp-1e2bfaa">!important is converted.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-1e2bfaa{color:red;background:blue}',
 				],
@@ -109,7 +109,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'!important_takes_precedence_over_inline' => [
 				'<header id="header" style="display: none;"><h1>This is the header.</h1></header><style>#header { display: block !important;width: 100%;background: #fff; }',
-				'<header id="header" class="amp-wp-224b51a"><h1>This is the header.</h1></header>',
+				'<header id="header" data-amp-original-style="display: none;" class="amp-wp-224b51a"><h1>This is the header.</h1></header>',
 				[
 					'#header{width:100%;background:#fff}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #header{display:block}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-224b51a{display:none}',
@@ -118,7 +118,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'two_nodes' => [
 				'<span style="color: #00ff00;"><span style="color: #ff0000;">This is red.</span></span>',
-				'<span class="amp-wp-bb01159"><span class="amp-wp-cc68ddc">This is red.</span></span>',
+				'<span data-amp-original-style="color: #00ff00;" class="amp-wp-bb01159"><span data-amp-original-style="color: #ff0000;" class="amp-wp-cc68ddc">This is red.</span></span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-bb01159{color:#0f0}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cc68ddc{color:#f00}',
@@ -127,7 +127,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'existing_class_attribute' => [
 				'<figure class="alignleft" style="background: #000"></figure>',
-				'<figure class="alignleft amp-wp-2864855"></figure>',
+				'<figure class="alignleft amp-wp-2864855" data-amp-original-style="background: #000"></figure>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-2864855{background:#000}',
 				],
@@ -153,7 +153,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'illegal_at_rule_in_style_attribute' => [
 				'<span style="color:brown; @media screen { color:green }">invalid @-rule omitted.</span>',
-				'<span class="amp-wp-481af57">invalid @-rule omitted.</span>',
+				'<span data-amp-original-style="color:brown; @media screen { color:green }" class="amp-wp-481af57">invalid @-rule omitted.</span>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-481af57{color:brown}',
 				],
@@ -179,7 +179,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'selector_specificity' => [
 				'<style>#child {color:red !important} #parent #child {color:pink !important} .foo { color:blue !important; } #me .foo { color: green !important; }</style><div id="parent"><span id="child" class="foo bar baz">one</span><span style="color: yellow;">two</span><span style="color: purple !important;">three</span></div><div id="me"><span class="foo"></span></div>',
-				'<div id="parent"><span id="child" class="foo bar baz">one</span><span class="amp-wp-64b4fd4">two</span><span class="amp-wp-ab79d9e">three</span></div><div id="me"><span class="foo"></span></div>',
+				'<div id="parent"><span id="child" class="foo bar baz">one</span><span data-amp-original-style="color: yellow;" class="amp-wp-64b4fd4">two</span><span data-amp-original-style="color: purple !important;" class="amp-wp-ab79d9e">three</span></div><div id="me"><span class="foo"></span></div>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #child{color:red}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #parent #child{color:pink}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) .foo{color:blue}:root:not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_):not(#_) #me .foo{color:green}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-64b4fd4{color:yellow}',
@@ -197,7 +197,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'col_with_width_attribute' => [
 				'<table><colgroup><col width="253"/></colgroup></table>',
-				'<table><colgroup><col class="amp-wp-cbcb5c2"></colgroup></table>',
+				'<table><colgroup><col data-amp-original-style="width: 253px" class="amp-wp-cbcb5c2"></colgroup></table>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cbcb5c2{width:253px}',
 				],
@@ -205,7 +205,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'col_with_percent_width_attribute' => [
 				'<table><colgroup><col width="50%"/></colgroup></table>',
-				'<table><colgroup><col class="amp-wp-cd7753e"></colgroup></table>',
+				'<table><colgroup><col data-amp-original-style="width: 50%" class="amp-wp-cd7753e"></colgroup></table>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-cd7753e{width:50%}',
 				],
@@ -219,7 +219,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'col_with_width_attribute_and_existing_style' => [
 				'<table><colgroup><col width="50" style="background-color: red; width: 60px"/></colgroup></table>',
-				'<table><colgroup><col class="amp-wp-c8aa9e9"></colgroup></table>',
+				'<table><colgroup><col data-amp-original-style="width: 50px;background-color: red; width: 60px" class="amp-wp-c8aa9e9"></colgroup></table>',
 				[
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c8aa9e9{width:50px;width:60px;background-color:red}',
 				],
@@ -709,6 +709,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<nav class="main-navigation focused"><ul><li><a href="https://example.com/">Example</a><ul><li><a href="https://example.org">Another example</a></li></ul></li></ul></nav>',
 				'.main-navigation ul ul li:hover > ul, .main-navigation ul ul li.focus > ul { left: 100%; right: auto; } nav.focused { outline:solid 1px red; }',
 				'.main-navigation ul ul li:hover > ul,.main-navigation ul ul li:focus-within > ul{left:100%;right:auto}nav.focused{outline:solid 1px red}',
+			],
+			'style_attribute_selector' => [
+				'<figure class="wp-block-pullquote" style="border-color:#ce3a0d">',
+				'.wp-block-pullquote:not(.is-style-solid-color)[style*="border-color"] { border: 2px solid; }',
+				'.wp-block-pullquote:not(.is-style-solid-color)[data-amp-original-style*="border-color"]{border:2px solid}',
 			],
 		];
 	}


### PR DESCRIPTION
## Summary

Some themes (and [formerly Gutenberg itself](https://github.com/WordPress/gutenberg/commit/509c9cb18beb140f4e6ec6e87aad2986650cc833#diff-b97453d47a1ae90ddc37e75f8047e560)) use CSS attribute selectors that target the `style` attribute itself. I thought this was not a common occurrence, but it turns out to be more common than I thought. Even [Twenty Twenty does it](https://github.com/WordPress/wordpress-develop/blob/06775e4df0b77f138b8e46ce241775a14ffe8afa/src/wp-content/themes/twentytwenty/style.css#L3366-L3378):

```css
.wp-block-quote[style="text-align:center"] {
	border-width: 0;
	padding: 0;
}

.wp-block-quote[style="text-align:right"] {

	/*rtl:begin:ignore*/
	border-width: 0 0.2rem 0 0;
	padding: 0 2rem 0 0;

	/*rtl:end:ignore*/
}
```

In fact, the use of such selectors occurs in 32 themes found on WordPress.org:

1. audioman
1. awada
1. bam
1. calibration
1. chaplin
1. conj-lite
1. cover2
1. digimag-lite
1. directory-starter
1. edin
1. euphony
1. gema-lite
1. magcast
1. materialis
1. mesmerize
1. mudra
1. my-music-band
1. nishiki
1. ocean-cream
1. oswald
1. oysters
1. pop-rock
1. raindrops
1. reykjavik
1. rock-band
1. satisfy
1. savana-lite
1. silk-lite
1. suki
1. tabut
1. twentytwenty
1. vasco

So this PR fixes the issue the issue by:

* Preserving `style` attribute contents in `data-amp-original-style`.
* Rewrite any `[style]` attribute selectors to instead use `[data-amp-original-style]`.

This will be helpful for debugging as well, since the original CSS text in the `style` attribute will be preserved.

## Testing

Add a Custom HTML block with the contents:

```html
<blockquote class="wp-block-quote" style="text-align:right">
    <p>This is a great quote!</p>
    <cite>Anonymous</cite>
</blockquote>
```

Activate Twenty Twenty and the non-AMP version of the content will appear as:

![image](https://user-images.githubusercontent.com/134745/72313799-64321780-3641-11ea-9596-626e2d4ec56b.png)

🚫 However, the AMP version will appear incorrectly:

![image](https://user-images.githubusercontent.com/134745/72313813-71e79d00-3641-11ea-8f75-6eb323f61a0d.png)

✅ With the changes in this PR checked out, the AMP version should then appear properly as:

![image](https://user-images.githubusercontent.com/134745/72313840-87f55d80-3641-11ea-9bfb-f3f1ca3fcb4d.png)

The HTML output by AMP appears as:

```html
<blockquote class="wp-block-quote amp-wp-f6e3d7f" data-amp-original-style="text-align:right">
    <p>This is a great quote!</p>
    <cite>Anonymous</cite>
</blockquote>
```

And a style rule is present now to target that element:

```css
.wp-block-quote[data-amp-original-style="text-align:right"] {
    border-width:0 .2rem 0 0;
    padding:0 2rem 0 0;
}
```

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
