### PR TITLE
Split Reader mode style template part stylesheet from action-supplied styles

### DIFF
--- a/templates/html-start.php
+++ b/templates/html-start.php
@@ -24,6 +24,10 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
 	<?php
+	// Note: The following two <style> tags are combined into <style amp-custom> via AMP_Style_Sanitizer.
+	// Splitting up the styles into two stylesheets allows for plugin-supplied styles via the amp_post_template_css action
+	// to be excluded from the styles in the style template part, which are more important given they style the overall page.
+
 	/**
 	 * Fires when rendering <head> in Reader mode templates.
 	 *
@@ -33,8 +37,10 @@
 	 */
 	do_action( 'amp_post_template_head', $this );
 	?>
-	<style amp-custom>
+	<style class="style-template-part">
 		<?php $this->load_parts( [ 'style' ] ); ?>
+	</style>
+	<style class="amp-post-template-css-action">
 		<?php
 		/**
 		 * Fires when printing CSS styles in Reader mode templates.


### PR DESCRIPTION
## Summary

### Splitting up stylesheets in Reader mode

The Reader mode templates have for a long time output all styles in a single `<style amp-custom>` tag. This was needed because the `AMP_Style_Sanitizer` was originally not able to handle the parsing of stylesheets but only `style` attributes. Now that the Reader mode templates are passed through the post-processor (via #2202) all `style` elements will be combined into a single `style[amp-custom]` element automatically. It is advantageous to split styles into multiple stylesheets because when a stylesheet goes above the limit of 50KB, it will get excluded. If a plugin adds a lot of styles via the `amp_post_template_head` action, the result can be that all of the styles in the `style` template part would also get excluded. 

By splitting the two sets of styles into separate stylesheets, only the styles in `amp_post_template_head` will be excluded if they are excessive. This is better because those styles are less important than those being included in the `style` template part, which control the overall layout and design of the template. Otherwise, there is no difference in how the styles are included in the page.

The inclusion of the class names on the `style` elements is purely for the purpose of debugging, when/if Reader mode templates get shown as Validated URLs in the admin, with the new stylesheet analysis (see #2169).

Here's some example code that causes too much CSS to be added in `amp_post_template_css`:

```php
add_action( 'amp_post_template_css', function() {
	printf( 'body:after{ content: "%s"; }', str_repeat( 'a', 50000 ) );
} );
```

See also #2044.

### Preventing invalid `style[amp-custom]` from passing through

I also noticed that in the `develop` branch this code actually does not get sanitized at all. In fact, in Reader mode more than 50KB of CSS are getting added to the page:

![image](https://user-images.githubusercontent.com/134745/73498433-2ab41880-4372-11ea-9d1a-d9afc6885db5.png)

The reason is that when there is only one single single `style` on the page and this stylesheet is greater than 50KB, then this condition is not entered since there are no included stylesheets:

https://github.com/ampproject/amp-wp/blob/0d3ce780414af6306c59dfd132967a8907ae0412/includes/sanitizers/class-amp-style-sanitizer.php#L2625-L2626

When that condition is not entered, then the previously-captured `amp_custom_style_element` element is not subsequently emptied out to populate with the processed CSS (since there is none):

https://github.com/ampproject/amp-wp/blob/0d3ce780414af6306c59dfd132967a8907ae0412/includes/sanitizers/class-amp-style-sanitizer.php#L2644-L2653

So the fix is simply to discontinue capturing any original `style[amp-custom]` in favor of just creating a fresh empty new one to add to the document only if there are valid stylesheets to include.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
