### PR TITLE
Improve conversion of resizable iframes and those containing placeholder overflow

### DIFF
--- a/tests/php/test-amp-iframe-sanitizer.php
+++ b/tests/php/test-amp-iframe-sanitizer.php
@@ -461,6 +461,77 @@ class AMP_Iframe_Converter_Test extends WP_UnitTestCase {
 						</noscript>
 					</amp-iframe>',
 			],
+
+			'iframe_with_resizable' => [
+				'<iframe resizable src="https://example.com" width="320" height="640"></iframe>',
+				'
+					<amp-iframe resizable="" src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+						<button overflow="">Show all</button>
+						<noscript>
+							<iframe resizable src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				[
+					'add_placeholder' => true,
+				],
+			],
+
+			'iframe_with_resizable_and_custom_overflow' => [
+				'<iframe data-amp-resizable data-amp-overflow-text="Expand me" src="https://example.com" width="320" height="640"></iframe>',
+				'
+					<amp-iframe resizable="" src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+						<button overflow="">Expand me</button>
+						<noscript>
+							<iframe src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				[
+					'add_placeholder' => true,
+				],
+			],
+
+			'iframe_with_custom_placeholder' => [
+				'
+					<iframe src="https://example.com" width="320" height="640">
+						<a placeholder href="https://example.com">Loading example site...</a>
+					</iframe>
+				',
+				'
+					<amp-iframe src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<a placeholder href="https://example.com">Loading example site...</a>
+						<noscript>
+							<iframe src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				[
+					'add_placeholder' => true,
+				],
+			],
+
+			'iframe_with_custom_overflow' => [
+				'
+					<iframe resizable src="https://example.com" width="320" height="640">
+						<button overflow>See more</button>
+					</iframe>
+				',
+				'
+					<amp-iframe resizable="" src="https://example.com" width="320" height="640" sandbox="allow-scripts allow-same-origin" layout="intrinsic" class="amp-wp-enforced-sizes">
+						<span placeholder="" class="amp-wp-iframe-placeholder"></span>
+						<button overflow>See more</button>
+						<noscript>
+							<iframe resizable src="https://example.com" width="320" height="640"></iframe>
+						</noscript>
+					</amp-iframe>
+				',
+				[
+					'add_placeholder' => true,
+				],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

* Move `iframe` child elements that have `placeholder` and `overflow` attributes to be direct children of `amp-iframe`, rather than erroneously keeping them in the `iframe` to be put in the `noscript` element.
* If an `iframe` has a `resizable` attribute (or `data-amp-resizable`), automatically provide the required `<button overflow>Show all</button>` element (if one is not already present). Allow the overflow "Show all" text to be customized via the `data-amp-overflow-text` attribute on the `iframe`.

Fixes #4288

Given this source input in a Custom HTML block:

```html
<iframe src="https://jump.sproutsocial.com/l/638801/2020-02-05/396zv" title="Time for 2020: Social Media Trends and What To Do Now" height="500" width="350" layout="responsive" resizable sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups" frameborder="0">
    <img
            src="https://media.sproutsocial.com/uploads/bg-transparent.gif"
            height="500"
            width="350"
            layout="intrinsic"
            placeholder/>
    <div overflow tabindex="0" role="button" aria-label="Show all">
        Show all
    </div>
</iframe>
```

Before the output would be (👎):

```html
<amp-iframe src="https://jump.sproutsocial.com/l/638801/2019-11-07/2wxmg" title="Time for 2020: Social Media Trends and What To Do Now" height="500" width="350" layout="responsive" resizable="" sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups" frameborder="0">
	<span placeholder="" class="amp-wp-iframe-placeholder"></span>
	<noscript>
		<iframe src="https://jump.sproutsocial.com/l/638801/2019-11-07/2wxmg" title="Time for 2020: Social Media Trends and What To Do Now" height="500" width="350" resizable sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups" frameborder="0">
			<amp-img src="https://media.sproutsocial.com/uploads/illustration-homepage-header@2x-2.png" height="500" width="350" layout="intrinsic" placeholder="" class="amp-wp-enforced-sizes"></amp-img>
			<div overflow role="button" tabindex="0">See all</div>
		</iframe>
	</noscript>
</amp-iframe>
```

And after it is (👍):

```html
<amp-iframe src="https://jump.sproutsocial.com/l/638801/2020-02-05/396zv" title="Time for 2020: Social Media Trends and What To Do Now" height="500" width="350" layout="responsive" resizable="" sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups" frameborder="0">
	<amp-anim src="https://media.sproutsocial.com/uploads/bg-transparent.gif" height="500" width="350" layout="intrinsic" placeholder="" class="amp-wp-enforced-sizes">
		<noscript>
			<img src="https://media.sproutsocial.com/uploads/bg-transparent.gif" height="500" width="350" placeholder>
		</noscript>
	</amp-anim>
	<div overflow tabindex="0" role="button" aria-label="Show all">
		Show all
	</div>
	<noscript>
		<iframe src="https://jump.sproutsocial.com/l/638801/2020-02-05/396zv" title="Time for 2020: Social Media Trends and What To Do Now" height="500" width="350" resizable sandbox="allow-scripts allow-same-origin allow-forms allow-top-navigation allow-popups" frameborder="0"></iframe>
	</noscript>
</amp-iframe>
```

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
