### PR TITLE
Load roboto the old fashioned way.

### DIFF
--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -402,8 +402,8 @@ class AMP_Story_Post_Type {
 	 */
 	public static function load_admin_fonts( $post ) {
 		$post_story_data = json_decode( $post->post_content_filtered, true );
-		$fonts           = [];
-		$font_slugs      = [];
+		$fonts           = [ AMP_Fonts::get_font( 'Roboto' ) ];
+		$font_slugs      = ['roboto'];
 		if ( $post_story_data ) {
 			foreach ( $post_story_data as $page ) {
 				foreach ( $page['elements'] as $element ) {

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -403,7 +403,7 @@ class AMP_Story_Post_Type {
 	public static function load_admin_fonts( $post ) {
 		$post_story_data = json_decode( $post->post_content_filtered, true );
 		$fonts           = [ AMP_Fonts::get_font( 'Roboto' ) ];
-		$font_slugs      = ['roboto'];
+		$font_slugs      = [ 'roboto' ];
 		if ( $post_story_data ) {
 			foreach ( $post_story_data as $page ) {
 				foreach ( $page['elements'] as $element ) {
@@ -414,17 +414,16 @@ class AMP_Story_Post_Type {
 					}
 				}
 			}
-
-			if ( $fonts ) {
-				foreach ( $fonts as $font ) {
-					if ( isset( $font['src'] ) && $font['src'] ) {
-						wp_enqueue_style(
-							$font['handle'],
-							$font['src'],
-							[],
-							AMP__VERSION
-						);
-					}
+		}
+		if ( $fonts ) {
+			foreach ( $fonts as $font ) {
+				if ( isset( $font['src'] ) && $font['src'] ) {
+					wp_enqueue_style(
+						$font['handle'],
+						$font['src'],
+						[],
+						AMP__VERSION
+					);
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Fixes font styling issue as roboto is not loaded. Introduced in #4120

![Screenshot 2020-01-20 at 10 57 53](https://user-images.githubusercontent.com/237508/72721607-5a923d80-3b74-11ea-8284-5a63b104aad9.png)


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
