### PR TITLE
Fix division by zero to calculate minification ratio when original size is zero

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2168,7 +2168,11 @@ class AMP_Validated_URL_Post_Type {
 				}
 				$origin_html .= '>';
 
-				$ratio = $stylesheet['final_size'] / $stylesheet['original_size'];
+				if ( 0 === $stylesheet['original_size'] ) {
+					$ratio = 1;
+				} else {
+					$ratio = $stylesheet['final_size'] / $stylesheet['original_size'];
+				}
 				?>
 				<tr class="<?php echo esc_attr( sprintf( 'stylesheet level-0 %s', 0 === $row % 2 ? 'even' : 'odd' ) ); ?>">
 					<td class="column-stylesheet_expand">


### PR DESCRIPTION
## Summary

When the AMP plugin processes a page that has an empty stylesheet, the result when looking at the Validated URL screen is a PHP Warning:

> Division by zero in /app/public/content/plugins/amp/includes/validation/class-amp-validated-url-post-type.php on line 2171

Bug introduced in #4026.

To reproduce this issue, simply create a new Custom HTML block and add `<style></style>`. Then look at the stylesheets metabox (note NaN):

![image](https://user-images.githubusercontent.com/134745/74201945-f2d58c80-4c1f-11ea-8773-258a37fc1c75.png)

After this PR:

![image](https://user-images.githubusercontent.com/134745/74201981-0b45a700-4c20-11ea-927e-a15afb1e589b.png)


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
