### PR TITLE
Fix validation error reporting for invalid attributes on the HTML element

### DIFF
--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -244,6 +244,15 @@ class AMP_Validation_Manager {
 		add_action( 'wp', [ __CLASS__, 'override_validation_error_statuses' ] );
 
 		if ( self::$is_validate_request ) {
+			/*
+			 * Always suppress the admin bar from being shown when performing a validation request. This ensures that
+			 * user-initiated validation requests perform the same as validation requests initiated by the WP-CLI
+			 * command `wp amp validate-site`, which does so as an unauthenticated user. Unauthenticated users should
+			 * not be shown the admin bar, and normal site visitors who read AMP content (such as via an AMP Cache) are
+			 * not authenticated, so it doesn't make sense to include the admin bar when doing validation.
+			 */
+			add_filter( 'show_admin_bar', '__return_false', PHP_INT_MAX );
+
 			self::add_validation_error_sourcing();
 		}
 	}


### PR DESCRIPTION
## Summary

In #2500 the admin bar was suppressed from being shown when doing validation requests. Then in #3187 this was reverted because the addition of dev mode meant that the presence of the admin bar would no longer make pages invalid. Nevertheless, this had an unexpected consequence. When the `<html>` element has invalid attributes, these are never detected during validation because a validation request is made as an authenticated user, and thus the admin bar is present, and the admin bar entails dev mode being enabled. Since the `data-ampdevmode` attribute is on the `html` element, any invalid attributes on the element are ignored for validation purposes. This is not expected.

For example, activate Twenty Twenty and add this plugin code:

```php
add_filter(
	'language_attributes',
	function ( $attr ) {
		if ( ! is_admin() ) {
			$attr .= ' amp-version="1902151859190" onclick="alert(\'hello\')" ';
		}
		return $attr;
	}
);
```

This adds two invalid AMP attributes, and when I look at an AMP page while logged-in, I see them:

```html
<html class="no-js" lang="en-US" amp-version="1902151859190" onclick="alert('hello')" amp="" data-ampdevmode="">
```

Nevertheless, the admin bar shows ✅ for validity.

However, if I access the same AMP page while being logged-out, I see:

```html
<html class="no-js" lang="en-US" amp="">
```

Similarly, if I go to validate the URL I see no validation errors:

![image](https://user-images.githubusercontent.com/134745/73316292-5b1b7b80-41e7-11ea-812e-b565b9e5c976.png)

This doesn't seem right.

To prevent this from happening, we can prevent showing the admin bar on the frontend as we were doing before. When that is done, the result when validating is:

![image](https://user-images.githubusercontent.com/134745/73316367-843c0c00-41e7-11ea-8ede-304a106707ff.png)

This reverts commit 3380451bc89ca732379a8dbe0b622ebfab27c27a from #3187.

## Todo

- [ ] What if someone is forcing the admin bar to be shown on the frontend even for unauthenticated users? Should the admin bar not be excluded in this case? 
- [ ] Will suppressing the admin bar make it more difficult to reconcile validation errors that occur on the frontend while logged-in but validation is is done with the admin bar suppressed?
- [ ] Should dev mode be filtered off in addition to the admin bar being excluded?

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
