### PR TITLE
Convert `head[profile]` attribute to `link[rel=profile]`

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -541,17 +541,22 @@ final class Document extends DOMDocument {
 	 * Converts a possible head[profile] attribute to link[rel=profile].
 	 *
 	 * The head[profile] attribute is only valid in HTML4, not HTML5.
-	 * So if it exists, add it to the <head> as a link[rel=profile] and strip the attribute.a -
+	 * So if it exists and isn't empty, add it to the <head> as a link[rel=profile] and strip the attribute.
 	 */
 	private function convert_head_profile_to_link() {
+		if ( ! $this->head->hasAttribute( 'profile' ) ) {
+			return;
+		}
+
 		$profile = $this->head->getAttribute( 'profile' );
 		if ( $profile ) {
 			$link = $this->createElement( 'link' );
 			$link->setAttribute( 'rel', 'profile' );
 			$link->setAttribute( 'href', $profile );
 			$this->head->appendChild( $link );
-			$this->head->removeAttribute( 'profile' );
 		}
+
+		$this->head->removeAttribute( 'profile' );
 	}
 
 	/**

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -359,6 +359,7 @@ final class Document extends DOMDocument {
 			$this->deduplicate_tag( self::TAG_HEAD );
 			$this->deduplicate_tag( self::TAG_BODY );
 			$this->move_invalid_head_nodes_to_body();
+			$this->convert_head_profile_to_link();
 		}
 
 		return $success;
@@ -533,6 +534,23 @@ final class Document extends DOMDocument {
 				$this->body->insertBefore( $this->head->removeChild( $node ), $this->body->firstChild );
 			}
 			$node = $next_sibling;
+		}
+	}
+
+	/**
+	 * Converts a possible head[profile] attribute to link[rel=profile].
+	 *
+	 * The head[profile] attribute is only valid in HTML4, not HTML5.
+	 * So if it exists, add it to the <head> as a link[rel=profile] and strip the attribute.
+	 */
+	private function convert_head_profile_to_link() {
+		$profile = $this->head->getAttribute( 'profile' );
+		if ( $profile ) {
+			$link = $this->createElement( 'link' );
+			$link->setAttribute( 'rel', 'profile' );
+			$link->setAttribute( 'href', $profile );
+			$this->head->appendChild( $link );
+			$this->head->removeAttribute( 'profile' );
 		}
 	}
 

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -541,17 +541,29 @@ final class Document extends DOMDocument {
 	 * Converts a possible head[profile] attribute to link[rel=profile].
 	 *
 	 * The head[profile] attribute is only valid in HTML4, not HTML5.
-	 * So if it exists, add it to the <head> as a link[rel=profile] and strip the attribute.
+	 * So if it exists and there's no link[rel=profile], add it to the <head> as a link[rel=profile].
 	 */
 	private function convert_head_profile_to_link() {
 		$profile = $this->head->getAttribute( 'profile' );
-		if ( $profile ) {
-			$link = $this->createElement( 'link' );
-			$link->setAttribute( 'rel', 'profile' );
-			$link->setAttribute( 'href', $profile );
-			$this->head->appendChild( $link );
-			$this->head->removeAttribute( 'profile' );
+		if ( ! $profile ) {
+			return;
 		}
+
+		// If there's already a head > link[rel=profile], don't create another.
+		$links = $this->head->getElementsByTagName( 'link' );
+		foreach( $links as $link ) {
+			if ( 'profile' === $link->getAttribute( 'rel' ) ) {
+				$this->head->removeAttribute( 'profile' );
+				return;
+			}
+		}
+
+		// Create a <link> and append it to <head>.
+		$new_link = $this->createElement( 'link' );
+		$new_link->setAttribute( 'rel', 'profile' );
+		$new_link->setAttribute( 'href', $profile );
+		$this->head->appendChild( $new_link );
+		$this->head->removeAttribute( 'profile' );
 	}
 
 	/**

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -551,7 +551,7 @@ final class Document extends DOMDocument {
 
 		// If there's already a head > link[rel=profile], don't create another.
 		$links = $this->head->getElementsByTagName( 'link' );
-		foreach( $links as $link ) {
+		foreach ( $links as $link ) {
 			if ( 'profile' === $link->getAttribute( 'rel' ) ) {
 				$this->head->removeAttribute( 'profile' );
 				return;

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -541,29 +541,17 @@ final class Document extends DOMDocument {
 	 * Converts a possible head[profile] attribute to link[rel=profile].
 	 *
 	 * The head[profile] attribute is only valid in HTML4, not HTML5.
-	 * So if it exists and there's no link[rel=profile], add it to the <head> as a link[rel=profile].
+	 * So if it exists, add it to the <head> as a link[rel=profile] and strip the attribute.a -
 	 */
 	private function convert_head_profile_to_link() {
 		$profile = $this->head->getAttribute( 'profile' );
-		if ( ! $profile ) {
-			return;
+		if ( $profile ) {
+			$link = $this->createElement( 'link' );
+			$link->setAttribute( 'rel', 'profile' );
+			$link->setAttribute( 'href', $profile );
+			$this->head->appendChild( $link );
+			$this->head->removeAttribute( 'profile' );
 		}
-
-		// If there's already a head > link[rel=profile], don't create another.
-		$links = $this->head->getElementsByTagName( 'link' );
-		foreach ( $links as $link ) {
-			if ( 'profile' === $link->getAttribute( 'rel' ) ) {
-				$this->head->removeAttribute( 'profile' );
-				return;
-			}
-		}
-
-		// Create a <link> and append it to <head>.
-		$new_link = $this->createElement( 'link' );
-		$new_link->setAttribute( 'rel', 'profile' );
-		$new_link->setAttribute( 'href', $profile );
-		$this->head->appendChild( $new_link );
-		$this->head->removeAttribute( 'profile' );
 	}
 
 	/**

--- a/tests/php/test-class-amp-dom-document.php
+++ b/tests/php/test-class-amp-dom-document.php
@@ -169,6 +169,11 @@ class Test_AMP_DOM_Document extends WP_UnitTestCase {
 				'<!DOCTYPE html><html><head profile="https://example.com"></head><body></body></html>',
 				'<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="profile" href="https://example.com"></head><body></body></html>',
 			],
+			'link_rel_profile_already_exists'          => [
+				'utf-8',
+				'<!DOCTYPE html><html><head profile="https://example.com"><link rel="profile" href="https://foo.com"></head><body></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="profile" href="https://foo.com"></head><body></body></html>',
+			],
 		];
 	}
 

--- a/tests/php/test-class-amp-dom-document.php
+++ b/tests/php/test-class-amp-dom-document.php
@@ -169,11 +169,6 @@ class Test_AMP_DOM_Document extends WP_UnitTestCase {
 				'<!DOCTYPE html><html><head profile="https://example.com"></head><body></body></html>',
 				'<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="profile" href="https://example.com"></head><body></body></html>',
 			],
-			'link_rel_profile_already_exists'          => [
-				'utf-8',
-				'<!DOCTYPE html><html><head profile="https://example.com"><link rel="profile" href="https://foo.com"></head><body></body></html>',
-				'<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="profile" href="https://foo.com"></head><body></body></html>',
-			],
 		];
 	}
 

--- a/tests/php/test-class-amp-dom-document.php
+++ b/tests/php/test-class-amp-dom-document.php
@@ -164,10 +164,15 @@ class Test_AMP_DOM_Document extends WP_UnitTestCase {
 				'<!--[if lt IE 7]> <html class="lt-ie9 lt-ie8 lt-ie7"> <![endif]--><!--[if IE 7]> <html class="lt-ie9 lt-ie8"> <![endif]--><!--[if IE 8]> <html class="lt-ie9"> <![endif]--><!--[if gt IE 8]><!--> <html class=""> <!--<![endif]--></html>',
 				'<!DOCTYPE html><html class="">' . $head . '<body></body></html>',
 			],
-			'link_attribute_in_head_converted_to_link' => [
+			'profile_attribute_in_head_moved_to_link'  => [
 				'utf-8',
 				'<!DOCTYPE html><html><head profile="https://example.com"></head><body></body></html>',
 				'<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="profile" href="https://example.com"></head><body></body></html>',
+			],
+			'profile_attribute_in_head_empty_string'   => [
+				'utf-8',
+				'<!DOCTYPE html><html><head profile=""></head><body></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"></head><body></body></html>',
 			],
 		];
 	}

--- a/tests/php/test-class-amp-dom-document.php
+++ b/tests/php/test-class-amp-dom-document.php
@@ -164,6 +164,11 @@ class Test_AMP_DOM_Document extends WP_UnitTestCase {
 				'<!--[if lt IE 7]> <html class="lt-ie9 lt-ie8 lt-ie7"> <![endif]--><!--[if IE 7]> <html class="lt-ie9 lt-ie8"> <![endif]--><!--[if IE 8]> <html class="lt-ie9"> <![endif]--><!--[if gt IE 8]><!--> <html class=""> <!--<![endif]--></html>',
 				'<!DOCTYPE html><html class="">' . $head . '<body></body></html>',
 			],
+			'link_attribute_in_head_converted_to_link' => [
+				'utf-8',
+				'<!DOCTYPE html><html><head profile="https://example.com"></head><body></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"><link rel="profile" href="https://example.com"></head><body></body></html>',
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary
Like Weston mentioned, `head[profile]` is invalid, so this converts it to a `link[rel=profile]`.

To test this, I made this change in Twenty Twenty:

```diff
diff --git a/header.php b/header.php
index d66d08f..99b02e0 100644
--- a/header.php
+++ b/header.php
@@ -13,13 +13,11 @@
 
 <html class="no-js" <?php language_attributes(); ?>>
 
-       <head>
+       <head profile="https://example-profile.com">
 
                <meta charset="<?php bloginfo( 'charset' ); ?>">
                <meta name="viewport" content="width=device-width, initial-scale=1.0" >
 
-               <link rel="profile" href="https://gmpg.org/xfn/11">
-
                <?php wp_head(); ?>
 
        </head>
```

...and with this PR, the `head[profile]` is stripped and moved to a new `head > link[rel=profile]`:

![rel-profile](https://user-images.githubusercontent.com/4063887/73395262-beb7ae80-42a4-11ea-8932-403254abbed4.png)

In the unlikely case that there's already a `head > link[rel=profile]`, this doesn't create a new one. It simply strips the `head[profile]` if it exists.

Fixes #4131

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
