### PR TITLE
Hide carousel arrows when scrolling to end

### DIFF
--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -157,11 +157,14 @@ function Carousel() {
 		}
 	};
 
+	const isAtBeginningOfList = 0 === scrollPercentage;
+	const isAtEndOfList = 1 === scrollPercentage;
+
 	return (
 		<Wrapper>
 			<Area area="left-navigation">
 				<LeftArrow
-					isHidden={ ! hasHorizontalOverflow || 0 === scrollPercentage }
+					isHidden={ ! hasHorizontalOverflow || isAtBeginningOfList }
 					onClick={ () => scrollBy( -( 2 * PAGE_WIDTH ) ) }
 					width="24"
 					height="24"
@@ -190,7 +193,7 @@ function Carousel() {
 			</List>
 			<Area area="right-navigation">
 				<RightArrow
-					isHidden={ ! hasHorizontalOverflow || 1 === scrollPercentage }
+					isHidden={ ! hasHorizontalOverflow || isAtEndOfList }
 					onClick={ () => scrollBy( ( 2 * PAGE_WIDTH ) ) }
 					width="24"
 					height="24"

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -60,6 +60,7 @@ const GridViewButton = styled( GridView )`
 function Carousel() {
 	const { state: { pages, currentPageIndex, currentPageId }, actions: { setCurrentPage } } = useStory();
 	const [ hasHorizontalOverflow, setHasHorizontalOverflow ] = useState( false );
+	const [ scrollPercentage, setScrollPercentage ] = useState( 0 );
 	const listRef = useRef();
 	const pageRefs = useRef( [] );
 
@@ -68,6 +69,9 @@ function Carousel() {
 			for ( const entry of entries ) {
 				const offsetWidth = entry.contentBoxSize ? entry.contentBoxSize.inlineSize : entry.contentRect.width;
 				setHasHorizontalOverflow( Math.ceil( listRef.current.scrollWidth ) > Math.ceil( offsetWidth ) );
+
+				const max = listRef.current.scrollWidth - offsetWidth;
+				setScrollPercentage( listRef.current.scrollLeft / max );
 			}
 		} );
 
@@ -91,6 +95,21 @@ function Carousel() {
 		}
 	}, [ currentPageId, hasHorizontalOverflow, pageRefs ] );
 
+	useLayoutEffect( () => {
+		const listElement = listRef.current;
+
+		const handleScroll = () => {
+			const max = listElement.scrollWidth - listElement.offsetWidth;
+			setScrollPercentage( listElement.scrollLeft / max );
+		};
+
+		listElement.addEventListener( 'scroll', handleScroll, { passive: true } );
+
+		return () => {
+			listElement.removeEventListener( 'scroll', handleScroll );
+		};
+	}, [ hasHorizontalOverflow ] );
+
 	const handleClickPage = ( page ) => () => setCurrentPage( { pageId: page.id } );
 
 	const scrollBy = useCallback( ( offset ) => {
@@ -109,7 +128,7 @@ function Carousel() {
 		<Wrapper>
 			<Area area="left-navigation">
 				<LeftArrow
-					isHidden={ ! hasHorizontalOverflow }
+					isHidden={ ! hasHorizontalOverflow || 0 === scrollPercentage }
 					onClick={ () => scrollBy( -( 2 * PAGE_WIDTH ) ) }
 					width="24"
 					height="24"
@@ -134,7 +153,7 @@ function Carousel() {
 			</List>
 			<Area area="right-navigation">
 				<RightArrow
-					isHidden={ ! hasHorizontalOverflow }
+					isHidden={ ! hasHorizontalOverflow || 1 === scrollPercentage }
 					onClick={ () => scrollBy( ( 2 * PAGE_WIDTH ) ) }
 					width="24"
 					height="24"


### PR DESCRIPTION
## Summary

This is a follow-up to #4106 as I didn't see the new section on Figma about this at first.

Hides the arrows in the page carousel when reaching the end/beginning of the list

See #3834.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
