### PR TITLE
Fix discrepancy when reporting CSS usage percentage

### DIFF
--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -1061,6 +1061,9 @@ class AMP_Validated_URL_Post_Type {
 				} else {
 					$total_size = 0;
 					foreach ( $stylesheets as $stylesheet ) {
+						if ( ! isset( $stylesheet['group'] ) || 'amp-custom' !== $stylesheet['group'] || ! empty( $stylesheet['duplicate'] ) ) {
+							continue;
+						}
 						$total_size += $stylesheet['final_size'];
 					}
 


### PR DESCRIPTION
## Summary

The CSS usage shown in the post list table does not match the CSS usage in the stylesheets metabox when there are duplicate stylesheets on the page. This fixes that.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
