### PR TITLE
Fix E2E tests on 1.4 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "phpcompatibility/phpcompatibility-wp": "2.1.0",
     "roave/security-advisories": "dev-master",
     "sirbrillig/phpcs-variable-analysis": "2.6.2",
-    "wp-cli/wp-cli": "2.3.0",
+    "wp-cli/wp-cli": "2.4.0",
     "wp-coding-standards/wpcs": "2.1.1",
     "xwp/wp-dev-lib": "1.3.2"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdd51f4b48767772fbcd1a09004b9a1f",
+    "content-hash": "c7a5669d92aa7edd6ba3155d03391fda",
     "packages": [
         {
             "name": "cweagans/composer-patches",
@@ -577,12 +577,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "67ac6ea8f4a078c3c9b7aec5d7ae70f098c37389"
+                "reference": "5e2ebc8340c8b7dcdc3f938dcbb9e2b99b72fd8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/67ac6ea8f4a078c3c9b7aec5d7ae70f098c37389",
-                "reference": "67ac6ea8f4a078c3c9b7aec5d7ae70f098c37389",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5e2ebc8340c8b7dcdc3f938dcbb9e2b99b72fd8e",
+                "reference": "5e2ebc8340c8b7dcdc3f938dcbb9e2b99b72fd8e",
                 "shasum": ""
             },
             "conflict": {
@@ -695,7 +695,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "stormpath/sdk": ">=0,<9.9.99",
-                "studio-42/elfinder": "<2.1.48",
+                "studio-42/elfinder": "<2.1.49",
                 "swiftmailer/swiftmailer": ">=4,<5.4.5",
                 "sylius/admin-bundle": ">=1,<1.0.17|>=1.1,<1.1.9|>=1.2,<1.2.2",
                 "sylius/grid": ">=1,<1.1.19|>=1.2,<1.2.18|>=1.3,<1.3.13|>=1.4,<1.4.5|>=1.5,<1.5.1",
@@ -789,7 +789,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2020-01-06T19:16:46+00:00"
+            "time": "2020-01-20T14:23:18+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
@@ -1038,19 +1038,20 @@
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "538d9be5ad490bd07b946dcd3b52b4d1c34dc193"
+                "reference": "74c949c74708e3a88ad0add70f3236c8675dfd85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/538d9be5ad490bd07b946dcd3b52b4d1c34dc193",
-                "reference": "538d9be5ad490bd07b946dcd3b52b4d1c34dc193",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/74c949c74708e3a88ad0add70f3236c8675dfd85",
+                "reference": "74c949c74708e3a88ad0add70f3236c8675dfd85",
                 "shasum": ""
             },
             "require": {
+                "cweagans/composer-patches": "^1.6",
                 "ext-curl": "*",
                 "mustache/mustache": "~2.4",
                 "php": "^5.4 || ^7.0",
@@ -1078,7 +1079,12 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "2.4.x-dev"
+                },
+                "patches": {
+                    "mustache/mustache": {
+                        "Avoid notices on PHP 7.4+": "https://patch-diff.githubusercontent.com/raw/bobthecow/mustache.php/pull/349.patch"
+                    }
                 }
             },
             "autoload": {
@@ -1096,7 +1102,7 @@
                 "cli",
                 "wordpress"
             ],
-            "time": "2019-08-13T23:12:27+00:00"
+            "time": "2019-11-12T15:26:05+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -318,16 +318,16 @@
         },
         {
             "name": "mustache/mustache",
-            "version": "v2.13.0",
+            "version": "v2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "e95c5a008c23d3151d59ea72484d4f72049ab7f4"
+                "reference": "fe8fe72e9d580591854de404cc59a1b83ca4d19e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e95c5a008c23d3151d59ea72484d4f72049ab7f4",
-                "reference": "e95c5a008c23d3151d59ea72484d4f72049ab7f4",
+                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/fe8fe72e9d580591854de404cc59a1b83ca4d19e",
+                "reference": "fe8fe72e9d580591854de404cc59a1b83ca4d19e",
                 "shasum": ""
             },
             "require": {
@@ -360,7 +360,7 @@
                 "mustache",
                 "templating"
             ],
-            "time": "2019-11-23T21:40:31+00:00"
+            "time": "2017-07-11T12:54:05+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2842,22 +2842,47 @@
       }
     },
     "@wordpress/e2e-test-utils": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-2.4.3.tgz",
-      "integrity": "sha512-I/83+QhF1E4anCMy+ZqkX8S9v6TKhDvitbYgx2DQNfRFPsf07KWFun2lttWI7+apZ081JRSBKT+5SCoU121iSA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-4.1.0.tgz",
+      "integrity": "sha512-kJou60MOQ/uQ/+APVf/4w6e8c2uz1QMawNkxo53OQM+FP+9JDNbOzuZ3piGI6EwsqlgVMHc9UCgSGwsFtpjEAA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@wordpress/keycodes": "^2.6.2",
-        "@wordpress/url": "^2.8.2",
+        "@wordpress/keycodes": "^2.8.0",
+        "@wordpress/url": "^2.9.0",
         "lodash": "^4.17.15",
         "node-fetch": "^1.7.3"
       },
       "dependencies": {
+        "@wordpress/i18n": {
+          "version": "3.8.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.8.0.tgz",
+          "integrity": "sha512-SXheA3E2aA/w5/cubrIho3fCLY5Jb7zdpg7NGS3DFXYEe5VICMdmgNxeYFoeyNSw2IkNmphJhsZXzVIMf92dYQ==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "gettext-parser": "^1.3.1",
+            "lodash": "^4.17.15",
+            "memize": "^1.0.5",
+            "sprintf-js": "^1.1.1",
+            "tannin": "^1.1.0"
+          }
+        },
+        "@wordpress/keycodes": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.8.0.tgz",
+          "integrity": "sha512-c1YQZbMEPplEgbXxxSDBUxG92zxwCB//SvVJw+poHBiQi+bcEuH/J/xezAXk4tfJO/gtb1r3LpFjcZqxZWc8SA==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@wordpress/i18n": "^3.8.0",
+            "lodash": "^4.17.15"
+          }
+        },
         "@wordpress/url": {
-          "version": "2.8.2",
-          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.8.2.tgz",
-          "integrity": "sha512-adTOs94K5G1riTQveIH/pJoDmFGegzBWFSDe/YzhP6mg64AGOWLQLwi0xzfIyoFC4d+kchx4fCyFTqYfcCbRVg==",
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.9.0.tgz",
+          "integrity": "sha512-ntrXO42/NElNHIrezoYPjWrXNyNYqyHzvvtBVSMLwwwMf7836t/C7GACuk56O3PwQEmSikMNStHQnNCwmyeaag==",
           "dev": true,
           "requires": {
             "@babel/runtime": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@wordpress/date": "3.5.0",
     "@wordpress/dom": "2.5.2",
     "@wordpress/dom-ready": "2.5.1",
-    "@wordpress/e2e-test-utils": "2.4.3",
+    "@wordpress/e2e-test-utils": "4.1.0",
     "@wordpress/edit-post": "3.8.4",
     "@wordpress/editor": "9.7.4",
     "@wordpress/element": "2.8.2",


### PR DESCRIPTION
## Summary

Updating the dependency:

- `wp-cli/wp-cli` to v2.4.0 resolves the issue of the Gutenberg plugin [failing to activate](https://travis-ci.org/ampproject/amp-wp/jobs/635359942#L870)
- `@wordpress/e2e-test-utils` to v4.1.0 resolves the issue of the Gutenberg editor welcome guide (aka tips) [failing to be disabled](https://travis-ci.org/ampproject/amp-wp/jobs/641866218#L939)

<!-- Please reference the issue this PR addresses. -->
Fixes #4174.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
