### PR TITLE
Avoid entering The Loop when rendering Reader template

### DIFF
--- a/includes/templates/reader-template-loader.php
+++ b/includes/templates/reader-template-loader.php
@@ -5,7 +5,18 @@
  * @package AMP
  */
 
-the_post();
+/**
+ * Queried post.
+ *
+ * @global WP_Post $post
+ */
+global $post;
+
+// Populate the $post without calling the_post() to prevent entering The Loop. This ensures that templates which
+// contain The Loop will still loop over the posts. Otherwise, if a template contains The Loop then calling the_post()
+// here will advance the WP_Query::$current_post to the next_post. See WP_Query::the_post().
+$post = get_queried_object(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+setup_postdata( $post );
 
 /**
  * Fires before rendering a post in AMP.


### PR DESCRIPTION
## Summary

This fixes an issue that was uncovered by @jackmcconnell in https://github.com/ampproject/amp-wp/issues/1780#issuecomment-571961056.

If an overridden Reader mode template attempted to use The Loop to render the title or content, for example:

```php
<?php if ( have_posts() ) : ?>
	<?php while ( have_posts() ) : the_post(); ?>
		<?php the_content(); ?>
	<?php endwhile; ?>
<?php endif; ?>
```

This would result in nothing being output because `reader-template-loader.php` was entering The Loop via `the_post()`. Since only one post is in The Loop in singular queries, the result was that `have_posts()` would return `false` and nothing would be output.

The fix is simply to directly populate the `$post` global and set up its global variables without advancing the `current_post` in the global `WP_Query`.

This fixes a regression that was introduced in #3781.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
