### PR TITLE
Update readme to add FAQs section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,10 @@ The plugin can be configured to follow one of three different template modes: St
 
 With the official AMP plugin for WordPress, the WordPress ecosystem is provided with the capabilities and tools it needs to build world-class AMP experiences without deviating from its standard, flexible, and well-known content creation workflow.
 
+## Frequently Asked Questions ##
+
+Please see the [FAQs on amp-wp.org](https://amp-wp.org/documentation/frequently-asked-questions/). Don't see an answer to your question? Please [search the support forum](https://wordpress.org/support/plugin/amp/) to see if someone has asked your question. Otherwise, please [open a new support topic](https://wordpress.org/support/plugin/amp/#new-post).
+
 ## Installation ##
 
 1. Upload the folder to the `/wp-content/plugins/` directory.

--- a/readme.txt
+++ b/readme.txt
@@ -26,6 +26,10 @@ The plugin can be configured to follow one of three different template modes: St
 
 With the official AMP plugin for WordPress, the WordPress ecosystem is provided with the capabilities and tools it needs to build world-class AMP experiences without deviating from its standard, flexible, and well-known content creation workflow.
 
+== Frequently Asked Questions ==
+
+Please see the [FAQs on amp-wp.org](https://amp-wp.org/documentation/frequently-asked-questions/). Don't see an answer to your question? Please [search the support forum](https://wordpress.org/support/plugin/amp/) to see if someone has asked your question. Otherwise, please [open a new support topic](https://wordpress.org/support/plugin/amp/#new-post).
+
 == Installation ==
 
 1. Upload the folder to the `/wp-content/plugins/` directory.


### PR DESCRIPTION
Add a section that directs users to the amp-wp.org site for their FAQs, and otherwise to the forums. 

Already committed to SVN: https://wordpress.org/plugins/amp/#faq

> ![image](https://user-images.githubusercontent.com/134745/72839315-f12f2f00-3c46-11ea-9f73-ea0230d9860a.png)
