### PR TITLE
Prevent validation errors for URLs with leading or trailing spaces

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1666,7 +1666,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string|null Protocol without colon if matched. Otherwise null.
 	 */
 	private function parse_protocol( $url ) {
-		if ( preg_match( '#^\s*([^/]+)(?=:)#', $url, $matches ) ) {
+		if ( preg_match( '#^\s*([^/]+):#', $url, $matches ) ) {
 			return $matches[1];
 		}
 		return null;

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1626,7 +1626,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function check_attr_spec_rule_valid_url( DOMElement $node, $attr_name, $attr_spec_rule ) {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ] ) && $node->hasAttribute( $attr_name ) ) {
 			foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-				$url = urldecode( $url );
+				$url = urldecode( trim( $url ) );
 
 				// Check whether the URL is parsable.
 				$parts = wp_parse_url( $url );
@@ -1689,7 +1689,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-					$url_scheme = $this->parse_protocol( $url );
+					$url_scheme = $this->parse_protocol( trim( $url ) );
 					if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 						return AMP_Rule_Spec::FAIL;
 					}
@@ -1701,7 +1701,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $attr_spec_rule[ AMP_Rule_Spec::ALTERNATIVE_NAMES ] as $alternative_name ) {
 					if ( $node->hasAttribute( $alternative_name ) ) {
 						foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $alternative_name ), $attr_name ) as $url ) {
-							$url_scheme = $this->parse_protocol( $url );
+							$url_scheme = $this->parse_protocol( trim( $url ) );
 							if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 								return AMP_Rule_Spec::FAIL;
 							}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1666,8 +1666,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string|null Protocol without colon if matched. Otherwise null.
 	 */
 	private function parse_protocol( $url ) {
-		if ( preg_match( '#^[^/]+(?=:)#', $url, $matches ) ) {
-			return $matches[0];
+		if ( preg_match( '#^\s*([^/]+)(?=:)#', $url, $matches ) ) {
+			return $matches[1];
 		}
 		return null;
 	}
@@ -1689,7 +1689,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-					$url_scheme = $this->parse_protocol( trim( $url ) );
+					$url_scheme = $this->parse_protocol( $url );
 					if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 						return AMP_Rule_Spec::FAIL;
 					}
@@ -1701,7 +1701,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $attr_spec_rule[ AMP_Rule_Spec::ALTERNATIVE_NAMES ] as $alternative_name ) {
 					if ( $node->hasAttribute( $alternative_name ) ) {
 						foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $alternative_name ), $attr_name ) as $url ) {
-							$url_scheme = $this->parse_protocol( trim( $url ) );
+							$url_scheme = $this->parse_protocol( $url );
 							if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 								return AMP_Rule_Spec::FAIL;
 							}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1626,7 +1626,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function check_attr_spec_rule_valid_url( DOMElement $node, $attr_name, $attr_spec_rule ) {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ] ) && $node->hasAttribute( $attr_name ) ) {
 			foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-				$url = urldecode( trim( $url ) );
+				$url = trim( $url );
 
 				// Check whether the URL is parsable.
 				$parts = wp_parse_url( $url );
@@ -1644,7 +1644,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				}
 
 				// Check if the host contains invalid chars (hostCharIsValid: https://github.com/ampproject/amphtml/blob/af1e3a550feeafd732226202b8d1f26dcefefa18/validator/engine/parse-url.js#L62-L103).
-				$host = wp_parse_url( $url, PHP_URL_HOST );
+				$host = wp_parse_url( urldecode( $url ), PHP_URL_HOST );
 				if ( $host && preg_match( '/[!"#$%&\'()*+,\/:;<=>?@[\]^`{|}~\s]/', $host ) ) {
 					return AMP_Rule_Spec::FAIL;
 				}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1626,7 +1626,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	private function check_attr_spec_rule_valid_url( DOMElement $node, $attr_name, $attr_spec_rule ) {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ] ) && $node->hasAttribute( $attr_name ) ) {
 			foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-				$url = trim( $url );
+				$url = $this->normalize_url_from_attribute_value( $url );
 
 				// Check whether the URL is parsable.
 				$parts = wp_parse_url( $url );
@@ -1673,6 +1673,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
+	 * Normalize a URL that appeared as a tag attribute.
+	 *
+	 * @param string $url The URL to normalize.
+	 * @return string The normalized URL.
+	 */
+	private function normalize_url_from_attribute_value( $url ) {
+		return preg_replace( '/\s/', '', $url );
+	}
+
+	/**
 	 * Check if attribute has a protocol value rule determine if it matches.
 	 *
 	 * @param DOMElement       $node           Node.
@@ -1689,7 +1699,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-					$url_scheme = $this->parse_protocol( trim( $url ) );
+					$url_scheme = $this->parse_protocol( $this->normalize_url_from_attribute_value( $url ) );
 					if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 						return AMP_Rule_Spec::FAIL;
 					}
@@ -1701,7 +1711,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $attr_spec_rule[ AMP_Rule_Spec::ALTERNATIVE_NAMES ] as $alternative_name ) {
 					if ( $node->hasAttribute( $alternative_name ) ) {
 						foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $alternative_name ), $attr_name ) as $url ) {
-							$url_scheme = $this->parse_protocol( trim( $url ) );
+							$url_scheme = $this->parse_protocol( $this->normalize_url_from_attribute_value( $url ) );
 							if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 								return AMP_Rule_Spec::FAIL;
 							}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1679,7 +1679,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string The normalized URL.
 	 */
 	private function normalize_url_from_attribute_value( $url ) {
-		return preg_replace( '/\s/', '', $url );
+		return preg_replace( '/[\t\r\n]/', '', trim( $url ) );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1666,8 +1666,8 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string|null Protocol without colon if matched. Otherwise null.
 	 */
 	private function parse_protocol( $url ) {
-		if ( preg_match( '#^\s*([^/]+):#', $url, $matches ) ) {
-			return $matches[1];
+		if ( preg_match( '#^[^/]+(?=:)#', $url, $matches ) ) {
+			return $matches[0];
 		}
 		return null;
 	}
@@ -1689,7 +1689,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ] ) ) {
 			if ( $node->hasAttribute( $attr_name ) ) {
 				foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $attr_name ) ) as $url ) {
-					$url_scheme = $this->parse_protocol( $url );
+					$url_scheme = $this->parse_protocol( trim( $url ) );
 					if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 						return AMP_Rule_Spec::FAIL;
 					}
@@ -1701,7 +1701,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				foreach ( $attr_spec_rule[ AMP_Rule_Spec::ALTERNATIVE_NAMES ] as $alternative_name ) {
 					if ( $node->hasAttribute( $alternative_name ) ) {
 						foreach ( $this->extract_attribute_urls( $node->getAttributeNode( $alternative_name ), $attr_name ) as $url ) {
-							$url_scheme = $this->parse_protocol( $url );
+							$url_scheme = $this->parse_protocol( trim( $url ) );
 							if ( isset( $url_scheme ) && ! in_array( strtolower( $url_scheme ), $attr_spec_rule[ AMP_Rule_Spec::VALUE_URL ][ AMP_Rule_Spec::ALLOWED_PROTOCOL ], true ) ) {
 								return AMP_Rule_Spec::FAIL;
 							}

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1715,7 +1715,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 			],
 			'space_inside'                  => [
 				' https: //exam ple.com ',
-				$normalized_url,
+				'https: //exam ple.com',
 			],
 			'tabs_inside'                   => [
 				"https:\t//exam\tple.com ",

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1650,6 +1650,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				'//image.png ',
 				false,
 			],
+			'two_colons'        => [
+				'foo:baz://image.png ',
+				'foo:baz',
+			],
 		];
 	}
 

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1675,6 +1675,87 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 	}
 
 	/**
+	 * Gets the test data for test_normalize_url_from_attribute_value().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_normalize_url_data() {
+		$normalized_url = 'https://example.com';
+
+		return [
+			'nothing_to_remove'             => [
+				'https://example.com',
+			],
+			'empty_string'                  => [
+				'',
+			],
+			'only_space'                    => [
+				'  ',
+				'',
+			],
+			'leading_space'                 => [
+				'  https://example.com',
+				$normalized_url,
+			],
+			'leading_tab'                   => [
+				"\thttps://example.com",
+				$normalized_url,
+			],
+			'trailing_linefeed'             => [
+				"https://example.com \n",
+				$normalized_url,
+			],
+			'trailing_space'                => [
+				'https://example.com  ',
+				$normalized_url,
+			],
+			'enclosed_in_spaces'            => [
+				' https://example.com ',
+				$normalized_url,
+			],
+			'space_inside'                  => [
+				' https: //exam ple.com ',
+				$normalized_url,
+			],
+			'tabs_inside'                   => [
+				"https:\t//exam\tple.com ",
+				$normalized_url,
+			],
+			'leading_slashes'               => [
+				'//example.com',
+			],
+			'url_encoded_space_not_removed' => [
+				'https://example.com?foo=++baz',
+			],
+		];
+	}
+
+	/**
+	 * Tests normalize_url_from_attribute_value.
+	 *
+	 * @dataProvider get_normalize_url_data
+	 * @group allowed-tags-private-methods
+	 * @covers AMP_Tag_And_Attribute_Sanitizer::normalize_url_from_attribute_value()
+	 *
+	 * @param array       $url      The URL to normalize.
+	 * @param string|null $expected The expected return value.
+	 * @throws ReflectionException If it's not possible to create a reflection to call the private method.
+	 */
+	public function test_normalize_url_from_attribute_value( $url, $expected = null ) {
+		if ( null === $expected ) {
+			$expected = $url;
+		}
+
+		$dom       = AMP_DOM_Utils::get_dom_from_content( '' );
+		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+
+		$this->assertEquals(
+			$expected,
+			$this->call_private_method( $sanitizer, 'normalize_url_from_attribute_value', [ $url ] )
+		);
+	}
+
+	/**
 	 * @dataProvider get_check_attr_spec_rule_allowed_protocol
 	 * @group allowed-tags-private-methods
 	 */

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1620,6 +1620,61 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 	}
 
 	/**
+	 * Gets the test data for test_parse_protocol().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_parse_protocol_data() {
+		return [
+			'empty_string'      => [
+				'',
+				false,
+			],
+			'only_space'        => [
+				'  ',
+				false,
+			],
+			'traditional_https' => [
+				'https://example.com',
+				'https',
+			],
+			'leading_space'     => [
+				'  https://foo',
+				'https',
+			],
+			'trailing_space'    => [
+				'https://foo.com ',
+				'https',
+			],
+			'no_colon'          => [
+				'//image.png ',
+				false,
+			],
+		];
+	}
+
+	/**
+	 * Tests parse_protocol.
+	 *
+	 * @dataProvider get_parse_protocol_data
+	 * @group allowed-tags-private-methods
+	 * @covers AMP_Tag_And_Attribute_Sanitizer::parse_protocol()
+	 *
+	 * @param array  $url      The URL to parse.
+	 * @param string $expected The expected return value.
+	 * @throws ReflectionException If it's not possible to create a reflection to call the private method.
+	 */
+	public function test_parse_protocol( $url, $expected ) {
+		$dom       = AMP_DOM_Utils::get_dom_from_content( '' );
+		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+
+		$this->assertEquals(
+			$expected,
+			$this->call_private_method( $sanitizer, 'parse_protocol', [ $url ] )
+		);
+	}
+
+	/**
 	 * @dataProvider get_check_attr_spec_rule_allowed_protocol
 	 * @group allowed-tags-private-methods
 	 */

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1638,10 +1638,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				'https://example.com',
 				'https',
 			],
-			'leading_space'     => [
-				'  https://foo',
-				'https',
-			],
 			'trailing_space'    => [
 				'https://foo.com ',
 				'https',

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1256,27 +1256,23 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL ],
 			],
 
-			'a_with_wrong_host'                            => [
+			'a_with_space_in_url'                          => [
 				'<a class="foo" href="http://foo bar">value</a>',
-				'<a class="foo">value</a>',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL ],
+				'<a class="foo" href="http://foo%20bar">value</a>',
 			],
 			'a_with_encoded_host'                          => [
 				'<a class="foo" href="http://%65%78%61%6d%70%6c%65%2e%63%6f%6d/foo/">value</a>',
 				null,
 			],
-			'a_with_wrong_schemeless_host'                 => [
-				'<a class="foo" href="//bad domain with a space.com/foo">value</a>',
-				'<a class="foo">value</a>',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL ],
+			'a_with_spaces_inside'                         => [
+				'<a class="foo" href="//domain with space.com/foo">value</a>',
+				'<a class="foo" href="//domain%20with%20space.com/foo">value</a>',
+			],
+			'a_with_schemaless_host'                       => [
+				'<a class="foo" href="//domain.om/foo">value</a>',
 			],
 			'a_with_mail_host'                             => [
-				'<a class="foo" href="mail to:foo@bar.com">value</a>',
-				'<a class="foo">value</a>',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL ],
+				'<a class="foo" href="mailto:foo@bar.com">value</a>',
 			],
 
 			// font is removed so we should check that other elements are checked as well.

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1256,7 +1256,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL ],
 			],
 
-			'a_with_space_in_url'                          => [
+			'a_with_wrong_host'                            => [
 				'<a class="foo" href="http://foo bar">value</a>',
 				'<a class="foo">value</a>',
 				[],
@@ -1266,8 +1266,11 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<a class="foo" href="http://%65%78%61%6d%70%6c%65%2e%63%6f%6d/foo/">value</a>',
 				null,
 			],
-			'a_with_schemaless_host'                       => [
-				'<a class="foo" href="//domain.om/foo">value</a>',
+			'a_with_wrong_schemeless_host'                 => [
+				'<a class="foo" href="//bad domain with a space.com/foo">value</a>',
+				'<a class="foo">value</a>',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL ],
 			],
 			'a_with_mail_host'                             => [
 				'<a class="foo" href="mail to:foo@bar.com">value</a>',

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1258,21 +1258,22 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'a_with_space_in_url'                          => [
 				'<a class="foo" href="http://foo bar">value</a>',
-				'<a class="foo" href="http://foo%20bar">value</a>',
+				'<a class="foo">value</a>',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL ],
 			],
 			'a_with_encoded_host'                          => [
 				'<a class="foo" href="http://%65%78%61%6d%70%6c%65%2e%63%6f%6d/foo/">value</a>',
 				null,
 			],
-			'a_with_spaces_inside'                         => [
-				'<a class="foo" href="//domain with space.com/foo">value</a>',
-				'<a class="foo" href="//domain%20with%20space.com/foo">value</a>',
-			],
 			'a_with_schemaless_host'                       => [
 				'<a class="foo" href="//domain.om/foo">value</a>',
 			],
 			'a_with_mail_host'                             => [
-				'<a class="foo" href="mailto:foo@bar.com">value</a>',
+				'<a class="foo" href="mail to:foo@bar.com">value</a>',
+				'<a class="foo">value</a>',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL ],
 			],
 
 			// font is removed so we should check that other elements are checked as well.


### PR DESCRIPTION
## Summary
Prevents a validation error if a URL has a leading or trailing space.

<!-- Please reference the issue this PR addresses. -->
Fixes #4117

## Background

As Weston found, a leading space in a URL can cause a validation error:

```html
<a href=" https://wp.org">Click Here</a>
```
>Unknown error (INVALID_URL_PROTOCOL)

Preventing that error with uncovered an `INVALID_URL` error, which needed `trim()` here:
https://github.com/ampproject/amp-wp/blob/bede7e335ab5aed624a2b5ea58b06ec11c1b101a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L1629

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
