### PR TITLE
Conditionally remove html[xmlns], convert html[xml:lang] to html[lang]

### DIFF
--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1029,7 +1029,7 @@ final class Document extends DOMDocument {
 	 * Conditionally removes html[xmlns], and converts html[xml:lang] to html[lang].
 	 */
 	private function normalize_html_attributes() {
-		$html = $this->getElementsByTagName( 'html' )->item( 0 );
+		$html = $this->documentElement;
 		if ( ! $html->hasAttributes()  ) {
 			return;
 		}

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1030,7 +1030,7 @@ final class Document extends DOMDocument {
 	 */
 	private function normalize_html_attributes() {
 		$html = $this->documentElement;
-		if ( ! $html->hasAttributes()  ) {
+		if ( ! $html->hasAttributes() ) {
 			return;
 		}
 

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1034,9 +1034,8 @@ final class Document extends DOMDocument {
 			return;
 		}
 
-		$xmlns                = $html->attributes->getNamedItem( 'xmlns' );
-		$xmlns_value_to_strip = 'http://www.w3.org/1999/xhtml';
-		if ( $xmlns && $xmlns_value_to_strip === $xmlns->nodeValue ) {
+		$xmlns = $html->attributes->getNamedItem( 'xmlns' );
+		if ( $xmlns && 'http://www.w3.org/1999/xhtml' === $xmlns->nodeValue ) {
 			$html->removeAttributeNode( $xmlns );
 		}
 

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1042,7 +1042,8 @@ final class Document extends DOMDocument {
 
 		$xml_lang = $html->attributes->getNamedItem( 'xml:lang' );
 		if ( $xml_lang ) {
-			if ( ! $html->attributes->getNamedItem( 'lang' ) && $xml_lang->nodeValue ) {
+			$lang_node = $html->attributes->getNamedItem( 'lang' );
+			if ( ( ! $lang_node || ! $lang_node->nodeValue ) && $xml_lang->nodeValue ) {
 				// Move the html[xml:lang] value to html[lang].
 				$html->setAttribute( 'lang', $xml_lang->nodeValue );
 			}

--- a/src/Dom/Document.php
+++ b/src/Dom/Document.php
@@ -1030,7 +1030,7 @@ final class Document extends DOMDocument {
 	 */
 	private function normalize_html_attributes() {
 		$html = $this->getElementsByTagName( 'html' )->item( 0 );
-		if ( ! $html->attributes ) {
+		if ( ! $html->hasAttributes()  ) {
 			return;
 		}
 

--- a/tests/php/test-class-amp-dom-document.php
+++ b/tests/php/test-class-amp-dom-document.php
@@ -108,6 +108,11 @@ class Test_AMP_DOM_Document extends WP_UnitTestCase {
 				'<!DOCTYPE html><html xml:lang="">' . $head . '<body></body></html>',
 				'<!DOCTYPE html><html>' . $head . '<body></body></html>',
 			],
+			'html_with_empty_lang'                     => [
+				'utf-8',
+				'<!DOCTYPE html><html lang="" xml:lang="es">' . $head . '<body></body></html>',
+				'<!DOCTYPE html><html lang="es">' . $head . '<body></body></html>',
+			],
 			'slashes_on_closing_tags'                  => [
 				'utf-8',
 				'<!DOCTYPE html><html amp lang="en"><head><meta charset="utf-8" /></head><body class="some-class"><p>Text</p></body></html>',

--- a/tests/php/test-class-amp-dom-document.php
+++ b/tests/php/test-class-amp-dom-document.php
@@ -88,6 +88,26 @@ class Test_AMP_DOM_Document extends WP_UnitTestCase {
 				'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd"><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
 				'<!DOCTYPE html><html amp lang="en">' . $head . '<body class="some-class"><p>Text</p></body></html>',
 			],
+			'html_with_xmlns_and_xml_lang'             => [
+				'utf-8',
+				'<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xml:lang="es">' . $head . '<body></body></html>',
+				'<!DOCTYPE html><html lang="es">' . $head . '<body></body></html>',
+			],
+			'html_with_xmlns_value_that_should_remain' => [
+				'utf-8',
+				'<!DOCTYPE html><html xmlns="http://www.w3.org/TR/html4/">' . $head . '<body></body></html>',
+				'<!DOCTYPE html><html xmlns="http://www.w3.org/TR/html4/">' . $head . '<body></body></html>',
+			],
+			'html_with_lang_and_xml_lang'              => [
+				'utf-8',
+				'<!DOCTYPE html><html lang="es" xml:lang="fr">' . $head . '<body></body></html>',
+				'<!DOCTYPE html><html lang="es">' . $head . '<body></body></html>',
+			],
+			'html_with_empty_xml_lang'                 => [
+				'utf-8',
+				'<!DOCTYPE html><html xml:lang="">' . $head . '<body></body></html>',
+				'<!DOCTYPE html><html>' . $head . '<body></body></html>',
+			],
 			'slashes_on_closing_tags'                  => [
 				'utf-8',
 				'<!DOCTYPE html><html amp lang="en"><head><meta charset="utf-8" /></head><body class="some-class"><p>Text</p></body></html>',


### PR DESCRIPTION
## Summary
* If http://www.w3.org/1999/xhtml === `html[xmlns]`, this strips the attribute
* If theres an `html[xml:lang]` but not `html[lang]`, it moves the `html[xml:lang]` value to `html[lang]`
* This strips the `html[xml:lang]` attribute if it exists, no matter its value

For example, with this change to Twenty Twenty:
```diff
diff --git a/header.php b/header.php
index d66d08f..f65eb8d 100644
--- a/header.php
+++ b/header.php
@@ -11,7 +11,7 @@
 
 ?><!DOCTYPE html>
 
-<html class="no-js" <?php language_attributes(); ?>>
+<html class="no-js" xmlns="http://www.w3.org/1999/xhtml" xml:lang="es">
```

...the `html[xmlns]` is stripped, and the `html[xml:lang]` is moved to `html[lang]`:

![xml-lang-converted](https://user-images.githubusercontent.com/4063887/73402392-cd0cc700-42b2-11ea-9460-54f0d70de8aa.png)

<!-- Please reference the issue this PR addresses. -->
Fixes #4132 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
