### PR TITLE
Limit Stories experience to WP 5.3 & Gutenberg 7.1.0

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -10,7 +10,7 @@ CHECK_SCOPE=all
 function after_wp_install {
 	if [[ "$WP_VERSION" != "4.9" ]]; then
 		echo -n "Installing Gutenberg 7.1.0..."
-		gutenberg_plugin_svn_url=http://plugins.svn.wordpress.org/gutenberg/tags/7.1.0/
+		gutenberg_plugin_svn_url=https://plugins.svn.wordpress.org/gutenberg/tags/7.1.0/
 		svn export -q "$gutenberg_plugin_svn_url" "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
 		echo "done"
 	fi

--- a/.dev-lib
+++ b/.dev-lib
@@ -9,8 +9,8 @@ CHECK_SCOPE=all
 
 function after_wp_install {
 	if [[ "$WP_VERSION" != "4.9" ]]; then
-		echo -n "Installing Gutenberg..."
-		gutenberg_plugin_svn_url=https://plugins.svn.wordpress.org/gutenberg/trunk/
+		echo -n "Installing Gutenberg 7.1.0..."
+		gutenberg_plugin_svn_url=http://plugins.svn.wordpress.org/gutenberg/tags/7.1.0/
 		svn export -q "$gutenberg_plugin_svn_url" "$WP_CORE_DIR/src/wp-content/plugins/gutenberg"
 		echo "done"
 	fi

--- a/bin/local-env/install-wordpress.sh
+++ b/bin/local-env/install-wordpress.sh
@@ -97,7 +97,7 @@ wp plugin activate amp --quiet
 
 # Install & activate Gutenberg plugin.
 echo -e $(status_message "Installing and activating Gutenberg plugin...")
-wp plugin install gutenberg --activate --force --quiet
+wp plugin install gutenberg --activate --force --quiet --version=7.1.0
 
 # Set pretty permalinks.
 echo -e $(status_message "Setting permalink structure...")

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -104,7 +104,7 @@ class AMP_Story_Post_Type {
 	 */
 	public static function has_required_block_capabilities() {
 		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) ) {
-			return (bool) GUTENBERG_DEVELOPMENT_MODE;
+			return false;
 		}
 
 		// If Gutenberg is installed only versions 6.6.0 - 7.1.0 are supported.

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -32,7 +32,14 @@ class AMP_Story_Post_Type {
 	 *
 	 * @var string
 	 */
-	const REQUIRED_GUTENBERG_VERSION = '6.6';
+	const MIN_REQUIRED_GUTENBERG_VERSION = '6.6.0';
+
+	/**
+	 * Minimum required version of Gutenberg required.
+	 *
+	 * @var string
+	 */
+	const MAX_REQUIRED_GUTENBERG_VERSION = '7.1.0';
 
 	/**
 	 * The slug of the story card CSS file.
@@ -93,20 +100,22 @@ class AMP_Story_Post_Type {
 	/**
 	 * Check if the required version of block capabilities available.
 	 *
-	 * Requires either Gutenberg 6.6+ or WordPress 5.3+ (which includes Gutenberg 6.6)
-	 *
-	 * @todo Eventually the Gutenberg requirement should be removed.
-	 *
 	 * @return bool Whether capabilities are available.
 	 */
 	public static function has_required_block_capabilities() {
-		return (
-			( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) && GUTENBERG_DEVELOPMENT_MODE )
-			||
-			( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, self::REQUIRED_GUTENBERG_VERSION, '>=' ) )
-			||
-			version_compare( get_bloginfo( 'version' ), '5.3-RC2', '>=' )
-		);
+		if ( defined( 'GUTENBERG_DEVELOPMENT_MODE' ) ) {
+			return (bool) GUTENBERG_DEVELOPMENT_MODE;
+		}
+
+		// If Gutenberg is installed only versions 6.6.0 - 7.1.0 are supported.
+		if ( defined( 'GUTENBERG_VERSION' ) ) {
+			return version_compare( GUTENBERG_VERSION, self::MIN_REQUIRED_GUTENBERG_VERSION, '>=' ) &&
+				version_compare( GUTENBERG_VERSION, self::MAX_REQUIRED_GUTENBERG_VERSION, '<=' );
+		}
+
+		// Only WordPress version 5.3 is supported (which includes Gutenberg 6.6.0).
+		return version_compare( get_bloginfo( 'version' ), '5.3-RC2', '>=' ) &&
+			version_compare( get_bloginfo( 'version' ), '5.4', '<' );
 	}
 
 	/**

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -35,7 +35,7 @@ class AMP_Story_Post_Type {
 	const MIN_REQUIRED_GUTENBERG_VERSION = '6.6.0';
 
 	/**
-	 * Minimum required version of Gutenberg required.
+	 * Maximum allowed version of Gutenberg.
 	 *
 	 * @var string
 	 */

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -232,12 +232,14 @@ class AMP_Options_Menu {
 								$gutenberg = 'Gutenberg';
 								// Link to Gutenberg plugin installation if eligible.
 								if ( current_user_can( 'install_plugins' ) ) {
-									$gutenberg = '<a href="' . esc_url( add_query_arg( 'tab', 'beta', admin_url( 'plugin-install.php' ) ) ) . '">' . $gutenberg . '</a>';
+									$gutenberg = '<a href="' . esc_url( add_query_arg( 'tab', 'featured', admin_url( 'plugin-install.php' ) ) ) . '">' . $gutenberg . '</a>';
 								}
 								printf(
-									/* translators: 1: WordPress version number. 2: Gutenberg plugin name */
-									esc_html__( 'To use stories, you must be running WordPress %1$s or higher, or have the latest version of the %2$s plugin activated.', 'amp' ),
+									/* translators: 1: WordPress version number. 2: Gutenberg plugin name,  */
+									esc_html__( 'To use Stories, you must be running WordPress %1$s, or have a version between %2$s and %3$s of the %4$s plugin activated.', 'amp' ),
 									'5.3',
+									'6.6.0',
+									'7.1.0',
 									$gutenberg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 								);
 								?>

--- a/tests/e2e/specs/block-editor/featured-image-notice.js
+++ b/tests/e2e/specs/block-editor/featured-image-notice.js
@@ -22,7 +22,7 @@ describe( 'Featured Image Notice', () => {
 	beforeEach( async () => {
 		await createNewPost( { postType: 'post' } );
 		await clickButton( 'Document' );
-		await clickButton( 'Featured image' );
+		await clickButton( 'Featured Image' );
 		await clickButton( 'Set featured image' );
 	} );
 


### PR DESCRIPTION
## Summary

Disables Stories experience if Gutenberg > v7.1.0 or WordPress > v5.3. The Stories editor is broken in Gutenberg v7.2.0, and Wordpress 5.4 ( which will include an incompatible version of the block editor).

<!-- Please reference the issue this PR addresses. -->
Fixes #4200.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
