### PR TITLE
Add missing npm dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5574,89 +5574,20 @@
       "dev": true
     },
     "@wordpress/nux": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.9.0.tgz",
-      "integrity": "sha512-23mcxcaTdf5chPv6Y+E6dInhRuHOUzocCw0QuZjIuZ4HLC0a5VKPy+e8JjC5k6Jr/tP65+Kityhw1AZM9tazdA==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.10.0.tgz",
+      "integrity": "sha512-sxAMjf7R4sftS4fJeo5WPzJAuUkI9sSFEEx6SDQklQKsClZfJIqVVhk7odnsf4gt1tu8LDfAMFsLPzUJS6mD7A==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/components": "^8.5.0",
-        "@wordpress/compose": "^3.9.0",
-        "@wordpress/data": "^4.11.0",
+        "@wordpress/components": "^9.0.0",
+        "@wordpress/compose": "^3.10.0",
+        "@wordpress/data": "^4.12.0",
+        "@wordpress/deprecated": "^2.6.1",
         "@wordpress/element": "^2.10.0",
-        "@wordpress/i18n": "^3.7.0",
+        "@wordpress/i18n": "^3.8.0",
         "lodash": "^4.17.15",
         "rememo": "^3.0.0"
-      },
-      "dependencies": {
-        "@wordpress/components": {
-          "version": "8.5.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.5.0.tgz",
-          "integrity": "sha512-2wBpL7a9udh2yvzIA242Fhu2+srNv4WXFa0jjXJrf99smlVm2BxLMQtlNgfaV4LkYFAAnc0Bkud90NdrOoZ/ig==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@emotion/core": "10.0.22",
-            "@emotion/styled": "10.0.23",
-            "@wordpress/a11y": "^2.5.1",
-            "@wordpress/compose": "^3.9.0",
-            "@wordpress/deprecated": "^2.6.1",
-            "@wordpress/dom": "^2.6.0",
-            "@wordpress/element": "^2.10.0",
-            "@wordpress/hooks": "^2.6.0",
-            "@wordpress/i18n": "^3.7.0",
-            "@wordpress/is-shallow-equal": "^1.6.1",
-            "@wordpress/keycodes": "^2.7.0",
-            "@wordpress/rich-text": "^3.9.0",
-            "classnames": "^2.2.5",
-            "clipboard": "^2.0.1",
-            "dom-scroll-into-view": "^1.2.1",
-            "downshift": "^3.3.4",
-            "gradient-parser": "^0.1.5",
-            "lodash": "^4.17.15",
-            "memize": "^1.0.5",
-            "moment": "^2.22.1",
-            "mousetrap": "^1.6.2",
-            "re-resizable": "^6.0.0",
-            "react-dates": "^17.1.1",
-            "react-spring": "^8.0.20",
-            "reakit": "^1.0.0-beta.12",
-            "rememo": "^3.0.0",
-            "tinycolor2": "^1.4.1",
-            "uuid": "^3.3.2"
-          }
-        },
-        "@wordpress/compose": {
-          "version": "3.9.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.9.0.tgz",
-          "integrity": "sha512-UhuHCQANb0ob5TBZSQl1y6i7FBTKXXI0jwzPKkWhLmMByjM8pIQte53nQu9RbwQ1I5ItHqhzKoy5wyaXdjgWkQ==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/element": "^2.10.0",
-            "@wordpress/is-shallow-equal": "^1.6.1",
-            "lodash": "^4.17.15"
-          }
-        },
-        "@wordpress/element": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.10.0.tgz",
-          "integrity": "sha512-CedhhFfcubM/lsluY7JPC49VG0/Ee0chOBJ1vyDEvIJmQk0bM3sLfgt5qVK773yivVOqD9blQMO+JihnaMXF8w==",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.4.4",
-            "@wordpress/escape-html": "^1.6.0",
-            "lodash": "^4.17.15",
-            "react": "^16.9.0",
-            "react-dom": "^16.9.0"
-          }
-        },
-        "dom-scroll-into-view": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
-          "integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4=",
-          "dev": true
-        }
       }
     },
     "@wordpress/plugins": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@wordpress/is-shallow-equal": "1.7.0",
     "@wordpress/jest-puppeteer-axe": "1.5.0",
     "@wordpress/keycodes": "2.8.0",
+    "@wordpress/nux": "3.10.0",
     "@wordpress/plugins": "2.10.0",
     "@wordpress/postcss-themes": "2.2.0",
     "@wordpress/rich-text": "3.10.0",


### PR DESCRIPTION
## Summary

Gutenberg itself doesn't seem to be using the nux package anymore, which means the package might not actually be available when being used in `amp-preview.js`. See WordPress/gutenberg#18041

This PR fixes that by explicitly adding it as a dev dependency, unblocking #4087 and preventing potential future issues.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
