### PR TITLE
Allow opting-out of AMP-to-AMP links, ensure 'Exit Reader Mode' link is non-AMP

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -928,7 +928,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		$sanitizers['AMP_Nav_Menu_Dropdown_Sanitizer'] = $theme_support_args['nav_menu_dropdown'];
 	}
 
-	if ( $amp_to_amp_linking_enabled ) {
+	if ( $amp_to_amp_linking_enabled && AMP_Theme_Support::STANDARD_MODE_SLUG !== AMP_Theme_Support::get_support_mode() ) {
 
 		/**
 		 * Filters the list of URLs which are excluded from being included in AMP-to-AMP linking.

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -929,9 +929,20 @@ function amp_get_content_sanitizers( $post = null ) {
 	}
 
 	if ( $amp_to_amp_linking_enabled ) {
-		$sanitizers['AMP_Link_Sanitizer'] = [
-			'paired' => ! amp_is_canonical(),
-		];
+
+		/**
+		 * Normally, when in a paired mode, links to the same origin will be to AMP.
+		 *
+		 * This allows passing URLs to exclude from having AMP-to-AMP links.
+		 *
+		 * @param string[] The URLs to exclude from having AMP-to-AMP links.
+		 */
+		$excluded_amp_links = apply_filters( 'excluded_links_from_amp_to_amp', [] );
+
+		$sanitizers['AMP_Link_Sanitizer'] = array_merge(
+			[ 'paired' => ! amp_is_canonical() ],
+			compact( 'excluded_amp_links' )
+		);
 	}
 
 	/**

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -938,6 +938,8 @@ function amp_get_content_sanitizers( $post = null ) {
 		 * when in Reader mode. This does not apply in Standard mode.
 		 * Only frontend URLs on the frontend need be excluded, as all other URLs are never made into AMP links.
 		 *
+		 * @since 1.5.0
+		 *
 		 * @param string[] The URLs to exclude from having AMP-to-AMP links.
 		 */
 		$excluded_urls = apply_filters( 'amp_to_amp_excluded_urls', [] );

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -937,7 +937,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		 *
 		 * @param string[] The URLs to exclude from having AMP-to-AMP links.
 		 */
-		$excluded_amp_links = apply_filters( 'excluded_links_from_amp_to_amp', [] );
+		$excluded_amp_links = apply_filters( 'amp_to_amp_excluded_links', [] );
 
 		$sanitizers['AMP_Link_Sanitizer'] = array_merge(
 			[ 'paired' => ! amp_is_canonical() ],

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -931,9 +931,12 @@ function amp_get_content_sanitizers( $post = null ) {
 	if ( $amp_to_amp_linking_enabled ) {
 
 		/**
-		 * Normally, when in a paired mode, links to the same origin will be to AMP.
+		 * Filters the list of URLs which are excluded from being included in AMP-to-AMP linking.
 		 *
-		 * This allows passing URLs to exclude from having AMP-to-AMP links.
+		 * This only applies when the amp_to_amp_linking_enabled filter returns true,
+		 * which it does by default in Transitional mode. This filter can be used to opt-in
+		 * when in Reader mode. This does not apply in Standard mode.
+		 * Only frontend URLs on the frontend need be excluded, as all other URLs are never made into AMP links.
 		 *
 		 * @param string[] The URLs to exclude from having AMP-to-AMP links.
 		 */

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -940,11 +940,11 @@ function amp_get_content_sanitizers( $post = null ) {
 		 *
 		 * @param string[] The URLs to exclude from having AMP-to-AMP links.
 		 */
-		$excluded_amp_links = apply_filters( 'amp_to_amp_excluded_urls', [] );
+		$excluded_urls = apply_filters( 'amp_to_amp_excluded_urls', [] );
 
 		$sanitizers['AMP_Link_Sanitizer'] = array_merge(
 			[ 'paired' => ! amp_is_canonical() ],
-			compact( 'excluded_amp_links' )
+			compact( 'excluded_urls' )
 		);
 	}
 

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -940,7 +940,7 @@ function amp_get_content_sanitizers( $post = null ) {
 		 *
 		 * @param string[] The URLs to exclude from having AMP-to-AMP links.
 		 */
-		$excluded_amp_links = apply_filters( 'amp_to_amp_excluded_links', [] );
+		$excluded_amp_links = apply_filters( 'amp_to_amp_excluded_urls', [] );
 
 		$sanitizers['AMP_Link_Sanitizer'] = array_merge(
 			[ 'paired' => ! amp_is_canonical() ],

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -149,11 +149,10 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			$href           = $element->getAttribute( 'href' );
-			$rel            = $element->hasAttribute( 'rel' ) ? trim( $element->getAttribute( 'rel' ) ) : '';
-			$is_rel_non_amp = self::REL_VALUE_NON_AMP_TO_AMP === $rel;
+			$href = $element->getAttribute( 'href' );
+			$rel  = $element->hasAttribute( 'rel' ) ? trim( $element->getAttribute( 'rel' ) ) : '';
 
-			if ( $is_rel_non_amp ) {
+			if ( self::REL_VALUE_NON_AMP_TO_AMP === $rel ) {
 				// This value is to opt-out of AMP-to-AMP links, so strip it and ensure the link is to non-AMP.
 				$element->removeAttribute( 'rel' );
 			} elseif (

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -56,7 +56,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	protected $DEFAULT_ARGS = [ // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 		'paired'             => false, // Only set to true when in a paired mode (will be false when amp_is_canonical()). Controls whether query var is added.
 		'meta_content'       => self::DEFAULT_META_CONTENT,
-		'excluded_amp_links' => [], // URLs in this won't have AMP-to-AMP links in paired mode.
+		'excluded_amp_links' => [], // URLs in this won't have AMP-to-AMP links in a paired mode.
 	];
 
 	/**
@@ -156,14 +156,10 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 			if ( $is_rel_non_amp ) {
 				// This value is to opt-out of AMP-to-AMP links, so strip it and ensure the link is to non-AMP.
 				$element->removeAttribute( 'rel' );
-			}
-
-			if (
+			} elseif (
 				$this->is_frontend_url( $href )
 				&&
 				'#' !== substr( $href, 0, 1 )
-				&&
-				! $is_rel_non_amp
 				&&
 				! in_array( $href, $this->args['excluded_amp_links'], true )
 			) {

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -56,7 +56,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	protected $DEFAULT_ARGS = [ // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 		'paired'             => false, // Only set to true when in a paired mode (will be false when amp_is_canonical()). Controls whether query var is added.
 		'meta_content'       => self::DEFAULT_META_CONTENT,
-		'excluded_amp_links' => [], // URLs in this won't have AMP-to-AMP links in a paired mode.
+		'excluded_urls' => [], // URLs in this won't have AMP-to-AMP links in a paired mode.
 	];
 
 	/**
@@ -165,7 +165,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 				&&
 				'#' !== substr( $href, 0, 1 )
 				&&
-				! in_array( $href, $this->args['excluded_amp_links'], true )
+				! in_array( $href, $this->args['excluded_urls'], true )
 			) {
 				// Always add the amphtml link relation when linking enabled.
 				array_push( $rel, self::REL_VALUE_AMP );

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -151,7 +151,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 
 			$href = $element->getAttribute( 'href' );
 			$rel  = $element->hasAttribute( 'rel' ) ? array_filter( preg_split( '/\s+/', $element->getAttribute( 'rel' ) ) ) : [];
-			$pos  = array_search( self::REL_VALUE_NON_AMP_TO_AMP, $rel );
+			$pos  = array_search( self::REL_VALUE_NON_AMP_TO_AMP, $rel, true );
 			if ( false !== $pos ) {
 				// The rel has a value to opt-out of AMP-to-AMP links, so strip it and ensure the link is to non-AMP.
 				unset( $rel[ $pos ] );

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -165,7 +165,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 				&&
 				'#' !== substr( $href, 0, 1 )
 				&&
-				! in_array( $href, $this->args['excluded_urls'], true )
+				! in_array( strtok( $href, '#' ), $this->args['excluded_urls'], true )
 			) {
 				// Always add the amphtml link relation when linking enabled.
 				array_push( $rel, self::REL_VALUE_AMP );

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -46,7 +46,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @var string
 	 */
-	const REL_VALUE_NON_AMP_TO_AMP = 'not-amphtml';
+	const REL_VALUE_NON_AMP_TO_AMP = 'noamphtml';
 
 	/**
 	 * Placeholder for default arguments, to be set in child classes.

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -41,7 +41,7 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * The rel attribute value that will force non-AMP links.
 	 *
-	 * Normally, in Paired mode, links to the same origin will be for AMP.
+	 * Normally, in a paired mode, links to the same origin will be for AMP.
 	 * But by adding this rel value, the link will be to non-AMP.
 	 *
 	 * @var string
@@ -54,8 +54,9 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [ // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
-		'paired'       => false, // Only set to true when in a paired mode (will be false when amp_is_canonical()). Controls whether query var is added.
-		'meta_content' => self::DEFAULT_META_CONTENT,
+		'paired'             => false, // Only set to true when in a paired mode (will be false when amp_is_canonical()). Controls whether query var is added.
+		'meta_content'       => self::DEFAULT_META_CONTENT,
+		'excluded_amp_links' => [], // URLs in this won't have AMP-to-AMP links in paired mode.
 	];
 
 	/**
@@ -157,7 +158,15 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 				$element->removeAttribute( 'rel' );
 			}
 
-			if ( $this->is_frontend_url( $href ) && '#' !== substr( $href, 0, 1 ) && ! $is_rel_non_amp ) {
+			if (
+				$this->is_frontend_url( $href )
+				&&
+				'#' !== substr( $href, 0, 1 )
+				&&
+				! $is_rel_non_amp
+				&&
+				! in_array( $href, $this->args['excluded_amp_links'], true )
+			) {
 				// Always add the amphtml link relation when linking enabled.
 				$rel = empty( $rel ) ? self::REL_VALUE_AMP : $rel . ' ' . self::REL_VALUE_AMP;
 				$element->setAttribute( 'rel', $rel );

--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -54,8 +54,8 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	 * @var array
 	 */
 	protected $DEFAULT_ARGS = [ // phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
-		'paired'             => false, // Only set to true when in a paired mode (will be false when amp_is_canonical()). Controls whether query var is added.
-		'meta_content'       => self::DEFAULT_META_CONTENT,
+		'paired'        => false, // Only set to true when in a paired mode (will be false when amp_is_canonical()). Controls whether query var is added.
+		'meta_content'  => self::DEFAULT_META_CONTENT,
 		'excluded_urls' => [], // URLs in this won't have AMP-to-AMP links in a paired mode.
 	];
 

--- a/templates/header-bar.php
+++ b/templates/header-bar.php
@@ -34,7 +34,7 @@
 		<?php $canonical_link_url = $this->get( 'post_canonical_link_url' ); ?>
 		<?php if ( $canonical_link_url ) : ?>
 			<?php $canonical_link_text = $this->get( 'post_canonical_link_text' ); ?>
-			<a class="amp-wp-canonical-link" rel="not-amphtml" href="<?php echo esc_url( $canonical_link_url ); ?>">
+			<a class="amp-wp-canonical-link" rel="noamphtml" href="<?php echo esc_url( $canonical_link_url ); ?>">
 				<?php echo esc_html( $canonical_link_text ); ?>
 			</a>
 		<?php endif; ?>

--- a/templates/header-bar.php
+++ b/templates/header-bar.php
@@ -34,7 +34,7 @@
 		<?php $canonical_link_url = $this->get( 'post_canonical_link_url' ); ?>
 		<?php if ( $canonical_link_url ) : ?>
 			<?php $canonical_link_text = $this->get( 'post_canonical_link_text' ); ?>
-			<a class="amp-wp-canonical-link" href="<?php echo esc_url( $canonical_link_url ); ?>">
+			<a class="amp-wp-canonical-link" rel="not-amphtml" href="<?php echo esc_url( $canonical_link_url ); ?>">
 				<?php echo esc_html( $canonical_link_text ); ?>
 			</a>
 		<?php endif; ?>

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -839,7 +839,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		$excluded_urls = [ 'https://baz.com', 'https://example.com/one' ];
 		add_filter(
-			'amp_to_amp_excluded_links',
+			'amp_to_amp_excluded_urls',
 			static function() use ( $excluded_urls ) {
 				return $excluded_urls;
 			}

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -839,7 +839,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		$excluded_urls = [ 'https://baz.com', 'https://example.com/one' ];
 		add_filter(
-			'excluded_links_from_amp_to_amp',
+			'amp_to_amp_excluded_links',
 			static function() use ( $excluded_urls ) {
 				return $excluded_urls;
 			}

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -832,7 +832,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'paired'             => true,
-				'excluded_amp_links' => [],
+				'excluded_urls' => [],
 			],
 			$sanitizers[ $link_sanitizer_class_name ]
 		);
@@ -850,7 +850,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'paired'             => true,
-				'excluded_amp_links' => $excluded_urls,
+				'excluded_urls' => $excluded_urls,
 			],
 			$sanitizers[ $link_sanitizer_class_name ]
 		);

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -820,10 +820,13 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	 */
 	public function test_amp_get_content_sanitizers_amp_to_amp() {
 		$link_sanitizer_class_name = 'AMP_Link_Sanitizer';
+
+		// If AMP-to-AMP linking isn't enabled, this sanitizer shouldn't be present.
 		add_filter( 'amp_to_amp_linking_enabled', '__return_false' );
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertArrayNotHasKey( $link_sanitizer_class_name, $sanitizers );
 
+		// Now that AMP-to-AMP linking is enabled, this sanitizer should be present.
 		add_filter( 'amp_to_amp_linking_enabled', '__return_true' );
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertEquals(
@@ -842,6 +845,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			}
 		);
 
+		// The excluded URLs passed to the filter should be present in the sanitizer.
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertEquals(
 			[

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -814,6 +814,45 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test AMP-to-AMP linking.
+	 *
+	 * @covers ::amp_get_content_sanitizers()
+	 */
+	public function test_amp_get_content_sanitizers_amp_to_amp() {
+		$link_sanitizer_class_name = 'AMP_Link_Sanitizer';
+		add_filter( 'amp_to_amp_linking_enabled', '__return_false' );
+		$sanitizers = amp_get_content_sanitizers();
+		$this->assertArrayNotHasKey( $link_sanitizer_class_name, $sanitizers );
+
+		add_filter( 'amp_to_amp_linking_enabled', '__return_true' );
+		$sanitizers = amp_get_content_sanitizers();
+		$this->assertEquals(
+			[
+				'paired'             => true,
+				'excluded_amp_links' => [],
+			],
+			$sanitizers[ $link_sanitizer_class_name ]
+		);
+
+		$excluded_urls = [ 'https://baz.com', 'https://example.com/one' ];
+		add_filter(
+			'excluded_links_from_amp_to_amp',
+			static function() use ( $excluded_urls ) {
+				return $excluded_urls;
+			}
+		);
+
+		$sanitizers = amp_get_content_sanitizers();
+		$this->assertEquals(
+			[
+				'paired'             => true,
+				'excluded_amp_links' => $excluded_urls,
+			],
+			$sanitizers[ $link_sanitizer_class_name ]
+		);
+	}
+
+	/**
 	 * Test post_supports_amp().
 	 *
 	 * @covers ::post_supports_amp()

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -831,7 +831,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertEquals(
 			[
-				'paired'             => true,
+				'paired'        => true,
 				'excluded_urls' => [],
 			],
 			$sanitizers[ $link_sanitizer_class_name ]
@@ -849,7 +849,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$sanitizers = amp_get_content_sanitizers();
 		$this->assertEquals(
 			[
-				'paired'             => true,
+				'paired'        => true,
 				'excluded_urls' => $excluded_urls,
 			],
 			$sanitizers[ $link_sanitizer_class_name ]

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -47,53 +47,71 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 		);
 
 		$links = [
-			'home-link'         => [
+			'home-link'           => [
 				'href'         => home_url( '/' ),
 				'expected_amp' => true,
 				'expected_rel' => 'amphtml',
 			],
-			'internal-link'     => [
+			'internal-link'       => [
 				'href'         => get_permalink( $post_to_link_to ),
 				'expected_amp' => true,
 				'expected_rel' => 'amphtml',
 			],
-			'ugc-link'          => [
+			'non_amp_to_amp_rel'  => [
+				'href'         => get_permalink( $post_to_link_to ),
+				'expected_amp' => false,
+				'rel'          => 'not-amphtml',
+				'expected_rel' => null,
+			],
+			'rel_trailing_space'  => [
+				'href'         => get_permalink( $post_to_link_to ),
+				'expected_amp' => false,
+				'rel'          => 'not-amphtml ',
+				'expected_rel' => null,
+			],
+			'ugc-link'            => [
 				'rel'          => 'ugc',
 				'href'         => home_url( '/some/user/generated/data/' ),
 				'expected_amp' => true,
 				'expected_rel' => 'ugc amphtml',
 			],
-			'page-anchor'       => [
+			'page-anchor'         => [
 				'href'         => '#top',
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
-			'other-page-anchor' => [
+			'other-page-anchor'   => [
 				'href'         => get_permalink( $post_to_link_to ) . '#top',
 				'expected_amp' => true,
 				'expected_rel' => 'amphtml',
 			],
-			'external-link'     => [
+			'external-link'       => [
 				'href'         => 'https://external.example.com/',
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
-			'php-file-link'     => [
+			'non_amp_rel_removed' => [
+				'href'         => 'https://external.example.com/',
+				'expected_amp' => false,
+				'rel'          => 'not-amphtml',
+				'expected_rel' => null,
+			],
+			'php-file-link'       => [
 				'href'         => site_url( '/wp-login.php' ),
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
-			'feed-link'         => [
+			'feed-link'           => [
 				'href'         => get_feed_link(),
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
-			'admin-link'        => [
+			'admin-link'          => [
 				'href'         => admin_url( 'options-general.php?page=some-plugin' ),
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
-			'image-link'        => [
+			'image-link'          => [
 				'href'         => content_url( '/some-image.jpg' ),
 				'expected_amp' => false,
 				'expected_rel' => null,

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -67,6 +67,18 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 				'rel'          => 'not-amphtml',
 				'expected_rel' => null,
 			],
+			'two_rel'             => [
+				'href'         => $post_link,
+				'expected_amp' => false,
+				'rel'          => 'help not-amphtml',
+				'expected_rel' => 'help',
+			],
+			'multiple_rel'        => [
+				'href'         => $post_link,
+				'expected_amp' => false,
+				'rel'          => 'not-amphtml nofollow help',
+				'expected_rel' => 'nofollow help',
+			],
 			'rel_trailing_space'  => [
 				'href'         => $post_link,
 				'expected_amp' => false,

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -64,25 +64,25 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 			'non_amp_to_amp_rel'  => [
 				'href'         => $post_link,
 				'expected_amp' => false,
-				'rel'          => 'not-amphtml',
+				'rel'          => 'noamphtml',
 				'expected_rel' => null,
 			],
 			'two_rel'             => [
 				'href'         => $post_link,
 				'expected_amp' => false,
-				'rel'          => 'help not-amphtml',
+				'rel'          => 'help noamphtml',
 				'expected_rel' => 'help',
 			],
 			'multiple_rel'        => [
 				'href'         => $post_link,
 				'expected_amp' => false,
-				'rel'          => 'not-amphtml nofollow help',
+				'rel'          => 'noamphtml nofollow help',
 				'expected_rel' => 'nofollow help',
 			],
 			'rel_trailing_space'  => [
 				'href'         => $post_link,
 				'expected_amp' => false,
-				'rel'          => 'not-amphtml ',
+				'rel'          => 'noamphtml ',
 				'expected_rel' => null,
 			],
 			'excluded_amp_link'   => [
@@ -114,7 +114,7 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 			'non_amp_rel_removed' => [
 				'href'         => 'https://external.example.com/',
 				'expected_amp' => false,
-				'rel'          => 'not-amphtml',
+				'rel'          => 'noamphtml',
 				'expected_rel' => null,
 			],
 			'php-file-link'       => [

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -48,7 +48,7 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 			)
 		);
 		$excluded_amp_link  = get_permalink( self::factory()->post->create() );
-		$excluded_amp_links = [ $excluded_amp_link ];
+		$excluded_urls      = [ $excluded_amp_link ];
 
 		$links = [
 			'home-link'           => [
@@ -155,7 +155,7 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 
 		$dom = AMP_DOM_Utils::get_dom_from_content( $html );
 
-		$sanitizer = new AMP_Link_Sanitizer( $dom, compact( 'paired', 'excluded_amp_links' ) );
+		$sanitizer = new AMP_Link_Sanitizer( $dom, compact( 'paired', 'excluded_urls' ) );
 		$sanitizer->sanitize();
 
 		// Confirm admin bar is unchanged.

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -90,6 +90,11 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
+			'fragment_identifier' => [
+				'href'         => $excluded_amp_link . '#heading',
+				'expected_amp' => false,
+				'expected_rel' => null,
+			],
 			'ugc-link'            => [
 				'rel'          => 'ugc',
 				'href'         => home_url( '/some/user/generated/data/' ),

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -38,7 +38,7 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 		$wp_rewrite->init();
 		$wp_rewrite->flush_rules();
 
-		$post_link          = get_permalink(
+		$post_link         = get_permalink(
 			self::factory()->post->create(
 				[
 					'post_name'   => 'link-target-post',
@@ -47,8 +47,8 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 				]
 			)
 		);
-		$excluded_amp_link  = get_permalink( self::factory()->post->create() );
-		$excluded_urls      = [ $excluded_amp_link ];
+		$excluded_amp_link = get_permalink( self::factory()->post->create() );
+		$excluded_urls     = [ $excluded_amp_link ];
 
 		$links = [
 			'home-link'           => [


### PR DESCRIPTION
## Summary
This allows opting out of AMP-to-AMP links via the filter `'excluded_links_from_amp_to_amp'` or adding `rel="not-amphtml"` to the `<a>`.

#### Rel attribute


```html
<a href="https://am.test/?p=195" rel="not-amphtml">To non-AMP</a>
```

...will produce a link to a non-AMP URL, with the `rel` stripped:

```html
<a href="https://am.test/?p=195">To non-AMP</a>
```

#### Filter
```php
// Excludes URLs from having AMP-to-AMP links.
add_filter(
	'amp_to_amp_excluded_links',
	static function() {
		return [
			'https://am.test/?p=195',
			'https://am.test/?p=199',
		 ];
	}
);
```

#### 'Exit Reader Mode' Link

Even with `add_filter( 'amp_to_amp_linking_enabled', '__return_true' );`, the 'Exit Reader Mode' link will now go to non-AMP:

<img width="555" alt="filter-mode" src="https://user-images.githubusercontent.com/4063887/72782525-91566b00-3be9-11ea-936f-ec221f9f7053.png">



Fixes #3689 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
