### PR TITLE
Enfore UTF-8 content-type header

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2054,7 +2054,9 @@ class AMP_Theme_Support {
 		}
 
 		// Enforce UTF-8 encoding as it is a requirement for AMP.
-		header( 'Content-Type: text/html; charset=utf-8' );
+		if ( ! headers_sent() ) {
+			header( 'Content-Type: text/html; charset=utf-8' );
+		}
 
 		/**
 		 * Filters whether response (post-processor) caching is enabled.

--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2053,6 +2053,9 @@ class AMP_Theme_Support {
 			return $response;
 		}
 
+		// Enforce UTF-8 encoding as it is a requirement for AMP.
+		header( 'Content-Type: text/html; charset=utf-8' );
+
 		/**
 		 * Filters whether response (post-processor) caching is enabled.
 		 *
@@ -2352,12 +2355,6 @@ class AMP_Theme_Support {
 				wp_safe_redirect( $non_amp_url, 302 );
 				return $response;
 			}
-		}
-
-		// @todo If 'utf-8' is not the blog charset, then we'll need to do some character encoding conversation or "entityification".
-		if ( 'utf-8' !== strtolower( get_bloginfo( 'charset' ) ) ) {
-			/* translators: %s: the charset of the current site. */
-			trigger_error( esc_html( sprintf( __( 'The database has the %s encoding when it needs to be utf-8 to work with AMP.', 'amp' ), get_bloginfo( 'charset' ) ) ), E_USER_WARNING ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 		}
 
 		AMP_Validation_Manager::finalize_validation( $dom );


### PR DESCRIPTION
## Summary


We're already convert the encoding from non-UTF-8 to UTF-8 within the DOMDocument extension, but WordPress still outputs a content-type header with the old charset.

This PR fixes this, and also removes a `trigger_error` that is not needed anymore.

Fixes #855

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).