### PR TITLE
Prevent validation error for WordPress.tv embed in Classic Editor

### DIFF
--- a/includes/embeds/class-amp-wordpress-tv-embed-handler.php
+++ b/includes/embeds/class-amp-wordpress-tv-embed-handler.php
@@ -14,33 +14,39 @@
 class AMP_WordPress_TV_Embed_Handler extends AMP_Base_Embed_Handler {
 
 	/**
+	 * The URL pattern to determine if an embed URL is for this type, copied from WP_oEmbed.
+	 *
+	 * @see https://github.com/WordPress/wordpress-develop/blob/e13480/src/wp-includes/class-wp-oembed.php#L64
+	 */
+	const URL_PATTERN = '#https?://wordpress\.tv/.*#i';
+
+	/**
 	 * Register embed.
 	 */
 	public function register_embed() {
-		add_filter( 'render_block', [ $this, 'filter_rendered_block' ], 10, 2 );
+		add_filter( 'embed_oembed_html', [ $this, 'filter_oembed_html' ], 10, 2 );
 	}
 
 	/**
 	 * Unregister embed.
 	 */
 	public function unregister_embed() {
-		remove_filter( 'render_block', [ $this, 'filter_rendered_block' ], 10 );
+		remove_filter( 'embed_oembed_html', [ $this, 'filter_oembed_html' ], 10 );
 	}
 
 	/**
-	 * Filters the content of a single block to make it AMP valid.
+	 * Filters the oembed HTML to make it valid AMP.
 	 *
-	 * @param string $block_content The block content about to be appended.
-	 * @param array  $block         The full block, including name and attributes.
-	 * @return string Filtered block content.
+	 * @param mixed  $cache The cached rendered markup.
+	 * @param string $url   The embed URL.
+	 * @return string The filtered embed markup.
 	 */
-	public function filter_rendered_block( $block_content, $block ) {
-		if ( ! isset( $block['blockName'] ) || 'core-embed/wordpress-tv' !== $block['blockName'] ) {
-			return $block_content;
+	public function filter_oembed_html( $cache, $url ) {
+		if ( ! preg_match( self::URL_PATTERN, $url ) ) {
+			return $cache;
 		}
 
-		$modified_block_content = preg_replace( '#<script(?:\s.*?)?>.*?</script>#s', '', $block_content );
-
-		return null !== $modified_block_content ? $modified_block_content : $block_content;
+		$modified_block_content = preg_replace( '#<script(?:\s.*?)?>.*?</script>#s', '', $cache );
+		return null !== $modified_block_content ? $modified_block_content : $cache;
 	}
 }


### PR DESCRIPTION
## Summary

In the classic editor, this prevents a validation error from a `<script>` appearing in the WordPress.tv oEmbed markup.

As [Weston mentioned](https://github.com/ampproject/amp-wp/issues/4130#issue-551704918), the previous `'render_block'` filter only applied to the WordPress.tv block. 

But this embed can be in the Classic Editor, or in a Custom HTML block in the block editor. 

This uses the suggested `'embed_oembed_html'` filter instead, which handles these cases without a validation error:

### Classic Editor

<img width="815" alt="tv-classic-editor" src="https://user-images.githubusercontent.com/4063887/72873159-b5cb4980-3cb4-11ea-86ba-f0242e7c151a.png">

### Block Editor

![custom-html](https://user-images.githubusercontent.com/4063887/72873186-c24fa200-3cb4-11ea-8c76-35a6b44706c0.png)

Fixes #4130 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
