### PR TITLE
Ensure AMP is not available for disabled posts in Reader mode

### DIFF
--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -181,10 +181,8 @@ function amp_add_amphtml_link() {
 		if ( AMP_Theme_Support::is_paired_available() ) {
 			$amp_url = add_query_arg( amp_get_slug(), '', $current_url );
 		}
-	} elseif ( is_singular() ) {
+	} elseif ( is_singular() && post_supports_amp( get_post( get_queried_object_id() ) ) ) {
 		$amp_url = amp_get_permalink( get_queried_object_id() );
-	} else {
-		$amp_url = add_query_arg( amp_get_slug(), '', $current_url );
 	}
 
 	if ( ! $amp_url ) {

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -324,6 +324,32 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that attempting to access an AMP a post in Reader mode that does not support AMP.
+	 *
+	 * @covers AMP_Theme_Support::finish_init()
+	 */
+	public function test_finish_init_when_accessing_singular_post_that_does_not_support_amp() {
+		$post          = $this->factory()->post->create();
+		$requested_url = get_permalink( $post );
+		$this->assertEquals( AMP_Theme_Support::READER_MODE_SLUG, AMP_Theme_Support::get_support_mode() );
+		$this->assertTrue( post_supports_amp( $post ) );
+		add_filter( 'amp_skip_post', '__return_true' );
+		$this->assertFalse( post_supports_amp( $post ) );
+
+		$redirected = false;
+		add_filter(
+			'wp_redirect',
+			function ( $url ) use ( $requested_url, &$redirected ) {
+				$this->assertEquals( $requested_url, $url );
+				$redirected = true;
+				return null;
+			}
+		);
+		$this->go_to( amp_get_permalink( $post ) );
+		$this->assertTrue( $redirected );
+	}
+
+	/**
 	 * Test that attempting to access an AMP page in Reader Mode for a non-singular query will redirect to the non-AMP version.
 	 *
 	 * @covers AMP_Theme_Support::finish_init()

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -324,7 +324,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that attempting to access an AMP a post in Reader mode that does not support AMP.
+	 * Test that attempting to access an AMP post in Reader mode that does not support AMP.
 	 *
 	 * @covers AMP_Theme_Support::finish_init()
 	 */


### PR DESCRIPTION
## Summary

This fixes a regression introduced in #3781 (for #2202) and a condition missed in #4184. In Reader mode, when a post has AMP disabled due to post type being unsupported, "AMP Enabled" toggled off, or `amp_skip_post` filters false:

* Prevent including the amphtml link to the AMP version.
* Redirect AMP URLs to the corresponding non-AMP URL.

In Reader mode, previously if you had created a post and AMP was not available for it (e.g. by toggling off “Enable AMP”):

> <img width="840" alt="Screen Shot 2020-01-31 at 21 56 09" src="https://user-images.githubusercontent.com/134745/73587765-8bc41500-4474-11ea-9110-0347f56894ef.png">

The `amphtml` link would unexpectedly be still added to the page (whereas in Transitional mode it would be correctly omitted):

> <img width="474" alt="Screen Shot 2020-01-31 at 21 57 23" src="https://user-images.githubusercontent.com/134745/73587783-c4fc8500-4474-11ea-8fc6-a1f1826730ac.png">

And the AMP version would be accessible (unlike Transitional mode):

> ![image](https://user-images.githubusercontent.com/134745/73587791-ee1d1580-4474-11ea-8e70-922ef5c58b83.png)

This PR corrects those to defects in Reader mode: the `link[amphtml]` element is omitted and direct access to the AMP endpoint will redirect to the non-AMP version.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
