### PR TITLE
Prevent errors in admin bar filters from non-array arguments

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1566,7 +1566,7 @@ class AMP_Theme_Support {
 	 */
 	public static function filter_admin_bar_style_loader_tag( $tag, $handle ) {
 		if (
-			in_array( $handle, wp_styles()->registered['admin-bar']->deps, true ) ?
+			is_array( wp_styles()->registered['admin-bar']->deps ) && in_array( $handle, wp_styles()->registered['admin-bar']->deps, true ) ?
 				self::is_exclusively_dependent( wp_styles(), $handle, 'admin-bar' ) :
 				self::has_dependency( wp_styles(), $handle, 'admin-bar' )
 		) {
@@ -1586,7 +1586,7 @@ class AMP_Theme_Support {
 	 */
 	public static function filter_admin_bar_script_loader_tag( $tag, $handle ) {
 		if (
-			in_array( $handle, wp_scripts()->registered['admin-bar']->deps, true ) ?
+			is_array( wp_scripts()->registered['admin-bar']->deps ) && in_array( $handle, wp_scripts()->registered['admin-bar']->deps, true ) ?
 				self::is_exclusively_dependent( wp_scripts(), $handle, 'admin-bar' ) :
 				self::has_dependency( wp_scripts(), $handle, 'admin-bar' )
 		) {

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1446,6 +1446,18 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test filter_admin_bar_style_loader_tag when ->deps is not an array.
+	 *
+	 * @covers \AMP_Theme_Support::filter_admin_bar_style_loader_tag()
+	 */
+	public function test_filter_admin_bar_style_loader_tag_non_array() {
+		wp_enqueue_style( 'admin-bar' );
+		$GLOBALS['wp_styles']->registered['admin-bar']->deps = null;
+		$tag = 'foo';
+		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_style_loader_tag( $tag, 'baz' ) );
+	}
+
+	/**
 	 * Get data to test AMP_Theme_Support::filter_admin_bar_script_loader_tag().
 	 *
 	 * @return array
@@ -1545,6 +1557,18 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		@$dom->loadHTML( $output ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
 		$assert_callback( new DOMXPath( $dom ) );
+	}
+
+	/**
+	 * Test filter_admin_bar_script_loader_tag when ->deps is not an array.
+	 *
+	 * @covers \AMP_Theme_Support::filter_admin_bar_script_loader_tag()
+	 */
+	public function test_filter_admin_bar_script_loader_tag_non_array() {
+		wp_enqueue_script( 'admin-bar' );
+		$GLOBALS['wp_scripts']->registered['admin-bar']->deps = null;
+		$tag = 'example-tag';
+		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_script_loader_tag( $tag, 'example' ) );
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1453,7 +1453,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_filter_admin_bar_style_loader_tag_non_array() {
 		wp_enqueue_style( 'admin-bar' );
 		$GLOBALS['wp_styles']->registered['admin-bar']->deps = null;
-		$tag = '<link rel="stylesheet" id="dashicons-css" href="https://example.com/wp-includes/css/dashicons.css?ver=5.3.2" media="all" />';
+		$tag = '<link rel="stylesheet" id="dashicons-css" href="https://example.com/wp-includes/css/dashicons.css?ver=5.3.2" media="all" />'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_style_loader_tag( $tag, 'baz' ) );
 	}
 
@@ -1567,7 +1567,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_filter_admin_bar_script_loader_tag_non_array() {
 		wp_enqueue_script( 'admin-bar' );
 		$GLOBALS['wp_scripts']->registered['admin-bar']->deps = null;
-		$tag = '<script src="https://example.com/wp-includes/js/admin-bar.js?ver=5.3.2"></script>';
+		$tag = '<script src="https://example.com/wp-includes/js/admin-bar.js?ver=5.3.2"></script>'; // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_script_loader_tag( $tag, 'example' ) );
 	}
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1453,7 +1453,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_filter_admin_bar_style_loader_tag_non_array() {
 		wp_enqueue_style( 'admin-bar' );
 		$GLOBALS['wp_styles']->registered['admin-bar']->deps = null;
-		$tag = 'foo';
+		$tag = '<link rel="stylesheet" id="dashicons-css" href="https://example.com/wp-includes/css/dashicons.css?ver=5.3.2" media="all" />';
 		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_style_loader_tag( $tag, 'baz' ) );
 	}
 
@@ -1567,7 +1567,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_filter_admin_bar_script_loader_tag_non_array() {
 		wp_enqueue_script( 'admin-bar' );
 		$GLOBALS['wp_scripts']->registered['admin-bar']->deps = null;
-		$tag = 'example-tag';
+		$tag = '<script src="https://example.com/wp-includes/js/admin-bar.js?ver=5.3.2"></script>';
 		$this->assertEquals( $tag, AMP_Theme_Support::filter_admin_bar_script_loader_tag( $tag, 'example' ) );
 	}
 


### PR DESCRIPTION
## Summary
* Props to Weston for the fix: https://github.com/ampproject/amp-wp/issues/4145#issuecomment-576535058
* Prevents an error from calling `in_array()` if the `->deps` are not an array

Fixes #4145

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
