### PR TITLE
Address notice and console error in Paired Browsing from async

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2476,14 +2476,13 @@ class AMP_Theme_Support {
 			true
 		);
 
-		// Whitelist enqueued script for AMP dev mdoe so that it is not removed.
+		// Whitelist enqueued script for AMP dev mode so that it is not removed.
 		// @todo Revisit with <https://github.com/google/site-kit-wp/pull/505#discussion_r348683617>.
 		add_filter(
 			'script_loader_tag',
 			static function( $tag, $handle ) {
 				if ( is_amp_endpoint() && self::has_dependency( wp_scripts(), 'amp-paired-browsing-client', $handle ) ) {
-					$attrs = [ AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, 'async' ];
-					$tag   = preg_replace( '/(?<=<script)(?=\s|>)/i', ' ' . implode( ' ', $attrs ), $tag );
+					$tag = preg_replace( '/(?<=<script)(?=\s|>)/i', ' ' . AMP_Rule_Spec::DEV_MODE_ATTRIBUTE, $tag );
 				}
 				return $tag;
 			},

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2472,6 +2472,89 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the enqueuing in setup_paired_browsing_client().
+	 *
+	 * @covers AMP_Theme_Support::setup_paired_browsing_client()
+	 */
+	public function test_setup_paired_browsing_client_enqueuing() {
+		$handle = 'amp-paired-browsing-client';
+
+		// The conditions aren't met, so this should not enqueue the script.
+		$_GET[ AMP_Theme_Support::PAIRED_BROWSING_QUERY_VAR ] = '1';
+		AMP_Theme_Support::setup_paired_browsing_client();
+		$this->assertFalse( wp_script_is( $handle ) );
+
+		// Only one condition is met, so this should still not enqueue the script.
+		unset( $_GET[ AMP_Theme_Support::PAIRED_BROWSING_QUERY_VAR ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		AMP_Theme_Support::setup_paired_browsing_client();
+		$this->assertFalse( wp_script_is( $handle ) );
+
+		// Both of the conditions to enqueue are met.
+		add_filter( 'amp_dev_mode_enabled', '__return_true' );
+		AMP_Theme_Support::setup_paired_browsing_client();
+		$this->assertTrue( wp_script_is( $handle ) );
+	}
+
+	/**
+	 * Gets the test data for test_setup_paired_browsing_client_filter().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_setup_paired_browsing_data() {
+		$original_script_tag      = '<script src="foo"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$script_tag_with_dev_mode = '<script data-ampdevmode src="foo"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+
+		return [
+			'no_parent_of_dependency'      => [
+				'',
+				$original_script_tag,
+				null,
+			],
+			'wrong_parent_of_dependency'   => [
+				'different-handle-completely',
+				$original_script_tag,
+				null,
+			],
+			'correct_parent_of_dependency' => [
+				'amp-paired-browsing-client',
+				$original_script_tag,
+				$script_tag_with_dev_mode,
+			],
+		];
+	}
+
+	/**
+	 * Test the filter in setup_paired_browsing_client().
+	 *
+	 * @dataProvider get_setup_paired_browsing_data
+	 * @covers AMP_Theme_Support::setup_paired_browsing_client()
+	 *
+	 * @param string $parent_of_dependency The script that has a dependency on the dependency handle.
+	 * @param string $original_script_tag  The <script> tag passed to the filter.
+	 * @param string $expected             The expected return value.
+	 */
+	public function test_setup_paired_browsing_client_filter( $parent_of_dependency, $original_script_tag, $expected ) {
+		if ( null === $expected ) {
+			$expected = $original_script_tag;
+		}
+
+		add_theme_support( AMP_Theme_Support::SLUG );
+		$this->go_to( get_permalink( self::factory()->post->create() ) );
+		add_filter( 'amp_dev_mode_enabled', '__return_true' );
+		$src               = 'https://example.com/script.js';
+		$dependency_handle = 'foo-handle';
+
+		wp_enqueue_script( $dependency_handle, $src, [], '0.1.0', true );
+		wp_enqueue_script( $parent_of_dependency, $src, [ $dependency_handle ], '0.1', true );
+		AMP_Theme_Support::setup_paired_browsing_client();
+
+		$this->assertEquals(
+			$expected,
+			apply_filters( 'script_loader_tag', $original_script_tag, $dependency_handle, '' )
+		);
+	}
+
+	/**
 	 * Test AMP_Theme_Support::whitelist_layout_in_wp_kses_allowed_html().
 	 *
 	 * @see AMP_Theme_Support::whitelist_layout_in_wp_kses_allowed_html()


### PR DESCRIPTION
## Summary
In Paired Browsing, this prevents the occasional notice and console error that Weston found, using his suggested fix.

Fixes #4127

### Before 
Sometimes, this would appear on a refresh with a cleared cache:

>TypeError: Cannot read property 'domReady' of undefined.

<img width="1088" alt="navigated-url-cache" src="https://user-images.githubusercontent.com/4063887/72871294-05f3dd00-3cb0-11ea-8956-6bf8389d8dc8.png">

### After
That issue didn't occur after refreshing 20 times.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
