### PR TITLE
Open story export instructions in a new window

### DIFF
--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -84,7 +84,7 @@ class AMP_Admin_Pointers {
 						[
 							esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
 							sprintf(
-								'<a href="%s">%s</a>',
+								'<a href="%s" target="_blank">%s</a>',
 								esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
 								esc_html__( 'View how to export your Stories', 'amp' )
 							),

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -595,7 +595,7 @@ class AMP_Options_Manager {
 				'<div class="notice notice-warning"><p>%s %s</p></div>',
 				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
 				sprintf(
-					'<a href="%s">%s</a>',
+					'<a href="%s" target="_blank">%s</a>',
 					esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
 					esc_html__( 'View how to export your Stories', 'amp' )
 				)
@@ -618,8 +618,8 @@ class AMP_Options_Manager {
 							'warning',
 							%s,
 							{
-						  		isDismissible: false,
-						  		actions: [
+								isDismissible: false,
+								actions: [
 									{
 										url: 'https://amp-wp.org/documentation/amp-stories/exporting-stories/',
 										label: %s,


### PR DESCRIPTION
## Summary

- [ ] Make export instructions open in a new window when clicked in the editor as well.

Amends #4219; see #4202.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
