### PR TITLE
Use travis_retry on PHPUnit for external-http tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
   - |
     if [[ ! -z "$PHPUNIT_EXTRA_SUITE" ]]; then
       echo "Running phpunit testsuite $PHPUNIT_EXTRA_SUITE"
-      phpunit --testsuite $PHPUNIT_EXTRA_SUITE
+      travis_retry phpunit --testsuite $PHPUNIT_EXTRA_SUITE
     fi
 
 after_script:
@@ -109,15 +109,6 @@ jobs:
     - name: PHP unit tests w/ external-http (7.3, WordPress latest)
       php: "7.3"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1 PHPUNIT_EXTRA_SUITE=external-http
-      script:
-        - npm run build:js
-        - npm run build:css
-        - source "$DEV_LIB_PATH/travis.script.sh"
-        - |
-          if [[ ! -z "$PHPUNIT_EXTRA_SUITE" ]]; then
-            echo "Running phpunit testsuite $PHPUNIT_EXTRA_SUITE"
-            travis_retry phpunit --testsuite $PHPUNIT_EXTRA_SUITE
-          fi
 
     - name: PHP unit tests (7.2, WordPress latest)
       php: "7.2"
@@ -146,15 +137,6 @@ jobs:
     - name: PHP unit tests w/ external-http (5.6, WordPress 4.9)
       php: "5.6"
       env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax                     PHPUNIT_EXTRA_SUITE=external-http
-      script:
-        - npm run build:js
-        - npm run build:css
-        - source "$DEV_LIB_PATH/travis.script.sh"
-        - |
-          if [[ ! -z "$PHPUNIT_EXTRA_SUITE" ]]; then
-            echo "Running phpunit testsuite $PHPUNIT_EXTRA_SUITE"
-            travis_retry phpunit --testsuite $PHPUNIT_EXTRA_SUITE
-          fi
 
     - name: PHP unit tests (7.3, WordPress trunk)
       php: "7.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,6 +146,15 @@ jobs:
     - name: PHP unit tests w/ external-http (5.6, WordPress 4.9)
       php: "5.6"
       env: WP_VERSION=4.9    DEV_LIB_ONLY=phpunit,phpsyntax                     PHPUNIT_EXTRA_SUITE=external-http
+      script:
+        - npm run build:js
+        - npm run build:css
+        - source "$DEV_LIB_PATH/travis.script.sh"
+        - |
+          if [[ ! -z "$PHPUNIT_EXTRA_SUITE" ]]; then
+            echo "Running phpunit testsuite $PHPUNIT_EXTRA_SUITE"
+            travis_retry phpunit --testsuite $PHPUNIT_EXTRA_SUITE
+          fi
 
     - name: PHP unit tests (7.3, WordPress trunk)
       php: "7.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,15 @@ jobs:
     - name: PHP unit tests w/ external-http (7.3, WordPress latest)
       php: "7.3"
       env: WP_VERSION=latest DEV_LIB_ONLY=phpunit                                INSTALL_PWA_PLUGIN=1 PHPUNIT_EXTRA_SUITE=external-http
+      script:
+        - npm run build:js
+        - npm run build:css
+        - source "$DEV_LIB_PATH/travis.script.sh"
+        - |
+          if [[ ! -z "$PHPUNIT_EXTRA_SUITE" ]]; then
+            echo "Running phpunit testsuite $PHPUNIT_EXTRA_SUITE"
+            travis_retry phpunit --testsuite $PHPUNIT_EXTRA_SUITE
+          fi
 
     - name: PHP unit tests (7.2, WordPress latest)
       php: "7.2"


### PR DESCRIPTION
## Summary

The test suite external-http can fail for occasional and random network issues.

This PR uses `travis_retry` to run PHPUnit for this test-suite, so that an occasional hiccup will be ignored in most cases because a subsequent retry will succeed.

Fixes #4187

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).