### PR TITLE
Editor page resize and units conversion

### DIFF
--- a/assets/src/edit-story/app/layout/index.js
+++ b/assets/src/edit-story/app/layout/index.js
@@ -32,10 +32,10 @@ const Editor = styled.div`
 		/ minmax(${ LIBRARY_MIN_WIDTH }px, ${ LIBRARY_MAX_WIDTH }px) 1fr minmax(${ INSPECTOR_MIN_WIDTH }px, ${ INSPECTOR_MAX_WIDTH }px);
 `;
 
-// @todo: set `overflow: hidden;` once page size is responsive.
 const Area = styled.div`
   grid-area: ${ ( { area } ) => area };
   position: relative;
+  overflow: hidden;
   z-index: ${ ( { area } ) => area === 'canv' ? 1 : 2 };
 `;
 

--- a/assets/src/edit-story/components/canvas/canvasLayout.js
+++ b/assets/src/edit-story/components/canvas/canvasLayout.js
@@ -4,6 +4,11 @@
 import styled from 'styled-components';
 
 /**
+ * WordPress dependencies
+ */
+import { useRef } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import EditLayer from './editLayer';
@@ -11,6 +16,7 @@ import DisplayLayer from './displayLayer';
 import FramesLayer from './framesLayer';
 import NavLayer from './navLayer';
 import SelectionCanvas from './selectionCanvas';
+import { useLayoutParams, useLayoutParamsCssVars } from './layout';
 
 const Background = styled.div`
 	background-color: ${ ( { theme } ) => theme.colors.bg.v1 };
@@ -21,8 +27,15 @@ const Background = styled.div`
 `;
 
 function CanvasLayout() {
+	const backgroundRef = useRef( null );
+
+	useLayoutParams( backgroundRef );
+	const layoutParamsCss = useLayoutParamsCssVars();
+
 	return (
-		<Background>
+		<Background
+			ref={ backgroundRef }
+			style={ layoutParamsCss }>
 			<SelectionCanvas>
 				<DisplayLayer />
 				<NavLayer />

--- a/assets/src/edit-story/components/canvas/canvasProvider.js
+++ b/assets/src/edit-story/components/canvas/canvasProvider.js
@@ -12,6 +12,8 @@ import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStory } from '../../app';
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../../constants';
+import UnitsProvider from '../../units/unitsProvider';
 import useEditingElement from './useEditingElement';
 import useCanvasSelectionCopyPaste from './useCanvasSelectionCopyPaste';
 import Context from './context';
@@ -19,9 +21,7 @@ import Context from './context';
 function CanvasProvider( { children } ) {
 	const [ lastSelectionEvent, setLastSelectionEvent ] = useState( null );
 
-	// @todo: most likely can be simplified/redone once we deal with changing
-	// page size and offsets. We can simply pass the page's boundaries here
-	// instead of the whole element.
+	const [ pageSize, setPageSize ] = useState( { width: PAGE_WIDTH, height: PAGE_HEIGHT } );
 	const [ pageContainer, setPageContainer ] = useState( null );
 
 	const {
@@ -107,6 +107,7 @@ function CanvasProvider( { children } ) {
 			editingElementState,
 			isEditing: Boolean( editingElement ),
 			lastSelectionEvent,
+			pageSize,
 		},
 		actions: {
 			setPageContainer,
@@ -118,12 +119,15 @@ function CanvasProvider( { children } ) {
 			selectIntersection,
 			registerTransformHandler,
 			pushTransform,
+			setPageSize,
 		},
 	};
 
 	return (
 		<Context.Provider value={ state }>
-			{ children }
+			<UnitsProvider pageSize={ pageSize }>
+				{ children }
+			</UnitsProvider>
 		</Context.Provider>
 	);
 }

--- a/assets/src/edit-story/components/canvas/carousel/index.js
+++ b/assets/src/edit-story/components/canvas/carousel/index.js
@@ -66,6 +66,7 @@ function Carousel() {
 	const openModal = useCallback( () => setIsGridViewOpen( true ), [ setIsGridViewOpen ] );
 	const closeModal = useCallback( () => setIsGridViewOpen( false ), [ setIsGridViewOpen ] );
 
+	// QQQQ: useResizeObserver
 	useLayoutEffect( () => {
 		const observer = new ResizeObserver( ( entries ) => {
 			for ( const entry of entries ) {

--- a/assets/src/edit-story/components/canvas/displayElement.js
+++ b/assets/src/edit-story/components/canvas/displayElement.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 
 /**
  * WordPress dependencies
@@ -13,7 +12,9 @@ import { useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { getDefinitionForType } from '../../elements';
-import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation } from '../../elements/shared';
+import StoryPropTypes from '../../types';
+import { useUnits } from '../../units';
 import useTransformHandler from './useTransformHandler';
 
 const Wrapper = styled.div`
@@ -23,27 +24,17 @@ const Wrapper = styled.div`
 	contain: layout paint;
 `;
 
-function DisplayElement( {
-	element: {
-		id,
-		type,
-		x,
-		y,
-		width,
-		height,
-		rotationAngle,
-		isFullbleed,
-		...rest
-	},
-} ) {
+function DisplayElement( { element } ) {
+	const { actions: { getBox } } = useUnits();
+
+	const { id, type } = element;
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { Display } = getDefinitionForType( type );
 
 	const wrapperRef = useRef( null );
 
-	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const props = { ...box, ...rest, id };
+	const box = getBox( element );
 
 	useTransformHandler( id, ( transform ) => {
 		const target = wrapperRef.current;
@@ -59,18 +50,23 @@ function DisplayElement( {
 		}
 	} );
 
+	// QQQQQ
+	if ( type !== 'image' ) {
+		return null;
+	}
+
 	return (
 		<Wrapper
 			ref={ wrapperRef }
 			{ ...box }
 		>
-			<Display { ...props } />
+			<Display element={ element } box={ box } />
 		</Wrapper>
 	);
 }
 
 DisplayElement.propTypes = {
-	element: PropTypes.object.isRequired,
+	element: StoryPropTypes.element.isRequired,
 };
 
 export default DisplayElement;

--- a/assets/src/edit-story/components/canvas/editElement.js
+++ b/assets/src/edit-story/components/canvas/editElement.js
@@ -8,7 +8,8 @@ import styled from 'styled-components';
  * Internal dependencies
  */
 import { getDefinitionForType } from '../../elements';
-import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation } from '../../elements/shared';
+import { useUnits } from '../../units';
 
 // Background color is used to make the edited element more prominent and
 // easier to see.
@@ -20,32 +21,22 @@ const Wrapper = styled.div`
 	background-color: ${ ( { theme } ) => theme.colors.whiteout };
 `;
 
-function EditElement( {
-	element: {
-		id,
-		type,
-		x,
-		y,
-		width,
-		height,
-		rotationAngle,
-		isFullbleed,
-		...rest
-	},
-} ) {
+function EditElement( { element } ) {
+	const { type } = element;
+	const { actions: { getBox } } = useUnits();
+
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
 	const { Edit } = getDefinitionForType( type );
 
-	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const props = { ...box, ...rest, id };
+	const box = getBox( element );
 
 	return (
 		<Wrapper
 			{ ...box }
 			onMouseDown={ ( evt ) => evt.stopPropagation() }
 		>
-			<Edit { ...props } />
+			<Edit element={ element } box={ box } />
 		</Wrapper>
 	);
 }

--- a/assets/src/edit-story/components/canvas/frameElement.js
+++ b/assets/src/edit-story/components/canvas/frameElement.js
@@ -14,7 +14,8 @@ import { useLayoutEffect, useRef } from '@wordpress/element';
  */
 import { getDefinitionForType } from '../../elements';
 import { useStory } from '../../app';
-import { ElementWithPosition, ElementWithSize, ElementWithRotation, getBox } from '../../elements/shared';
+import { ElementWithPosition, ElementWithSize, ElementWithRotation } from '../../elements/shared';
+import { useUnits } from '../../units';
 import useCanvas from './useCanvas';
 
 const Wrapper = styled.div`
@@ -28,42 +29,27 @@ const Wrapper = styled.div`
   }
 `;
 
-function FrameElement( {
-	element: {
-		id,
-		type,
-		x,
-		y,
-		width,
-		height,
-		rotationAngle,
-		isFullbleed,
-		...rest
-	},
-} ) {
+function FrameElement( { element } ) {
+	const { id, type } = element;
 	const { Frame } = getDefinitionForType( type );
-	const element = useRef();
+	const elementRef = useRef();
 
-	const {
-		actions: { setNodeForElement, handleSelectElement },
-	} = useCanvas();
-
-	const {
-		state: { selectedElements },
-	} = useStory();
+	const { actions: { setNodeForElement, handleSelectElement } } = useCanvas();
+	const { state: { selectedElements } } = useStory();
+	const { actions: { getBox } } = useUnits();
 
 	useLayoutEffect( () => {
-		setNodeForElement( id, element.current );
+		setNodeForElement( id, elementRef.current );
 	}, [ id, setNodeForElement ] );
 
 	const isSelected = selectedElements.includes( id );
 
-	const box = getBox( { x, y, width, height, rotationAngle, isFullbleed } );
-	const props = { ...box, ...rest, id };
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const box = getBox( element );
 
 	return (
 		<Wrapper
-			ref={ element }
+			ref={ elementRef }
 			{ ...box }
 			onMouseDown={ ( evt ) => {
 				if ( ! isSelected ) {
@@ -73,7 +59,7 @@ function FrameElement( {
 			} }
 		>
 			{ Frame && (
-				<Frame { ...props } />
+				<Frame element={ element } box={ box } />
 			) }
 		</Wrapper>
 	);

--- a/assets/src/edit-story/components/canvas/layout.js
+++ b/assets/src/edit-story/components/canvas/layout.js
@@ -8,11 +8,20 @@ import styled from 'styled-components';
  */
 import { PAGE_NAV_WIDTH, PAGE_WIDTH, PAGE_HEIGHT, HEADER_HEIGHT } from '../../constants';
 import PointerEventsCss from '../../utils/pointerEventsCss';
+import useResizeEffect from '../../utils/useResizeEffect';
+import useCanvas from './useCanvas';
 
 /**
  * @file See https://user-images.githubusercontent.com/726049/72654503-bfffe780-3944-11ea-912c-fc54d68b6100.png
  * for the layering details.
  */
+
+const MENU_HEIGHT = 48;
+const MIN_CAROUSEL_HEIGHT = 65;
+const ALLOWED_PAGE_SIZES = [
+	[ PAGE_WIDTH, PAGE_HEIGHT ],
+	[ 268, 476 ],
+];
 
 // @todo: the menu and carousel heights are not correct until we make a var-size
 // page.
@@ -29,11 +38,11 @@ const Layer = styled.div`
   grid:
     "head      head      head      head      head    " ${ HEADER_HEIGHT }px
     ".         .         .         .         .       " 1fr
-    ".         prev      page      next      .       " ${ PAGE_HEIGHT }px
-    ".         .         menu      .         .       " 48px
+    ".         prev      page      next      .       " var(--page-height-px)
+    ".         .         menu      .         .       " ${ MENU_HEIGHT }px
     ".         .         .         .         .       " 1fr
-    "carousel  carousel  carousel  carousel  carousel" 65px
-    / 1fr ${ PAGE_NAV_WIDTH }px ${ PAGE_WIDTH }px ${ PAGE_NAV_WIDTH }px 1fr;
+    "carousel  carousel  carousel  carousel  carousel" ${ MIN_CAROUSEL_HEIGHT }px
+    / 1fr ${ PAGE_NAV_WIDTH }px var(--page-width-px) ${ PAGE_NAV_WIDTH }px 1fr;
 `;
 
 const Area = styled.div`
@@ -66,6 +75,39 @@ const NavNextArea = styled( NavArea ).attrs( { area: 'next' } )``;
 
 const CarouselArea = styled( Area ).attrs( { area: 'carousel', overflow: false } )``;
 
+/**
+ * @param {!{current: ?Element}} containerRef
+ */
+function useLayoutParams( containerRef ) {
+	const { actions: { setPageSize } } = useCanvas();
+
+	useResizeEffect( containerRef, ( { width, height } ) => {
+		// See Layer's `grid` CSS above. Per the layout, the maximum available
+		// space for the page is:
+		const maxWidth = width - ( PAGE_NAV_WIDTH * 2 );
+		const maxHeight = height - HEADER_HEIGHT - MENU_HEIGHT - MIN_CAROUSEL_HEIGHT;
+
+		// Find the first size that fits within the [maxWidth, maxHeight].
+		let bestSize = ALLOWED_PAGE_SIZES[ ALLOWED_PAGE_SIZES.length - 1 ];
+		for ( let i = 0; i < ALLOWED_PAGE_SIZES.length; i++ ) {
+			const size = ALLOWED_PAGE_SIZES[ i ];
+			if ( size[ 0 ] <= maxWidth && size[ 1 ] <= maxHeight ) {
+				bestSize = size;
+				break;
+			}
+		}
+		setPageSize( { width: bestSize[ 0 ], height: bestSize[ 1 ] } );
+	} );
+}
+
+function useLayoutParamsCssVars() {
+	const { state: { pageSize } } = useCanvas();
+	return {
+		'--page-width-px': `${ pageSize.width }px`,
+		'--page-height-px': `${ pageSize.height }px`,
+	};
+}
+
 export {
 	Layer,
 	PageArea,
@@ -74,4 +116,6 @@ export {
 	NavPrevArea,
 	NavNextArea,
 	CarouselArea,
+	useLayoutParams,
+	useLayoutParamsCssVars,
 };

--- a/assets/src/edit-story/components/canvas/selectionCanvas.js
+++ b/assets/src/edit-story/components/canvas/selectionCanvas.js
@@ -13,9 +13,10 @@ import { useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { useStory } from '../../app';
-import useCanvas from '../canvas/useCanvas';
 import withOverlay from '../overlay/withOverlay';
 import InOverlay from '../overlay';
+import { useUnits } from '../../units';
+import useCanvas from './useCanvas';
 
 const LassoMode = {
 	OFF: 0,
@@ -42,13 +43,9 @@ const Lasso = styled.div`
 `;
 
 function SelectionCanvas( { children } ) {
-	const {
-		actions: { clearSelection },
-	} = useStory();
-	const {
-		state: { pageContainer },
-		actions: { clearEditing, selectIntersection },
-	} = useCanvas();
+	const { actions: { clearSelection } } = useStory();
+	const { state: { pageContainer }, actions: { clearEditing, selectIntersection } } = useCanvas();
+	const { actions: { editorToDataX, editorToDataY } } = useUnits();
 
 	const overlayRef = useRef( null );
 	const lassoRef = useRef( null );
@@ -116,9 +113,11 @@ function SelectionCanvas( { children } ) {
 
 	const onMouseUp = ( ) => {
 		if ( lassoModeRef.current === LassoMode.ON ) {
-			const [ ox, oy, width, height ] = getLassoBox();
-			const x = ox - pageContainer.offsetLeft;
-			const y = oy - pageContainer.offsetTop;
+			const [ lx, ly, lwidth, lheight ] = getLassoBox();
+			const x = editorToDataX( lx - pageContainer.offsetLeft );
+			const y = editorToDataY( ly - pageContainer.offsetTop );
+			const width = editorToDataX( lwidth );
+			const height = editorToDataY( lheight );
 			clearSelection();
 			clearEditing();
 			selectIntersection( { x, y, width, height } );

--- a/assets/src/edit-story/elements/image/display.js
+++ b/assets/src/edit-story/elements/image/display.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -14,6 +13,7 @@ import { useRef } from '@wordpress/element';
  */
 import { ElementFillContent } from '../shared';
 import { useTransformHandler } from '../../components/canvas';
+import StoryPropTypes from '../../types';
 import { ImageWithScale, getImgProps, getImageWithScaleCss } from './util';
 
 const Element = styled.div`
@@ -26,7 +26,10 @@ const Img = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageDisplay( { id, src, origRatio, width, height, scale, focalX, focalY } ) {
+function ImageDisplay( {
+	element: { id, src, origRatio, scale, focalX, focalY },
+	box: { width, height },
+} ) {
 	const imageRef = useRef( null );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
@@ -53,20 +56,8 @@ function ImageDisplay( { id, src, origRatio, width, height, scale, focalX, focal
 }
 
 ImageDisplay.propTypes = {
-	id: PropTypes.string.isRequired,
-	src: PropTypes.string.isRequired,
-	origRatio: PropTypes.number.isRequired,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	scale: PropTypes.number,
-	focalX: PropTypes.number,
-	focalY: PropTypes.number,
-};
-
-ImageDisplay.defaultProps = {
-	scale: null,
-	focalX: null,
-	focalY: null,
+	element: StoryPropTypes.elements.image.isRequired,
+	box: StoryPropTypes.box.isRequired,
 };
 
 export default ImageDisplay;

--- a/assets/src/edit-story/elements/image/edit.js
+++ b/assets/src/edit-story/elements/image/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -14,6 +13,7 @@ import { useCallback, useState } from '@wordpress/element';
  */
 import { ElementFillContent } from '../shared';
 import { useStory } from '../../app';
+import StoryPropTypes from '../../types';
 import { getImgProps, ImageWithScale } from './util';
 import EditPanMovable from './editPanMovable';
 import EditCropMovable from './editCropMovable';
@@ -54,7 +54,10 @@ const CropImg = styled.img`
 	${ ImageWithScale }
 `;
 
-function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, focalY, rotationAngle, isFullbleed } ) {
+function ImageEdit( {
+	element: { id, src, origRatio, scale, focalX, focalY, isFullbleed },
+	box: { x, y, width, height, rotationAngle },
+} ) {
 	const [ fullImage, setFullImage ] = useState( null );
 	const [ croppedImage, setCroppedImage ] = useState( null );
 	const [ cropBox, setCropBox ] = useState( null );
@@ -116,24 +119,8 @@ function ImageEdit( { id, src, origRatio, width, height, x, y, scale, focalX, fo
 }
 
 ImageEdit.propTypes = {
-	id: PropTypes.string.isRequired,
-	src: PropTypes.string.isRequired,
-	origRatio: PropTypes.number.isRequired,
-	width: PropTypes.number.isRequired,
-	height: PropTypes.number.isRequired,
-	x: PropTypes.number.isRequired,
-	y: PropTypes.number.isRequired,
-	rotationAngle: PropTypes.number.isRequired,
-	isFullbleed: PropTypes.bool,
-	scale: PropTypes.number,
-	focalX: PropTypes.number,
-	focalY: PropTypes.number,
-};
-
-ImageEdit.defaultProps = {
-	scale: null,
-	focalX: null,
-	focalY: null,
+	element: StoryPropTypes.elements.image.isRequired,
+	box: StoryPropTypes.box.isRequired,
 };
 
 export default ImageEdit;

--- a/assets/src/edit-story/elements/image/frame.js
+++ b/assets/src/edit-story/elements/image/frame.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 /**
@@ -15,12 +14,13 @@ import { useCallback } from '@wordpress/element';
 import { useCanvas } from '../../components/canvas';
 import useDoubleClick from '../../utils/useDoubleClick';
 import { ElementFillContent } from '../shared';
+import StoryPropTypes from '../../types';
 
 const Element = styled.div`
   ${ ElementFillContent }
 `;
 
-function ImageFrame( { id } ) {
+function ImageFrame( { element: { id } } ) {
 	const {
 		actions: { setEditingElement },
 	} = useCanvas();
@@ -33,7 +33,7 @@ function ImageFrame( { id } ) {
 }
 
 ImageFrame.propTypes = {
-	id: PropTypes.string.isRequired,
+	element: StoryPropTypes.elements.image.isRequired,
 };
 
 export default ImageFrame;

--- a/assets/src/edit-story/elements/index.js
+++ b/assets/src/edit-story/elements/index.js
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import uuid from 'uuid/v4';
+
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */

--- a/assets/src/edit-story/elements/shared.js
+++ b/assets/src/edit-story/elements/shared.js
@@ -70,6 +70,7 @@ export const getCommonAttributes = ( ( { width, height, x, y, rotationAngle } ) 
 	};
 } );
 
+// QQQQ: migrate to useUnits() everywhere and remove.
 export function getBox( { x, y, width, height, rotationAngle, isFullbleed } ) {
 	return {
 		x: isFullbleed ? 0 : x,

--- a/assets/src/edit-story/types.js
+++ b/assets/src/edit-story/types.js
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+
+const StoryPropTypes = {};
+
+export const StoryElementPropsTypes = {
+	id: PropTypes.string.isRequired,
+	type: PropTypes.string.isRequired,
+	x: PropTypes.number.isRequired,
+	y: PropTypes.number.isRequired,
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+	rotationAngle: PropTypes.number.isRequired,
+	isFullbleed: PropTypes.bool.isRequired,
+};
+
+StoryPropTypes.size = PropTypes.exact( {
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+} );
+
+StoryPropTypes.box = PropTypes.exact( {
+	x: PropTypes.number.isRequired,
+	y: PropTypes.number.isRequired,
+	width: PropTypes.number.isRequired,
+	height: PropTypes.number.isRequired,
+	rotationAngle: PropTypes.number.isRequired,
+} );
+
+StoryPropTypes.children = PropTypes.oneOfType( [
+	PropTypes.arrayOf( PropTypes.node ),
+	PropTypes.node,
+] );
+
+StoryPropTypes.page = PropTypes.shape( {
+	id: PropTypes.string.isRequired,
+} );
+
+StoryPropTypes.element = PropTypes.shape( StoryElementPropsTypes );
+
+StoryPropTypes.elements = {};
+
+StoryPropTypes.elements.image = PropTypes.shape( {
+	...StoryElementPropsTypes,
+	src: PropTypes.string.isRequired,
+	origRatio: PropTypes.number.isRequired,
+	scale: PropTypes.number.isRequired,
+	focalX: PropTypes.number,
+	focalY: PropTypes.number,
+} );
+
+export default StoryPropTypes;

--- a/assets/src/edit-story/units/context.js
+++ b/assets/src/edit-story/units/context.js
@@ -1,0 +1,6 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+export default createContext( { actions: {}, state: {} } );

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -1,0 +1,39 @@
+
+/**
+ * Internal dependencies
+ */
+import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
+
+export function dataUnit( v ) {
+	return Number( v.toFixed( 0 ) );
+}
+
+export function editorUnit( v ) {
+	return Number( v.toFixed( 5 ) );
+}
+
+export function dataToEditorX( x, pageWidth ) {
+	return editorUnit( x * pageWidth / PAGE_WIDTH );
+}
+
+export function dataToEditorY( y, pageHeight ) {
+	return editorUnit( y * pageHeight / PAGE_HEIGHT );
+}
+
+export function editorToDataX( x, pageWidth ) {
+	return dataUnit( x * PAGE_WIDTH / pageWidth );
+}
+
+export function editorToDataY( y, pageHeight ) {
+	return dataUnit( y * PAGE_HEIGHT / pageHeight );
+}
+
+export function getBox( { x, y, width, height, rotationAngle, isFullbleed }, pageWidth, pageHeight ) {
+	return {
+		x: dataToEditorX( isFullbleed ? 0 : x, pageWidth ),
+		y: dataToEditorY( isFullbleed ? 0 : y, pageHeight ),
+		width: dataToEditorX( isFullbleed ? PAGE_WIDTH : width, pageWidth ),
+		height: dataToEditorY( isFullbleed ? PAGE_HEIGHT : height, pageHeight ),
+		rotationAngle: isFullbleed ? 0 : rotationAngle,
+	};
+}

--- a/assets/src/edit-story/units/dimensions.js
+++ b/assets/src/edit-story/units/dimensions.js
@@ -4,30 +4,85 @@
  */
 import { PAGE_WIDTH, PAGE_HEIGHT } from '../constants';
 
-export function dataUnit( v ) {
+/**
+ * Rounds the pixel value to the max allowed precision in the "data" space.
+ *
+ * @param {number} v The value to be rounded.
+ * @return {number} The value rounded to the "data" space precision.
+ */
+export function dataPixels( v ) {
 	return Number( v.toFixed( 0 ) );
 }
 
-export function editorUnit( v ) {
+/**
+ * Rounds the pixel value to the max allowed precision in the "editor" space.
+ *
+ * @param {number} v The value to be rounded.
+ * @return {number} The value rounded to the "editor" space precision.
+ */
+export function editorPixels( v ) {
 	return Number( v.toFixed( 5 ) );
 }
 
+/**
+ * Converts a "data" pixel value to the value in the "editor" space along
+ * the horizontal (X) dimension.
+ *
+ * @param {number} x The value to be converted.
+ * @param {number} pageWidth The basis value for the page's width in the "editor" space.
+ * @return {number} The value in the "editor" space.
+ */
 export function dataToEditorX( x, pageWidth ) {
-	return editorUnit( x * pageWidth / PAGE_WIDTH );
+	return editorPixels( x * pageWidth / PAGE_WIDTH );
 }
 
+/**
+ * Converts a "data" pixel value to the value in the "editor" space along
+ * the vertical (Y) dimension.
+ *
+ * @param {number} y The value to be converted.
+ * @param {number} pageHeight The basis value for the page's height in the "editor" space.
+ * @return {number} The value in the "editor" space.
+ */
 export function dataToEditorY( y, pageHeight ) {
-	return editorUnit( y * pageHeight / PAGE_HEIGHT );
+	return editorPixels( y * pageHeight / PAGE_HEIGHT );
 }
 
+/**
+ * Converts a "editor" pixel value to the value in the "data" space along
+ * the horizontal (X) dimension.
+ *
+ * @param {number} x The value to be converted.
+ * @param {number} pageWidth The basis value for the page's width in the "editor" space.
+ * @return {number} The value in the "data" space.
+ */
 export function editorToDataX( x, pageWidth ) {
-	return dataUnit( x * PAGE_WIDTH / pageWidth );
+	return dataPixels( x * PAGE_WIDTH / pageWidth );
 }
 
+/**
+ * Converts a "editor" pixel value to the value in the "data" space along
+ * the vertical (Y) dimension.
+ *
+ * @param {number} y The value to be converted.
+ * @param {number} pageHeight The basis value for the page's height in the "editor" space.
+ * @return {number} The value in the "data" space.
+ */
 export function editorToDataY( y, pageHeight ) {
-	return dataUnit( y * PAGE_HEIGHT / pageHeight );
+	return dataPixels( y * PAGE_HEIGHT / pageHeight );
 }
 
+/**
+ * Converts the element's position, width, and rotation) to the "box" in the
+ * "editor" coordinate space.
+ *
+ * @param {{x:number, y:number, width:number, height:number, rotationAngle:number, isFullbleed:boolean}} element The
+ * element's position, width, and rotation. See `StoryPropTypes.element`.
+ * @param {number} pageWidth The basis value for the page's width in the "editor" space.
+ * @param {number} pageHeight The basis value for the page's height in the "editor" space.
+ * @return {{x:number, y:number, width:number, height:number, rotationAngle:number}} The
+ * "box" in the editor space.
+ */
 export function getBox( { x, y, width, height, rotationAngle, isFullbleed }, pageWidth, pageHeight ) {
 	return {
 		x: dataToEditorX( isFullbleed ? 0 : x, pageWidth ),

--- a/assets/src/edit-story/units/index.js
+++ b/assets/src/edit-story/units/index.js
@@ -1,0 +1,1 @@
+export { default as useUnits } from './useUnits';

--- a/assets/src/edit-story/units/unitsProvider.js
+++ b/assets/src/edit-story/units/unitsProvider.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import StoryPropTypes from '../types';
+import Context from './context';
+import {
+	dataToEditorX,
+	dataToEditorY,
+	editorToDataX,
+	editorToDataY,
+	getBox,
+} from './dimensions';
+
+function UnitsProvider( { pageSize, children } ) {
+	const { width: pageWidth, height: pageHeight } = pageSize;
+	const state = useMemo(
+		() => ( {
+			state: {
+				pageSize: { width: pageWidth, height: pageHeight },
+			},
+			actions: {
+				dataToEditorX: ( x ) => dataToEditorX( x, pageWidth ),
+				dataToEditorY: ( y ) => dataToEditorY( y, pageHeight ),
+				editorToDataX: ( x ) => editorToDataX( x, pageWidth ),
+				editorToDataY: ( y ) => editorToDataY( y, pageHeight ),
+				getBox: ( element ) => getBox( element, pageWidth, pageHeight ),
+			},
+		} ),
+		[ pageWidth, pageHeight ] );
+
+	return (
+		<Context.Provider value={ state }>
+			{ children }
+		</Context.Provider>
+	);
+}
+
+UnitsProvider.propTypes = {
+	pageSize: StoryPropTypes.size.isRequired,
+	children: StoryPropTypes.children.isRequired,
+};
+
+export default UnitsProvider;

--- a/assets/src/edit-story/units/useUnits.js
+++ b/assets/src/edit-story/units/useUnits.js
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Context from './context';
+
+function useUnits() {
+	return useContext( Context );
+}
+
+export default useUnits;

--- a/assets/src/edit-story/utils/useResizeEffect.js
+++ b/assets/src/edit-story/utils/useResizeEffect.js
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import ResizeObserver from 'resize-observer-polyfill';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * @param {!{current: ?Element}} ref Target node ref.
+ * @param {function( {width: number, height: number} )} handler The resize
+ * handler.
+ * @param {!Array=} deps The effect's dependencies.
+ */
+function useResizeEffect( ref, handler, deps = undefined ) {
+	useEffect(
+		() => {
+			const node = ref.current;
+			if ( ! node ) {
+				return null;
+			}
+
+			const observer = new ResizeObserver( ( entries ) => {
+				const last = entries.length > 0 ? entries[ entries.length - 1 ] : null;
+				if ( last ) {
+					const { width, height } = last.contentRect;
+					handler( { width, height } );
+				}
+			} );
+
+			observer.observe( node );
+
+			return () => observer.disconnect();
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		deps || [],
+	);
+}
+
+export default useResizeEffect;


### PR DESCRIPTION
## Summary

Partial for #27.

TODO: 

- [ ] Migrate all element types
- [ ] Migrate multi-selection movable
- [ ] Migrate carousel to use `useResizeEffect` hook
- [ ] Remove old APIs

This PR does the following:

* Implements breakpoints for a couple of different allowed sizes of the "page" area.
* Uses `units` system to convert between "data" and "editor" pixels.
* Migrates element templates to use `{element, box, ...}` shape to allow use of both data and physical pixels as necessary.
* Cleans up typing a little.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
