### PR TITLE
Redirect to non-AMP version when making non-singular AMP request; prevent using Reader mode template for Stories

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -410,7 +410,12 @@ class AMP_Theme_Support {
 			add_filter( 'template_include', [ __CLASS__, 'serve_paired_browsing_experience' ] );
 		}
 
-		if ( ! is_amp_endpoint() ) {
+		if ( self::READER_MODE_SLUG === self::get_support_mode() && ! is_singular() && false !== get_query_var( amp_get_slug(), false ) ) {
+			// Reader mode only supports the singular template (for now) so redirect non-singular queries in reader mode to non-AMP version.
+			// A temporary redirect is used for admin users to allow them to see changes between reader mode and transitional modes.
+			wp_safe_redirect( amp_remove_endpoint( amp_get_current_url() ), current_user_can( 'manage_options' ) ? 302 : 301 );
+			return;
+		} elseif ( ! is_amp_endpoint() ) {
 			/*
 			 * Redirect to AMP-less variable if AMP is not available for this URL and yet the query var is present.
 			 * Temporary redirect is used for admin users because implied transitional mode and template support can be
@@ -422,11 +427,6 @@ class AMP_Theme_Support {
 			}
 
 			amp_add_frontend_actions();
-			return;
-		} elseif ( self::READER_MODE_SLUG === self::get_support_mode() && ! is_singular() ) {
-			// Reader mode only supports the singular template (for now) so redirect non-singular queries in reader mode to non-AMP version.
-			// A temporary redirect is used for admin users to allow them to see changes between reader mode and transitional modes.
-			wp_safe_redirect( amp_remove_endpoint( amp_get_current_url() ), current_user_can( 'manage_options' ) ? 302 : 301 );
 			return;
 		}
 

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -410,7 +410,8 @@ class AMP_Theme_Support {
 			add_filter( 'template_include', [ __CLASS__, 'serve_paired_browsing_experience' ] );
 		}
 
-		if ( self::READER_MODE_SLUG === self::get_support_mode() && ! is_singular() && false !== get_query_var( amp_get_slug(), false ) ) {
+		$is_reader_mode = self::READER_MODE_SLUG === self::get_support_mode();
+		if ( $is_reader_mode && ! is_singular() && false !== get_query_var( amp_get_slug(), false ) ) {
 			// Reader mode only supports the singular template (for now) so redirect non-singular queries in reader mode to non-AMP version.
 			// A temporary redirect is used for admin users to allow them to see changes between reader mode and transitional modes.
 			wp_safe_redirect( amp_remove_endpoint( amp_get_current_url() ), current_user_can( 'manage_options' ) ? 302 : 301 );
@@ -432,11 +433,10 @@ class AMP_Theme_Support {
 
 		self::ensure_proper_amp_location();
 
-		$is_reader_mode = self::READER_MODE_SLUG === self::get_support_mode();
-		$theme_support  = self::get_theme_support_args();
+		$theme_support = self::get_theme_support_args();
 		if ( ! empty( $theme_support['template_dir'] ) ) {
 			self::add_amp_template_filters();
-		} elseif ( $is_reader_mode ) {
+		} elseif ( $is_reader_mode && ! is_singular( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			add_filter(
 				'template_include',
 				static function() {
@@ -448,7 +448,7 @@ class AMP_Theme_Support {
 
 		self::add_hooks();
 		self::$sanitizer_classes = amp_get_content_sanitizers();
-		if ( ! $is_reader_mode ) {
+		if ( ! $is_reader_mode || is_singular( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			self::$sanitizer_classes = AMP_Validation_Manager::filter_sanitizer_args( self::$sanitizer_classes );
 		}
 		self::$embed_handlers = self::register_content_embed_handlers();

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -423,6 +423,11 @@ class AMP_Theme_Support {
 
 			amp_add_frontend_actions();
 			return;
+		} elseif ( self::READER_MODE_SLUG === self::get_support_mode() && ! is_singular() ) {
+			// Reader mode only supports the singular template (for now) so redirect non-singular queries in reader mode to non-AMP version.
+			// A temporary redirect is used for admin users to allow them to see changes between reader mode and transitional modes.
+			wp_safe_redirect( amp_remove_endpoint( amp_get_current_url() ), current_user_can( 'manage_options' ) ? 302 : 301 );
+			return;
 		}
 
 		self::ensure_proper_amp_location();

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -323,6 +323,28 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that attempting to access an AMP page in Reader Mode for a non-singular query will redirect to the non-AMP version.
+	 *
+	 * @covers AMP_Theme_Support::finish_init()
+	 */
+	public function test_finish_init_when_accessing_non_singular_amp_page_in_reader_mode() {
+		$category     = current( get_categories( [ 'hide_empty' => true ] ) );
+		$category_url = get_category_link( $category );
+		$this->assertEquals( AMP_Theme_Support::READER_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
+		$redirected = false;
+		add_filter(
+			'wp_redirect',
+			function ( $url ) use ( $category_url, &$redirected ) {
+				$this->assertEquals( $category_url, $url );
+				$redirected = true;
+				return null;
+			}
+		);
+		$this->go_to( add_query_arg( amp_get_slug(), '', $category_url ) );
+		$this->assertTrue( $redirected );
+	}
+
+	/**
 	 * Test ensure_proper_amp_location for canonical.
 	 *
 	 * @covers AMP_Theme_Support::ensure_proper_amp_location()


### PR DESCRIPTION
## Summary

This PR fixes three issues with how Reader mode is served:

1. Reader mode only supports rendering AMP pages for the singular template. When attempting to access the AMP version for a non-singular template, the AMP plugin needs to redirect to the non-AMP URL. This was not the case in v1.4, where the `?amp` query parameter was just ignored. This was not good because if a site switched from Transitional mode to Reader mode, then the AMP URLs for non-singular templates would start serving back non-AMP pages. The AMP plugin should redirect to the non-AMP version to make it clear that an AMP page is not being served, either to inform search crawlers who may have indexed an AMP version or for users who are manually trying to access the AMP URL.
2. In 1.5-alpha after #3781, the above issue is more problematic because the lack of a redirect is resulting in a non-singular template being routed into the `single.php` Reader template. For example, if doing a search for “Sticky” with the URL`/?s=sticky` and you add the `amp` query var to go to `/?s=sticky&amp`, currently in `develop` the AMP plugin will try to render the `WP_Query` onto the `single.php` template, resulting in just the first post in the query being rendered. This is wrong! In this case we need to redirect to the non-AMP version in Reader mode when AMP is not available.
3. Lastly, when Reader mode was active, accessing a story permalink was resulting in the Reader template being used as opposed to the proper story template.

## Testing Instructions

Non-singular templates:

1. Enable Reader mode.
1. Try viewing the AMP version of a non-singular template, e.g. `/category/uncategorized/?amp`.
1. PASS: User is redirected to `/category/uncategorized/`; FAIL: Reader mode template renders the most recent post in the category.

Story template:

1. Enable the Stories experience and create a story.
1. View a single story.
1. PASS: Story renders as expected. FAIL: Reader mode template is unexpectedly used to render a story.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
