### PR TITLE
attachShadowDocAsStream expects a string type variable

### DIFF
--- a/assets/js/amp-wp-app-shell.js
+++ b/assets/js/amp-wp-app-shell.js
@@ -175,7 +175,7 @@
 				 * https://www.ampproject.org/latest/blog/streaming-in-the-shadow-reader/
 				 * https://github.com/ampproject/amphtml/blob/master/spec/amp-shadow-doc.md#fetching-and-attaching-shadow-docs
 				 */
-				currentShadowDoc = AMP.attachShadowDocAsStream( newContainer, url, {} );
+				currentShadowDoc = AMP.attachShadowDocAsStream( newContainer, String( url ), {} );
 
 				// @todo If it is not an AMP document, then the loaded document needs to break out of the app shell. This should be done in readChunk() below.
 				currentShadowDoc.ampdoc.whenReady().then( () => {


### PR DESCRIPTION
## Summary

A recent change on the AMP platform enforces the URL parameter to be a string, but a URL object instance is passed on navigation or form submission currently. Adding an explicit type cast fixes
the issue.

ref. https://github.com/ampproject/amphtml/blob/f41de5e5205ae37a823e774af817e2748ad5ed09/src/multidoc-manager.js#L273
ref. https://github.com/ampproject/amphtml/commit/f41de5e5205ae37a823e774af817e2748ad5ed09

- There is no issue created for this in amp-wp.
- Fixes an issue in https://github.com/ampproject/amp-wp/pull/1519