### PR TITLE
Preview: reimplement workspace layering

### DIFF
--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -37,6 +37,7 @@ const Editor = styled.div`
 const Area = styled.div`
   grid-area: ${ ( { area } ) => area };
   position: relative;
+  overflow: hidden;
   z-index: ${ ( { area } ) => area === 'canv' ? 1 : 2 };
 `;
 

--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -34,10 +34,10 @@ const Editor = styled.div`
 		/ minmax(${ LIBRARY_MIN_WIDTH }px, ${ LIBRARY_MAX_WIDTH }px) 1fr minmax(${ INSPECTOR_MIN_WIDTH }px, ${ INSPECTOR_MAX_WIDTH }px);
 `;
 
+// @todo: set `overflow: hidden;` once page size is responsive.
 const Area = styled.div`
   grid-area: ${ ( { area } ) => area };
   position: relative;
-  overflow: hidden;
   z-index: ${ ( { area } ) => area === 'canv' ? 1 : 2 };
 `;
 

--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -37,6 +37,7 @@ const Editor = styled.div`
 const Area = styled.div`
   grid-area: ${ ( { area } ) => area };
   position: relative;
+  z-index: ${ ( { area } ) => area === 'canv' ? 1 : 2 };
 `;
 
 function Layout() {

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -6,60 +6,29 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { PAGE_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
-import Page from './page';
-import PageMenu from './pagemenu';
-import PageNav from './pagenav';
-import Carousel from './carousel';
+import EditLayer from './editLayer';
+import DisplayLayer from './page';
+import FramesLayer from './framesLayer';
+import NavLayer from './navLayer';
 import SelectionCanvas from './selectionCanvas';
-
-const PAGE_PADDING = 30;
 
 const Background = styled.div`
 	background-color: ${ ( { theme } ) => theme.colors.bg.v1 };
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	height: 100%;
-
-	display: grid;
-	grid:
-    ".         .         .         .         .       " minmax(${ PAGE_PADDING }px, 1fr)
-    ".         prev      page      next      .       " ${ PAGE_HEIGHT }px
-    ".         .         menu      .         .       " 48px
-    ".         .         .         .         .       " minmax(${ PAGE_PADDING }px, 1fr)
-    "carousel  carousel  carousel  carousel  carousel" auto
-    / 1fr ${ PAGE_NAV_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_WIDTH }px 1fr;
-`;
-
-const Area = styled.div`
-	grid-area: ${ ( { area } ) => area };
-	height: 100%;
 	width: 100%;
+	height: 100%;
+	position: relative;
+	user-select: none;
 `;
 
 function CanvasLayout() {
-	// @todo SelectionCanvas should not be there, will be addressed separately.
 	return (
 		<Background>
-			<Area area="page">
-				<SelectionCanvas>
-					<Page />
-				</SelectionCanvas>
-			</Area>
-			<Area area="menu">
-				<PageMenu />
-			</Area>
-			<Area area="prev">
-				<PageNav isNext={ false } />
-			</Area>
-			<Area area="next">
-				<PageNav />
-			</Area>
-			<Area area="carousel">
-				<Carousel />
-			</Area>
+			<SelectionCanvas>
+				<DisplayLayer />
+				<NavLayer />
+				<FramesLayer />
+			</SelectionCanvas>
+			<EditLayer />
 		</Background>
 	);
 }

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -7,7 +7,7 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import EditLayer from './editLayer';
-import DisplayLayer from './page';
+import DisplayLayer from './displayLayer';
 import FramesLayer from './framesLayer';
 import NavLayer from './navLayer';
 import SelectionCanvas from './selectionCanvas';

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 /**
  * WordPress dependencies
  */
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -80,6 +80,25 @@ function CanvasProvider( { children } ) {
 
 	useCanvasSelectionCopyPaste( pageContainer );
 
+	const transformHandlersRef = useRef( {} );
+
+	const registerTransformHandler = useCallback( ( id, handler ) => {
+		const handlerListMap = transformHandlersRef.current;
+		const handlerList = ( handlerListMap[ id ] || ( handlerListMap[ id ] = [] ) );
+		handlerList.push( handler );
+		return () => {
+			handlerList.splice( handlerList.indexOf( handler ), 1 );
+		};
+	}, [ ] );
+
+	const pushTransform = useCallback( ( id, transform ) => {
+		const handlerListMap = transformHandlersRef.current;
+		const handlerList = handlerListMap[ id ];
+		if ( handlerList ) {
+			handlerList.forEach( ( handler ) => handler( transform ) );
+		}
+	}, [ ] );
+
 	const state = {
 		state: {
 			pageContainer,
@@ -97,6 +116,8 @@ function CanvasProvider( { children } ) {
 			clearEditing,
 			handleSelectElement,
 			selectIntersection,
+			registerTransformHandler,
+			pushTransform,
 		},
 	};
 

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -24,6 +24,7 @@ const Wrapper = styled.div`
 	position: relative;
 	display: grid;
 	grid: "left-navigation carousel right-navigation" auto / 53px 1fr 53px;
+	background-color: ${ ( { theme } ) => theme.colors.bg.v1 };
 	color:  ${ ( { theme } ) => theme.colors.fg.v1 };
 `;
 

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -17,8 +17,10 @@ import { useStory } from '../../../app';
 import { LeftArrow, RightArrow, GridView } from '../../button';
 import DropZone from '../../dropzone';
 
-const PAGE_WIDTH = 72;
-const PAGE_HEIGHT = 128;
+// @todo: Make responsive. Blocked on the header reimplementation and
+// responsive "page" size.
+const PAGE_HEIGHT = 50;
+const PAGE_WIDTH = PAGE_HEIGHT * 9 / 16;
 
 const Wrapper = styled.div`
 	position: relative;
@@ -26,6 +28,8 @@ const Wrapper = styled.div`
 	grid: "left-navigation carousel right-navigation" auto / 53px 1fr 53px;
 	background-color: ${ ( { theme } ) => theme.colors.bg.v1 };
 	color:  ${ ( { theme } ) => theme.colors.fg.v1 };
+	width: 100%;
+	height: 100%;
 `;
 
 const Area = styled.div`
@@ -47,11 +51,15 @@ const List = styled( Area )`
 const Page = styled.button`
 	padding: 0;
 	margin: 0 5px;
-	border: 3px solid ${ ( { isActive, theme } ) => isActive ? theme.colors.selection : theme.colors.bg.v1 };
 	height: ${ PAGE_HEIGHT }px;
 	width: ${ PAGE_WIDTH }px;
 	background-color: ${ ( { isActive, theme } ) => isActive ? theme.colors.fg.v1 : theme.colors.mg.v1 };
 	flex: none;
+
+	outline: 2px solid ${ ( { isActive, theme } ) => isActive ? theme.colors.selection : theme.colors.bg.v1 };
+	&:focus, &:hover {
+		outline: 2px solid ${ ( { theme } ) => theme.colors.selection };
+	}
 `;
 
 const GridViewButton = styled( GridView )`

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -1,4 +1,3 @@
-// QQQ: rename to `elementDisplay.js`
 /**
  * External dependencies
  */
@@ -24,7 +23,7 @@ const Wrapper = styled.div`
 	contain: layout paint;
 `;
 
-function ElementDisplay( {
+function DisplayElement( {
 	element: {
 		id,
 		type,
@@ -70,8 +69,8 @@ function ElementDisplay( {
 	);
 }
 
-ElementDisplay.propTypes = {
+DisplayElement.propTypes = {
 	element: PropTypes.object.isRequired,
 };
 
-export default ElementDisplay;
+export default DisplayElement;

--- a/assets/src/edit-story/components/canvas/displayLayer.js
+++ b/assets/src/edit-story/components/canvas/displayLayer.js
@@ -1,4 +1,3 @@
-//QQQQ: rename file to `displayLayer.js`
 /**
  * External dependencies
  */
@@ -9,7 +8,7 @@ import styled from 'styled-components';
  */
 import { useStory } from '../../app';
 import useCanvas from './useCanvas';
-import Element from './element';
+import DisplayElement from './displayElement';
 import { Layer, PageArea } from './layout';
 
 const DisplayPageArea = styled( PageArea ).attrs( { className: 'container', overflow: false } )`
@@ -33,7 +32,7 @@ function DisplayLayer() {
 						return null;
 					}
 					return (
-						<Element
+						<DisplayElement
 							key={ id }
 							element={ { id, ...rest } }
 						/>

--- a/assets/src/edit-story/components/canvas/editElement.js
+++ b/assets/src/edit-story/components/canvas/editElement.js
@@ -20,7 +20,7 @@ const Wrapper = styled.div`
 	background-color: ${ ( { theme } ) => theme.colors.whiteout };
 `;
 
-function ElementEdit( {
+function EditElement( {
 	element: {
 		id,
 		type,
@@ -50,8 +50,8 @@ function ElementEdit( {
 	);
 }
 
-ElementEdit.propTypes = {
+EditElement.propTypes = {
 	element: PropTypes.object.isRequired,
 };
 
-export default ElementEdit;
+export default EditElement;

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { getDefinitionForType } from '../../elements';
+import { useStory } from '../../app';
+import withOverlay from '../overlay/withOverlay';
+import ElementEdit from './elementEdit';
+import { Layer, PageArea } from './layout';
+import useCanvas from './useCanvas';
+
+const LayerWithGrayout = styled( Layer )`
+  background-color: ${ ( { grayout, theme } ) => grayout ? theme.colors.grayout : 'transparent' };
+`;
+
+const EditPageArea = withOverlay( styled( PageArea ).attrs( { className: 'container' } )`
+  position: relative;
+  width: 100%;
+  height: 100%;
+` );
+
+function EditLayer( {} ) {
+	const { state: { currentPage } } = useStory();
+	const { state: { editingElement: editingElementId } } = useCanvas();
+
+	const editingElement =
+    editingElementId &&
+    currentPage &&
+    currentPage.elements.find( ( element ) => element.id === editingElementId );
+
+	if ( ! editingElement ) {
+		return null;
+	}
+
+	const { editModeGrayout } = getDefinitionForType( editingElement.type );
+
+	return (
+		<LayerWithGrayout grayout={ editModeGrayout } pointerEvents={ false }>
+			<EditPageArea>
+				<ElementEdit element={ editingElement } />
+			</EditPageArea>
+		</LayerWithGrayout>
+	);
+}
+
+export default EditLayer;

--- a/assets/src/edit-story/components/canvas/editLayer.js
+++ b/assets/src/edit-story/components/canvas/editLayer.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { getDefinitionForType } from '../../elements';
 import { useStory } from '../../app';
 import withOverlay from '../overlay/withOverlay';
-import ElementEdit from './elementEdit';
+import EditElement from './editElement';
 import { Layer, PageArea } from './layout';
 import useCanvas from './useCanvas';
 
@@ -41,7 +41,7 @@ function EditLayer( {} ) {
 	return (
 		<LayerWithGrayout grayout={ editModeGrayout } pointerEvents={ false }>
 			<EditPageArea>
-				<ElementEdit element={ editingElement } />
+				<EditElement element={ editingElement } />
 			</EditPageArea>
 		</LayerWithGrayout>
 	);

--- a/assets/src/edit-story/components/canvas/elementEdit.js
+++ b/assets/src/edit-story/components/canvas/elementEdit.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { getDefinitionForType } from '../../elements';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+
+// Background color is used to make the edited element more prominent and
+// easier to see.
+const Wrapper = styled.div`
+  ${ ElementWithPosition }
+  ${ ElementWithSize }
+  ${ ElementWithRotation }
+  pointer-events: initial;
+	background-color: ${ ( { theme } ) => theme.colors.whiteout };
+`;
+
+function ElementEdit( {
+	element: {
+		id,
+		type,
+		x,
+		y,
+		width,
+		height,
+		rotationAngle,
+		isFullbleed,
+		...rest
+	},
+} ) {
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { Edit } = getDefinitionForType( type );
+
+	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const props = { ...box, ...rest, id };
+
+	return (
+		<Wrapper
+			{ ...box }
+			onMouseDown={ ( evt ) => evt.stopPropagation() }
+		>
+			<Edit { ...props } />
+		</Wrapper>
+	);
+}
+
+ElementEdit.propTypes = {
+	element: PropTypes.object.isRequired,
+};
+
+export default ElementEdit;

--- a/assets/src/edit-story/components/canvas/elementFrame.js
+++ b/assets/src/edit-story/components/canvas/elementFrame.js
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+import { useLayoutEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { getDefinitionForType } from '../../elements';
+import { useStory } from '../../app';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import useCanvas from './useCanvas';
+
+const Wrapper = styled.div`
+  ${ ElementWithPosition }
+  ${ ElementWithSize }
+  ${ ElementWithRotation }
+  pointer-events: initial;
+
+  &:focus, &:active, &:hover {
+    outline: 1px solid ${ ( { theme } ) => theme.colors.selection };
+  }
+`;
+
+function ElementFrame( {
+	element: {
+		id,
+		type,
+		x,
+		y,
+		width,
+		height,
+		rotationAngle,
+		isFullbleed,
+		...rest
+	},
+} ) {
+	const { Frame } = getDefinitionForType( type );
+	const element = useRef();
+
+	const {
+		actions: { setNodeForElement, handleSelectElement },
+	} = useCanvas();
+
+	const {
+		state: { selectedElements },
+	} = useStory();
+
+	useLayoutEffect( () => {
+		setNodeForElement( id, element.current );
+	}, [ id, setNodeForElement ] );
+
+	const isSelected = selectedElements.includes( id );
+
+	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
+	const props = { ...box, ...rest, id };
+
+	return (
+		<Wrapper
+			ref={ element }
+			{ ...box }
+			onMouseDown={ ( evt ) => {
+				if ( ! isSelected ) {
+					handleSelectElement( id, evt );
+				}
+				evt.stopPropagation();
+			} }
+		>
+			{ Frame && (
+				<Frame { ...props } />
+			) }
+		</Wrapper>
+	);
+}
+
+ElementFrame.propTypes = {
+	element: PropTypes.object.isRequired,
+};
+
+export default ElementFrame;

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -28,7 +28,7 @@ const Wrapper = styled.div`
   }
 `;
 
-function ElementFrame( {
+function FrameElement( {
 	element: {
 		id,
 		type,
@@ -79,8 +79,8 @@ function ElementFrame( {
 	);
 }
 
-ElementFrame.propTypes = {
+FrameElement.propTypes = {
 	element: PropTypes.object.isRequired,
 };
 
-export default ElementFrame;
+export default FrameElement;

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { useStory } from '../../app';
+import withOverlay from '../overlay/withOverlay';
+import { Layer, PageArea } from './layout';
+import ElementFrame from './elementFrame';
+import Selection from './selection';
+
+const FramesPageArea = withOverlay( styled( PageArea ).attrs( { className: 'container', pointerEvents: true } )`
+  background-color: ${ ( { theme } ) => theme.colors.fg.v1 };
+` );
+
+function FramesLayer() {
+	const { state: { currentPage } } = useStory();
+
+	return (
+		<Layer pointerEvents={ false }>
+			<FramesPageArea>
+				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
+					return (
+						<ElementFrame
+							key={ id }
+							element={ { id, ...rest } }
+						/>
+					);
+				} ) }
+				<Selection />
+			</FramesPageArea>
+		</Layer>
+	);
+}
+
+export default FramesLayer;

--- a/assets/src/edit-story/components/canvas/framesLayer.js
+++ b/assets/src/edit-story/components/canvas/framesLayer.js
@@ -9,7 +9,7 @@ import styled from 'styled-components';
 import { useStory } from '../../app';
 import withOverlay from '../overlay/withOverlay';
 import { Layer, PageArea } from './layout';
-import ElementFrame from './elementFrame';
+import FrameElement from './frameElement';
 import Selection from './selection';
 
 const FramesPageArea = withOverlay( styled( PageArea ).attrs( { className: 'container', pointerEvents: true } )`
@@ -24,7 +24,7 @@ function FramesLayer() {
 			<FramesPageArea>
 				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
 					return (
-						<ElementFrame
+						<FrameElement
 							key={ id }
 							element={ { id, ...rest } }
 						/>

--- a/assets/src/edit-story/components/canvas/index.js
+++ b/assets/src/edit-story/components/canvas/index.js
@@ -1,2 +1,3 @@
 export { default } from './canvas';
 export { default as useCanvas } from './useCanvas';
+export { default as useTransformHandler } from './useTransformHandler';

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -6,10 +6,8 @@ import styled from 'styled-components';
 /**
  * Internal dependencies
  */
-import { PAGE_NAV_WIDTH, LEFT_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT, PAGE_NAV_BUTTON_WIDTH } from '../../constants';
+import { PAGE_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
 import PointerEventsCss from '../../utils/pointerEventsCss';
-
-const PAGE_PADDING = 30;
 
 /**
  * @file See https://user-images.githubusercontent.com/726049/72654503-bfffe780-3944-11ea-912c-fc54d68b6100.png

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -36,15 +36,6 @@ const Layer = styled.div`
     "carousel  carousel  carousel  carousel  carousel" 65px
     / 1fr ${ PAGE_NAV_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_WIDTH }px 1fr;
 `;
-/* QQQQQ
-  --qqqq-grid:
-    ".    .      . .          . .        ." 1fr
-    ".    prev   . page       . next     ." ${ PAGE_HEIGHT }px
-    ".    .      . menu       . .        ." 48px
-    ".    .      . .          . .        ." 1fr
-    ".    carousel      carousel carousel  carousel carousel        ." 60px
-    / 1fr ${ LEFT_NAV_WIDTH }px ${ PAGE_NAV_BUTTON_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_BUTTON_WIDTH }px ${ LEFT_NAV_WIDTH }px 1fr;
-*/
 
 const Area = styled.div`
   ${ PointerEventsCss }

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_NAV_WIDTH, LEFT_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT, PAGE_NAV_BUTTON_WIDTH } from '../../constants';
+import PointerEventsCss from '../../utils/pointerEventsCss';
+
+const PAGE_PADDING = 30;
+
+/**
+ * @file See https://user-images.githubusercontent.com/726049/72654503-bfffe780-3944-11ea-912c-fc54d68b6100.png
+ * for the layering details.
+ */
+
+// @todo: the menu and carousel heights are not correct until we make a var-size
+// page.
+const Layer = styled.div`
+  ${ PointerEventsCss }
+
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  display: grid;
+  grid:
+    ".         .         .         .         .       " minmax(${ PAGE_PADDING }px, 1fr)
+    ".         prev      page      next      .       " ${ PAGE_HEIGHT }px
+    ".         .         menu      .         .       " 48px
+    ".         .         .         .         .       " minmax(${ PAGE_PADDING }px, 1fr)
+    "carousel  carousel  carousel  carousel  carousel" auto
+    / 1fr ${ PAGE_NAV_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_WIDTH }px 1fr;
+  --qqqq-grid:
+    ".    .      . .          . .        ." 1fr
+    ".    prev   . page       . next     ." ${ PAGE_HEIGHT }px
+    ".    .      . menu       . .        ." 48px
+    ".    .      . .          . .        ." 1fr
+    ".    carousel      carousel carousel  carousel carousel        ." 60px
+    / 1fr ${ LEFT_NAV_WIDTH }px ${ PAGE_NAV_BUTTON_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_BUTTON_WIDTH }px ${ LEFT_NAV_WIDTH }px 1fr;
+`;
+
+const Area = styled.div`
+  ${ PointerEventsCss }
+
+  grid-area: ${ ( { area } ) => area };
+  overflow: ${ ( { overflow } ) => overflow ? 'visible' : 'hidden' };
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+// Page area is not `overflow:hidden` by default to allow different clipping
+// mechanisms.
+const PageArea = styled( Area ).attrs( { area: 'page', overflow: true } )``;
+
+const MenuArea = styled( Area ).attrs( { area: 'menu', overflow: false } )``;
+
+const NavArea = styled( Area ).attrs( { overflow: false } )`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const NavPrevArea = styled( NavArea ).attrs( { area: 'prev' } )``;
+
+const NavNextArea = styled( NavArea ).attrs( { area: 'next' } )``;
+
+const CarouselArea = styled( Area ).attrs( { area: 'carousel', overflow: false } )``;
+
+export {
+	Layer,
+	PageArea,
+	MenuArea,
+	NavPrevArea,
+	NavNextArea,
+	CarouselArea,
+};

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -29,12 +29,14 @@ const Layer = styled.div`
 
   display: grid;
   grid:
-    ".         .         .         .         .       " minmax(${ PAGE_PADDING }px, 1fr)
+    ".         .         .         .         .       " 1fr
     ".         prev      page      next      .       " ${ PAGE_HEIGHT }px
     ".         .         menu      .         .       " 48px
-    ".         .         .         .         .       " minmax(${ PAGE_PADDING }px, 1fr)
-    "carousel  carousel  carousel  carousel  carousel" auto
+    ".         .         .         .         .       " 1fr
+    "carousel  carousel  carousel  carousel  carousel" 65px
     / 1fr ${ PAGE_NAV_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_WIDTH }px 1fr;
+`;
+/* QQQQQ
   --qqqq-grid:
     ".    .      . .          . .        ." 1fr
     ".    prev   . page       . next     ." ${ PAGE_HEIGHT }px
@@ -42,7 +44,7 @@ const Layer = styled.div`
     ".    .      . .          . .        ." 1fr
     ".    carousel      carousel carousel  carousel carousel        ." 60px
     / 1fr ${ LEFT_NAV_WIDTH }px ${ PAGE_NAV_BUTTON_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_BUTTON_WIDTH }px ${ LEFT_NAV_WIDTH }px 1fr;
-`;
+*/
 
 const Area = styled.div`
   ${ PointerEventsCss }

--- a/assets/src/edit-story/components/canvas/multiSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/multiSelectionMovable.js
@@ -73,6 +73,7 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 	const resetMoveable = () => {
 		targetList.forEach( ( { id, node }, i ) => {
 			frames[ i ].translate = [ 0, 0 ];
+			frames[ i ].resize = [ 0, 0 ];
 			node.style.transform = '';
 			node.style.width = '';
 			node.style.height = '';
@@ -106,8 +107,8 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 				properties.rotationAngle = frames[ i ].rotate;
 			}
 			if ( isResize ) {
-				properties.width = parseInt( target.style.width );
-				properties.height = parseInt( target.style.height );
+				properties.width = frames[ i ].resize.width;
+				properties.height = frames[ i ].resize.height;
 				const isText = 'text' === targetList[ i ].type;
 				if ( isText ) {
 					properties.fontSize = calculateFitTextFontSize( target.firstChild, properties.height, properties.width );
@@ -177,7 +178,8 @@ function MultiSelectionMovable( { selectedElements, nodesById } ) {
 						target.style.fontSize = calculateFitTextFontSize( target.firstChild, height, width );
 					}
 					sFrame.translate = drag.beforeTranslate;
-					setTransformStyle( target, sFrame );
+					sFrame.resize = [ width, height ];
+					setTransformStyle( targetList[ i ].id, target, sFrame );
 				} );
 			} }
 			onResizeGroupEnd={ ( { targets } ) => {

--- a/assets/src/edit-story/components/canvas/multiSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/multiSelectionMovable.js
@@ -13,8 +13,8 @@ import { useRef, useEffect } from '@wordpress/element';
  */
 import Movable from '../movable';
 import { useStory } from '../../app/story';
-import useCanvas from './useCanvas';
 import calculateFitTextFontSize from '../../utils/calculateFitTextFontSize';
+import useCanvas from './useCanvas';
 
 const CORNER_HANDLES = [ 'nw', 'ne', 'sw', 'se' ];
 

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -3,7 +3,7 @@
  */
 import PageMenu from './pagemenu';
 import PageNav from './pagenav';
-import Carrousel from './carrousel';
+import Carousel from './carousel';
 import {
 	Layer,
 	MenuArea,
@@ -25,7 +25,7 @@ function NavLayer() {
 				<PageNav />
 			</NavNextArea>
 			<CarouselArea pointerEvents={ true }>
-				<Carrousel />
+				<Carousel />
 			</CarouselArea>
 		</Layer>
 	);

--- a/assets/src/edit-story/components/canvas/navLayer.js
+++ b/assets/src/edit-story/components/canvas/navLayer.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import PageMenu from './pagemenu';
+import PageNav from './pagenav';
+import Carrousel from './carrousel';
+import {
+	Layer,
+	MenuArea,
+	NavPrevArea,
+	NavNextArea,
+	CarouselArea,
+} from './layout';
+
+function NavLayer() {
+	return (
+		<Layer pointerEvents={ false } onMouseDown={ ( evt ) => evt.stopPropagation() }>
+			<MenuArea pointerEvents={ true }>
+				<PageMenu />
+			</MenuArea>
+			<NavPrevArea>
+				<PageNav isNext={ false } />
+			</NavPrevArea>
+			<NavNextArea>
+				<PageNav />
+			</NavNextArea>
+			<CarouselArea pointerEvents={ true }>
+				<Carrousel />
+			</CarouselArea>
+		</Layer>
+	);
+}
+
+export default NavLayer;

--- a/assets/src/edit-story/components/canvas/page.js
+++ b/assets/src/edit-story/components/canvas/page.js
@@ -1,3 +1,4 @@
+//QQQQ: rename file to `displayLayer.js`
 /**
  * External dependencies
  */
@@ -7,41 +8,40 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { useStory } from '../../app';
-import withOverlay from '../overlay/withOverlay';
-import Selection from './selection';
 import useCanvas from './useCanvas';
 import Element from './element';
+import { Layer, PageArea } from './layout';
 
-const Background = withOverlay( styled.div.attrs( { className: 'container' } )`
+const DisplayPageArea = styled( PageArea ).attrs( { className: 'container', overflow: false } )`
 	background-color: ${ ( { theme } ) => theme.colors.fg.v1 };
-	position: relative;
-	width: 100%;
-	height: 100%;
-` );
+`;
 
-function Page() {
+function DisplayLayer() {
 	const {
 		state: { currentPage },
 	} = useStory();
-
 	const {
+		state: { editingElement },
 		actions: { setPageContainer },
 	} = useCanvas();
 
 	return (
-		<Background ref={ setPageContainer }>
-			{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
-				return (
-					<Element
-						key={ id }
-						element={ { id, ...rest } }
-					/>
-				);
-			} ) }
-
-			<Selection />
-		</Background>
+		<Layer pointerEvents={ false }>
+			<DisplayPageArea ref={ setPageContainer }>
+				{ currentPage && currentPage.elements.map( ( { id, ...rest } ) => {
+					if ( editingElement === id ) {
+						return null;
+					}
+					return (
+						<Element
+							key={ id }
+							element={ { id, ...rest } }
+						/>
+					);
+				} ) }
+			</DisplayPageArea>
+		</Layer>
 	);
 }
 
-export default Page;
+export default DisplayLayer;

--- a/assets/src/edit-story/components/canvas/pagemenu/index.js
+++ b/assets/src/edit-story/components/canvas/pagemenu/index.js
@@ -30,6 +30,7 @@ const Wrapper = styled.div`
 `;
 
 const Box = styled.div`
+	background-color: ${ ( { theme } ) => theme.colors.bg.v1 };
 	display: flex;
 	flex-direction: row;
 	align-items: center;

--- a/assets/src/edit-story/components/canvas/pagenav/index.js
+++ b/assets/src/edit-story/components/canvas/pagenav/index.js
@@ -21,8 +21,12 @@ const Wrapper = styled.div`
 	display: flex;
 	align-items: center;
 	justify-content: ${ ( { isNext } ) => isNext ? 'flex-end' : 'flex-start' };
-	height: 100%;
 	color:  ${ ( { theme } ) => theme.colors.fg.v1 };
+	width: ${ PAGE_NAV_BUTTON_WIDTH }px;
+	height: ${ PAGE_NAV_BUTTON_WIDTH }px;
+	& > * {
+		pointer-events: initial;
+	}
 `;
 
 function PageNav( { isNext } ) {
@@ -40,7 +44,7 @@ function PageNav( { isNext } ) {
 		'aria-label': isNext ? __( 'Next Page', 'amp' ) : __( 'Previous Page', 'amp' ),
 		onClick: handleClick,
 		width: PAGE_NAV_BUTTON_WIDTH,
-		height: 40,
+		height: PAGE_NAV_BUTTON_WIDTH,
 	};
 	return (
 		<Wrapper isNext={ isNext }>

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -24,23 +24,27 @@ const LassoMode = {
 };
 
 const Container = withOverlay( styled.div`
-  width: 100%;
-  height: 100%;
-  user-select: none;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	width: 100%;
+	height: 100%;
+	user-select: none;
 ` );
 
 const Lasso = styled.div`
-  display: none;
-  position: absolute;
-  border: 1px dotted ${ ( { theme } ) => theme.colors.selection };
-  z-index: 1;
+	display: none;
+	position: absolute;
+	border: 1px dotted ${ ( { theme } ) => theme.colors.selection };
+	z-index: 1;
 `;
 
 function SelectionCanvas( { children } ) {
 	const {
 		actions: { clearSelection },
 	} = useStory();
-
 	const {
 		state: { pageContainer },
 		actions: { clearEditing, selectIntersection },

--- a/assets/src/edit-story/components/canvas/singleSelectionMovable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMovable.js
@@ -13,10 +13,10 @@ import { useRef, useEffect, useState } from '@wordpress/element';
  */
 import { getBox } from '../../elements/shared';
 import { useStory } from '../../app';
-import useCanvas from './useCanvas';
 import Movable from '../movable';
 import calculateFitTextFontSize from '../../utils/calculateFitTextFontSize';
 import getAdjustedElementDimensions from '../../utils/getAdjustedElementDimensions';
+import useCanvas from './useCanvas';
 
 const ALL_HANDLES = [ 'n', 's', 'e', 'w', 'nw', 'ne', 'sw', 'se' ];
 

--- a/assets/src/edit-story/components/canvas/useTransformHandler.js
+++ b/assets/src/edit-story/components/canvas/useTransformHandler.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import useCanvas from './useCanvas';
+
+/**
+ * @param {string} id Target element's id.
+ * @param {function(?Object)} handler The transform handler. The argument is
+ * the frame object. The `null` value resets the transform.
+ * @param {!Array=} deps The effect's dependencies.
+ */
+function useTransformHandler( id, handler, deps = undefined ) {
+	const {
+		actions: { registerTransformHandler },
+	} = useCanvas();
+
+	useEffect(
+		() => registerTransformHandler( id, handler ),
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		deps,
+	);
+}
+
+export default useTransformHandler;

--- a/assets/src/edit-story/components/movable/index.js
+++ b/assets/src/edit-story/components/movable/index.js
@@ -19,6 +19,7 @@ function MovableWithRef( { ...moveableProps }, ref ) {
 	return (
 		<InOverlay
 			zIndex={ DEFAULT_Z_INDEX }
+			pointerEvents={ true }
 			render={ ( { container } ) => {
 				return (
 					<Moveable

--- a/assets/src/edit-story/components/overlay/index.js
+++ b/assets/src/edit-story/components/overlay/index.js
@@ -11,9 +11,11 @@ import { forwardRef, useContext, createPortal } from '@wordpress/element';
 /**
  * Internal dependencies
  */
+import PointerEventsCss from '../../utils/pointerEventsCss';
 import Context from './context';
 
 const Wrapper = styled.div`
+  ${ PointerEventsCss }
   position: absolute;
   top: 0;
   left: 0;
@@ -22,7 +24,7 @@ const Wrapper = styled.div`
   z-index: ${ ( { zIndex } ) => `${ zIndex }` };
 `;
 
-function InOverlayWithRef( { zIndex, render, children }, ref ) {
+function InOverlayWithRef( { zIndex, pointerEvents, render, children }, ref ) {
 	const { container, overlay } = useContext( Context );
 	if ( ! container || ! overlay ) {
 		return null;
@@ -31,6 +33,7 @@ function InOverlayWithRef( { zIndex, render, children }, ref ) {
 		<Wrapper
 			ref={ ref }
 			zIndex={ zIndex || 0 }
+			pointerEvents={ pointerEvents }
 			onMouseDown={ ( evt ) => evt.stopPropagation() }>
 			{ render ? render( { container, overlay } ) : children }
 		</Wrapper>

--- a/assets/src/edit-story/elements/image/frame.js
+++ b/assets/src/edit-story/elements/image/frame.js
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { useCanvas } from '../../components/canvas';
+import useDoubleClick from '../../utils/useDoubleClick';
+import { ElementFillContent } from '../shared';
+
+const Element = styled.div`
+  ${ ElementFillContent }
+`;
+
+function ImageFrame( { id } ) {
+	const {
+		actions: { setEditingElement },
+	} = useCanvas();
+	const handleSingleClick = useCallback( () => {}, [] );
+	const handleDoubleClick = useCallback( () => setEditingElement( id ), [ id, setEditingElement ] );
+	const getHandleClick = useDoubleClick( handleSingleClick, handleDoubleClick );
+	return (
+		<Element onClick={ getHandleClick( id ) } />
+	);
+}
+
+ImageFrame.propTypes = {
+	id: PropTypes.string.isRequired,
+};
+
+export default ImageFrame;

--- a/assets/src/edit-story/elements/image/index.js
+++ b/assets/src/edit-story/elements/image/index.js
@@ -5,12 +5,15 @@ import { PanelTypes } from '../../panels';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
 export { default as Save } from './save';
+export { default as Frame } from './frame';
 export { default as TextContent } from './textContent';
 
 export const defaultAttributes = {
 };
 
 export const hasEditMode = true;
+
+export const editModeGrayout = true;
 
 export const panels = [
 	PanelTypes.SIZE,

--- a/assets/src/edit-story/elements/image/scalePanel.js
+++ b/assets/src/edit-story/elements/image/scalePanel.js
@@ -66,7 +66,7 @@ const ResetButton = styled.button`
 
 function ScalePanel( { setProperties, width, height, x, y, scale } ) {
 	return (
-		<InOverlay zIndex={ Z_INDEX_CANVAS.FLOAT_PANEL }>
+		<InOverlay zIndex={ Z_INDEX_CANVAS.FLOAT_PANEL } pointerEvents={ true } >
 			<Container x={ x } y={ y } width={ width } height={ height } >
 				<Range
 					value={ scale }

--- a/assets/src/edit-story/elements/image/util.js
+++ b/assets/src/edit-story/elements/image/util.js
@@ -10,6 +10,12 @@ export const ImageWithScale = css`
 	top: ${ ( { offsetY } ) => `${ -offsetY }px` };
 `;
 
+export function getImageWithScaleCss( { width, height, offsetX, offsetY } ) {
+	// todo@: This is a complete duplication of `ImageWithScale` above. But
+	// no other apparent way to execute interpolate `ImageWithScale` dynamically.
+	return `width:${ width }px; height:${ height }px; left:${ -offsetX }px; top:${ -offsetY }px;`;
+}
+
 export function getImgProps( width, height, scale, focalX, focalY, imgRatio ) {
 	const ratio = width / height;
 	scale = Math.max( scale || 100, 100 );

--- a/assets/src/edit-story/elements/text/display.js
+++ b/assets/src/edit-story/elements/text/display.js
@@ -7,14 +7,12 @@ import styled from 'styled-components';
 /**
  * WordPress dependencies
  */
-import { useRef, useEffect, useCallback, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import getCaretCharacterOffsetWithin from '../../utils/getCaretCharacterOffsetWithin';
-import { useStory, useFont } from '../../app';
-import { useCanvas } from '../../components/canvas';
+import { useFont } from '../../app';
 import {
 	ElementFillContent,
 	ElementWithFont,
@@ -31,21 +29,12 @@ const Element = styled.p`
 	${ ElementWithBackgroundColor }
 	${ ElementWithFontColor }
 	${ ElementWithStyle }
-
-	user-select: ${ ( { canSelect } ) => canSelect ? 'initial' : 'none' };
-
-	&:focus {
-		outline: none;
-	}
 `;
 
 function TextDisplay( {
-	id,
 	content,
 	color,
 	backgroundColor,
-	width,
-	height,
 	fontFamily,
 	fontFallback,
 	fontSize,
@@ -67,95 +56,18 @@ function TextDisplay( {
 		letterSpacing,
 		lineHeight,
 		padding,
-		width,
-		height,
 		textAlign,
 	};
 	const {
-		state: { selectedElementIds },
-	} = useStory();
-	const {
 		actions: { maybeEnqueueFontStyle },
 	} = useFont();
-
-	const {
-		actions: { setEditingElement, setEditingElementWithState },
-	} = useCanvas();
-	const isElementSelected = selectedElementIds.includes( id );
-	const isElementOnlySelection = isElementSelected && selectedElementIds.length === 1;
-	const [ hasFocus, setHasFocus ] = useState( false );
-	useEffect( () => {
-		if ( isElementOnlySelection ) {
-			const timeout = window.setTimeout( setHasFocus, 300, true );
-			return () => {
-				window.clearTimeout( timeout );
-			};
-		}
-
-		clickTime.current = 0;
-		setHasFocus( false );
-		return undefined;
-	}, [ isElementOnlySelection ] );
 
 	useEffect( () => {
 		maybeEnqueueFontStyle( fontFamily );
 	}, [ fontFamily, maybeEnqueueFontStyle ] );
 
-	const clickTime = useRef();
-	const handleMouseDown = useCallback( () => {
-		clickTime.current = window.performance.now();
-	}, [] );
-	const handleMouseUp = useCallback( ( evt ) => {
-		const timingDifference = window.performance.now() - clickTime.current;
-		if ( timingDifference > 100 ) {
-			// Only short clicks count
-			return;
-		}
-		// Enter editing mode and place cursor at current selection offset
-		evt.stopPropagation();
-		setEditingElementWithState( id, { offset: getCaretCharacterOffsetWithin( element.current, evt.clientX, evt.clientY ) } );
-	}, [ id, setEditingElementWithState ] );
-
-	const handleKeyDown = ( evt ) => {
-		if ( evt.metaKey || evt.altKey || evt.ctrlKey ) {
-			// Some modifier (except shift) was pressed. Ignore and bubble
-			return;
-		}
-
-		if ( evt.key === 'Enter' ) {
-			// Enter editing without writing or selecting anything
-			setEditingElement( id );
-			evt.stopPropagation();
-			// Make sure no actual Enter is pressed
-			evt.preventDefault();
-		} else if ( /^\w$/.test( evt.key ) ) {
-			// TODO: in above check all printable characters across alphabets, no just a-z0-9 as \w is
-			// Enter editing and clear content (first letter will be correctly inserted from keyup)
-			setEditingElementWithState( id, { clearContent: true } );
-			evt.stopPropagation();
-		}
-
-		// ignore everything else and bubble.
-	};
-
-	if ( hasFocus ) {
-		props.onKeyDown = handleKeyDown;
-		props.onMouseDown = handleMouseDown;
-		props.onMouseUp = handleMouseUp;
-		props.tabIndex = 0;
-	}
-
-	const element = useRef();
-	useEffect( () => {
-		if ( isElementOnlySelection && element.current ) {
-			element.current.focus();
-		}
-	}, [ isElementOnlySelection ] );
-
 	return (
 		<Element
-			canSelect={ hasFocus }
-			ref={ element }
 			dangerouslySetInnerHTML={ { __html: content } }
 			{ ...props }
 		/>
@@ -163,7 +75,6 @@ function TextDisplay( {
 }
 
 TextDisplay.propTypes = {
-	id: PropTypes.string.isRequired,
 	content: PropTypes.string,
 	color: PropTypes.string,
 	backgroundColor: PropTypes.string,
@@ -178,9 +89,6 @@ TextDisplay.propTypes = {
 	] ),
 	lineHeight: PropTypes.number,
 	padding: PropTypes.number,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	setClickHandler: PropTypes.func,
 	textAlign: PropTypes.string,
 };
 

--- a/assets/src/edit-story/elements/text/frame.js
+++ b/assets/src/edit-story/elements/text/frame.js
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+/**
+ * WordPress dependencies
+ */
+import { useRef, useEffect, useCallback, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import getCaretCharacterOffsetWithin from '../../utils/getCaretCharacterOffsetWithin';
+import { useStory } from '../../app';
+import { useCanvas } from '../../components/canvas';
+import {
+	ElementFillContent,
+	ElementWithFont,
+	ElementWithBackgroundColor,
+	ElementWithFontColor,
+} from '../shared';
+import { generateFontFamily } from './util';
+
+const Element = styled.p`
+  margin: 0;
+  ${ ElementFillContent }
+  ${ ElementWithFont }
+  ${ ElementWithBackgroundColor }
+  ${ ElementWithFontColor }
+
+  opacity: 0;
+  user-select: ${ ( { canSelect } ) => canSelect ? 'initial' : 'none' };
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+function TextFrame( { id, content, color, backgroundColor, width, height, fontFamily, fontFallback, fontSize, fontWeight, fontStyle } ) {
+	const props = {
+		color,
+		backgroundColor,
+		fontFamily: generateFontFamily( fontFamily, fontFallback ),
+		fontFallback,
+		fontStyle,
+		fontSize,
+		fontWeight,
+		width,
+		height,
+	};
+	const {
+		state: { selectedElementIds },
+	} = useStory();
+
+	const {
+		actions: { setEditingElement, setEditingElementWithState },
+	} = useCanvas();
+	const isElementSelected = selectedElementIds.includes( id );
+	const isElementOnlySelection = isElementSelected && selectedElementIds.length === 1;
+	const [ hasFocus, setHasFocus ] = useState( false );
+	useEffect( () => {
+		if ( isElementOnlySelection ) {
+			const timeout = window.setTimeout( setHasFocus, 300, true );
+			return () => {
+				window.clearTimeout( timeout );
+			};
+		}
+
+		clickTime.current = 0;
+		setHasFocus( false );
+		return undefined;
+	}, [ isElementOnlySelection ] );
+
+	const clickTime = useRef();
+	const handleMouseDown = useCallback( () => {
+		clickTime.current = window.performance.now();
+	}, [] );
+	const handleMouseUp = useCallback( ( evt ) => {
+		const timingDifference = window.performance.now() - clickTime.current;
+		if ( timingDifference > 100 ) {
+			// Only short clicks count
+			return;
+		}
+		// Enter editing mode and place cursor at current selection offset
+		evt.stopPropagation();
+		setEditingElementWithState( id, { offset: getCaretCharacterOffsetWithin( element.current, evt.clientX, evt.clientY ) } );
+	}, [ id, setEditingElementWithState ] );
+
+	const handleKeyDown = ( evt ) => {
+		if ( evt.metaKey || evt.altKey || evt.ctrlKey ) {
+			// Some modifier (except shift) was pressed. Ignore and bubble
+			return;
+		}
+
+		if ( evt.key === 'Enter' ) {
+			// Enter editing without writing or selecting anything
+			setEditingElement( id );
+			evt.stopPropagation();
+			// Make sure no actual Enter is pressed
+			evt.preventDefault();
+		} else if ( /^\w$/.test( evt.key ) ) {
+			// TODO: in above check all printable characters across alphabets, no just a-z0-9 as \w is
+			// Enter editing and clear content (first letter will be correctly inserted from keyup)
+			setEditingElementWithState( id, { clearContent: true } );
+			evt.stopPropagation();
+		}
+
+		// ignore everything else and bubble.
+	};
+
+	if ( hasFocus ) {
+		props.onKeyDown = handleKeyDown;
+		props.onMouseDown = handleMouseDown;
+		props.onMouseUp = handleMouseUp;
+		props.tabIndex = 0;
+	}
+
+	const element = useRef();
+	useEffect( () => {
+		if ( isElementOnlySelection && element.current ) {
+			element.current.focus();
+		}
+	}, [ isElementOnlySelection ] );
+
+	return (
+		<Element
+			canSelect={ hasFocus }
+			ref={ element }
+			dangerouslySetInnerHTML={ { __html: content } }
+			{ ...props }
+		/>
+	);
+}
+
+TextFrame.propTypes = {
+	id: PropTypes.string.isRequired,
+	content: PropTypes.string,
+	color: PropTypes.string,
+	backgroundColor: PropTypes.string,
+	fontFamily: PropTypes.string,
+	fontFallback: PropTypes.array,
+	fontSize: PropTypes.number,
+	fontWeight: PropTypes.number,
+	fontStyle: PropTypes.string,
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+	setClickHandler: PropTypes.func,
+};
+
+export default TextFrame;

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -4,6 +4,7 @@
 import { PanelTypes } from '../../panels';
 export { default as Display } from './display';
 export { default as Edit } from './edit';
+export { default as Frame } from './frame';
 export { default as Save } from './save';
 export { default as TextContent } from './textContent';
 

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -34,6 +34,8 @@ const theme = {
 		action: '#47A0F4',
 		danger: '#FF0000',
 		selection: '#44aaff',
+		grayout: 'rgba(0, 0, 0, 0.5)',
+		whiteout: 'rgba(255, 255, 255, 0.5)',
 	},
 	fonts: {
 		body1: {

--- a/assets/src/edit-story/utils/pointerEventsCss.js
+++ b/assets/src/edit-story/utils/pointerEventsCss.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { css } from 'styled-components';
+
+const PointerEventsCss = css`
+  ${ ( { pointerEvents } ) => {
+		if ( typeof pointerEvents === 'boolean' ) {
+			return `pointer-events: ${ pointerEvents ? 'initial' : 'none' };`;
+		}
+		if ( typeof pointerEvents === 'string' && pointerEvents ) {
+			return `pointer-events: ${ pointerEvents };`;
+		}
+		return '';
+	} }
+`;
+
+export default PointerEventsCss;


### PR DESCRIPTION
## Summary

Supersedes #4110. This is a major redo of the workspace layering to support new "Anatomy of the workspace" in designs (/cc @samitron7). The current state is very preliminary to get the feedback ASAP. Many features are still broken.

The following layering has been implemented:
![WP Story editor](https://user-images.githubusercontent.com/726049/72654503-bfffe780-3944-11ea-912c-fc54d68b6100.png)

This might seem complicated, but this is the most straightforward way I see at this moment that supports the needed features, while being less fragile overall. Key notes here:

* Layers are layered on top of each other using `position:absolute; inset:0`.
* All layers use the same `grid-template` to ensure that the positions of the areas always match.
* Lasso layer is at the very bottom to allow lasso to start on the page's area and outside of it.
* Display area is right on top of lasso layer.
* Critically, the display area is now clipped to borders (`overflow:hidden`). And element overflowing off the side of the page is no longer displayed.
* Tools layer (`NavLayer` in code) overlays the headers, footers, menus on top of the display area. The event propagation is blocked to avoid lasso.
* Frames & selection are on top of both display and tools. Per spec, frames and selection has to be shown on top of everything else in the workplace (i.e. never clipped). The frames and selection are also selectable/interactable outside the page area, even if on top of other workspace elements.
* Frames also show outline on hover. The gray outline is only for debugging. Note that frames are not obscured by other elements either.
* `Display` templates are split into two categories: `Display` and `Frame`. `Display` is only to render the element: all event handlers are removed. `Frame` would normally only render the outline, but it handles all events (focus, mouse, keyboard).
* Edit layer now moves the `Edit` mode into a separate layer. This is done so that the editing element is always on top and we can, when needed, show graypane over the workspace, safe/unsafe area, etc - as requested by the UX.

You can see the actual layers by changing `DEBUG_ANGLE` constant to a non-zero value, e.g. `const DEBUG_ANGLE = 60;`.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
