### PR TITLE
Improve handling of fetching external stylesheets

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1366,6 +1366,12 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @return string|WP_Error Stylesheet contents or WP_Error.
 	 */
 	private function fetch_external_stylesheet( $url ) {
+
+		// Prepend schemeless stylesheet URL with the same URL scheme as the current site.
+		if ( '//' === substr( $url, 0, 2 ) ) {
+			$url = wp_parse_url( home_url(), PHP_URL_SCHEME ) . ':' . $url;
+		}
+
 		$cache_key = md5( $url );
 		$contents  = get_transient( $cache_key );
 		if ( false === $contents ) {

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -41,7 +41,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	const CSS_SYNTAX_INVALID_IMPORTANT       = 'CSS_SYNTAX_INVALID_IMPORTANT';
 	const CSS_SYNTAX_PARSE_ERROR             = 'CSS_SYNTAX_PARSE_ERROR';
 	const STYLESHEET_TOO_LONG                = 'STYLESHEET_TOO_LONG';
-	const STYLESHEET_INVALID_FILE_URL        = 'STYLESHEET_INVALID_FILE_URL';
+	const STYLESHEET_FETCH_ERROR             = 'STYLESHEET_FETCH_ERROR';
 
 	// These are internal to the sanitizer and not exposed as validation error codes.
 	const STYLESHEET_DISALLOWED_FILE_EXT   = 'STYLESHEET_DISALLOWED_FILE_EXT';
@@ -344,7 +344,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			self::CSS_SYNTAX_INVALID_PROPERTY,
 			self::CSS_SYNTAX_INVALID_PROPERTY_NOLIST,
 			self::CSS_SYNTAX_PARSE_ERROR,
-			self::STYLESHEET_INVALID_FILE_URL,
+			self::STYLESHEET_FETCH_ERROR,
 			self::STYLESHEET_TOO_LONG,
 		];
 	}
@@ -1286,10 +1286,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			$this->remove_invalid_child(
 				$element,
 				[
-					// @todo Also include details about the error.
-					'code' => self::STYLESHEET_INVALID_FILE_URL,
-					'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-					'url'  => $normalized_url,
+					'code'    => self::STYLESHEET_FETCH_ERROR,
+					'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
+					'url'     => $normalized_url,
+					'message' => $stylesheet->get_error_message(),
 				]
 			);
 			return;
@@ -1377,7 +1377,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		if ( false === $contents ) {
 			$r    = wp_remote_get( $url );
 			$code = wp_remote_retrieve_response_code( $r );
-			if ( $code < 200 || $code >= 300 ) {
+			if ( is_wp_error( $r ) ) {
+				$contents = $r;
+			} elseif ( $code < 200 || $code >= 300 ) {
 				$message = wp_remote_retrieve_response_message( $r );
 				if ( ! $code ) {
 					$code = 'http_error';
@@ -1553,10 +1555,10 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$stylesheet = $this->get_stylesheet_from_url( $import_stylesheet_url );
 		if ( $stylesheet instanceof WP_Error ) {
 			$error     = [
-				// @todo Also include details about the error.
-				'code' => self::STYLESHEET_INVALID_FILE_URL,
-				'type' => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
-				'url'  => $import_stylesheet_url,
+				'code'    => self::STYLESHEET_FETCH_ERROR,
+				'type'    => AMP_Validation_Error_Taxonomy::CSS_ERROR_TYPE,
+				'url'     => $import_stylesheet_url,
+				'message' => $stylesheet->get_error_message(),
 			];
 			$sanitized = $this->should_sanitize_validation_error( $error );
 			if ( $sanitized ) {

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2930,8 +2930,8 @@ class AMP_Validation_Error_Taxonomy {
 				return esc_html__( 'Unrecognized CSS', 'amp' );
 			case AMP_Style_Sanitizer::CSS_SYNTAX_PARSE_ERROR:
 				return esc_html__( 'CSS parse error', 'amp' );
-			case AMP_Style_Sanitizer::STYLESHEET_INVALID_FILE_URL:
-				return esc_html__( 'Missing stylesheet file', 'amp' );
+			case AMP_Style_Sanitizer::STYLESHEET_FETCH_ERROR:
+				return esc_html__( 'Stylesheet fetch error', 'amp' );
 			case AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_PROPERTY:
 			case AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_PROPERTY_NOLIST:
 				$title = esc_html__( 'Illegal CSS property', 'amp' );

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -1364,7 +1364,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				home_url( '/this.is.not.css' ),
 				'image/jpeg',
 				'JPEG...',
-				[ AMP_Style_Sanitizer::STYLESHEET_INVALID_FILE_URL ],
+				[ AMP_Style_Sanitizer::STYLESHEET_FETCH_ERROR ],
 			],
 		];
 	}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -1342,6 +1342,12 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'html{background-color:lightblue}',
 				[],
 			],
+			'external_file_schemeless' => [
+				'//stylesheets.example.com/style.css',
+				'text/css',
+				'html{background-color:lightblue}',
+				[],
+			],
 			'dynamic_file' => [
 				set_url_scheme( add_query_arg( 'action', 'kirki-styles', home_url() ), 'http' ),
 				'text/css',
@@ -1378,7 +1384,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$request_count = 0;
 		add_filter(
 			'pre_http_request',
-			static function( $preempt, $request, $url ) use ( $href, &$request_count, $content_type, $response_body ) {
+			function( $preempt, $request, $url ) use ( $href, &$request_count, $content_type, $response_body ) {
+				$this->assertRegExp( '#^https?://#', $url );
 				if ( set_url_scheme( $url, 'https' ) === set_url_scheme( $href, 'https' ) ) {
 					$request_count++;
 					$preempt = [


### PR DESCRIPTION
## Summary

I discovered that an external stylesheet with a schemeless URL fails to be fetched because `wp_remote_get()` does not support such URLs. 

For example, given this plugin:

```php
<?php
/**
 * Plugin Name: Try External Stylesheet Schemeless URL
 */
add_action( 'wp_head', function() {
	?>
	<link rel="stylesheet" href="//make.wordpress.org/core/wp-content/plugins/o2/modules/follow/css/style.css?ver=<?php echo (int) time(); ?>">
	<?php
} );
```

The result is an error like so:

![image](https://user-images.githubusercontent.com/134745/74094137-1f0ed300-4a91-11ea-9427-edd95992e5c2.png)

Not only should the URL be fetchable but the error message displayed here is not helpful.

So this PR ensures that a URL scheme is supplied when fetching an external stylesheet to prevent `wp_remote_get()` from failing. It uses the same URL scheme as the scheme for the `home_url()`, as this is the behavior of a schemeless URL.

Additionally, when the URL is actually invalid the error messages are now much more helpful (resolving some code todos), as the WP HTTP error message is passed through. For example:

```html
<link rel="stylesheet" href="bad://example.com/foo.css">
```

![image](https://user-images.githubusercontent.com/134745/74094175-cab82300-4a91-11ea-897b-c40683cc3b06.png)

```html
<link rel="stylesheet" href="http://not-existing.example.com/foo.css">
```

![image](https://user-images.githubusercontent.com/134745/74094187-f3401d00-4a91-11ea-9d22-fc05d234f7fb.png)

```html
<link rel="stylesheet" href="http://example.com/notfound.css">
```

![image](https://user-images.githubusercontent.com/134745/74094192-03f09300-4a92-11ea-9b7f-8ad4593131ba.png)

Relates to #1420.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
