### PR TITLE
Fix validation of links with mailto: protocol

### DIFF
--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -204,6 +204,10 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	public function is_frontend_url( $url ) {
 		$parsed_url = wp_parse_url( $url );
 
+		if ( ! empty( $parsed_url['scheme'] ) && ! in_array( strtolower( $parsed_url['scheme'] ), [ 'http', 'https' ], true ) ) {
+			return false;
+		}
+
 		// Skip adding query var to links on other URLs.
 		if ( ! empty( $parsed_url['host'] ) && $this->home_host !== $parsed_url['host'] ) {
 			return false;

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -142,6 +142,11 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
+			'mailto-link'         => [
+				'href'         => 'mailto:nobody@example.com',
+				'expected_amp' => false,
+				'expected_rel' => null,
+			],
 		];
 
 		$admin_bar_link_href = home_url( '/?do_something' );


### PR DESCRIPTION
## Summary

Fixes #4182.

- [ ] Prevent `INVALID_URL_PROTOCOL` validation error from being raised for links to `mailto:?&subject=Example&body=https://example.com/` 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
