### PR TITLE
[WIP] Add/prefixinput and iconswitch

### DIFF
--- a/assets/src/edit-story/components/PrefixInput.js
+++ b/assets/src/edit-story/components/PrefixInput.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+/**
+ * WordPress dependencies
+ */
+
+const Label = styled.span`
+	color: ${ ( { theme } ) => theme.colors.fg.v5 };
+	font-size: 15px;
+  line-height: 16px;
+  text-align: center;
+	width: 35px;
+`;
+
+const Input = styled.input`
+  color: ${ ( { theme } ) => theme.colors.fg.v6 };
+  border: 0 !important;
+	font-size: 15px;
+	line-height: 16px;
+  width: 63px;
+  padding: 0 !important;
+  margin: 0;
+  
+  :focus {
+    outline: none !important;
+    box-shadow: none !important;
+  }
+`;
+
+const Group = styled.label`
+	color: ${ ( { theme } ) => theme.colors.mg.v1 };
+  display: flex;
+  align-items: center;
+  border: 1px solid ${ ( { theme } ) => theme.colors.fg.v3 };
+  border-radius: 4px;
+  width: 100px;
+	margin-bottom: 5px;
+	opacity: ${ ( { disabled } ) => disabled ? 0.7 : 1 };
+`;
+
+function PrefixInput( { type, label, value, isMultiple, onChange, disabled, min, max } ) {
+	const placeholder = isMultiple ? '( multiple )' : '';
+	return (
+		<Group disabled={ disabled }>
+			<Label>
+				{ label }
+			</Label>
+			<Input
+				type={ type || 'number' }
+				disabled={ disabled }
+				onChange={ ( evt ) => onChange( evt.target.value, evt ) }
+				onBlur={ ( evt ) => evt.target.form.dispatchEvent( new window.Event( 'submit' ) ) }
+				placeholder={ placeholder }
+				value={ value }
+				min={ min ? min : null }
+				max={ max ? max : null }
+			/>
+		</Group>
+	);
+}
+
+PrefixInput.propTypes = {
+	type: PropTypes.string,
+	label: PropTypes.string.isRequired,
+	value: PropTypes.any.isRequired,
+	isMultiple: PropTypes.bool.isRequired,
+	onChange: PropTypes.func.isRequired,
+	disabled: PropTypes.bool,
+	min: PropTypes.any,
+	max: PropTypes.any,
+};
+
+PrefixInput.defaultProps = {
+	type: 'number',
+	disabled: false,
+	min: null,
+	max: null,
+};
+
+export default PrefixInput;

--- a/assets/src/edit-story/panels/size.js
+++ b/assets/src/edit-story/panels/size.js
@@ -12,6 +12,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import PrefixInput from '../components/PrefixInput';
 import { Panel, Title, InputGroup, getCommonValue } from './shared';
 
 function SizePanel( { selectedElements, onSetProperties } ) {
@@ -32,6 +33,36 @@ function SizePanel( { selectedElements, onSetProperties } ) {
 			<Title>
 				{ __( 'Size', 'amp' ) }
 			</Title>
+			<PrefixInput
+				label={ __( 'W', 'amp' ) }
+				value={ state.width }
+				isMultiple={ width === '' }
+				onChange={ ( value ) => {
+					const ratio = width / height;
+					const newWidth = isNaN( value ) || value === '' ? '' : parseFloat( value );
+					setState( {
+						...state,
+						width: newWidth,
+						height: typeof newWidth === 'number' && lockRatio ? newWidth / ratio : height,
+					} );
+				} }
+				disabled={ isFullbleed }
+			/>
+			<PrefixInput
+				label={ __( 'H', 'amp' ) }
+				value={ state.height }
+				isMultiple={ height === '' }
+				onChange={ ( value ) => {
+					const ratio = width / height;
+					const newHeight = isNaN( value ) || value === '' ? '' : parseFloat( value );
+					setState( {
+						...state,
+						height: newHeight,
+						width: typeof newHeight === 'number' && lockRatio ? newHeight * ratio : width,
+					} );
+				} }
+				disabled={ isFullbleed }
+			/>
 			<InputGroup
 				label={ __( 'Width', 'amp' ) }
 				value={ state.width }

--- a/assets/src/edit-story/theme.js
+++ b/assets/src/edit-story/theme.js
@@ -30,6 +30,8 @@ const theme = {
 			v2: '#E5E5E5',
 			v3: '#D4D3D4',
 			v4: '#B3B3B3',
+			v5: '#80868B',
+			v6: '#3C4043',
 		},
 		action: '#47A0F4',
 		danger: '#FF0000',

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Official AMP plugin, supported by the AMP team. Formerly Accelerated Mobile Page
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 **Requires PHP:** 5.4  
 
-[![Build Status](https://travis-ci.org/ampproject/amp-wp.svg?branch=develop)](https://travis-ci.org/ampproject/amp-wp) [![Coverage Status](https://img.shields.io/codecov/c/github/ampproject/amp-wp/develop.svg)](https://codecov.io/gh/ampproject/amp-wp) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 
+[![Build Status](https://travis-ci.org/ndev1991/amp-wp.svg?branch=develop)](https://travis-ci.org/ndev1991/amp-wp) [![Coverage Status](https://img.shields.io/codecov/c/github/ndev1991/amp-wp/develop.svg)](https://codecov.io/gh/ndev1991/amp-wp) [![Built with Grunt](https://gruntjs.com/cdn/builtwith.svg)](http://gruntjs.com) 
 
 ## Description ##
 


### PR DESCRIPTION
## Summary

Add prefixinput and iconswitch to replace original size and keep ratio part.

To do:
- [ ] Create prefixinput with styling
- [ ] Create iconswitch with styling
- [ ] Replace prefixinput and iconswitch for origianl InputGroup on size section
Fixes #

## Checklist

- [X] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
