### PR TITLE
Prevent validation errors on valid mailto: links; restrict AMP-to-AMP linking to HTTP(S) protocol links

### DIFF
--- a/includes/sanitizers/class-amp-link-sanitizer.php
+++ b/includes/sanitizers/class-amp-link-sanitizer.php
@@ -204,6 +204,10 @@ class AMP_Link_Sanitizer extends AMP_Base_Sanitizer {
 	public function is_frontend_url( $url ) {
 		$parsed_url = wp_parse_url( $url );
 
+		if ( ! empty( $parsed_url['scheme'] ) && ! in_array( strtolower( $parsed_url['scheme'] ), [ 'http', 'https' ], true ) ) {
+			return false;
+		}
+
 		// Skip adding query var to links on other URLs.
 		if ( ! empty( $parsed_url['host'] ) && $this->home_host !== $parsed_url['host'] ) {
 			return false;

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1666,7 +1666,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string|null Protocol without colon if matched. Otherwise null.
 	 */
 	private function parse_protocol( $url ) {
-		if ( preg_match( '#^[^/]+(?=:)#', $url, $matches ) ) {
+		if ( preg_match( '#^[^/]+?(?=:)#', $url, $matches ) ) {
 			return $matches[0];
 		}
 		return null;

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -1616,6 +1616,22 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				],
 				AMP_Rule_Spec::FAIL,
 			],
+			'protocol_mailto_pass'        => [
+				[
+					'source'         => '<a href="mailto:foo@example.com?&#038;subject=Example&#038;body=https://example.com/"></a>',
+					'node_tag_name'  => 'a',
+					'attr_name'      => 'href',
+					'attr_spec_rule' => [
+						'value_url' => [
+							'protocol' => [
+								'mailto',
+								'https',
+							],
+						],
+					],
+				],
+				AMP_Rule_Spec::PASS,
+			],
 		];
 	}
 
@@ -1646,9 +1662,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				'//image.png ',
 				false,
 			],
-			'two_colons'        => [
-				'foo:baz://image.png ',
-				'foo:baz',
+			'mailto'            => [
+				'mailto:?&#038;subject=Foo&#038;body=https://example.com/',
+				'mailto',
 			],
 		];
 	}

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -142,6 +142,11 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 				'expected_amp' => false,
 				'expected_rel' => null,
 			],
+			'mailto-link'         => [
+				'href'         => 'mailto:nobody@example.com',
+				'expected_amp' => false,
+				'expected_rel' => null,
+			],
 		];
 
 		$admin_bar_link_href = home_url( '/?do_something' );

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1272,11 +1272,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL ],
 			],
-			'a_with_mail_host'                             => [
-				'<a class="foo" href="mail to:foo@bar.com">value</a>',
-				'<a class="foo">value</a>',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL ],
+			'a_with_valid_mail_host'                       => [
+				'<a class="foo" href="mailto:foo@bar.com&amp;body=https://example.org/">value</a>',
+				null,
 			],
 
 			// font is removed so we should check that other elements are checked as well.


### PR DESCRIPTION
## Summary

* Prevents validation errors on `mailto:` links, like Weston's example of `<a href="mailto:foo@example.com?&#038;subject=Example&#038;body=https://example.com/">Email this</a>`
* Uses lazy instead of greedy matching, so the lookahead of `(?=:)` will only match the first `:`

<!-- Please reference the issue this PR addresses. -->
Fixes #4182 

## Testing
1. Activate Standard mode
2. Create a new post
3. Add a Custom HTML block with this markup that Weston shared in #4182 
```html
<a href="mailto:?&#038;subject=Example&#038;body=https://example.com/">Email this</a>
<a href="mailto:foo@example.com?&#038;subject=Example&#038;body=https://example.com/">Email this</a>
```
4. Go to the AMP URL
5. Expected: there's no validation error

## Regex
Your suggestion worked pretty well overall:

```diff
diff --git a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
index 9227c6a62..73944f731 100644
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1666,7 +1666,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string|null Protocol without colon if matched. Otherwise null.
 	 */
 	private function parse_protocol( $url ) {
-		if ( preg_match( '#^[^/]+?(?=:)#', $url, $matches ) ) {
+		if ( preg_match( '#^[a-z][a-z0-9+.-]*(?=:)#', $url, $matches ) ) {
 			return $matches[0];
 		}
 		return null;
```

...but there were 2 unit test failures:

https://github.com/ampproject/amp-wp/blob/19d54bdf0ac4c41a37927e11241b723cdb754de8/tests/php/test-tag-and-attribute-sanitizer.php#L2018
and 
https://github.com/ampproject/amp-wp/blob/19d54bdf0ac4c41a37927e11241b723cdb754de8/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php#L1439

For the `'malformed_attribute_syntax_curly_quotes'` failure, I think that's because `$this->parse_protocol()` returned `null` when passed `%E2%80%9Chttps://example.com/path/to/post/%E2%80%9D` here:
https://github.com/ampproject/amp-wp/blob/19d54bdf0ac4c41a37927e11241b723cdb754de8/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php#L1702-L1705

...so the conditional on the next line was false, and it didn't return an invalid protocol error as it should have.

It doesn't look like I could edit this to return `AMP_Rule_Spec::FAIL` if `$this->parse_protocol()` returns `null`. But maybe there is a fix to this that I missed 😄 

Thanks, Weston!

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
