### PR TITLE
Support `mandatory_oneof` and `mandatory_anyof` constraints

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -655,6 +655,14 @@ def GetTagRules(tag_spec):
 				amp_layout[ field[0].name ] = field[1]
 		tag_rules['amp_layout'] = amp_layout
 
+	mandatory_anyof = GetMandatoryOf(tag_spec.attrs, 'mandatory_anyof')
+	if mandatory_anyof:
+		tag_rules.update( mandatory_anyof )
+
+	mandatory_oneof = GetMandatoryOf(tag_spec.attrs, 'mandatory_oneof')
+	if mandatory_oneof:
+		tag_rules.update( mandatory_oneof )
+
 	logging.info('... done')
 	return tag_rules
 
@@ -708,9 +716,6 @@ def GetValues(attr_spec):
 	# mandatory is a boolean
 	if attr_spec.HasField('mandatory'):
 		value_dict['mandatory'] = attr_spec.mandatory
-
-	value_dict = AddMandatoryOf( value_dict, attr_spec, 'mandatory_anyof' )
-	value_dict = AddMandatoryOf( value_dict, attr_spec, 'mandatory_oneof' )
 
 	# Add allowed value
 	if attr_spec.value:
@@ -776,21 +781,21 @@ def UnicodeEscape(string):
 	"""
 	return ('' + string).encode('unicode-escape')
 
-def AddMandatoryOf( spec_dict, attribute_spec, constraint ):
+def GetMandatoryOf( attr, constraint ):
 	"""Gets the spec dictionary, with mandatory_*of constraints possibly added.
 
 	Args:
-		spec_dict: A dictionary of the attr_spec values to possibly add the constraint to.
-		attribute_spec: The attribute spec in which to look for the mandatory_*of constraint.
+		attr: The attributes in which to look for the mandatory_*of constraint.
 		constraint: A string of the mandatory_*of constraint, like 'mandatory_anyof'.
 	Returns:
-		The spec_dict, with the constraint possibly added.
+		A spec_dict with the constraint added, or null.
 	"""
-	if attribute_spec.HasField(constraint):
-		mandatory_of = getattr(attribute_spec, constraint).lstrip('[').rstrip(']').split(',')
-		spec_dict[constraint] = [GetMandatoryOfAttr( oneof ) for oneof in mandatory_of]
-
-	return spec_dict
+	for attr_spec in attr:
+		if attr_spec.HasField(constraint):
+			spec_dict = {}
+			mandatory_of = getattr(attr_spec, constraint).lstrip('[').rstrip(']').split(',')
+			spec_dict[constraint] = [GetMandatoryOfAttr(oneof) for oneof in mandatory_of]
+			return spec_dict
 
 def GetMandatoryOfAttr( attribute ):
 	"""Gets mandatory_*of attribute value to add to the generated file.

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -28,6 +28,7 @@ import json
 import google
 from collections import defaultdict
 import imp
+import re
 
 seen_spec_names = set()
 
@@ -787,9 +788,26 @@ def AddMandatoryOf( spec_dict, attribute_spec, constraint ):
 	"""
 	if attribute_spec.HasField(constraint):
 		mandatory_of = getattr(attribute_spec, constraint).lstrip('[').rstrip(']').split(',')
-		spec_dict[constraint] = [oneof.strip(' ').strip("'").replace('[', 'data-amp-bind-').rstrip(']') for oneof in mandatory_of]
+		spec_dict[constraint] = [GetMandatoryOfAttr( oneof ) for oneof in mandatory_of]
 
 	return spec_dict
+
+def GetMandatoryOfAttr( attribute ):
+	"""Gets mandatory_*of attribute value to add to the generated file.
+
+	Args:
+		attribute: A string mandatory_*of attribute value, as parsed from the spec file.
+	Returns:
+		The attribute to pass to the generated PHP file.
+	"""
+	parsed_attribute = attribute.strip(' ').strip("'")
+
+	# Convert something like [src] to data-amp-bind-src.
+	return re.sub(
+		"^\[(\S+)\]$",
+		r"data-amp-bind-\1",
+		parsed_attribute
+	)
 
 def Phpize(data, indent=0):
 	"""Helper function to convert JSON-serializable data into PHP literals.

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -657,11 +657,11 @@ def GetTagRules(tag_spec):
 
 	mandatory_anyof = GetMandatoryOf(tag_spec.attrs, 'mandatory_anyof')
 	if mandatory_anyof:
-		tag_rules.update( mandatory_anyof )
+		tag_rules.update(mandatory_anyof)
 
 	mandatory_oneof = GetMandatoryOf(tag_spec.attrs, 'mandatory_oneof')
 	if mandatory_oneof:
-		tag_rules.update( mandatory_oneof )
+		tag_rules.update(mandatory_oneof)
 
 	logging.info('... done')
 	return tag_rules

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -782,18 +782,18 @@ def UnicodeEscape(string):
 	return ('' + string).encode('unicode-escape')
 
 def GetMandatoryOf( attr, constraint ):
-	"""Gets the spec dictionary, with mandatory_*of constraints possibly added.
+	"""Gets the mandatory_*of value, if it exists.
 
 	Args:
 		attr: The attributes in which to look for the mandatory_*of constraint.
 		constraint: A string of the mandatory_*of constraint, like 'mandatory_anyof'.
 	Returns:
-		A spec_dict with the constraint added, or null.
+		A dictionary with the constraint name mapped to its value.
 	"""
 	for attr_spec in attr:
 		if attr_spec.HasField(constraint):
 			spec_dict = {}
-			mandatory_of = getattr(attr_spec, constraint).lstrip('[').rstrip(']').split(',')
+			mandatory_of = getattr(attr_spec, constraint).strip('[]').split(',')
 			spec_dict[constraint] = [GetMandatoryOfAttr(oneof) for oneof in mandatory_of]
 			return spec_dict
 

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -708,9 +708,8 @@ def GetValues(attr_spec):
 	if attr_spec.HasField('mandatory'):
 		value_dict['mandatory'] = attr_spec.mandatory
 
-	if attr_spec.HasField('mandatory_oneof'):
-		mandatory_oneof = attr_spec.mandatory_oneof.lstrip('[').rstrip(']').split(', ')
-		value_dict['mandatory_oneof'] = [oneof.strip("'") for oneof in mandatory_oneof]
+	value_dict = AddMandatoryOf( value_dict, attr_spec, 'mandatory_anyof' )
+	value_dict = AddMandatoryOf( value_dict, attr_spec, 'mandatory_oneof' )
 
 	# Add allowed value
 	if attr_spec.value:
@@ -775,6 +774,22 @@ def UnicodeEscape(string):
 		An escaped string.
 	"""
 	return ('' + string).encode('unicode-escape')
+
+def AddMandatoryOf( spec_dict, attribute_spec, constraint ):
+	"""Gets the spec dictionary, with mandatory_*of constraints possibly added.
+
+	Args:
+		spec_dict: A dictionary of the attr_spec values to possibly add the constraint to.
+		attribute_spec: The attribute spec in which to look for the mandatory_*of constraint.
+		constraint: A string of the mandatory_*of constraint, like 'mandatory_anyof'.
+	Returns:
+		The spec_dict, with the constraint possibly added.
+	"""
+	if attribute_spec.HasField(constraint):
+		mandatory_of = getattr(attribute_spec, constraint).lstrip('[').rstrip(']').split(',')
+		spec_dict[constraint] = [oneof.strip(' ').strip("'") for oneof in mandatory_of]
+
+	return spec_dict
 
 def Phpize(data, indent=0):
 	"""Helper function to convert JSON-serializable data into PHP literals.

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -799,6 +799,7 @@ def GetMandatoryOf( attr, constraint ):
 				)
 			)
 
+	attributes.sort()
 	return attributes
 
 def Phpize(data, indent=0):

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -787,7 +787,7 @@ def AddMandatoryOf( spec_dict, attribute_spec, constraint ):
 	"""
 	if attribute_spec.HasField(constraint):
 		mandatory_of = getattr(attribute_spec, constraint).lstrip('[').rstrip(']').split(',')
-		spec_dict[constraint] = [oneof.strip(' ').strip("'") for oneof in mandatory_of]
+		spec_dict[constraint] = [oneof.strip(' ').strip("'").replace('[', 'data-amp-bind-').rstrip(']') for oneof in mandatory_of]
 
 	return spec_dict
 

--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -708,6 +708,10 @@ def GetValues(attr_spec):
 	if attr_spec.HasField('mandatory'):
 		value_dict['mandatory'] = attr_spec.mandatory
 
+	if attr_spec.HasField('mandatory_oneof'):
+		mandatory_oneof = attr_spec.mandatory_oneof.lstrip('[').rstrip(']').split(', ')
+		value_dict['mandatory_oneof'] = [oneof.strip("'") for oneof in mandatory_oneof]
+
 	# Add allowed value
 	if attr_spec.value:
 		value_dict['value'] = list( attr_spec.value )

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -3296,6 +3296,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
+					'mandatory_oneof' => array(
+						'src',
+						'srcdoc',
+					),
 					'amp_layout' => array(
 						'supported_layouts' => array(
 							6,

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,7 +13,7 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 997;
+	private static $spec_file_revision = 999;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
@@ -50,12 +50,14 @@ class AMP_Allowed_Tags_Generated {
 			'ol',
 			'option',
 			'p',
+			'path',
 			'section',
 			'span',
 			'strike',
 			'strong',
 			'sub',
 			'sup',
+			'svg',
 			'table',
 			'tbody',
 			'td',
@@ -3959,7 +3961,13 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'credentials' => array(),
 					'data-amp-bind-is-layout-container' => array(),
-					'data-amp-bind-src' => array(),
+					'data-amp-bind-src' => array(
+						'mandatory_anyof' => array(
+							'src',
+							'[src]',
+							'data-amp-bind-src',
+						),
+					),
 					'diffable' => array(
 						'value' => array(
 							'',
@@ -3990,6 +3998,11 @@ class AMP_Allowed_Tags_Generated {
 					'single-item' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory_anyof' => array(
+							'src',
+							'[src]',
+							'data-amp-bind-src',
+						),
 						'value_url' => array(
 							'allow_relative' => true,
 							'protocol' => array(
@@ -16625,7 +16638,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'validate_keyframes' => false,
 					),
-					'max_bytes' => 50000,
+					'max_bytes' => 75000,
 					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size',
 				),
 				'tag_spec' => array(
@@ -18545,8 +18558,18 @@ class AMP_Allowed_Tags_Generated {
 		),
 		'AMP-MEGA-MENU > AMP-LIST' => array(
 			'attr_spec_list' => array(
-				'data-amp-bind-src' => array(),
-				'src' => array(),
+				'data-amp-bind-src' => array(
+					'mandatory_anyof' => array(
+						'src',
+						'[src]',
+					),
+				),
+				'src' => array(
+					'mandatory_anyof' => array(
+						'src',
+						'[src]',
+					),
+				),
 			),
 			'tag_spec' => array(
 				'child_tags' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -1125,8 +1125,8 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'mandatory_oneof' => array(
-						'data-apester-media-id',
 						'data-apester-channel-token',
+						'data-apester-media-id',
 					),
 					'requires_extension' => array(
 						'amp-apester-media',
@@ -3873,8 +3873,8 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_oneof' => array(
 						'load-more-button',
 						'load-more-failed',
-						'load-more-end',
 						'load-more-loading',
+						'load-more-end',
 					),
 					'mandatory_parent' => 'amp-list',
 					'requires_extension' => array(
@@ -4609,8 +4609,8 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'mandatory_oneof' => array(
-						'data-video',
 						'data-terms',
+						'data-video',
 					),
 					'requires_extension' => array(
 						'amp-powr-player',
@@ -5086,8 +5086,8 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'mandatory_oneof' => array(
-						'data-trackid',
 						'data-playlistid',
+						'data-trackid',
 					),
 					'requires_extension' => array(
 						'amp-soundcloud',

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -3296,10 +3296,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_oneof' => array(
-						'src',
-						'srcdoc',
-					),
 					'amp_layout' => array(
 						'supported_layouts' => array(
 							6,

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -946,12 +946,7 @@ class AMP_Allowed_Tags_Generated {
 		'amp-addthis' => array(
 			array(
 				'attr_spec_list' => array(
-					'data-product-code' => array(
-						'mandatory_oneof' => array(
-							'data-product-code',
-							'data-widget-id',
-						),
-					),
+					'data-product-code' => array(),
 					'data-share-media' => array(
 						'value_url' => array(
 							'allow_empty' => true,
@@ -970,12 +965,7 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'data-widget-id' => array(
-						'mandatory_oneof' => array(
-							'data-product-code',
-							'data-widget-id',
-						),
-					),
+					'data-widget-id' => array(),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -993,6 +983,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-product-code',
+						'data-widget-id',
 					),
 					'requires_extension' => array(
 						'amp-addthis',
@@ -1107,17 +1101,9 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-apester-channel-token' => array(
-						'mandatory_oneof' => array(
-							'data-apester-media-id',
-							'data-apester-channel-token',
-						),
 						'value_regex' => '[0-9a-zA-Z]+',
 					),
 					'data-apester-media-id' => array(
-						'mandatory_oneof' => array(
-							'data-apester-media-id',
-							'data-apester-channel-token',
-						),
 						'value_regex' => '[0-9a-zA-Z]+',
 					),
 					'media' => array(),
@@ -1137,6 +1123,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-apester-media-id',
+						'data-apester-channel-token',
 					),
 					'requires_extension' => array(
 						'amp-apester-media',
@@ -1681,11 +1671,6 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[a-z]+',
 					),
 					'data-outstream' => array(
-						'mandatory_oneof' => array(
-							'data-outstream',
-							'data-playlist',
-							'data-video',
-						),
 						'value_regex' => '[0-9]+',
 					),
 					'data-partner' => array(
@@ -1697,19 +1682,9 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-9]+',
 					),
 					'data-playlist' => array(
-						'mandatory_oneof' => array(
-							'data-outstream',
-							'data-playlist',
-							'data-video',
-						),
 						'value_regex' => '.+',
 					),
 					'data-video' => array(
-						'mandatory_oneof' => array(
-							'data-outstream',
-							'data-playlist',
-							'data-video',
-						),
 						'value_regex' => '[0-9]+',
 					),
 					'media' => array(),
@@ -1729,6 +1704,11 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-outstream',
+						'data-playlist',
+						'data-video',
 					),
 					'requires_extension' => array(
 						'amp-brid-player',
@@ -2162,12 +2142,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'end-date' => array(
-						'mandatory_oneof' => array(
-							'end-date',
-							'timeleft-ms',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => '\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])',
 					),
 					'locale' => array(
@@ -2201,30 +2175,12 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'template' => array(),
 					'timeleft-ms' => array(
-						'mandatory_oneof' => array(
-							'end-date',
-							'timeleft-ms',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => '\\d+',
 					),
 					'timestamp-ms' => array(
-						'mandatory_oneof' => array(
-							'end-date',
-							'timeleft-ms',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => '\\d{13}',
 					),
 					'timestamp-seconds' => array(
-						'mandatory_oneof' => array(
-							'end-date',
-							'timeleft-ms',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => '\\d{10}',
 					),
 					'when-ended' => array(
@@ -2245,6 +2201,12 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'mandatory_oneof' => array(
+						'end-date',
+						'timeleft-ms',
+						'timestamp-ms',
+						'timestamp-seconds',
+					),
 					'requires_extension' => array(
 						'amp-date-countdown',
 					),
@@ -2255,11 +2217,6 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'datetime' => array(
-						'mandatory_oneof' => array(
-							'datetime',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => 'now|(\\d{4}-[01]\\d-[0-3]\\d(T[0-2]\\d:[0-5]\\d(:[0-6]\\d(\\.\\d\\d?\\d?)?)?(Z|[+-][0-1]\\d:[0-5]\\d)?)?)',
 					),
 					'display-in' => array(
@@ -2279,19 +2236,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'template' => array(),
 					'timestamp-ms' => array(
-						'mandatory_oneof' => array(
-							'datetime',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => '\\d+',
 					),
 					'timestamp-seconds' => array(
-						'mandatory_oneof' => array(
-							'datetime',
-							'timestamp-ms',
-							'timestamp-seconds',
-						),
 						'value_regex' => '\\d+',
 					),
 				),
@@ -2305,6 +2252,11 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'datetime',
+						'timestamp-ms',
+						'timestamp-seconds',
 					),
 					'requires_extension' => array(
 						'amp-date-display',
@@ -3330,10 +3282,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'mandatory_oneof' => array(
-							'src',
-							'srcdoc',
-						),
 						'value_url' => array(
 							'allow_relative' => true,
 							'protocol' => array(
@@ -3342,12 +3290,7 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'srcdoc' => array(
-						'mandatory_oneof' => array(
-							'src',
-							'srcdoc',
-						),
-					),
+					'srcdoc' => array(),
 					'tabindex' => array(
 						'value_regex' => '-?\\d+',
 					),
@@ -3363,6 +3306,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'src',
+						'srcdoc',
 					),
 					'requires_extension' => array(
 						'amp-iframe',
@@ -3676,10 +3623,6 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-media-id' => array(
-						'mandatory_oneof' => array(
-							'data-media-id',
-							'data-playlist-id',
-						),
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
 					'data-player-id' => array(
@@ -3687,10 +3630,6 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
 					'data-playlist-id' => array(
-						'mandatory_oneof' => array(
-							'data-media-id',
-							'data-playlist-id',
-						),
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
 				),
@@ -3704,6 +3643,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-media-id',
+						'data-playlist-id',
 					),
 					'requires_extension' => array(
 						'amp-jwplayer',
@@ -3840,12 +3783,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'credentials' => array(),
 					'data-amp-bind-is-layout-container' => array(),
-					'data-amp-bind-src' => array(
-						'mandatory_anyof' => array(
-							'src',
-							'data-amp-bind-src',
-						),
-					),
+					'data-amp-bind-src' => array(),
 					'data-amp-bind-state' => array(),
 					'diffable' => array(
 						'value' => array(
@@ -3877,10 +3815,6 @@ class AMP_Allowed_Tags_Generated {
 					'single-item' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'mandatory_anyof' => array(
-							'src',
-							'data-amp-bind-src',
-						),
 						'value_url' => array(
 							'allow_relative' => true,
 							'protocol' => array(
@@ -3901,6 +3835,10 @@ class AMP_Allowed_Tags_Generated {
 							4,
 						),
 					),
+					'mandatory_anyof' => array(
+						'src',
+						'data-amp-bind-src',
+					),
 					'requires_extension' => array(
 						'amp-list',
 					),
@@ -3911,51 +3849,33 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'load-more-button' => array(
-						'mandatory_oneof' => array(
-							'load-more-button',
-							'load-more-failed',
-							'load-more-end',
-							'load-more-loading',
-						),
 						'value' => array(
 							'',
 						),
 					),
 					'load-more-end' => array(
-						'mandatory_oneof' => array(
-							'load-more-button',
-							'load-more-failed',
-							'load-more-end',
-							'load-more-loading',
-						),
 						'value' => array(
 							'',
 						),
 					),
 					'load-more-failed' => array(
-						'mandatory_oneof' => array(
-							'load-more-button',
-							'load-more-failed',
-							'load-more-end',
-							'load-more-loading',
-						),
 						'value' => array(
 							'',
 						),
 					),
 					'load-more-loading' => array(
-						'mandatory_oneof' => array(
-							'load-more-button',
-							'load-more-failed',
-							'load-more-end',
-							'load-more-loading',
-						),
 						'value' => array(
 							'',
 						),
 					),
 				),
 				'tag_spec' => array(
+					'mandatory_oneof' => array(
+						'load-more-button',
+						'load-more-failed',
+						'load-more-end',
+						'load-more-loading',
+					),
 					'mandatory_parent' => 'amp-list',
 					'requires_extension' => array(
 						'amp-list',
@@ -4581,12 +4501,7 @@ class AMP_Allowed_Tags_Generated {
 							'true',
 						),
 					),
-					'data-item' => array(
-						'mandatory_oneof' => array(
-							'data-item',
-							'src',
-						),
-					),
+					'data-item' => array(),
 					'data-item-info' => array(
 						'value_casei' => array(
 							'false',
@@ -4605,12 +4520,7 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'src' => array(
-						'mandatory_oneof' => array(
-							'data-item',
-							'src',
-						),
-					),
+					'src' => array(),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -4618,6 +4528,10 @@ class AMP_Allowed_Tags_Generated {
 							4,
 							3,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-item',
+						'src',
 					),
 					'requires_extension' => array(
 						'amp-playbuzz',
@@ -4672,17 +4586,8 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_regex' => '[0-9a-zA-Z-]+',
 					),
-					'data-terms' => array(
-						'mandatory_oneof' => array(
-							'data-video',
-							'data-terms',
-						),
-					),
+					'data-terms' => array(),
 					'data-video' => array(
-						'mandatory_oneof' => array(
-							'data-video',
-							'data-terms',
-						),
 						'value_regex' => '[0-9a-zA-Z-]+',
 					),
 					'media' => array(),
@@ -4702,6 +4607,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-video',
+						'data-terms',
 					),
 					'requires_extension' => array(
 						'amp-powr-player',
@@ -4857,18 +4766,9 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'sandbox' => array(),
-					'script' => array(
-						'mandatory_oneof' => array(
-							'script',
-							'src',
-						),
-					),
+					'script' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'mandatory_oneof' => array(
-							'script',
-							'src',
-						),
 						'value_url' => array(
 							'allow_relative' => false,
 							'protocol' => array(
@@ -4891,6 +4791,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'disallowed_ancestor' => array(
 						'amp-script',
+					),
+					'mandatory_oneof' => array(
+						'script',
+						'src',
 					),
 					'requires_extension' => array(
 						'amp-script',
@@ -5148,20 +5052,12 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex_casei' => '([0-9a-f]{3}){1,2}',
 					),
 					'data-playlistid' => array(
-						'mandatory_oneof' => array(
-							'data-trackid',
-							'data-playlistid',
-						),
 						'value_regex' => '[0-9]+',
 					),
 					'data-secret-token' => array(
 						'value_regex' => '[A-Za-z0-9_-]+',
 					),
 					'data-trackid' => array(
-						'mandatory_oneof' => array(
-							'data-trackid',
-							'data-playlistid',
-						),
 						'value_regex' => '[0-9]+',
 					),
 					'data-visual' => array(
@@ -5188,6 +5084,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-trackid',
+						'data-playlistid',
 					),
 					'requires_extension' => array(
 						'amp-soundcloud',
@@ -5679,11 +5579,6 @@ class AMP_Allowed_Tags_Generated {
 					'data-conversation' => array(),
 					'data-limit' => array(),
 					'data-momentid' => array(
-						'mandatory_oneof' => array(
-							'data-momentid',
-							'data-timeline-source-type',
-							'data-tweetid',
-						),
 						'value_regex' => '\\d+',
 					),
 					'data-timeline-id' => array(
@@ -5692,13 +5587,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-timeline-owner-screen-name' => array(),
 					'data-timeline-screen-name' => array(),
 					'data-timeline-slug' => array(),
-					'data-timeline-source-type' => array(
-						'mandatory_oneof' => array(
-							'data-momentid',
-							'data-timeline-source-type',
-							'data-tweetid',
-						),
-					),
+					'data-timeline-source-type' => array(),
 					'data-timeline-url' => array(
 						'value_url' => array(
 							'allow_relative' => false,
@@ -5711,13 +5600,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-timeline-user-id' => array(
 						'value_regex' => '\\d+',
 					),
-					'data-tweetid' => array(
-						'mandatory_oneof' => array(
-							'data-momentid',
-							'data-timeline-source-type',
-							'data-tweetid',
-						),
-					),
+					'data-tweetid' => array(),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -5736,6 +5619,11 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-momentid',
+						'data-timeline-source-type',
+						'data-tweetid',
 					),
 					'requires_extension' => array(
 						'amp-twitter',
@@ -6619,17 +6507,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'data-amp-bind-data-videoid' => array(),
 					'data-live-channelid' => array(
-						'mandatory_oneof' => array(
-							'data-live-channelid',
-							'data-videoid',
-						),
 						'value_regex' => '[^=/?:]+',
 					),
 					'data-videoid' => array(
-						'mandatory_oneof' => array(
-							'data-live-channelid',
-							'data-videoid',
-						),
 						'value_regex' => '[^=/?:]+',
 					),
 					'dock' => array(
@@ -6659,6 +6539,10 @@ class AMP_Allowed_Tags_Generated {
 							1,
 							4,
 						),
+					),
+					'mandatory_oneof' => array(
+						'data-live-channelid',
+						'data-videoid',
 					),
 					'requires_extension' => array(
 						'amp-youtube',
@@ -8716,10 +8600,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
-						'mandatory_oneof' => array(
-							'src',
-							'srcdoc',
-						),
 						'value_url' => array(
 							'allow_relative' => false,
 							'protocol' => array(
@@ -8728,17 +8608,16 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'srcdoc' => array(
-						'mandatory_oneof' => array(
-							'src',
-							'srcdoc',
-						),
-					),
+					'srcdoc' => array(),
 					'width' => array(),
 				),
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'noscript',
 					'mandatory_ancestor_suggested_alternative' => 'amp-iframe',
+					'mandatory_oneof' => array(
+						'src',
+						'srcdoc',
+					),
 					'spec_url' => 'https://amp.dev/documentation/components/amp-iframe',
 				),
 			),

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -3836,8 +3836,8 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'mandatory_anyof' => array(
-						'src',
 						'data-amp-bind-src',
+						'src',
 					),
 					'requires_extension' => array(
 						'amp-list',
@@ -3872,9 +3872,9 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_oneof' => array(
 						'load-more-button',
+						'load-more-end',
 						'load-more-failed',
 						'load-more-loading',
-						'load-more-end',
 					),
 					'mandatory_parent' => 'amp-list',
 					'requires_extension' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,110 +13,10 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 999;
+	private static $spec_file_revision = 961;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
-		'amp-mega-menu-allowed-descendants' => array(
-			'a',
-			'amp-ad',
-			'amp-carousel',
-			'amp-embed',
-			'amp-img',
-			'amp-lightbox',
-			'amp-list',
-			'amp-video',
-			'b',
-			'br',
-			'button',
-			'col',
-			'colgroup',
-			'div',
-			'em',
-			'fieldset',
-			'form',
-			'h1',
-			'h2',
-			'h3',
-			'h4',
-			'h5',
-			'h6',
-			'i',
-			'input',
-			'label',
-			'li',
-			'mark',
-			'nav',
-			'ol',
-			'option',
-			'p',
-			'path',
-			'section',
-			'span',
-			'strike',
-			'strong',
-			'sub',
-			'sup',
-			'svg',
-			'table',
-			'tbody',
-			'td',
-			'template',
-			'th',
-			'time',
-			'title',
-			'tr',
-			'u',
-			'ul',
-		),
-		'amp-nested-menu-allowed-descendants' => array(
-			'a',
-			'amp-accordion',
-			'amp-img',
-			'amp-list',
-			'b',
-			'br',
-			'button',
-			'col',
-			'colgroup',
-			'div',
-			'em',
-			'fieldset',
-			'form',
-			'h1',
-			'h2',
-			'h3',
-			'h4',
-			'h5',
-			'h6',
-			'i',
-			'input',
-			'label',
-			'li',
-			'mark',
-			'nav',
-			'ol',
-			'option',
-			'p',
-			'path',
-			'section',
-			'span',
-			'strike',
-			'strong',
-			'sub',
-			'sup',
-			'svg',
-			'table',
-			'tbody',
-			'td',
-			'template',
-			'th',
-			'time',
-			'title',
-			'tr',
-			'u',
-			'ul',
-		),
 		'amp-story-bookend-allowed-descendants' => array(
 			'script',
 		),
@@ -207,7 +107,6 @@ class AMP_Allowed_Tags_Generated {
 			'small',
 			'solidcolor',
 			'span',
-			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -239,6 +138,7 @@ class AMP_Allowed_Tags_Generated {
 			'amp-experiment',
 			'amp-fit-text',
 			'amp-font',
+			'amp-gfycat',
 			'amp-gist',
 			'amp-google-vrview-image',
 			'amp-img',
@@ -334,7 +234,6 @@ class AMP_Allowed_Tags_Generated {
 			'solidcolor',
 			'source',
 			'span',
-			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -389,8 +288,11 @@ class AMP_Allowed_Tags_Generated {
 			'amp-fx-collection',
 			'amp-fx-flying-carpet',
 			'amp-gfycat',
+			'amp-gfycat',
+			'amp-gist',
 			'amp-gist',
 			'amp-google-document-embed',
+			'amp-google-vrview-image',
 			'amp-google-vrview-image',
 			'amp-hulu',
 			'amp-ima-video',
@@ -402,6 +304,8 @@ class AMP_Allowed_Tags_Generated {
 			'amp-jwplayer',
 			'amp-kaltura-player',
 			'amp-list',
+			'amp-list',
+			'amp-live-list',
 			'amp-live-list',
 			'amp-mathml',
 			'amp-megaphone',
@@ -513,7 +417,6 @@ class AMP_Allowed_Tags_Generated {
 			'solidcolor',
 			'source',
 			'span',
-			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -564,7 +467,6 @@ class AMP_Allowed_Tags_Generated {
 								'maps',
 								'bip',
 								'bbmi',
-								'chrome',
 								'itms-services',
 								'fb-me',
 								'fb-messenger',
@@ -1434,7 +1336,6 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-amp-bind-src' => array(),
 					'filter' => array(
-						'mandatory' => true,
 						'value_casei' => array(
 							'custom',
 							'fuzzy',
@@ -1451,7 +1352,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'filter-value' => array(),
 					'highlight-user-entry' => array(),
-					'inline' => array(),
 					'items' => array(),
 					'max-entries' => array(),
 					'media' => array(),
@@ -1461,7 +1361,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'query' => array(),
 					'src' => array(
 						'value_url' => array(
 							'allow_relative' => true,
@@ -2443,11 +2342,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'hide-keyboard-shortcuts-panel' => array(
-						'value' => array(
-							'',
-						),
-					),
 					'highlighted' => array(),
 					'input-selector' => array(),
 					'locale' => array(),
@@ -2536,11 +2430,6 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-6]',
 					),
 					'format' => array(),
-					'hide-keyboard-shortcuts-panel' => array(
-						'value' => array(
-							'',
-						),
-					),
 					'highlighted' => array(),
 					'input-selector' => array(),
 					'locale' => array(),
@@ -2633,11 +2522,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'format' => array(),
 					'fullscreen' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'hide-keyboard-shortcuts-panel' => array(
 						'value' => array(
 							'',
 						),
@@ -2739,11 +2623,6 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-6]',
 					),
 					'format' => array(),
-					'hide-keyboard-shortcuts-panel' => array(
-						'value' => array(
-							'',
-						),
-					),
 					'highlighted' => array(),
 					'locale' => array(),
 					'max' => array(),
@@ -3965,9 +3844,9 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory_anyof' => array(
 							'src',
 							'[src]',
-							'data-amp-bind-src',
 						),
 					),
+					'data-amp-bind-state' => array(),
 					'diffable' => array(
 						'value' => array(
 							'',
@@ -4001,7 +3880,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory_anyof' => array(
 							'src',
 							'[src]',
-							'data-amp-bind-src',
 						),
 						'value_url' => array(
 							'allow_relative' => true,
@@ -4011,7 +3889,6 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'template' => array(),
-					'xssi-prefix' => array(),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -4161,47 +4038,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-mathml',
 					),
-				),
-			),
-		),
-		'amp-mega-menu' => array(
-			array(
-				'attr_spec_list' => array(
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							3,
-						),
-					),
-					'child_tags' => array(
-						'child_tag_name_oneof' => array(
-							'nav',
-							'amp-list',
-						),
-						'mandatory_num_child_tags' => 1,
-					),
-					'descendant_tag_list' => 'amp-mega-menu-allowed-descendants',
-					'reference_points' => array(
-						'AMP-MEGA-MENU > AMP-LIST' => array(
-							'mandatory' => false,
-							'unique' => false,
-						),
-						'AMP-MEGA-MENU > NAV' => array(
-							'mandatory' => false,
-							'unique' => false,
-						),
-					),
-					'requires_extension' => array(
-						'amp-mega-menu',
-					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-mega-menu',
 				),
 			),
 		),
@@ -4373,37 +4209,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-mowplayer',
 					),
-				),
-			),
-		),
-		'amp-nested-menu' => array(
-			array(
-				'attr_spec_list' => array(
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'side' => array(
-						'value' => array(
-							'left',
-							'right',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							6,
-						),
-					),
-					'descendant_tag_list' => 'amp-nested-menu-allowed-descendants',
-					'mandatory_ancestor' => 'amp-sidebar',
-					'requires_extension' => array(
-						'amp-sidebar',
-					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-nested-menu',
 				),
 			),
 		),
@@ -4963,37 +4768,6 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
-		'amp-redbull-player' => array(
-			array(
-				'attr_spec_list' => array(
-					'data-param-videoid' => array(
-						'mandatory' => true,
-					),
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							2,
-							3,
-							4,
-							6,
-							7,
-							8,
-							9,
-						),
-					),
-					'requires_extension' => array(
-						'amp-redbull-player',
-					),
-				),
-			),
-		),
 		'amp-reddit' => array(
 			array(
 				'attr_spec_list' => array(
@@ -5111,7 +4885,6 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
-							9,
 							1,
 							4,
 						),
@@ -5216,7 +4989,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
-					'spec_name' => 'amp-sidebar',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
 				),
 			),
@@ -5619,6 +5391,7 @@ class AMP_Allowed_Tags_Generated {
 							'amp-geo',
 							'amp-pixel',
 							'amp-sidebar',
+							'amp-story-access',
 							'amp-story-auto-ads',
 							'amp-story-bookend',
 							'amp-story-page',
@@ -5628,6 +5401,30 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-story',
+					),
+				),
+			),
+		),
+		'amp-story-access' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'type' => array(
+						'value' => array(
+							'blocking',
+							'notification',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-story',
+					'requires_extension' => array(
+						'amp-access',
 					),
 				),
 			),
@@ -5763,7 +5560,6 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 						'mandatory' => true,
 					),
-					'next-page-no-ad' => array(),
 				),
 				'tag_spec' => array(
 					'child_tags' => array(
@@ -5944,6 +5740,41 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-twitter',
 					),
+				),
+			),
+		),
+		'amp-user-location' => array(
+			array(
+				'attr_spec_list' => array(
+					'id' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'src' => array(
+						'value_url' => array(
+							'allow_relative' => false,
+							'protocol' => array(
+								'https',
+							),
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'requires_extension' => array(
+						'amp-user-location',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
 				),
 			),
 		),
@@ -7027,26 +6858,6 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'amp-list-load-more button[load-more-clickable]',
 				),
 			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'button amp-nested-menu',
-				),
-			),
 		),
 		'canvas' => array(
 			array(
@@ -7586,38 +7397,6 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-list',
 					'spec_name' => 'AMP-LIST DIV [fetch-error]',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu',
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu',
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu',
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'disallowed_ancestor' => array(
-						'amp-accordion',
-					),
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'div amp-nested-menu',
 				),
 			),
 		),
@@ -8807,26 +8586,6 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'h2 amp-nested-menu',
-				),
-			),
 		),
 		'h3' => array(
 			array(
@@ -8834,26 +8593,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'h3 amp-nested-menu',
-				),
 			),
 		),
 		'h4' => array(
@@ -8863,26 +8602,6 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'h4 amp-nested-menu',
-				),
-			),
 		),
 		'h5' => array(
 			array(
@@ -8891,26 +8610,6 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'h5 amp-nested-menu',
-				),
-			),
 		),
 		'h6' => array(
 			array(
@@ -8918,26 +8617,6 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
-			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'h6 amp-nested-menu',
-				),
 			),
 		),
 		'head' => array(
@@ -11945,11 +11624,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'src' => array(
 						'dispatch_key' => 2,
@@ -11971,50 +11645,9 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory_alternatives' => 'amphtml engine v0.js script',
+					'mandatory' => true,
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js script',
-					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
-					'unique' => true,
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
-					'nonce' => array(),
-					'src' => array(
-						'dispatch_key' => 2,
-						'mandatory' => true,
-						'value' => array(
-							'https://cdn.ampproject.org/lts/v0.js',
-						),
-					),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'cdata' => array(
-					'blacklisted_cdata_regex' => array(
-						'error_message' => 'contents',
-						'regex' => '.',
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_alternatives' => 'amphtml engine v0.js script',
-					'mandatory_parent' => 'head',
-					'spec_name' => 'amphtml engine v0.js lts script',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
@@ -12098,11 +11731,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12128,11 +11756,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12156,11 +11779,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12192,11 +11810,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12225,11 +11838,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12256,11 +11864,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12320,11 +11923,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12350,11 +11948,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12378,11 +11971,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12411,11 +11999,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12442,11 +12025,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12470,11 +12048,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12528,11 +12101,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12556,11 +12124,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12613,11 +12176,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12641,11 +12199,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12673,11 +12226,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12703,11 +12251,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12731,11 +12274,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12788,11 +12326,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12818,11 +12351,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12846,11 +12374,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12906,11 +12429,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12934,11 +12452,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12966,11 +12479,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12994,11 +12502,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13026,11 +12529,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13054,11 +12552,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13087,11 +12580,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13115,11 +12603,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13173,11 +12656,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13201,11 +12679,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13233,11 +12706,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13261,11 +12729,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13293,11 +12756,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13321,11 +12779,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13353,11 +12806,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13381,11 +12829,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13439,11 +12882,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13467,11 +12905,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13499,11 +12932,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13527,11 +12955,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13559,11 +12982,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13587,11 +13005,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13619,11 +13032,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13647,11 +13055,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13679,11 +13082,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13707,11 +13105,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13765,11 +13158,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13793,11 +13181,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13825,11 +13208,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13853,11 +13231,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13885,11 +13258,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13913,11 +13281,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13945,11 +13308,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13973,11 +13331,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14005,11 +13358,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14033,11 +13381,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14065,11 +13408,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14093,11 +13431,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14125,11 +13458,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14153,11 +13481,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14185,11 +13508,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14213,11 +13531,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14245,11 +13558,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14273,11 +13581,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14330,11 +13633,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14358,11 +13656,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14392,11 +13685,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14420,41 +13708,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-mega-menu',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14482,11 +13735,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14512,11 +13760,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14540,11 +13783,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14611,41 +13849,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-nested-menu',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14690,11 +13893,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14718,11 +13916,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14750,11 +13943,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14778,11 +13966,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14810,11 +13993,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14838,11 +14016,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14870,11 +14043,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14898,11 +14066,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14930,11 +14093,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14958,11 +14116,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14990,11 +14143,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15018,41 +14166,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-redbull-player',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15080,11 +14193,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15108,11 +14216,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15177,11 +14280,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15205,11 +14303,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15237,11 +14330,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15265,11 +14353,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15297,11 +14380,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15325,11 +14403,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15357,11 +14430,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15385,11 +14453,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15416,11 +14479,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15472,11 +14530,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15575,11 +14628,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15637,11 +14685,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15664,68 +14707,10 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
-					'cryptokeys' => array(
-						'dispatch_key' => 2,
-						'mandatory' => true,
-						'value' => array(
-							'',
-						),
-					),
-					'sha-256-hash' => array(
-						'mandatory' => true,
-					),
-					'type' => array(
-						'mandatory' => true,
-						'value_casei' => array(
-							'application/json',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'head',
-					'requires_extension' => array(
-						'amp-subscriptions',
-					),
-					'spec_name' => 'cryptokeys .json script',
-					'unique' => true,
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'ciphertext' => array(
-						'dispatch_key' => 1,
-						'mandatory' => true,
-					),
-					'type' => array(
-						'mandatory' => true,
-						'value_casei' => array(
-							'application/octet-stream',
-						),
-					),
-				),
-				'cdata' => array(
-					'blacklisted_cdata_regex' => array(
-						'error_message' => 'html comments',
-						'regex' => '<!--',
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'body',
-					'mandatory_parent' => 'subscriptions-section content swg_amp_cache_nonce',
-					'spec_name' => 'subscriptions script ciphertext',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15753,11 +14738,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15781,11 +14761,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15813,9 +14788,55 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-user-location',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'nonce' => array(),
+					'type' => array(
+						'dispatch_key' => 3,
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/json',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'amp-user-location',
+					'requires_extension' => array(
+						'amp-user-location',
+					),
+					'spec_name' => 'amp-user-location extension .json script',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
 						'value' => array(
-							'anonymous',
+							'',
 						),
 					),
 					'nonce' => array(),
@@ -15841,11 +14862,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15874,11 +14890,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15902,11 +14913,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15935,11 +14941,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -15963,11 +14964,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15995,11 +14991,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -16023,11 +15014,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -16055,11 +15041,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -16083,11 +15064,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -16115,11 +15091,6 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
-						),
-					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -16144,11 +15115,6 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
-						),
-					),
-					'crossorigin' => array(
-						'value' => array(
-							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -16213,26 +15179,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'mandatory_parent' => 'amp-accordion',
 					'spec_name' => 'amp-accordion > section',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'encrypted' => array(
-						'dispatch_key' => 1,
-						'mandatory' => true,
-					),
-					'subscriptions-section' => array(
-						'value_casei' => array(
-							'content',
-						),
-					),
-					'swg_amp_cache_nonce' => array(
-						'mandatory' => true,
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'body',
-					'spec_name' => 'subscriptions-section content swg_amp_cache_nonce',
 				),
 			),
 		),
@@ -16509,41 +15455,6 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
 			),
-			array(
-				'attr_spec_list' => array(
-					'amp-nested-submenu-close' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-					'amp-nested-submenu-open' => array(
-						'mandatory_oneof' => array(
-							'amp-nested-submenu-close',
-							'amp-nested-submenu-open',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'amp-nested-menu',
-					'spec_name' => 'span amp-nested-menu',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'swg_amp_cache_nonce' => array(
-						'dispatch_key' => 1,
-						'mandatory' => true,
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_ancestor' => 'body',
-					'requires_extension' => array(
-						'amp-subscriptions',
-					),
-					'spec_name' => 'span swg_amp_cache_nonce',
-				),
-			),
 		),
 		'stop' => array(
 			array(
@@ -16638,7 +15549,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 						'validate_keyframes' => false,
 					),
-					'max_bytes' => 75000,
+					'max_bytes' => 50000,
 					'max_bytes_spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size',
 				),
 				'tag_spec' => array(
@@ -18450,7 +17361,6 @@ class AMP_Allowed_Tags_Generated {
 				'rangeUnderflow',
 				'stepMismatch',
 				'tooLong',
-				'tooShort',
 				'typeMismatch',
 				'valueMissing',
 			),
@@ -18554,150 +17464,6 @@ class AMP_Allowed_Tags_Generated {
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [update]',
 				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#update',
-			),
-		),
-		'AMP-MEGA-MENU > AMP-LIST' => array(
-			'attr_spec_list' => array(
-				'data-amp-bind-src' => array(
-					'mandatory_anyof' => array(
-						'src',
-						'[src]',
-					),
-				),
-				'src' => array(
-					'mandatory_anyof' => array(
-						'src',
-						'[src]',
-					),
-				),
-			),
-			'tag_spec' => array(
-				'child_tags' => array(
-					'child_tag_name_oneof' => array(
-						'template',
-					),
-					'mandatory_num_child_tags' => 1,
-				),
-				'reference_points' => array(
-					'AMP-MEGA-MENU > AMP-LIST > TEMPLATE' => array(
-						'mandatory' => false,
-						'unique' => false,
-					),
-				),
-				'spec_name' => 'AMP-MEGA-MENU > AMP-LIST',
-			),
-		),
-		'AMP-MEGA-MENU > AMP-LIST > TEMPLATE' => array(
-			'attr_spec_list' => array(),
-			'tag_spec' => array(
-				'child_tags' => array(
-					'child_tag_name_oneof' => array(
-						'nav',
-					),
-					'mandatory_num_child_tags' => 1,
-				),
-				'mandatory_parent' => 'amp-list',
-				'reference_points' => array(
-					'AMP-MEGA-MENU > NAV' => array(
-						'mandatory' => false,
-						'unique' => false,
-					),
-				),
-				'spec_name' => 'AMP-MEGA-MENU > AMP-LIST > TEMPLATE',
-			),
-		),
-		'AMP-MEGA-MENU > NAV' => array(
-			'attr_spec_list' => array(),
-			'tag_spec' => array(
-				'child_tags' => array(
-					'child_tag_name_oneof' => array(
-						'ol',
-						'ul',
-					),
-					'mandatory_num_child_tags' => 1,
-				),
-				'reference_points' => array(
-					'AMP-MEGA-MENU NAV > UL/OL' => array(
-						'mandatory' => false,
-						'unique' => false,
-					),
-				),
-				'spec_name' => 'AMP-MEGA-MENU > NAV',
-			),
-		),
-		'AMP-MEGA-MENU NAV > UL/OL' => array(
-			'attr_spec_list' => array(),
-			'tag_spec' => array(
-				'child_tags' => array(
-					'child_tag_name_oneof' => array(
-						'li',
-					),
-					'mandatory_min_num_child_tags' => 1,
-				),
-				'mandatory_parent' => 'nav',
-				'reference_points' => array(
-					'AMP-MEGA-MENU NAV > UL/OL > LI' => array(
-						'mandatory' => false,
-						'unique' => false,
-					),
-				),
-				'spec_name' => 'AMP-MEGA-MENU NAV > UL/OL',
-			),
-		),
-		'AMP-MEGA-MENU NAV > UL/OL > LI' => array(
-			'attr_spec_list' => array(),
-			'tag_spec' => array(
-				'child_tags' => array(
-					'child_tag_name_oneof' => array(
-						'a',
-						'button',
-						'div',
-						'h1',
-						'h2',
-						'h3',
-						'h4',
-						'h5',
-						'h6',
-						'span',
-					),
-					'mandatory_min_num_child_tags' => 1,
-				),
-				'reference_points' => array(
-					'AMP-MEGA-MENU item-content' => array(
-						'mandatory' => false,
-						'unique' => true,
-					),
-					'AMP-MEGA-MENU item-heading' => array(
-						'mandatory' => true,
-						'unique' => true,
-					),
-				),
-				'spec_name' => 'AMP-MEGA-MENU NAV > UL/OL > LI',
-			),
-		),
-		'AMP-MEGA-MENU item-content' => array(
-			'attr_spec_list' => array(
-				'role' => array(
-					'mandatory' => true,
-					'value' => array(
-						'dialog',
-					),
-				),
-			),
-			'tag_spec' => array(
-				'spec_name' => 'AMP-MEGA-MENU item-content',
-			),
-		),
-		'AMP-MEGA-MENU item-heading' => array(
-			'attr_spec_list' => array(
-				'role' => array(
-					'value' => array(
-						'button',
-					),
-				),
-			),
-			'tag_spec' => array(
-				'spec_name' => 'AMP-MEGA-MENU item-heading',
 			),
 		),
 		'AMP-NEXT-PAGE > [separator]' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -3843,7 +3843,7 @@ class AMP_Allowed_Tags_Generated {
 					'data-amp-bind-src' => array(
 						'mandatory_anyof' => array(
 							'src',
-							'[src]',
+							'data-amp-bind-src',
 						),
 					),
 					'data-amp-bind-state' => array(),
@@ -3879,7 +3879,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory_anyof' => array(
 							'src',
-							'[src]',
+							'data-amp-bind-src',
 						),
 						'value_url' => array(
 							'allow_relative' => true,

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,10 +13,108 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 961;
+	private static $spec_file_revision = 997;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
+		'amp-mega-menu-allowed-descendants' => array(
+			'a',
+			'amp-ad',
+			'amp-carousel',
+			'amp-embed',
+			'amp-img',
+			'amp-lightbox',
+			'amp-list',
+			'amp-video',
+			'b',
+			'br',
+			'button',
+			'col',
+			'colgroup',
+			'div',
+			'em',
+			'fieldset',
+			'form',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'i',
+			'input',
+			'label',
+			'li',
+			'mark',
+			'nav',
+			'ol',
+			'option',
+			'p',
+			'section',
+			'span',
+			'strike',
+			'strong',
+			'sub',
+			'sup',
+			'table',
+			'tbody',
+			'td',
+			'template',
+			'th',
+			'time',
+			'title',
+			'tr',
+			'u',
+			'ul',
+		),
+		'amp-nested-menu-allowed-descendants' => array(
+			'a',
+			'amp-accordion',
+			'amp-img',
+			'amp-list',
+			'b',
+			'br',
+			'button',
+			'col',
+			'colgroup',
+			'div',
+			'em',
+			'fieldset',
+			'form',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'i',
+			'input',
+			'label',
+			'li',
+			'mark',
+			'nav',
+			'ol',
+			'option',
+			'p',
+			'path',
+			'section',
+			'span',
+			'strike',
+			'strong',
+			'sub',
+			'sup',
+			'svg',
+			'table',
+			'tbody',
+			'td',
+			'template',
+			'th',
+			'time',
+			'title',
+			'tr',
+			'u',
+			'ul',
+		),
 		'amp-story-bookend-allowed-descendants' => array(
 			'script',
 		),
@@ -107,6 +205,7 @@ class AMP_Allowed_Tags_Generated {
 			'small',
 			'solidcolor',
 			'span',
+			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -138,7 +237,6 @@ class AMP_Allowed_Tags_Generated {
 			'amp-experiment',
 			'amp-fit-text',
 			'amp-font',
-			'amp-gfycat',
 			'amp-gist',
 			'amp-google-vrview-image',
 			'amp-img',
@@ -234,6 +332,7 @@ class AMP_Allowed_Tags_Generated {
 			'solidcolor',
 			'source',
 			'span',
+			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -288,11 +387,8 @@ class AMP_Allowed_Tags_Generated {
 			'amp-fx-collection',
 			'amp-fx-flying-carpet',
 			'amp-gfycat',
-			'amp-gfycat',
-			'amp-gist',
 			'amp-gist',
 			'amp-google-document-embed',
-			'amp-google-vrview-image',
 			'amp-google-vrview-image',
 			'amp-hulu',
 			'amp-ima-video',
@@ -304,8 +400,6 @@ class AMP_Allowed_Tags_Generated {
 			'amp-jwplayer',
 			'amp-kaltura-player',
 			'amp-list',
-			'amp-list',
-			'amp-live-list',
 			'amp-live-list',
 			'amp-mathml',
 			'amp-megaphone',
@@ -417,6 +511,7 @@ class AMP_Allowed_Tags_Generated {
 			'solidcolor',
 			'source',
 			'span',
+			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -467,6 +562,7 @@ class AMP_Allowed_Tags_Generated {
 								'maps',
 								'bip',
 								'bbmi',
+								'chrome',
 								'itms-services',
 								'fb-me',
 								'fb-messenger',
@@ -946,7 +1042,12 @@ class AMP_Allowed_Tags_Generated {
 		'amp-addthis' => array(
 			array(
 				'attr_spec_list' => array(
-					'data-product-code' => array(),
+					'data-product-code' => array(
+						'mandatory_oneof' => array(
+							'data-product-code',
+							'data-widget-id',
+						),
+					),
 					'data-share-media' => array(
 						'value_url' => array(
 							'allow_empty' => true,
@@ -965,7 +1066,12 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'data-widget-id' => array(),
+					'data-widget-id' => array(
+						'mandatory_oneof' => array(
+							'data-product-code',
+							'data-widget-id',
+						),
+					),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -1097,9 +1203,17 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-apester-channel-token' => array(
+						'mandatory_oneof' => array(
+							'data-apester-media-id',
+							'data-apester-channel-token',
+						),
 						'value_regex' => '[0-9a-zA-Z]+',
 					),
 					'data-apester-media-id' => array(
+						'mandatory_oneof' => array(
+							'data-apester-media-id',
+							'data-apester-channel-token',
+						),
 						'value_regex' => '[0-9a-zA-Z]+',
 					),
 					'media' => array(),
@@ -1318,6 +1432,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-amp-bind-src' => array(),
 					'filter' => array(
+						'mandatory' => true,
 						'value_casei' => array(
 							'custom',
 							'fuzzy',
@@ -1334,6 +1449,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'filter-value' => array(),
 					'highlight-user-entry' => array(),
+					'inline' => array(),
 					'items' => array(),
 					'max-entries' => array(),
 					'media' => array(),
@@ -1343,6 +1459,7 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'query' => array(),
 					'src' => array(
 						'value_url' => array(
 							'allow_relative' => true,
@@ -1663,6 +1780,11 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[a-z]+',
 					),
 					'data-outstream' => array(
+						'mandatory_oneof' => array(
+							'data-outstream',
+							'data-playlist',
+							'data-video',
+						),
 						'value_regex' => '[0-9]+',
 					),
 					'data-partner' => array(
@@ -1674,9 +1796,19 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-9]+',
 					),
 					'data-playlist' => array(
+						'mandatory_oneof' => array(
+							'data-outstream',
+							'data-playlist',
+							'data-video',
+						),
 						'value_regex' => '.+',
 					),
 					'data-video' => array(
+						'mandatory_oneof' => array(
+							'data-outstream',
+							'data-playlist',
+							'data-video',
+						),
 						'value_regex' => '[0-9]+',
 					),
 					'media' => array(),
@@ -2129,6 +2261,12 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'end-date' => array(
+						'mandatory_oneof' => array(
+							'end-date',
+							'timeleft-ms',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => '\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d(:[0-5]\\d(\\.\\d+)?)?(Z|[+-][0-1][0-9]:[0-5][0-9])',
 					),
 					'locale' => array(
@@ -2162,12 +2300,30 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'template' => array(),
 					'timeleft-ms' => array(
+						'mandatory_oneof' => array(
+							'end-date',
+							'timeleft-ms',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => '\\d+',
 					),
 					'timestamp-ms' => array(
+						'mandatory_oneof' => array(
+							'end-date',
+							'timeleft-ms',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => '\\d{13}',
 					),
 					'timestamp-seconds' => array(
+						'mandatory_oneof' => array(
+							'end-date',
+							'timeleft-ms',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => '\\d{10}',
 					),
 					'when-ended' => array(
@@ -2198,6 +2354,11 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'datetime' => array(
+						'mandatory_oneof' => array(
+							'datetime',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => 'now|(\\d{4}-[01]\\d-[0-3]\\d(T[0-2]\\d:[0-5]\\d(:[0-6]\\d(\\.\\d\\d?\\d?)?)?(Z|[+-][0-1]\\d:[0-5]\\d)?)?)',
 					),
 					'display-in' => array(
@@ -2217,9 +2378,19 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'template' => array(),
 					'timestamp-ms' => array(
+						'mandatory_oneof' => array(
+							'datetime',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => '\\d+',
 					),
 					'timestamp-seconds' => array(
+						'mandatory_oneof' => array(
+							'datetime',
+							'timestamp-ms',
+							'timestamp-seconds',
+						),
 						'value_regex' => '\\d+',
 					),
 				),
@@ -2266,6 +2437,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'format' => array(),
 					'fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'hide-keyboard-shortcuts-panel' => array(
 						'value' => array(
 							'',
 						),
@@ -2358,6 +2534,11 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-6]',
 					),
 					'format' => array(),
+					'hide-keyboard-shortcuts-panel' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'highlighted' => array(),
 					'input-selector' => array(),
 					'locale' => array(),
@@ -2450,6 +2631,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'format' => array(),
 					'fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'hide-keyboard-shortcuts-panel' => array(
 						'value' => array(
 							'',
 						),
@@ -2551,6 +2737,11 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-6]',
 					),
 					'format' => array(),
+					'hide-keyboard-shortcuts-panel' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'highlighted' => array(),
 					'locale' => array(),
 					'max' => array(),
@@ -3258,6 +3449,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory_oneof' => array(
+							'src',
+							'srcdoc',
+						),
 						'value_url' => array(
 							'allow_relative' => true,
 							'protocol' => array(
@@ -3266,7 +3461,12 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'srcdoc' => array(),
+					'srcdoc' => array(
+						'mandatory_oneof' => array(
+							'src',
+							'srcdoc',
+						),
+					),
 					'tabindex' => array(
 						'value_regex' => '-?\\d+',
 					),
@@ -3595,6 +3795,10 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'data-media-id' => array(
+						'mandatory_oneof' => array(
+							'data-media-id',
+							'data-playlist-id',
+						),
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
 					'data-player-id' => array(
@@ -3602,6 +3806,10 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
 					'data-playlist-id' => array(
+						'mandatory_oneof' => array(
+							'data-media-id',
+							'data-playlist-id',
+						),
 						'value_regex_casei' => '[0-9a-z]{8}',
 					),
 				),
@@ -3752,7 +3960,6 @@ class AMP_Allowed_Tags_Generated {
 					'credentials' => array(),
 					'data-amp-bind-is-layout-container' => array(),
 					'data-amp-bind-src' => array(),
-					'data-amp-bind-state' => array(),
 					'diffable' => array(
 						'value' => array(
 							'',
@@ -3791,6 +3998,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'template' => array(),
+					'xssi-prefix' => array(),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -3813,21 +4021,45 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'load-more-button' => array(
+						'mandatory_oneof' => array(
+							'load-more-button',
+							'load-more-failed',
+							'load-more-end',
+							'load-more-loading',
+						),
 						'value' => array(
 							'',
 						),
 					),
 					'load-more-end' => array(
+						'mandatory_oneof' => array(
+							'load-more-button',
+							'load-more-failed',
+							'load-more-end',
+							'load-more-loading',
+						),
 						'value' => array(
 							'',
 						),
 					),
 					'load-more-failed' => array(
+						'mandatory_oneof' => array(
+							'load-more-button',
+							'load-more-failed',
+							'load-more-end',
+							'load-more-loading',
+						),
 						'value' => array(
 							'',
 						),
 					),
 					'load-more-loading' => array(
+						'mandatory_oneof' => array(
+							'load-more-button',
+							'load-more-failed',
+							'load-more-end',
+							'load-more-loading',
+						),
 						'value' => array(
 							'',
 						),
@@ -3916,6 +4148,47 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-mathml',
 					),
+				),
+			),
+		),
+		'amp-mega-menu' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							3,
+						),
+					),
+					'child_tags' => array(
+						'child_tag_name_oneof' => array(
+							'nav',
+							'amp-list',
+						),
+						'mandatory_num_child_tags' => 1,
+					),
+					'descendant_tag_list' => 'amp-mega-menu-allowed-descendants',
+					'reference_points' => array(
+						'AMP-MEGA-MENU > AMP-LIST' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-MEGA-MENU > NAV' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
+					'requires_extension' => array(
+						'amp-mega-menu',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-mega-menu',
 				),
 			),
 		),
@@ -4087,6 +4360,37 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-mowplayer',
 					),
+				),
+			),
+		),
+		'amp-nested-menu' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'side' => array(
+						'value' => array(
+							'left',
+							'right',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+						),
+					),
+					'descendant_tag_list' => 'amp-nested-menu-allowed-descendants',
+					'mandatory_ancestor' => 'amp-sidebar',
+					'requires_extension' => array(
+						'amp-sidebar',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-nested-menu',
 				),
 			),
 		),
@@ -4459,7 +4763,12 @@ class AMP_Allowed_Tags_Generated {
 							'true',
 						),
 					),
-					'data-item' => array(),
+					'data-item' => array(
+						'mandatory_oneof' => array(
+							'data-item',
+							'src',
+						),
+					),
 					'data-item-info' => array(
 						'value_casei' => array(
 							'false',
@@ -4478,7 +4787,12 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'src' => array(),
+					'src' => array(
+						'mandatory_oneof' => array(
+							'data-item',
+							'src',
+						),
+					),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -4540,8 +4854,17 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value_regex' => '[0-9a-zA-Z-]+',
 					),
-					'data-terms' => array(),
+					'data-terms' => array(
+						'mandatory_oneof' => array(
+							'data-video',
+							'data-terms',
+						),
+					),
 					'data-video' => array(
+						'mandatory_oneof' => array(
+							'data-video',
+							'data-terms',
+						),
 						'value_regex' => '[0-9a-zA-Z-]+',
 					),
 					'media' => array(),
@@ -4623,6 +4946,37 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-form',
 						'amp-recaptcha-input',
+					),
+				),
+			),
+		),
+		'amp-redbull-player' => array(
+			array(
+				'attr_spec_list' => array(
+					'data-param-videoid' => array(
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+							4,
+							6,
+							7,
+							8,
+							9,
+						),
+					),
+					'requires_extension' => array(
+						'amp-redbull-player',
 					),
 				),
 			),
@@ -4716,9 +5070,18 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'sandbox' => array(),
-					'script' => array(),
+					'script' => array(
+						'mandatory_oneof' => array(
+							'script',
+							'src',
+						),
+					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory_oneof' => array(
+							'script',
+							'src',
+						),
 						'value_url' => array(
 							'allow_relative' => false,
 							'protocol' => array(
@@ -4735,6 +5098,7 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
+							9,
 							1,
 							4,
 						),
@@ -4839,6 +5203,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
+					'spec_name' => 'amp-sidebar',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
 				),
 			),
@@ -4998,12 +5363,20 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex_casei' => '([0-9a-f]{3}){1,2}',
 					),
 					'data-playlistid' => array(
+						'mandatory_oneof' => array(
+							'data-trackid',
+							'data-playlistid',
+						),
 						'value_regex' => '[0-9]+',
 					),
 					'data-secret-token' => array(
 						'value_regex' => '[A-Za-z0-9_-]+',
 					),
 					'data-trackid' => array(
+						'mandatory_oneof' => array(
+							'data-trackid',
+							'data-playlistid',
+						),
 						'value_regex' => '[0-9]+',
 					),
 					'data-visual' => array(
@@ -5233,7 +5606,6 @@ class AMP_Allowed_Tags_Generated {
 							'amp-geo',
 							'amp-pixel',
 							'amp-sidebar',
-							'amp-story-access',
 							'amp-story-auto-ads',
 							'amp-story-bookend',
 							'amp-story-page',
@@ -5243,30 +5615,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-story',
-					),
-				),
-			),
-		),
-		'amp-story-access' => array(
-			array(
-				'attr_spec_list' => array(
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'type' => array(
-						'value' => array(
-							'blocking',
-							'notification',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'amp-story',
-					'requires_extension' => array(
-						'amp-access',
 					),
 				),
 			),
@@ -5402,6 +5750,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 						'mandatory' => true,
 					),
+					'next-page-no-ad' => array(),
 				),
 				'tag_spec' => array(
 					'child_tags' => array(
@@ -5521,6 +5870,11 @@ class AMP_Allowed_Tags_Generated {
 					'data-conversation' => array(),
 					'data-limit' => array(),
 					'data-momentid' => array(
+						'mandatory_oneof' => array(
+							'data-momentid',
+							'data-timeline-source-type',
+							'data-tweetid',
+						),
 						'value_regex' => '\\d+',
 					),
 					'data-timeline-id' => array(
@@ -5529,7 +5883,13 @@ class AMP_Allowed_Tags_Generated {
 					'data-timeline-owner-screen-name' => array(),
 					'data-timeline-screen-name' => array(),
 					'data-timeline-slug' => array(),
-					'data-timeline-source-type' => array(),
+					'data-timeline-source-type' => array(
+						'mandatory_oneof' => array(
+							'data-momentid',
+							'data-timeline-source-type',
+							'data-tweetid',
+						),
+					),
 					'data-timeline-url' => array(
 						'value_url' => array(
 							'allow_relative' => false,
@@ -5542,7 +5902,13 @@ class AMP_Allowed_Tags_Generated {
 					'data-timeline-user-id' => array(
 						'value_regex' => '\\d+',
 					),
-					'data-tweetid' => array(),
+					'data-tweetid' => array(
+						'mandatory_oneof' => array(
+							'data-momentid',
+							'data-timeline-source-type',
+							'data-tweetid',
+						),
+					),
 					'media' => array(),
 					'noloading' => array(
 						'value' => array(
@@ -5565,41 +5931,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-twitter',
 					),
-				),
-			),
-		),
-		'amp-user-location' => array(
-			array(
-				'attr_spec_list' => array(
-					'id' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
-						'mandatory' => true,
-					),
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'src' => array(
-						'value_url' => array(
-							'allow_relative' => false,
-							'protocol' => array(
-								'https',
-							),
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							1,
-						),
-					),
-					'requires_extension' => array(
-						'amp-user-location',
-					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
 				),
 			),
 		),
@@ -6444,9 +6775,17 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'data-amp-bind-data-videoid' => array(),
 					'data-live-channelid' => array(
+						'mandatory_oneof' => array(
+							'data-live-channelid',
+							'data-videoid',
+						),
 						'value_regex' => '[^=/?:]+',
 					),
 					'data-videoid' => array(
+						'mandatory_oneof' => array(
+							'data-live-channelid',
+							'data-videoid',
+						),
 						'value_regex' => '[^=/?:]+',
 					),
 					'dock' => array(
@@ -6673,6 +7012,26 @@ class AMP_Allowed_Tags_Generated {
 						'amp-list',
 					),
 					'spec_name' => 'amp-list-load-more button[load-more-clickable]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'button amp-nested-menu',
 				),
 			),
 		),
@@ -7214,6 +7573,38 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-list',
 					'spec_name' => 'AMP-LIST DIV [fetch-error]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu',
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu',
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu',
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'disallowed_ancestor' => array(
+						'amp-accordion',
+					),
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'div amp-nested-menu',
 				),
 			),
 		),
@@ -8403,6 +8794,26 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h2 amp-nested-menu',
+				),
+			),
 		),
 		'h3' => array(
 			array(
@@ -8410,6 +8821,26 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h3 amp-nested-menu',
+				),
 			),
 		),
 		'h4' => array(
@@ -8419,6 +8850,26 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h4 amp-nested-menu',
+				),
+			),
 		),
 		'h5' => array(
 			array(
@@ -8427,6 +8878,26 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h5 amp-nested-menu',
+				),
+			),
 		),
 		'h6' => array(
 			array(
@@ -8434,6 +8905,26 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h6 amp-nested-menu',
+				),
 			),
 		),
 		'head' => array(
@@ -8533,6 +9024,10 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
+						'mandatory_oneof' => array(
+							'src',
+							'srcdoc',
+						),
 						'value_url' => array(
 							'allow_relative' => false,
 							'protocol' => array(
@@ -8541,7 +9036,12 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
-					'srcdoc' => array(),
+					'srcdoc' => array(
+						'mandatory_oneof' => array(
+							'src',
+							'srcdoc',
+						),
+					),
 					'width' => array(),
 				),
 				'tag_spec' => array(
@@ -11432,6 +11932,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'src' => array(
 						'dispatch_key' => 2,
@@ -11453,9 +11958,50 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory' => true,
+					'mandatory_alternatives' => 'amphtml engine v0.js script',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js script',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'src' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'https://cdn.ampproject.org/lts/v0.js',
+						),
+					),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'contents',
+						'regex' => '.',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_alternatives' => 'amphtml engine v0.js script',
+					'mandatory_parent' => 'head',
+					'spec_name' => 'amphtml engine v0.js lts script',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
@@ -11539,6 +12085,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11564,6 +12115,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11587,6 +12143,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11618,6 +12179,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11646,6 +12212,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11672,6 +12243,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11731,6 +12307,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11756,6 +12337,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11779,6 +12365,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11807,6 +12398,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11833,6 +12429,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11856,6 +12457,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11909,6 +12515,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11932,6 +12543,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11984,6 +12600,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12007,6 +12628,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12034,6 +12660,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12059,6 +12690,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12082,6 +12718,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12134,6 +12775,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12159,6 +12805,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12182,6 +12833,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12237,6 +12893,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12260,6 +12921,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12287,6 +12953,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12310,6 +12981,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12337,6 +13013,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12360,6 +13041,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12388,6 +13074,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12411,6 +13102,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12464,6 +13160,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12487,6 +13188,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12514,6 +13220,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12537,6 +13248,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12564,6 +13280,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12587,6 +13308,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12614,6 +13340,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12637,6 +13368,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12690,6 +13426,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12713,6 +13454,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12740,6 +13486,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12763,6 +13514,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12790,6 +13546,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12813,6 +13574,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12840,6 +13606,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12863,6 +13634,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12890,6 +13666,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12913,6 +13694,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12966,6 +13752,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12989,6 +13780,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13016,6 +13812,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13039,6 +13840,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13066,6 +13872,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13089,6 +13900,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13116,6 +13932,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13139,6 +13960,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13166,6 +13992,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13189,6 +14020,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13216,6 +14052,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13239,6 +14080,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13266,6 +14112,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13289,6 +14140,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13316,6 +14172,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13339,6 +14200,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13366,6 +14232,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13389,6 +14260,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13441,6 +14317,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13464,6 +14345,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13493,6 +14379,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13516,6 +14407,41 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-mega-menu',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13543,6 +14469,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13568,6 +14499,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13591,6 +14527,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13657,6 +14598,41 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-nested-menu',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13701,6 +14677,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13724,6 +14705,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13751,6 +14737,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13774,6 +14765,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13801,6 +14797,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13824,6 +14825,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13851,6 +14857,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13874,6 +14885,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13901,6 +14917,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13924,6 +14945,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13951,6 +14977,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13974,6 +15005,41 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-redbull-player',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14001,6 +15067,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14024,6 +15095,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14088,6 +15164,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14111,6 +15192,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14138,6 +15224,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14161,6 +15252,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14188,6 +15284,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14211,6 +15312,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14238,6 +15344,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14261,6 +15372,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14287,6 +15403,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14338,6 +15459,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14436,6 +15562,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14493,6 +15624,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14515,10 +15651,68 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'cryptokeys' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'sha-256-hash' => array(
+						'mandatory' => true,
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/json',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'head',
+					'requires_extension' => array(
+						'amp-subscriptions',
+					),
+					'spec_name' => 'cryptokeys .json script',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'ciphertext' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/octet-stream',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'body',
+					'mandatory_parent' => 'subscriptions-section content swg_amp_cache_nonce',
+					'spec_name' => 'subscriptions script ciphertext',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14546,6 +15740,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14569,6 +15768,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14596,55 +15800,9 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-user-location',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'nonce' => array(),
-					'type' => array(
-						'dispatch_key' => 3,
-						'mandatory' => true,
-						'value_casei' => array(
-							'application/json',
-						),
-					),
-				),
-				'cdata' => array(
-					'blacklisted_cdata_regex' => array(
-						'error_message' => 'html comments',
-						'regex' => '<!--',
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'amp-user-location',
-					'requires_extension' => array(
-						'amp-user-location',
-					),
-					'spec_name' => 'amp-user-location extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
+					'crossorigin' => array(
 						'value' => array(
-							'',
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14670,6 +15828,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14698,6 +15861,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14721,6 +15889,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14749,6 +15922,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14772,6 +15950,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14799,6 +15982,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14822,6 +16010,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14849,6 +16042,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14872,6 +16070,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14899,6 +16102,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14923,6 +16131,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14987,6 +16200,26 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'mandatory_parent' => 'amp-accordion',
 					'spec_name' => 'amp-accordion > section',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'encrypted' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+					),
+					'subscriptions-section' => array(
+						'value_casei' => array(
+							'content',
+						),
+					),
+					'swg_amp_cache_nonce' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'body',
+					'spec_name' => 'subscriptions-section content swg_amp_cache_nonce',
 				),
 			),
 		),
@@ -15262,6 +16495,41 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+					'amp-nested-submenu-open' => array(
+						'mandatory_oneof' => array(
+							'amp-nested-submenu-close',
+							'amp-nested-submenu-open',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'span amp-nested-menu',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'swg_amp_cache_nonce' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'body',
+					'requires_extension' => array(
+						'amp-subscriptions',
+					),
+					'spec_name' => 'span swg_amp_cache_nonce',
+				),
 			),
 		),
 		'stop' => array(
@@ -17169,6 +18437,7 @@ class AMP_Allowed_Tags_Generated {
 				'rangeUnderflow',
 				'stepMismatch',
 				'tooLong',
+				'tooShort',
 				'typeMismatch',
 				'valueMissing',
 			),
@@ -17272,6 +18541,140 @@ class AMP_Allowed_Tags_Generated {
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [update]',
 				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#update',
+			),
+		),
+		'AMP-MEGA-MENU > AMP-LIST' => array(
+			'attr_spec_list' => array(
+				'data-amp-bind-src' => array(),
+				'src' => array(),
+			),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'template',
+					),
+					'mandatory_num_child_tags' => 1,
+				),
+				'reference_points' => array(
+					'AMP-MEGA-MENU > AMP-LIST > TEMPLATE' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU > AMP-LIST',
+			),
+		),
+		'AMP-MEGA-MENU > AMP-LIST > TEMPLATE' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'nav',
+					),
+					'mandatory_num_child_tags' => 1,
+				),
+				'mandatory_parent' => 'amp-list',
+				'reference_points' => array(
+					'AMP-MEGA-MENU > NAV' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU > AMP-LIST > TEMPLATE',
+			),
+		),
+		'AMP-MEGA-MENU > NAV' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'ol',
+						'ul',
+					),
+					'mandatory_num_child_tags' => 1,
+				),
+				'reference_points' => array(
+					'AMP-MEGA-MENU NAV > UL/OL' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU > NAV',
+			),
+		),
+		'AMP-MEGA-MENU NAV > UL/OL' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'li',
+					),
+					'mandatory_min_num_child_tags' => 1,
+				),
+				'mandatory_parent' => 'nav',
+				'reference_points' => array(
+					'AMP-MEGA-MENU NAV > UL/OL > LI' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU NAV > UL/OL',
+			),
+		),
+		'AMP-MEGA-MENU NAV > UL/OL > LI' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'a',
+						'button',
+						'div',
+						'h1',
+						'h2',
+						'h3',
+						'h4',
+						'h5',
+						'h6',
+						'span',
+					),
+					'mandatory_min_num_child_tags' => 1,
+				),
+				'reference_points' => array(
+					'AMP-MEGA-MENU item-content' => array(
+						'mandatory' => false,
+						'unique' => true,
+					),
+					'AMP-MEGA-MENU item-heading' => array(
+						'mandatory' => true,
+						'unique' => true,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU NAV > UL/OL > LI',
+			),
+		),
+		'AMP-MEGA-MENU item-content' => array(
+			'attr_spec_list' => array(
+				'role' => array(
+					'mandatory' => true,
+					'value' => array(
+						'dialog',
+					),
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-MEGA-MENU item-content',
+			),
+		),
+		'AMP-MEGA-MENU item-heading' => array(
+			'attr_spec_list' => array(
+				'role' => array(
+					'value' => array(
+						'button',
+					),
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-MEGA-MENU item-heading',
 			),
 		),
 		'AMP-NEXT-PAGE > [separator]' => array(

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -45,6 +45,7 @@ abstract class AMP_Rule_Spec {
 	const ALTERNATIVE_NAMES       = 'alternative_names';
 	const BLACKLISTED_VALUE_REGEX = 'blacklisted_value_regex';
 	const MANDATORY               = 'mandatory';
+	const MANDATORY_ANYOF         = 'mandatory_anyof';
 	const MANDATORY_ONEOF         = 'mandatory_oneof';
 	const VALUE                   = 'value';
 	const VALUE_CASEI             = 'value_casei';

--- a/includes/sanitizers/class-amp-rule-spec.php
+++ b/includes/sanitizers/class-amp-rule-spec.php
@@ -45,6 +45,7 @@ abstract class AMP_Rule_Spec {
 	const ALTERNATIVE_NAMES       = 'alternative_names';
 	const BLACKLISTED_VALUE_REGEX = 'blacklisted_value_regex';
 	const MANDATORY               = 'mandatory';
+	const MANDATORY_ONEOF         = 'mandatory_oneof';
 	const VALUE                   = 'value';
 	const VALUE_CASEI             = 'value_casei';
 	const VALUE_REGEX             = 'value_regex';

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -731,13 +731,11 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return null;
 		}
 
-		$mandatory_anyof_result = $this->check_attr_spec_rule_mandatory_number_of( $node, $merged_attr_spec_list, AMP_Rule_Spec::MANDATORY_ANYOF );
-		$mandatory_oneof_result = $this->check_attr_spec_rule_mandatory_number_of( $node, $merged_attr_spec_list, AMP_Rule_Spec::MANDATORY_ONEOF );
-		if ( AMP_Rule_Spec::FAIL === $mandatory_anyof_result ) {
+		if ( AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_mandatory_number_of( $node, $merged_attr_spec_list, AMP_Rule_Spec::MANDATORY_ANYOF ) ) {
 			$anyof_code = self::MANDATORY_ANYOF_ATTR_MISSING;
 		}
 
-		if ( AMP_Rule_Spec::FAIL === $mandatory_oneof_result ) {
+		if ( AMP_Rule_Spec::FAIL === $this->check_attr_spec_rule_mandatory_number_of( $node, $merged_attr_spec_list, AMP_Rule_Spec::MANDATORY_ONEOF ) ) {
 			$anyof_code = self::MANDATORY_ONEOF_ATTR_MISSING;
 		}
 
@@ -1517,7 +1515,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Gets whether the matched attribute count is valid, for the the type of constraint.
 	 *
-	 * @param int    $count              The count of matched attributes.
+	 * @param int    $count           The count of matched attributes.
 	 * @param string $constraint_type The type of constraint, like 'mandatory_oneof'.
 	 * @return bool Whether the count is acceptable for the constraint type.
 	 */

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1473,11 +1473,15 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					)
 				);
 
-				return 1 === $attribute_count ? AMP_Rule_Spec::PASS : AMP_Rule_Spec::FAIL;
+				if ( 1 !== $attribute_count ) {
+					return AMP_Rule_Spec::FAIL;
+				}
+
+				$validity = AMP_Rule_Spec::PASS;
 			}
 		}
 
-		return AMP_Rule_Spec::NOT_APPLICABLE;
+		return isset( $validity ) ? $validity : AMP_Rule_Spec::NOT_APPLICABLE;
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1457,9 +1457,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array[]    $attr_spec The full attribute spec.
 	 *
 	 * @return string:
-	 *      - AMP_Rule_Spec::PASS - $attr_name is mandatory and it exists
-	 *      - AMP_Rule_Spec::FAIL - $attr_name is mandatory, but doesn't exist
-	 *      - AMP_Rule_Spec::NOT_APPLICABLE - $attr_name is not mandatory
+	 *      - AMP_Rule_Spec::PASS - there is a mandatory_onoeof, and exactly one of the attributes is present
+	 *      - AMP_Rule_Spec::FAIL - there is a mandatory_onoeof, and either 0 or more than 1 attributes are present
+	 *      - AMP_Rule_Spec::NOT_APPLICABLE - there is no mandatory_oneof
 	 */
 	private function check_attr_spec_rule_mandatory_oneof( DOMElement $node, $attr_spec ) {
 		foreach ( $attr_spec as $attr_name => $attr_spec_rule_value ) {

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1501,7 +1501,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * If it exists, this gets a mandatory_*of spec rule that is unsatisfied.
 	 *
-	 * For example, if the $constraint_type is 'mandatory_anyof' and one of the attributes wasn't present,
+	 * For example, if the $constraint_type is mandatory_anyof and one of the attributes isn't present,
 	 * this will return the attributes in the spec rule.
 	 *
 	 * @param DOMElement $node            The node to examine.

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -729,7 +729,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return null;
 		}
 
-		$unsatisfied_mandatory_anyof_attributes = $this->get_unsatisfied_attr_spec_rule( $node, $tag_spec, AMP_Rule_Spec::MANDATORY_ANYOF );
+		$unsatisfied_mandatory_anyof_attributes = $this->get_unsatisfied_number_of_rule( $node, $tag_spec, AMP_Rule_Spec::MANDATORY_ANYOF );
 		if ( ! empty( $unsatisfied_mandatory_anyof_attributes ) ) {
 			$this->remove_invalid_child(
 				$node,
@@ -742,7 +742,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return null;
 		}
 
-		$unsatisfied_mandatory_oneof_attributes = $this->get_unsatisfied_attr_spec_rule( $node, $tag_spec, AMP_Rule_Spec::MANDATORY_ONEOF );
+		$unsatisfied_mandatory_oneof_attributes = $this->get_unsatisfied_number_of_rule( $node, $tag_spec, AMP_Rule_Spec::MANDATORY_ONEOF );
 		if ( ! empty( $unsatisfied_mandatory_oneof_attributes ) ) {
 			$this->remove_invalid_child(
 				$node,
@@ -1452,16 +1452,16 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * If it exists, this gets a mandatory_*of spec rule that is unsatisfied.
 	 *
-	 * For example, if the $constraint_type is mandatory_anyof and one of the attributes isn't present,
+	 * For example, if the $constraint_type is 'mandatory_anyof' and one of the attributes isn't present,
 	 * this will return the attributes in the spec rule.
 	 *
 	 * @param DOMElement $node            The node to examine.
 	 * @param array[]    $tag_spec        The spec for the tag.
 	 * @param string     $constraint_type The type of constraint, like 'mandatory_oneof'.
 	 *
-	 * @return array|null The attribute spec rule that isn't satisfied, like a rule for mandatory_oneof, or null.
+	 * @return string[]|null The mandatory_*of rule that isn't satisfied, like a rule for 'mandatory_oneof', or null.
 	 */
-	private function get_unsatisfied_attr_spec_rule( DOMElement $node, $tag_spec, $constraint_type ) {
+	private function get_unsatisfied_number_of_rule( DOMElement $node, $tag_spec, $constraint_type ) {
 		if ( ! empty( $tag_spec[ $constraint_type ] ) ) {
 			$matched_attribute_count = count(
 				array_filter(

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1480,9 +1480,9 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param string     $constraint_type The type of constraint, like 'mandatory_oneof'.
 	 *
 	 * @return string:
-	 *      - AMP_Rule_Spec::PASS - there is a mandatory_*of, and exactly one of the attributes is present
-	 *      - AMP_Rule_Spec::FAIL - there is a mandatory_*eof, and either 0 or more than 1 attributes are present
-	 *      - AMP_Rule_Spec::NOT_APPLICABLE - there is no mandatory_*of
+	 *      - AMP_Rule_Spec::PASS - the constraint type is present in the spec, and the proper number of attributes is present
+	 *      - AMP_Rule_Spec::FAIL - the constraint type is present but the proper number of attributes is not present
+	 *      - AMP_Rule_Spec::NOT_APPLICABLE - the constraint type is not present, so there was nothing to check
 	 */
 	private function check_attr_spec_rule_mandatory_number_of( DOMElement $node, $attr_spec, $constraint_type ) {
 		$checked_oneof_constraints = [];

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -729,7 +729,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return null;
 		}
 
-		$unsatisfied_mandatory_anyof_attributes = $this->get_unsatisfied_attr_spec_rule( $node, $merged_attr_spec_list, AMP_Rule_Spec::MANDATORY_ANYOF );
+		$unsatisfied_mandatory_anyof_attributes = $this->get_unsatisfied_attr_spec_rule( $node, $tag_spec, AMP_Rule_Spec::MANDATORY_ANYOF );
 		if ( ! empty( $unsatisfied_mandatory_anyof_attributes ) ) {
 			$this->remove_invalid_child(
 				$node,
@@ -742,7 +742,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			return null;
 		}
 
-		$unsatisfied_mandatory_oneof_attributes = $this->get_unsatisfied_attr_spec_rule( $node, $merged_attr_spec_list, AMP_Rule_Spec::MANDATORY_ONEOF );
+		$unsatisfied_mandatory_oneof_attributes = $this->get_unsatisfied_attr_spec_rule( $node, $tag_spec, AMP_Rule_Spec::MANDATORY_ONEOF );
 		if ( ! empty( $unsatisfied_mandatory_oneof_attributes ) ) {
 			$this->remove_invalid_child(
 				$node,
@@ -1056,30 +1056,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 				} elseif ( AMP_Rule_Spec::FAIL === $result ) {
 					return 0;
 				}
-			}
-		}
-
-		// If a mandatory_anyof constraint exists, change the score accordingly.
-		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::MANDATORY_ANYOF ] ) ) {
-			$mandatory_count++;
-
-			$result = $this->check_attr_spec_rule_mandatory_number_of( $node, $attr_spec_list, AMP_Rule_Spec::MANDATORY_ANYOF );
-			if ( AMP_Rule_Spec::PASS === $result ) {
-				$score += 2;
-			} elseif ( AMP_Rule_Spec::FAIL === $result ) {
-				return 0;
-			}
-		}
-
-		// If a mandatory_oneof constraint exists, update the score.
-		if ( isset( $attr_spec_rule[ AMP_Rule_Spec::MANDATORY_ONEOF ] ) ) {
-			$mandatory_count++;
-
-			$result = $this->check_attr_spec_rule_mandatory_number_of( $node, $attr_spec_list, AMP_Rule_Spec::MANDATORY_ONEOF );
-			if ( AMP_Rule_Spec::PASS === $result ) {
-				$score += 2;
-			} elseif ( AMP_Rule_Spec::FAIL === $result ) {
-				return 0;
 			}
 		}
 
@@ -1474,62 +1450,30 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	}
 
 	/**
-	 * Gets whether a mandatory_*of constraint exists and is satisfied.
-	 *
-	 * If it exists, there must be the proper number of attributes present.
-	 * This number varies by the type of constraint.
-	 *
-	 * @param DOMElement $node            The node to examine.
-	 * @param array[]    $attr_spec       The full attribute spec.
-	 * @param string     $constraint_type The type of constraint, like 'mandatory_oneof'.
-	 *
-	 * @return string:
-	 *      - AMP_Rule_Spec::PASS - the constraint type is present in the spec, and the proper number of attributes is present
-	 *      - AMP_Rule_Spec::FAIL - the constraint type is present but the proper number of attributes is not present
-	 *      - AMP_Rule_Spec::NOT_APPLICABLE - the constraint type is not present, so there was nothing to check
-	 */
-	private function check_attr_spec_rule_mandatory_number_of( DOMElement $node, $attr_spec, $constraint_type ) {
-		$matched_constraints = wp_list_pluck( $attr_spec, $constraint_type );
-		if ( empty( $matched_constraints ) ) {
-			return AMP_Rule_Spec::NOT_APPLICABLE; // The $constraint_type like 'mandatory_oneof' wasn't in the spec, so no need to check more.
-		}
-
-		$unsatisfied_attr_spec = $this->get_unsatisfied_attr_spec_rule( $node, $attr_spec, $constraint_type );
-		return empty( $unsatisfied_attr_spec ) ? AMP_Rule_Spec::PASS : AMP_Rule_Spec::FAIL;
-	}
-
-	/**
 	 * If it exists, this gets a mandatory_*of spec rule that is unsatisfied.
 	 *
 	 * For example, if the $constraint_type is mandatory_anyof and one of the attributes isn't present,
 	 * this will return the attributes in the spec rule.
 	 *
 	 * @param DOMElement $node            The node to examine.
-	 * @param array[]    $attr_spec       The full attribute spec.
+	 * @param array[]    $tag_spec        The spec for the tag.
 	 * @param string     $constraint_type The type of constraint, like 'mandatory_oneof'.
 	 *
 	 * @return array|null The attribute spec rule that isn't satisfied, like a rule for mandatory_oneof, or null.
 	 */
-	private function get_unsatisfied_attr_spec_rule( DOMElement $node, $attr_spec, $constraint_type ) {
-		$checked_oneof_constraints = [];
-		foreach ( $attr_spec as $attr_name => $attr_spec_rule_value ) {
-			if ( ! empty( $attr_spec_rule_value[ $constraint_type ] ) &&
-				! in_array( $attr_spec_rule_value[ $constraint_type ], $checked_oneof_constraints, true ) ) {
+	private function get_unsatisfied_attr_spec_rule( DOMElement $node, $tag_spec, $constraint_type ) {
+		if ( ! empty( $tag_spec[ $constraint_type ] ) ) {
+			$matched_attribute_count = count(
+				array_filter(
+					$tag_spec[ $constraint_type ],
+					static function( $attribute ) use ( $node ) {
+						return $node->hasAttribute( $attribute );
+					}
+				)
+			);
 
-				// Store this as checked so it's not checked again.
-				$checked_oneof_constraints[] = $attr_spec_rule_value[ $constraint_type ];
-				$matched_attribute_count     = count(
-					array_filter(
-						$attr_spec_rule_value[ $constraint_type ],
-						static function( $attribute ) use ( $node ) {
-							return $node->hasAttribute( $attribute );
-						}
-					)
-				);
-
-				if ( ! $this->is_matched_attribute_count_acceptable( $matched_attribute_count, $constraint_type ) ) {
-					return $attr_spec_rule_value[ $constraint_type ];
-				}
+			if ( ! $this->is_matched_attribute_count_acceptable( $matched_attribute_count, $constraint_type ) ) {
+				return $tag_spec[ $constraint_type ];
 			}
 		}
 	}

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -22,8 +22,6 @@ use Amp\AmpWP\Dom\Document;
  *     - `ChildTagSpec`       - Places restrictions on the number and type of child tags.
  *     - `if_value_regex`     - if one attribute value matches, this places a restriction
  *                              on another attribute/value.
- *     - `mandatory_oneof`    - Within the context of the tag, exactly one of the attributes
- *                              must be present.
  */
 class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1462,9 +1462,14 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *      - AMP_Rule_Spec::NOT_APPLICABLE - there is no mandatory_oneof
 	 */
 	private function check_attr_spec_rule_mandatory_oneof( DOMElement $node, $attr_spec ) {
+		$checked_oneof_constraints = [];
 		foreach ( $attr_spec as $attr_name => $attr_spec_rule_value ) {
-			if ( ! empty( $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY_ONEOF ] ) ) {
-				$attribute_count = count(
+			if ( ! empty( $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY_ONEOF ] ) &&
+				! in_array( $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY_ONEOF ], $checked_oneof_constraints, true ) ) {
+
+				// Store this as checked so it's not checked again.
+				$checked_oneof_constraints[] = $attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY_ONEOF ];
+				$matched_attribute_count     = count(
 					array_filter(
 						$attr_spec_rule_value[ AMP_Rule_Spec::MANDATORY_ONEOF ],
 						static function( $attribute ) use ( $node ) {
@@ -1473,7 +1478,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 					)
 				);
 
-				if ( 1 !== $attribute_count ) {
+				if ( 1 !== $matched_attribute_count ) {
 					return AMP_Rule_Spec::FAIL;
 				}
 

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2141,7 +2141,7 @@ class AMP_Validation_Error_Taxonomy {
 				if ( $is_element_attributes && empty( $value ) ) {
 					continue;
 				}
-				if ( in_array( $key, [ 'code', 'type', 'property_value' ], true ) ) {
+				if ( in_array( $key, [ 'code', 'type', 'property_value', 'mandatory_anyof_attrs', 'mandatory_oneof_attrs' ], true ) ) {
 					continue; // Handled above.
 				}
 				?>
@@ -2215,13 +2215,24 @@ class AMP_Validation_Error_Taxonomy {
 								</tr>
 							<?php endforeach; ?>
 						</table>
+					<?php elseif ( 'duplicate_oneof_attrs' === $key ) : ?>
+						<ul>
+						<?php foreach ( $value as $attr ) : ?>
+							<li><code><?php echo esc_html( $attr ); ?></code></li>
+						<?php endforeach; ?>
+						</ul>
 					<?php elseif ( is_array( $value ) ) : ?>
 						<?php foreach ( $value as $value_key => $attr ) : ?>
 							<?php
-							printf( '<strong>%s</strong>', esc_html( $value_key ) );
-							if ( ! empty( $attr ) ) :
-								printf( ': %s', esc_html( $attr ) );
-							endif;
+							if ( is_int( $value_key ) ) {
+								echo esc_html( $attr );
+							} else {
+								printf( '<strong>%s</strong>', esc_html( $value_key ) );
+								if ( ! empty( $attr ) ) {
+									echo ': ';
+									echo esc_html( $attr );
+								}
+							}
 							?>
 							<br />
 						<?php endforeach; ?>
@@ -3027,6 +3038,8 @@ class AMP_Validation_Error_Taxonomy {
 				return __( 'Parent element', 'amp' );
 			case 'property_name':
 				return __( 'CSS property', 'amp' );
+			case 'duplicate_oneof_attrs':
+				return __( 'Mutually exclusive attributes', 'amp' );
 			case 'text':
 				return __( 'Text content', 'amp' );
 			case 'type':

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2951,6 +2951,48 @@ class AMP_Validation_Error_Taxonomy {
 					$title .= sprintf( ': <code>%s</code>', esc_html( $validation_error['property_name'] ) );
 				}
 				return $title;
+			case AMP_Tag_And_Attribute_Sanitizer::DUPLICATE_ONEOF_ATTRS:
+				$title = __( 'Mutually exclusive attributes encountered', 'amp' );
+				if ( ! empty( $validation_error['duplicate_oneof_attrs'] ) ) {
+					$title .= ': ';
+					$title .= implode(
+						', ',
+						array_map(
+							static function ( $attribute_name ) {
+								return sprintf( '<code>%s</code>', $attribute_name );
+							},
+							$validation_error['duplicate_oneof_attrs']
+						)
+					);
+					return $title;
+				}
+				break;
+			case AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING:
+			case AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ANYOF_ATTR_MISSING:
+				$attributes_key = null;
+				if ( AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING === $validation_error['code'] ) {
+					$title          = __( 'Missing exclusive mandatory attribute', 'amp' );
+					$attributes_key = 'mandatory_oneof_attrs';
+				} else {
+					$title          = __( 'Missing at least one mandatory attribute', 'amp' );
+					$attributes_key = 'mandatory_anyof_attrs';
+				}
+
+				// @todo This should not be needed because we can look it up from the spec. See https://github.com/ampproject/amp-wp/pull/3817.
+				if ( ! empty( $validation_error[ $attributes_key ] ) ) {
+					$title .= ': ';
+					$title .= implode(
+						', ',
+						array_map(
+							static function ( $attribute_name ) {
+								return sprintf( '<code>%s</code>', $attribute_name );
+							},
+							$validation_error[ $attributes_key ]
+						)
+					);
+				}
+				return $title;
+
 			default:
 				/* translators: %s error code */
 				return sprintf( __( 'Unknown error (%s)', 'amp' ), $validation_error['code'] );

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -931,6 +931,42 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				],
 				2,
 			],
+			'attributes_mandatory_oneof_valid' => [
+				[
+					'source' => '<div attribute2></div>',
+					'node_tag_name' => 'div',
+					'attr_spec_list' => [
+						'attribute1' => [
+							'mandatory_oneof' => [ 'attribute1', 'attribute2', 'attribute3' ],
+						],
+					],
+				],
+				2,
+			],
+			'attributes_mandatory_oneof_invalid_none_present' => [
+				[
+					'source' => '<div attribute5></div>',
+					'node_tag_name' => 'div',
+					'attr_spec_list' => [
+						'attribute1' => [
+							'mandatory_oneof' => [ 'attribute1', 'attribute2' ],
+						],
+					],
+				],
+				0,
+			],
+			'attributes_mandatory_oneof_invalid_too_many' => [
+				[
+					'source' => '<div attribute1 attribute2></div>',
+					'node_tag_name' => 'div',
+					'attr_spec_list' => [
+						'attribute1' => [
+							'mandatory_oneof' => [ 'attribute1', 'attribute2', 'attribute3' ],
+						],
+					],
+				],
+				0,
+			],
 			'attributes_value' => [
 				[
 					'source' => '<div attribute1="required_value"></div>',

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -931,66 +931,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				],
 				2,
 			],
-			'attributes_mandatory_anyof_valid' => [
-				[
-					'source' => '<div attribute1 attribute2></div>',
-					'node_tag_name' => 'div',
-					'attr_spec_list' => [
-						'attribute1' => [
-							'mandatory_anyof' => [ 'attribute1', 'attribute2', 'attribute3' ],
-						],
-					],
-				],
-				4,
-			],
-			'attributes_mandatory_anyof_invalid' => [
-				[
-					'source' => '<div attribute9></div>',
-					'node_tag_name' => 'div',
-					'attr_spec_list' => [
-						'attribute1' => [
-							'mandatory_anyof' => [ 'attribute1', 'attribute2' ],
-						],
-					],
-				],
-				0,
-			],
-			'attributes_mandatory_oneof_valid' => [
-				[
-					'source' => '<div attribute2></div>',
-					'node_tag_name' => 'div',
-					'attr_spec_list' => [
-						'attribute1' => [
-							'mandatory_oneof' => [ 'attribute1', 'attribute2', 'attribute3' ],
-						],
-					],
-				],
-				2,
-			],
-			'attributes_mandatory_oneof_invalid_none_present' => [
-				[
-					'source' => '<div attribute5></div>',
-					'node_tag_name' => 'div',
-					'attr_spec_list' => [
-						'attribute1' => [
-							'mandatory_oneof' => [ 'attribute1', 'attribute2' ],
-						],
-					],
-				],
-				0,
-			],
-			'attributes_mandatory_oneof_invalid_too_many' => [
-				[
-					'source' => '<div attribute1 attribute2></div>',
-					'node_tag_name' => 'div',
-					'attr_spec_list' => [
-						'attribute1' => [
-							'mandatory_oneof' => [ 'attribute1', 'attribute2', 'attribute3' ],
-						],
-					],
-				],
-				0,
-			],
 			'attributes_value' => [
 				[
 					'source' => '<div attribute1="required_value"></div>',

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -931,6 +931,30 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 				],
 				2,
 			],
+			'attributes_mandatory_anyof_valid' => [
+				[
+					'source' => '<div attribute1 attribute2></div>',
+					'node_tag_name' => 'div',
+					'attr_spec_list' => [
+						'attribute1' => [
+							'mandatory_anyof' => [ 'attribute1', 'attribute2', 'attribute3' ],
+						],
+					],
+				],
+				4,
+			],
+			'attributes_mandatory_anyof_invalid' => [
+				[
+					'source' => '<div attribute9></div>',
+					'node_tag_name' => 'div',
+					'attr_spec_list' => [
+						'attribute1' => [
+							'mandatory_anyof' => [ 'attribute1', 'attribute2' ],
+						],
+					],
+				],
+				0,
+			],
 			'attributes_mandatory_oneof_valid' => [
 				[
 					'source' => '<div attribute2></div>',

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -1983,16 +1983,14 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-truncate-text' ],
 			],
 
-			// Removed from spec: https://github.com/ampproject/amphtml/pull/25639.
 			'amp-user-location'                            => [
 				'
 					<button on="tap: location.request()">Use my location</button>
 					<amp-user-location id="location" on="approve:AMP.setState({located: true})" layout="nodisplay">
 					</amp-user-location>
 				',
-				'<button on="tap: location.request()">Use my location</button>',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
+				null,
+				[ 'amp-user-location' ],
 			],
 
 			'amp-megaphone'                                => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -246,9 +246,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'amp-iframe_incorrect_protocol'                => [
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="masterprotocol://www.example.com"></amp-iframe>',
-				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0"></amp-iframe>',
-				[ 'amp-iframe' ],
-				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL ],
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL, AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
 			],
 
 			'amp-ima-video'                                => [
@@ -333,8 +333,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'amp-playbuzz_no_src'                          => [
 				'<amp-playbuzz height="500" data-item-info="true"></amp-playbuzz>',
-				null, // @todo This actually should be stripped because .
-				[ 'amp-playbuzz' ],
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
 			],
 
 			'invalid_element_stripped'                     => [
@@ -890,6 +891,20 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
+			],
+
+			'remove_node_no_mandatory_oneof_attribute'     => [
+				'<amp-iframe width="200" height="100"></amp-iframe>',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+			],
+
+			'remove_node_two_mandatory_oneof_attributes'   => [
+				'<amp-iframe src="https://example.com" srcdoc="https://foo.com" width="200" height="100"></amp-iframe>',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
 			],
 
 			'remove_script_with_async_attribute'           => [
@@ -1968,14 +1983,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-truncate-text' ],
 			],
 
+			// Removed from spec: https://github.com/ampproject/amphtml/pull/25639.
 			'amp-user-location'                            => [
 				'
 					<button on="tap: location.request()">Use my location</button>
 					<amp-user-location id="location" on="approve:AMP.setState({located: true})" layout="nodisplay">
 					</amp-user-location>
 				',
-				null,
-				[ 'amp-user-location' ],
+				'<button on="tap: location.request()">Use my location</button>',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
 			],
 
 			'amp-megaphone'                                => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -319,6 +319,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-bind' ],
 			],
 
+			'amp-list-load-more_no_mandatory_anyof'        => [
+				'<amp-list src="https://foo.com" width="400" height="800"><amp-list-load-more></amp-list-load-more></amp-list>',
+				'<amp-list src="https://foo.com" width="400" height="800"></amp-list>',
+				[ 'amp-list' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+			],
+
 			'amp-nexxtv-player'                            => [
 				'<amp-nexxtv-player data-mediaid="123ABC" data-client="4321"></amp-nexxtv-player>',
 				null, // No change.

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -319,7 +319,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-bind' ],
 			],
 
-			'amp-list-load-more_no_mandatory_anyof'        => [
+			'amp-list-load-more_no_mandatory_oneof'        => [
 				'<amp-list src="https://foo.com" width="400" height="800"><amp-list-load-more></amp-list-load-more></amp-list>',
 				'<amp-list src="https://foo.com" width="400" height="800"></amp-list>',
 				[ 'amp-list' ],

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -248,7 +248,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-iframe width="600" height="200" sandbox="allow-scripts allow-same-origin" layout="responsive" frameborder="0" src="masterprotocol://www.example.com"></amp-iframe>',
 				'',
 				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL, AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+				[
+					AMP_Tag_And_Attribute_Sanitizer::INVALID_URL_PROTOCOL,
+					[
+						'code'                  => AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING,
+						'mandatory_oneof_attrs' => [ 'src', 'srcdoc' ],
+					],
+				],
 			],
 
 			'amp-ima-video'                                => [
@@ -323,7 +329,17 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-list src="https://foo.com" width="400" height="800"><amp-list-load-more></amp-list-load-more></amp-list>',
 				'<amp-list src="https://foo.com" width="400" height="800"></amp-list>',
 				[ 'amp-list' ],
-				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+				[
+					[
+						'code'                  => AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING,
+						'mandatory_oneof_attrs' => [
+							'load-more-button',
+							'load-more-end',
+							'load-more-failed',
+							'load-more-loading',
+						],
+					],
+				],
 			],
 
 			'amp-nexxtv-player'                            => [
@@ -342,7 +358,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-playbuzz height="500" data-item-info="true"></amp-playbuzz>',
 				'',
 				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+				[
+					[
+						'code'                  => AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING,
+						'mandatory_oneof_attrs' => [
+							'data-item',
+							'src',
+						],
+					],
+				],
 			],
 
 			'invalid_element_stripped'                     => [
@@ -904,7 +928,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-list width="400" height="400"></amp-list>',
 				'',
 				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ANYOF_ATTR_MISSING ],
+				[
+					[
+						'code'                  => AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ANYOF_ATTR_MISSING,
+						'mandatory_anyof_attrs' => [
+							'data-amp-bind-src',
+							'src',
+						],
+					],
+				],
 			],
 
 			'allow_amp_list_two_mandatory_anyof_attrs'     => [
@@ -924,7 +956,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-iframe src="https://example.com" srcdoc="https://foo.com" width="200" height="100"></amp-iframe>',
 				'',
 				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+				[
+					[
+						'code'                  => AMP_Tag_And_Attribute_Sanitizer::DUPLICATE_ONEOF_ATTRS,
+						'duplicate_oneof_attrs' => [
+							'src',
+							'srcdoc',
+						],
+					],
+				],
 			],
 
 			'allow_amp_iframe_one_mandatory_oneof_attr'    => [
@@ -1842,6 +1882,32 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-list', 'amp-mustache' ],
 			],
 
+			'amp-list-load-more-bad-buttons'               => [
+				'
+					<amp-list load-more="auto" src="https://www.load.more.example.com/" width="400" height="800">
+						<amp-list-load-more load-more-button load-more-end load-more-failed load-more-loading>
+							<template type="amp-mustache">
+								Showing {{#count}} out of {{#total}} items
+								<button>Click here to see more!</button>
+							</template>
+						</amp-list-load-more>
+					</amp-list>
+				',
+				'<amp-list load-more="auto" src="https://www.load.more.example.com/" width="400" height="800"></amp-list>',
+				[ 'amp-list' ],
+				[
+					[
+						'code'                  => AMP_Tag_And_Attribute_Sanitizer::DUPLICATE_ONEOF_ATTRS,
+						'duplicate_oneof_attrs' => [
+							'load-more-button',
+							'load-more-end',
+							'load-more-failed',
+							'load-more-loading',
+						],
+					],
+				],
+			],
+
 			'amp-recaptcha-input'                          => [
 				'<form action-xhr="/" target="_top" method="post"><amp-recaptcha-input layout="nodisplay" name="reCAPTCHA_body_key" data-sitekey="reCAPTCHA_site_key" data-action="reCAPTCHA_example_action"></amp-recaptcha-input></form>',
 				null,
@@ -2505,7 +2571,10 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( wp_list_pluck( $expected_errors, 'code' ), wp_list_pluck( $actual_errors, 'code' ) );
 		foreach ( $expected_errors as $i => $expected_error ) {
-			$this->assertArraySubset( $expected_error, $actual_errors[ $i ] );
+			foreach ( array_keys( $expected_error ) as $key ) {
+				$this->assertArrayHasKey( $key, $actual_errors[ $i ] );
+				$this->assertEquals( $expected_error[ $key ], $actual_errors[ $i ][ $key ], "For key: $key" );
+			}
 		}
 	}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -900,25 +900,37 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
 			],
 
-			'remove_node_no_mandatory_anyof_attribute'     => [
+			'remove_amp_list_no_mandatory_anyof_attribute' => [
 				'<amp-list width="400" height="400"></amp-list>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ANYOF_ATTR_MISSING ],
 			],
 
-			'remove_node_no_mandatory_oneof_attribute'     => [
+			'allow_amp_list_two_mandatory_anyof_attribute' => [
+				'<amp-list src="https://foo.com" data-amp-bind-src="https://baz.com" width="400" height="400"></amp-list>',
+				null,
+				[ 'amp-bind', 'amp-list' ],
+			],
+
+			'remove_amp_iframe_no_mandatory_oneof_attr'    => [
 				'<amp-iframe width="200" height="100"></amp-iframe>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
 			],
 
-			'remove_node_two_mandatory_oneof_attributes'   => [
+			'remove_amp_iframe_two_mandatory_oneof_attrs'  => [
 				'<amp-iframe src="https://example.com" srcdoc="https://foo.com" width="200" height="100"></amp-iframe>',
 				'',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ONEOF_ATTR_MISSING ],
+			],
+
+			'allow_amp_iframe_one_mandatory_oneof_attr'    => [
+				'<amp-iframe srcdoc="https://foo.com" width="200" height="100"></amp-iframe>',
+				null,
+				[ 'amp-iframe' ],
 			],
 
 			'remove_script_with_async_attribute'           => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -907,7 +907,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ANYOF_ATTR_MISSING ],
 			],
 
-			'allow_amp_list_two_mandatory_anyof_attribute' => [
+			'allow_amp_list_two_mandatory_anyof_attrs'     => [
 				'<amp-list src="https://foo.com" data-amp-bind-src="https://baz.com" width="400" height="400"></amp-list>',
 				null,
 				[ 'amp-bind', 'amp-list' ],

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -893,6 +893,13 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
 			],
 
+			'remove_node_no_mandatory_anyof_attribute'     => [
+				'<amp-list width="400" height="400"></amp-list>',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_ANYOF_ATTR_MISSING ],
+			],
+
 			'remove_node_no_mandatory_oneof_attribute'     => [
 				'<amp-iframe width="200" height="100"></amp-iframe>',
 				'',


### PR DESCRIPTION
## Summary

Adds `mandatory_anyof` and `mandatory_oneof` to `amphtml-update.py`, and verifies against it in the sanitizer

## Testing
1. As the description of #938 mentions, adding this to a Custom HTML block:

```html
<iframe src="about:blank">
```

...now results in the `<amp-iframe>` being stripped, and the validation errors now include:

![mandatory-oneof](https://user-images.githubusercontent.com/4063887/74404442-1fd89980-4df0-11ea-84cc-ff73bac59eea.png)

2. And adding this to a Custom HTML block:
```html
<amp-list width="400" height="400"></amp-list>
```
...now results in this validation error:

![yan-spec](https://user-images.githubusercontent.com/4063887/74405132-fc165300-4df1-11ea-893f-e61f110dd79e.png)

Fixes #938

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
