### PR TITLE
Hide Stories options and add deprecation notice

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -383,9 +383,7 @@ function amp_init() {
 		add_filter( 'old_slug_redirect_url', 'amp_redirect_old_slug_to_new_url' );
 	}
 
-	if ( AMP_Options_Manager::is_stories_experience_enabled() ) {
-		AMP_Story_Post_Type::register();
-	}
+	AMP_Story_Post_Type::register();
 
 	// Does its own is_stories_experience_enabled() check.
 	add_action( 'wp_loaded', 'amp_story_templates' );

--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -62,9 +62,9 @@ class AMP_Admin_Pointers {
 				'amp_template_mode_pointer_10',
 				[
 					'selector'        => '#toplevel_page_amp-options',
-					'heading'         => __( 'AMP', 'amp' ),
-					'subheading'      => __( 'New AMP Template Modes', 'amp' ),
-					'description'     => __( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Standard&#8221; modes.', 'amp' ),
+					'heading'         => esc_html__( 'AMP', 'amp' ),
+					'subheading'      => esc_html__( 'New AMP Template Modes', 'amp' ),
+					'description'     => esc_html__( 'You can now reuse your theme\'s templates and styles in AMP responses, in both &#8220;Transitional&#8221; and &#8220;Standard&#8221; modes.', 'amp' ),
 					'position'        => [
 						'align' => 'middle',
 					],
@@ -74,34 +74,27 @@ class AMP_Admin_Pointers {
 				]
 			),
 			new AMP_Admin_Pointer(
-				'amp_stories_support_pointer_12',
-				[
-					'selector'        => '#toplevel_page_amp-options',
-					'heading'         => __( 'AMP', 'amp' ),
-					'subheading'      => __( 'Stories', 'amp' ),
-					'description'     => __( 'You can now enable Stories, a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences.', 'amp' ),
-					'position'        => [
-						'align' => 'middle',
-					],
-					'active_callback' => static function( $hook_suffix ) {
-						if ( 'toplevel_page_amp-options' === $hook_suffix ) {
-							return false;
-						}
-						return ! AMP_Options_Manager::is_stories_experience_enabled();
-					},
-				]
-			),
-			new AMP_Admin_Pointer(
-				'amp_stories_menu_pointer_12',
+				'amp_stories_support_deprecated_pointer_143',
 				[
 					'selector'        => '#menu-posts-' . AMP_Story_Post_Type::POST_TYPE_SLUG,
-					'heading'         => __( 'AMP', 'amp' ),
-					'description'     => __( 'Head over here to create your first story.', 'amp' ),
+					'heading'         => esc_html__( 'AMP', 'amp' ),
+					'subheading'      => esc_html__( 'Back up your Stories!', 'amp' ),
+					'description'     => implode(
+						' ',
+						[
+							esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
+							sprintf(
+								'<a href="%s">%s</a>',
+								esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
+								esc_html__( 'View how to export your Stories', 'amp' )
+							),
+						]
+					),
 					'position'        => [
 						'align' => 'middle',
 					],
-					'active_callback' => static function( $hook_suffix ) {
-						if ( 'edit.php' === $hook_suffix && AMP_Story_Post_Type::POST_TYPE_SLUG === filter_input( INPUT_GET, 'post_type' ) ) {
+					'active_callback' => static function() {
+						if ( get_current_screen() && AMP_Story_Post_Type::POST_TYPE_SLUG === get_current_screen()->post_type ) {
 							return false;
 						}
 						return AMP_Options_Manager::is_stories_experience_enabled();

--- a/includes/admin/class-amp-story-templates.php
+++ b/includes/admin/class-amp-story-templates.php
@@ -32,6 +32,10 @@ class AMP_Story_Templates {
 	 * Init.
 	 */
 	public function init() {
+		if ( ! AMP_Options_Manager::is_stories_experience_enabled() ) {
+			return;
+		}
+
 		// Always hide the story templates.
 		add_filter( 'pre_get_posts', [ $this, 'filter_pre_get_posts' ] );
 
@@ -40,10 +44,6 @@ class AMP_Story_Templates {
 
 		// We need to register the taxonomy even if AMP Stories is disabled for tax_query.
 		$this->register_taxonomy();
-
-		if ( ! AMP_Options_Manager::is_stories_experience_enabled() ) {
-			return;
-		}
 
 		add_action( 'save_post_wp_block', [ $this, 'flag_template_as_modified' ] );
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -124,7 +124,7 @@ class AMP_Story_Post_Type {
 	 * @return void
 	 */
 	public static function register() {
-		if ( ! AMP_Options_Manager::is_stories_experience_enabled() || ! self::has_required_block_capabilities() ) {
+		if ( ! AMP_Options_Manager::is_stories_experience_enabled( false ) || ! self::has_required_block_capabilities() ) {
 			return;
 		}
 

--- a/includes/class-amp-story-post-type.php
+++ b/includes/class-amp-story-post-type.php
@@ -124,7 +124,10 @@ class AMP_Story_Post_Type {
 	 * @return void
 	 */
 	public static function register() {
-		if ( ! AMP_Options_Manager::is_stories_experience_enabled( false ) || ! self::has_required_block_capabilities() ) {
+		if (
+			! self::has_required_block_capabilities() ||
+			! in_array( AMP_Options_Manager::STORIES_EXPERIENCE, AMP_Options_Manager::get_option( 'experiences' ), true )
+		) {
 			return;
 		}
 
@@ -2360,5 +2363,19 @@ class AMP_Story_Post_Type {
 			$sanitized_value = call_user_func( $meta_definitions[ $option_key ]['meta_args']['sanitize_callback'], $value );
 			add_post_meta( $post_id, self::STORY_SETTINGS_META_PREFIX . $option_key, $sanitized_value, true );
 		}
+	}
+
+	/**
+	 * Returns total number of Story posts.
+	 *
+	 * @return int
+	 */
+	public static function get_posts_count() {
+		if ( post_type_exists( self::POST_TYPE_SLUG ) ) {
+			$story_posts_count = (array) wp_count_posts( self::POST_TYPE_SLUG );
+			return array_sum( array_values( $story_posts_count ) );
+		}
+
+		return 0;
 	}
 }

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -199,12 +199,22 @@ class AMP_Options_Manager {
 	 *
 	 * @since 1.2
 	 *
+	 * @param bool $include_posts_check Include check to see if any `amp_story` posts exists.
 	 * @return bool Enabled.
 	 */
-	public static function is_stories_experience_enabled() {
+	public static function is_stories_experience_enabled( $include_posts_check = true ) {
+		$has_stories_posts = true;
+
+		// Note: A post count cannot be done until the post type is registered (see AMP_Story_Post_Type::register).
+		if ( $include_posts_check ) {
+			$story_posts_count       = (array) wp_count_posts( AMP_Story_Post_Type::POST_TYPE_SLUG );
+			$total_story_posts_count = array_sum( array_values( $story_posts_count ) );
+			$has_stories_posts       = 0 < $total_story_posts_count;
+		}
+
 		return (
-			AMP_Story_Post_Type::has_required_block_capabilities()
-			&&
+			$has_stories_posts &&
+			AMP_Story_Post_Type::has_required_block_capabilities() &&
 			in_array( self::STORIES_EXPERIENCE, self::get_option( 'experiences' ), true )
 		);
 	}

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -66,6 +66,7 @@ class AMP_Options_Manager {
 
 		add_action( 'update_option_' . self::OPTION_NAME, [ __CLASS__, 'maybe_flush_rewrite_rules' ], 10, 2 );
 		add_action( 'admin_notices', [ __CLASS__, 'render_welcome_notice' ] );
+		add_action( 'admin_notices', [ __CLASS__, 'render_stories_deprecation_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'persistent_object_caching_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'render_cache_miss_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'render_php_css_parser_conflict_notice' ] );
@@ -570,6 +571,20 @@ class AMP_Options_Manager {
 			);
 			echo '</p></div>';
 		}
+	}
+
+	/**
+	 * Render the Stories deprecation admin notice.
+	 */
+	public static function render_stories_deprecation_notice() {
+		if ( 'toplevel_page_' . self::OPTION_NAME !== get_current_screen()->id ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-error"><p>%s</p></div>',
+			esc_html__( 'AMP Stories has been deprecated and will no longer be supported. A separate plugin will soon be available for testing.', 'amp' )
+		);
 	}
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -582,8 +582,8 @@ class AMP_Options_Manager {
 		}
 
 		printf(
-			'<div class="notice notice-error"><p>%s</p></div>',
-			esc_html__( 'AMP Stories has been deprecated and will no longer be supported. A separate plugin will soon be available for testing.', 'amp' )
+			'<div class="notice notice-warning"><p>%s</p></div>',
+			esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
 		);
 	}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -571,15 +571,17 @@ class AMP_Options_Manager {
 	 * Render the Stories deprecation admin notice.
 	 */
 	public static function render_stories_deprecation_notice() {
-		// If the user has `amp_story` posts, always show the notice. Otherwise, only show it on the AMP options page.
-		if ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME !== get_current_screen()->id ) {
-			return;
+		if ( self::is_stories_experience_enabled() ) {
+			printf(
+				'<div class="notice notice-warning"><p>%s</p></div>',
+				esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
+			);
+		} elseif ( 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
+			printf(
+				'<div class="notice notice-info"><p>%s</p></div>',
+				esc_html__( 'The Stories experience has been removed from the AMP plugin. This beta feature is being split into a separate standalone plugin which will be available for installation soon.', 'amp' )
+			);
 		}
-
-		printf(
-			'<div class="notice notice-warning"><p>%s</p></div>',
-			esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
-		);
 	}
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -584,7 +584,7 @@ class AMP_Options_Manager {
 		) {
 			printf(
 				'<div class="notice notice-warning"><p>%s</p></div>',
-				esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
+				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
 			);
 		} elseif ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
@@ -606,7 +606,7 @@ class AMP_Options_Manager {
 							{ isDismissible: false }
 						);
 					} )( window.wp );",
-			esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
+			esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
 		);
 
 		wp_add_inline_script( AMP_Story_Post_Type::AMP_STORIES_SCRIPT_HANDLE, $script );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -582,10 +582,18 @@ class AMP_Options_Manager {
 				'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id
 			)
 		) {
+			echo '<div class="notice notice-warning"><p>';
 			printf(
-				'<div class="notice notice-warning"><p>%s</p></div>',
-				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
+				'%s %s %s',
+				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or', 'amp' ),
+				sprintf(
+					'<a href="%s">%s</a>',
+					esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
+					esc_html__( 'export your existing Stories', 'amp' )
+				),
+				esc_html__( 'as they will not be available in the next version of the AMP plugin.', 'amp' )
 			);
+			echo '</p></div>';
 		} elseif ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
 				'<div class="notice notice-info"><p>%s</p></div>',
@@ -603,7 +611,15 @@ class AMP_Options_Manager {
 						wp.data.dispatch( 'core/notices' ).createNotice(
 							'warning',
 							%s,
-							{ isDismissible: false }
+							{
+						  		isDismissible: false,
+						  		actions: [
+									{
+										url: 'https://amp-wp.org/documentation/amp-stories/exporting-stories/',
+										label: 'View how to export your Stories',
+									},
+								],
+						    }
 						);
 					} )( window.wp );",
 			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) )

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -616,7 +616,7 @@ class AMP_Options_Manager {
 						  		actions: [
 									{
 										url: 'https://amp-wp.org/documentation/amp-stories/exporting-stories/',
-										label: 'View how to export your Stories',
+										label: <?php echo wp_json_encode( __( 'View how to export your Stories', 'amp' ) ) ?>,
 									},
 								],
 						    }

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -602,11 +602,11 @@ class AMP_Options_Manager {
 			"( function( wp ) {
 						wp.data.dispatch( 'core/notices' ).createNotice(
 							'warning',
-							'%s',
+							%s,
 							{ isDismissible: false }
 						);
 					} )( window.wp );",
-			esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
+			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) )
 		);
 
 		wp_add_inline_script( AMP_Story_Post_Type::AMP_STORIES_SCRIPT_HANDLE, $script );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -582,18 +582,15 @@ class AMP_Options_Manager {
 				'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id
 			)
 		) {
-			echo '<div class="notice notice-warning"><p>';
 			printf(
-				'%s %s %s',
-				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or', 'amp' ),
+				'<div class="notice notice-warning"><p>%s %s</p></div>',
+				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
 				sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
-					esc_html__( 'export your existing Stories', 'amp' )
-				),
-				esc_html__( 'as they will not be available in the next version of the AMP plugin.', 'amp' )
+					esc_html__( 'View how to export your Stories', 'amp' )
+				)
 			);
-			echo '</p></div>';
 		} elseif ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
 				'<div class="notice notice-info"><p>%s</p></div>',
@@ -616,13 +613,14 @@ class AMP_Options_Manager {
 						  		actions: [
 									{
 										url: 'https://amp-wp.org/documentation/amp-stories/exporting-stories/',
-										label: <?php echo wp_json_encode( __( 'View how to export your Stories', 'amp' ) ) ?>,
+										label: %s,
 									},
 								],
 						    }
 						);
 					} )( window.wp );",
-			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) )
+			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) ),
+			wp_json_encode( __( 'View how to export your Stories', 'amp' ) )
 		);
 
 		wp_add_inline_script( AMP_Story_Post_Type::AMP_STORIES_SCRIPT_HANDLE, $script );

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -233,8 +233,10 @@ class AMP_Options_Manager {
 		}
 
 		// Experiences.
-		if ( isset( $new_options['experiences'] ) && is_array( $new_options['experiences'] ) ) {
-
+		if ( ! isset( $new_options['experiences'][ self::STORIES_EXPERIENCE ] ) && ! AMP_Story_Post_Type::has_posts() ) {
+			// If there are no Story posts and the experience is disabled, only the Website experience is considered enabled.
+			$options['experiences'] = [ self::WEBSITE_EXPERIENCE ];
+		} elseif ( isset( $new_options['experiences'] ) && is_array( $new_options['experiences'] ) ) {
 			// Validate the selected experiences.
 			$options['experiences'] = array_intersect(
 				$new_options['experiences'],
@@ -353,16 +355,18 @@ class AMP_Options_Manager {
 			AMP_Theme_Support::reset_cache_miss_url_option();
 		}
 
-		// Handle the base URL for exported stories.
-		$options['story_export_base_url'] = isset( $new_options['story_export_base_url'] ) ? esc_url_raw( $new_options['story_export_base_url'], [ 'https' ] ) : '';
+		if ( isset( $new_options['experiences'] ) && in_array( self::STORIES_EXPERIENCE, $new_options['experiences'], true ) ) {
+			// Handle the base URL for exported stories.
+			$options['story_export_base_url'] = isset( $new_options['story_export_base_url'] ) ? esc_url_raw( $new_options['story_export_base_url'], [ 'https' ] ) : '';
 
-		// AMP stories settings definitions.
-		$definitions = AMP_Story_Post_Type::get_stories_settings_definitions();
+			// AMP stories settings definitions.
+			$definitions = AMP_Story_Post_Type::get_stories_settings_definitions();
 
-		// Handle the AMP stories settings sanitization.
-		foreach ( $definitions as $option_name => $definition ) {
-			$value = $new_options[ AMP_Story_Post_Type::STORY_SETTINGS_OPTION ][ $option_name ];
-			$options[ AMP_Story_Post_Type::STORY_SETTINGS_OPTION ][ $option_name ] = call_user_func( $definition['meta_args']['sanitize_callback'], $value );
+			// Handle the AMP stories settings sanitization.
+			foreach ( $definitions as $option_name => $definition ) {
+				$value = $new_options[ AMP_Story_Post_Type::STORY_SETTINGS_OPTION ][ $option_name ];
+				$options[ AMP_Story_Post_Type::STORY_SETTINGS_OPTION ][ $option_name ] = call_user_func( $definition['meta_args']['sanitize_callback'], $value );
+			}
 		}
 
 		return $options;

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -200,21 +200,15 @@ class AMP_Options_Manager {
 	 *
 	 * @since 1.2
 	 *
-	 * @param bool $include_posts_check Include check to see if any `amp_story` posts exists.
 	 * @return bool Enabled.
 	 */
-	public static function is_stories_experience_enabled( $include_posts_check = true ) {
-		$has_stories_posts = true;
-
-		// Note: A post count cannot be done until the post type is registered (see AMP_Story_Post_Type::register).
-		if ( $include_posts_check ) {
-			$story_posts_count       = (array) wp_count_posts( AMP_Story_Post_Type::POST_TYPE_SLUG );
-			$total_story_posts_count = array_sum( array_values( $story_posts_count ) );
-			$has_stories_posts       = 0 < $total_story_posts_count;
+	public static function is_stories_experience_enabled() {
+		if ( 0 === AMP_Story_Post_Type::get_posts_count() ) {
+			unregister_post_type( AMP_Story_Post_Type::POST_TYPE_SLUG );
+			return false;
 		}
 
 		return (
-			$has_stories_posts &&
 			AMP_Story_Post_Type::has_required_block_capabilities() &&
 			in_array( self::STORIES_EXPERIENCE, self::get_option( 'experiences' ), true )
 		);

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -593,7 +593,7 @@ class AMP_Options_Manager {
 		) {
 			printf(
 				'<div class="notice notice-warning"><p>%s %s</p></div>',
-				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
+				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
 				sprintf(
 					'<a href="%s">%s</a>',
 					esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
@@ -628,7 +628,7 @@ class AMP_Options_Manager {
 						    }
 						);
 					} )( window.wp );",
-			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) ),
+			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) ),
 			wp_json_encode( __( 'View how to export your Stories', 'amp' ) )
 		);
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -571,7 +571,8 @@ class AMP_Options_Manager {
 	 * Render the Stories deprecation admin notice.
 	 */
 	public static function render_stories_deprecation_notice() {
-		if ( 'toplevel_page_' . self::OPTION_NAME !== get_current_screen()->id ) {
+		// If the user has `amp_story` posts, always show the notice. Otherwise, only show it on the AMP options page.
+		if ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME !== get_current_screen()->id ) {
 			return;
 		}
 

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -234,7 +234,7 @@ class AMP_Options_Manager {
 
 		// Experiences.
 		if ( ! isset( $new_options['experiences'][ self::STORIES_EXPERIENCE ] ) && ! AMP_Story_Post_Type::has_posts() ) {
-			// If there are no Story posts and the experience is disabled, only the Website experience is considered enabled.
+			// If there are no Story posts and the Story experience is disabled, only the Website experience is considered enabled.
 			$options['experiences'] = [ self::WEBSITE_EXPERIENCE ];
 		} elseif ( isset( $new_options['experiences'] ) && is_array( $new_options['experiences'] ) ) {
 			// Validate the selected experiences.

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -71,6 +71,10 @@ class AMP_Options_Manager {
 		add_action( 'admin_notices', [ __CLASS__, 'render_cache_miss_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'render_php_css_parser_conflict_notice' ] );
 		add_action( 'admin_notices', [ __CLASS__, 'insecure_connection_notice' ] );
+
+		if ( self::is_stories_experience_enabled() ) {
+			add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'render_stories_deprecation_editor_notice' ] );
+		}
 	}
 
 	/**
@@ -588,6 +592,24 @@ class AMP_Options_Manager {
 				esc_html__( 'The Stories experience has been removed from the AMP plugin. This beta feature is being split into a separate standalone plugin which will be available for installation soon.', 'amp' )
 			);
 		}
+	}
+
+	/**
+	 * Render the Stories deprecation notice in the Story editor.
+	 */
+	public static function render_stories_deprecation_editor_notice() {
+		$script = sprintf(
+			"( function( wp ) {
+						wp.data.dispatch( 'core/notices' ).createNotice(
+							'warning',
+							'%s',
+							{ isDismissible: false }
+						);
+					} )( window.wp );",
+			esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
+		);
+
+		wp_add_inline_script( AMP_Story_Post_Type::AMP_STORIES_SCRIPT_HANDLE, $script );
 	}
 
 	/**

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -571,12 +571,18 @@ class AMP_Options_Manager {
 	 * Render the Stories deprecation admin notice.
 	 */
 	public static function render_stories_deprecation_notice() {
-		if ( self::is_stories_experience_enabled() ) {
+		if (
+			self::is_stories_experience_enabled() &&
+			(
+				'edit-amp_story' === get_current_screen()->id ||
+				'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id
+			)
+		) {
 			printf(
 				'<div class="notice notice-warning"><p>%s</p></div>',
 				esc_html__( 'The Stories experience in the AMP plugin has been deprecated and will no longer be supported. A separate plugin for Stories be available soon for testing. Please backup or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' )
 			);
-		} elseif ( 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
+		} elseif ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
 				'<div class="notice notice-info"><p>%s</p></div>',
 				esc_html__( 'The Stories experience has been removed from the AMP plugin. This beta feature is being split into a separate standalone plugin which will be available for installation soon.', 'amp' )

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -112,27 +112,29 @@ class AMP_Options_Menu {
 			]
 		);
 
-		add_settings_field(
-			'stories_export',
-			__( 'Stories Export', 'amp' ),
-			[ $this, 'render_stories_export' ],
-			AMP_Options_Manager::OPTION_NAME,
-			'general',
-			[
-				'class' => 'amp-stories-export-field',
-			]
-		);
+		if ( AMP_Options_Manager::is_stories_experience_enabled() ) {
+			add_settings_field(
+				'stories_export',
+				__( 'Stories Export', 'amp' ),
+				[ $this, 'render_stories_export' ],
+				AMP_Options_Manager::OPTION_NAME,
+				'general',
+				[
+					'class' => 'amp-stories-export-field',
+				]
+			);
 
-		add_settings_field(
-			'stories_settings',
-			__( 'Stories Settings', 'amp' ),
-			[ $this, 'render_stories_settings' ],
-			AMP_Options_Manager::OPTION_NAME,
-			'general',
-			[
-				'class' => 'amp-stories-settings-field',
-			]
-		);
+			add_settings_field(
+				'stories_settings',
+				__( 'Stories Settings', 'amp' ),
+				[ $this, 'render_stories_settings' ],
+				AMP_Options_Manager::OPTION_NAME,
+				'general',
+				[
+					'class' => 'amp-stories-settings-field',
+				]
+			);
+		}
 
 		add_action(
 			'admin_print_styles',
@@ -218,44 +220,46 @@ class AMP_Options_Menu {
 					);
 					?>
 				</dd>
-				<dt>
-					<input type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[experiences][]' ); ?>" id="stories_experience" value="<?php echo esc_attr( AMP_Options_Manager::STORIES_EXPERIENCE ); ?>" <?php disabled( ! $has_required_block_capabilities ); ?> <?php checked( in_array( AMP_Options_Manager::STORIES_EXPERIENCE, $experiences, true ) ); ?>>
-					<label for="stories_experience">
-						<strong><?php echo wp_kses_post( __( 'Stories <span>Beta</span>', 'amp' ) ); ?></strong>
-					</label>
-				</dt>
-				<dd>
-					<?php if ( ! $has_required_block_capabilities ) : ?>
-						<div class="notice notice-info notice-alt inline">
-							<p>
-								<?php
-								$gutenberg = 'Gutenberg';
-								// Link to Gutenberg plugin installation if eligible.
-								if ( current_user_can( 'install_plugins' ) ) {
-									$gutenberg = '<a href="' . esc_url( add_query_arg( 'tab', 'featured', admin_url( 'plugin-install.php' ) ) ) . '">' . $gutenberg . '</a>';
-								}
-								printf(
-									/* translators: 1: WordPress version number. 2: Gutenberg plugin name,  */
-									esc_html__( 'To use Stories, you must be running WordPress %1$s, or have a version between %2$s and %3$s of the %4$s plugin activated.', 'amp' ),
-									'5.3',
-									'6.6.0',
-									'7.1.0',
-									$gutenberg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-								);
-								?>
-							</p>
-						</div>
-					<?php endif; ?>
-					<?php
-					echo wp_kses_post(
-						sprintf(
-							/* translators: %s: Stories documentation URL. */
-							__( 'Stories is a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences. Stories can be a great addition to your overall content strategy. Read more about <a href="%s" target="_blank">AMP Stories</a>.', 'amp' ),
-							esc_url( 'https://amp.dev/about/stories' )
-						)
-					);
-					?>
-				</dd>
+				<?php if ( AMP_Options_Manager::is_stories_experience_enabled() ) : ?>
+					<dt>
+						<input type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[experiences][]' ); ?>" id="stories_experience" value="<?php echo esc_attr( AMP_Options_Manager::STORIES_EXPERIENCE ); ?>" <?php disabled( ! $has_required_block_capabilities ); ?> <?php checked( in_array( AMP_Options_Manager::STORIES_EXPERIENCE, $experiences, true ) ); ?>>
+						<label for="stories_experience">
+							<strong><?php echo wp_kses_post( __( 'Stories <span>Beta</span>', 'amp' ) ); ?></strong>
+						</label>
+					</dt>
+					<dd>
+						<?php if ( ! $has_required_block_capabilities ) : ?>
+							<div class="notice notice-info notice-alt inline">
+								<p>
+									<?php
+									$gutenberg = 'Gutenberg';
+									// Link to Gutenberg plugin installation if eligible.
+									if ( current_user_can( 'install_plugins' ) ) {
+										$gutenberg = '<a href="' . esc_url( add_query_arg( 'tab', 'featured', admin_url( 'plugin-install.php' ) ) ) . '">' . $gutenberg . '</a>';
+									}
+									printf(
+										/* translators: 1: WordPress version number. 2: Gutenberg plugin name,  */
+										esc_html__( 'To use Stories, you must be running WordPress %1$s, or have a version between %2$s and %3$s of the %4$s plugin activated.', 'amp' ),
+										'5.3',
+										'6.6.0',
+										'7.1.0',
+										$gutenberg // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+									);
+									?>
+								</p>
+							</div>
+						<?php endif; ?>
+						<?php
+						echo wp_kses_post(
+							sprintf(
+								/* translators: %s: Stories documentation URL. */
+								__( 'Stories is a visual storytelling format for the open web which immerses your readers in fast-loading, full-screen, and visually rich experiences. Stories can be a great addition to your overall content strategy. Read more about <a href="%s" target="_blank">AMP Stories</a>.', 'amp' ),
+								esc_url( 'https://amp.dev/about/stories' )
+							)
+						);
+						?>
+					</dd>
+				<?php endif; ?>
 			</dl>
 			<script>
 				/*

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -79,16 +79,18 @@ class AMP_Options_Menu {
 			AMP_Options_Manager::OPTION_NAME
 		);
 
-		add_settings_field(
-			'experiences',
-			__( 'Experiences', 'amp' ),
-			[ $this, 'render_experiences' ],
-			AMP_Options_Manager::OPTION_NAME,
-			'general',
-			[
-				'class' => 'experiences',
-			]
-		);
+		if ( AMP_Options_Manager::is_stories_experience_enabled() ) {
+			add_settings_field(
+				'experiences',
+				__( 'Experiences', 'amp' ),
+				[ $this, 'render_experiences' ],
+				AMP_Options_Manager::OPTION_NAME,
+				'general',
+				[
+					'class' => 'experiences',
+				]
+			);
+		}
 
 		add_settings_field(
 			'theme_support',
@@ -138,7 +140,10 @@ class AMP_Options_Menu {
 
 		add_action(
 			'admin_print_styles',
-			function() {
+			static function() {
+				if ( ! AMP_Options_Manager::is_stories_experience_enabled() ) {
+					return;
+				}
 				?>
 				<style>
 					body:not(.amp-experience-website) .amp-website-mode,

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -94,7 +94,7 @@ class AMP_Options_Menu {
 
 		add_settings_field(
 			'theme_support',
-			__( 'Website Mode', 'amp' ),
+			__( 'Template mode', 'amp' ),
 			[ $this, 'render_theme_support' ],
 			AMP_Options_Manager::OPTION_NAME,
 			'general',

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -79,7 +79,7 @@ class AMP_Options_Menu {
 			AMP_Options_Manager::OPTION_NAME
 		);
 
-		if ( AMP_Options_Manager::is_stories_experience_enabled() ) {
+		if ( AMP_Story_Post_Type::has_posts() ) {
 			add_settings_field(
 				'experiences',
 				__( 'Experiences', 'amp' ),
@@ -114,7 +114,7 @@ class AMP_Options_Menu {
 			]
 		);
 
-		if ( AMP_Options_Manager::is_stories_experience_enabled() ) {
+		if ( AMP_Story_Post_Type::has_posts() ) {
 			add_settings_field(
 				'stories_export',
 				__( 'Stories Export', 'amp' ),
@@ -141,7 +141,7 @@ class AMP_Options_Menu {
 		add_action(
 			'admin_print_styles',
 			static function() {
-				if ( ! AMP_Options_Manager::is_stories_experience_enabled() ) {
+				if ( ! AMP_Story_Post_Type::has_posts() ) {
 					return;
 				}
 				?>
@@ -225,7 +225,7 @@ class AMP_Options_Menu {
 					);
 					?>
 				</dd>
-				<?php if ( AMP_Options_Manager::is_stories_experience_enabled() ) : ?>
+				<?php if ( AMP_Story_Post_Type::has_posts() ) : ?>
 					<dt>
 						<input type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[experiences][]' ); ?>" id="stories_experience" value="<?php echo esc_attr( AMP_Options_Manager::STORIES_EXPERIENCE ); ?>" <?php disabled( ! $has_required_block_capabilities ); ?> <?php checked( in_array( AMP_Options_Manager::STORIES_EXPERIENCE, $experiences, true ) ); ?>>
 						<label for="stories_experience">

--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -94,7 +94,7 @@ class AMP_Options_Menu {
 
 		add_settings_field(
 			'theme_support',
-			__( 'Template mode', 'amp' ),
+			__( 'Template Mode', 'amp' ),
 			[ $this, 'render_theme_support' ],
 			AMP_Options_Manager::OPTION_NAME,
 			'general',

--- a/tests/e2e/specs/amp-options.js
+++ b/tests/e2e/specs/amp-options.js
@@ -27,32 +27,6 @@ describe( 'AMP Settings Screen', () => {
 		await expect( page ).toMatchElement( '.notice-success p', { text: 'Your active theme is known to work well in standard or transitional mode.' } );
 	} );
 
-	it( 'should toggle Website Mode section', async () => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-
-		await page.evaluate( () => {
-			document.querySelector( 'tr.amp-website-mode' ).scrollIntoView();
-		} );
-
-		const websiteModeSection = await page.$( 'tr.amp-website-mode' );
-
-		expect( await websiteModeSection.isIntersectingViewport() ).toBe( true );
-
-		await page.click( '#website_experience' );
-
-		expect( await websiteModeSection.isIntersectingViewport() ).toBe( false );
-	} );
-
-	it( 'requires at least one AMP experience to be selected', async () => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-
-		expect( await page.$eval( '#amp-settings', ( el ) => el.matches( ':invalid' ) ) ).toBe( false );
-
-		await page.click( '#website_experience' );
-
-		expect( await page.$eval( '#amp-settings', ( el ) => el.matches( ':invalid' ) ) ).toBe( true );
-	} );
-
 	it( 'should not allow AMP Stories to be enabled when Gutenberg is not active', async () => {
 		await deactivatePlugin( 'gutenberg' );
 
@@ -63,11 +37,5 @@ describe( 'AMP Settings Screen', () => {
 		await expect( page ).toMatchElement( '.notice-info p', { text: 'To use stories, you must be running WordPress' } );
 
 		await activatePlugin( 'gutenberg' );
-	} );
-
-	it( 'should allow AMP Stories to be enabled when Gutenberg is active', async () => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-
-		expect( await page.$eval( '#stories_experience', ( el ) => el.matches( ':disabled' ) ) ).toBe( false );
 	} );
 } );

--- a/tests/e2e/specs/block-editor/amp-toggle.js
+++ b/tests/e2e/specs/block-editor/amp-toggle.js
@@ -9,13 +9,6 @@ import { createNewPost } from '@wordpress/e2e-test-utils';
 import { activatePlugin, deactivatePlugin } from '../../utils';
 
 describe( 'Enable AMP Toggle', () => {
-	it( 'is enabled by default', async () => {
-		await createNewPost();
-
-		await expect( page ).toMatchElement( 'label[for="amp-enabled"]', { text: 'Enable AMP' } );
-		await expect( page ).toMatchElement( 'label[for="amp-enabled"] + .components-form-toggle.is-checked' );
-	} );
-
 	it( 'should display even when Gutenberg is not active', async () => {
 		await deactivatePlugin( 'gutenberg' );
 		await createNewPost();

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -1257,6 +1257,10 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 			$this->markTestSkipped( 'Lacking required block capabilities.' );
 		}
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
+
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+
 		AMP_Story_Post_Type::register();
 
 		$site_icon_attachment_id   = $this->insert_site_icon_attachment( DIR_TESTDATA . '/images/33772.jpg' );

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -264,7 +264,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		if ( AMP_Story_Post_Type::has_required_block_capabilities() ) {
 			AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 			$this->assertFalse( AMP_Options_Manager::is_website_experience_enabled() );
-			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
+			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled( false ) );
 		}
 	}
 

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -266,8 +266,9 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 			$this->assertFalse( AMP_Options_Manager::is_website_experience_enabled() );
 
 			// Test that Stories experience is enabled if at least one post exists.
-			AMP_Story_Post_Type::register();
+			wp_cache_delete( 'count-' . AMP_Story_Post_Type::POST_TYPE_SLUG );
 			$this->factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+			AMP_Story_Post_Type::register();
 			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
 		}
 	}

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -263,7 +263,8 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		if ( AMP_Story_Post_Type::has_required_block_capabilities() ) {
 			// Test that enabling Stories experience will not work if posts do not exist.
 			AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
-			$this->assertFalse( AMP_Options_Manager::is_website_experience_enabled() );
+			// Website experience is considered enabled if there are no Story posts and the experience is disabled.
+			$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
 
 			// Test that Stories experience is enabled if at least one post exists.
 			wp_cache_delete( 'count-' . AMP_Story_Post_Type::POST_TYPE_SLUG );

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -260,11 +260,15 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertFalse( AMP_Options_Manager::get_option( 'enable_response_caching' ) );
 		$this->assertEquals( 'http://example.org/test-post', get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
 
-		// Test that enabling Stories experience works.
 		if ( AMP_Story_Post_Type::has_required_block_capabilities() ) {
+			// Test that enabling Stories experience will not work if posts do not exist.
 			AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 			$this->assertFalse( AMP_Options_Manager::is_website_experience_enabled() );
-			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled( false ) );
+
+			// Test that Stories experience is enabled if at least one post exists.
+			AMP_Story_Post_Type::register();
+			$this->factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
 		}
 	}
 

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -261,15 +261,15 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertEquals( 'http://example.org/test-post', get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, null ) );
 
 		if ( AMP_Story_Post_Type::has_required_block_capabilities() ) {
+			// Create dummy post to keep Stories experience enabled.
+			self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+
 			// Test that enabling Stories experience will not work if posts do not exist.
 			AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 			// Website experience is considered enabled if there are no Story posts and the experience is disabled.
-			$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
+			$this->assertFalse( AMP_Options_Manager::is_website_experience_enabled() );
 
 			// Test that Stories experience is enabled if at least one post exists.
-			wp_cache_delete( 'count-' . AMP_Story_Post_Type::POST_TYPE_SLUG );
-			$this->factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
-			AMP_Story_Post_Type::register();
 			$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
 		}
 	}

--- a/tests/php/test-class-amp-options-menu.php
+++ b/tests/php/test-class-amp-options-menu.php
@@ -82,7 +82,6 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'amp-options', $wp_settings_fields );
 		$this->assertArrayHasKey( 'general', $wp_settings_fields['amp-options'] );
 		$this->assertArrayHasKey( 'supported_templates', $wp_settings_fields['amp-options']['general'] );
-		$this->assertArrayHasKey( 'stories_settings', $wp_settings_fields['amp-options']['general'] );
 	}
 
 	/**

--- a/tests/php/test-class-amp-options-menu.php
+++ b/tests/php/test-class-amp-options-menu.php
@@ -82,6 +82,7 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'amp-options', $wp_settings_fields );
 		$this->assertArrayHasKey( 'general', $wp_settings_fields['amp-options'] );
 		$this->assertArrayHasKey( 'supported_templates', $wp_settings_fields['amp-options']['general'] );
+		$this->assertArrayNotHasKey( 'stories_settings', $wp_settings_fields['amp-options']['general'] );
 	}
 
 	/**

--- a/tests/php/test-class-amp-story-media.php
+++ b/tests/php/test-class-amp-story-media.php
@@ -32,6 +32,9 @@ class AMP_Story_Media_Test extends WP_UnitTestCase {
 		$wp_styles = null;
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+
 		AMP_Story_Post_Type::register(); // This calls AMP_Story_Media::init().
 	}
 

--- a/tests/php/test-class-amp-story-post-type.php
+++ b/tests/php/test-class-amp-story-post-type.php
@@ -82,6 +82,8 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 		AMP_Story_Post_Type::register();
 		$this->assertFalse( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) );
 
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
 		$this->assertTrue( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) );
@@ -163,6 +165,8 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Post_Type::enqueue_embed_styling()
 	 */
 	public function test_enqueue_embed_styling() {
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		AMP_Story_Post_Type::register();
 
 		// None of the conditional is satisfied, so this should not enqueue the stylesheet.
@@ -188,6 +192,8 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	public function test_override_story_embed_callback() {
 		global $wp_rewrite;
 
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		AMP_Story_Post_Type::register();
 
 		/*
@@ -294,6 +300,9 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers \AMP_Story_Post_Type::render_block_latest_stories()
 	 */
 	public function test_render_block_latest_stories() {
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+
 		AMP_Story_Post_Type::register();
 
 		$attributes = [
@@ -449,6 +458,9 @@ class AMP_Story_Post_Type_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Post_Type::filter_rest_request_for_kses
 	 */
 	public function test_filter_rest_request_for_kses() {
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+
 		AMP_Story_Post_Type::register();
 
 		$author_id = self::factory()->user->create( [ 'role' => 'author' ] );

--- a/tests/php/test-class-amp-story-templates.php
+++ b/tests/php/test-class-amp-story-templates.php
@@ -29,6 +29,8 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 		}
 
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		AMP_Story_Post_Type::register();
 	}
 
@@ -53,11 +55,11 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Templates::filter_user_has_cap()
 	 */
 	public function test_filter_user_has_cap() {
-		$story_id = self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
-		wp_set_object_terms( $story_id, AMP_Story_Templates::TEMPLATES_TERM, AMP_Story_Templates::TEMPLATES_TAXONOMY );
-
 		$amp_story_templates = new AMP_Story_Templates();
 		$amp_story_templates->init();
+
+		$story_id = self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+		wp_set_object_terms( $story_id, AMP_Story_Templates::TEMPLATES_TERM, AMP_Story_Templates::TEMPLATES_TAXONOMY );
 
 		$allcaps = [
 			'edit_others_posts'    => true,

--- a/tests/php/test-class-amp-story-templates.php
+++ b/tests/php/test-class-amp-story-templates.php
@@ -55,11 +55,11 @@ class AMP_Story_Templates_Test extends WP_UnitTestCase {
 	 * @covers AMP_Story_Templates::filter_user_has_cap()
 	 */
 	public function test_filter_user_has_cap() {
-		$amp_story_templates = new AMP_Story_Templates();
-		$amp_story_templates->init();
-
 		$story_id = self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		wp_set_object_terms( $story_id, AMP_Story_Templates::TEMPLATES_TERM, AMP_Story_Templates::TEMPLATES_TAXONOMY );
+
+		$amp_story_templates = new AMP_Story_Templates();
+		$amp_story_templates->init();
 
 		$allcaps = [
 			'edit_others_posts'    => true,

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -179,7 +179,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		if ( ! AMP_Story_Post_Type::has_required_block_capabilities() ) {
 			$this->markTestSkipped( 'Environment does not support Stories.' );
 		}
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
+		AMP_Story_Post_Type::register();
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
@@ -1908,7 +1911,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
-		$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
+		$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled( false ) );
 		AMP_Story_Post_Type::register();
 		if ( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			$post = $this->factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -179,6 +179,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		if ( ! AMP_Story_Post_Type::has_required_block_capabilities() ) {
 			$this->markTestSkipped( 'Environment does not support Stories.' );
 		}
+
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
 		// Create dummy post to keep Stories experience enabled.
@@ -1909,10 +1913,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::enqueue_block_validation();
 		$this->assertNotContains( $slug, wp_scripts()->queue );
 
-		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
-		AMP_Story_Post_Type::register();
 		// Create dummy post to keep Stories experience enabled.
 		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
+		AMP_Story_Post_Type::register();
 		$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
 		$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
 		if ( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -179,10 +179,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		if ( ! AMP_Story_Post_Type::has_required_block_capabilities() ) {
 			$this->markTestSkipped( 'Environment does not support Stories.' );
 		}
-		// Create dummy post to keep Stories experience enabled.
-		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::STORIES_EXPERIENCE ] );
 		AMP_Story_Post_Type::register();
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		AMP_Validation_Manager::init();
 
@@ -1910,9 +1910,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$this->assertNotContains( $slug, wp_scripts()->queue );
 
 		AMP_Options_Manager::update_option( 'experiences', [ AMP_Options_Manager::WEBSITE_EXPERIENCE, AMP_Options_Manager::STORIES_EXPERIENCE ] );
-		$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
-		$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled( false ) );
 		AMP_Story_Post_Type::register();
+		// Create dummy post to keep Stories experience enabled.
+		self::factory()->post->create( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
+		$this->assertTrue( AMP_Options_Manager::is_website_experience_enabled() );
+		$this->assertTrue( AMP_Options_Manager::is_stories_experience_enabled() );
 		if ( post_type_exists( AMP_Story_Post_Type::POST_TYPE_SLUG ) ) {
 			$post = $this->factory()->post->create_and_get( [ 'post_type' => AMP_Story_Post_Type::POST_TYPE_SLUG ] );
 			AMP_Validation_Manager::enqueue_block_validation();


### PR DESCRIPTION
## Summary

### Stories experience enabled

The following table summarizes what happens when the Stories experience is enabled:

‏‏‎ ‎ | With `amp_story` posts | Without `amp_story` posts
---|:---:|:---:
Story posts can be managed | :heavy_check_mark:  | :x:
Stories settings are available | :heavy_check_mark: | :x:
Notice shown on AMP settings page | ![image](https://user-images.githubusercontent.com/16200219/74094553-2eb30980-4adb-11ea-98e4-62fc92bd5cf2.png) | ![image](https://user-images.githubusercontent.com/16200219/74094563-56a26d00-4adb-11ea-97f0-5e382f861eac.png)

NB: In the case with existing `amp_story` posts, the deprecated notice is also shown on the Stories post list page:

![image](https://user-images.githubusercontent.com/16200219/74094602-e6e0b200-4adb-11ea-841a-3541ed4daaf8.png)

And also in the Story editor:

![image](https://user-images.githubusercontent.com/134745/73989394-7b8bba00-48fa-11ea-9b02-46b0bed10905.png)

And an admin pointer on non-story screens, when the Stories experience is enabled:

<img width="562" alt="Screen Shot 2020-02-08 at 21 16 58" src="https://user-images.githubusercontent.com/134745/74096853-0fa38000-4ab9-11ea-8254-bce9842446be.png">

### Stories experience disabled

The following table summarizes what happens when the Stories experience is disabled:

‏‏‎ ‎ | With `amp_story` posts | Without `amp_story` posts
---|:---:|:---:
Story posts can be managed | :x:  | :x:
Stories settings are available | :heavy_check_mark: | :x:
Notice shown on AMP settings page | ![image](https://user-images.githubusercontent.com/16200219/74094553-2eb30980-4adb-11ea-98e4-62fc92bd5cf2.png) | ![image](https://user-images.githubusercontent.com/16200219/74094563-56a26d00-4adb-11ea-97f0-5e382f861eac.png)

---

Fixes #4201.
Fixes #4202.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
