### PR TITLE
Load block styles via amp_post_template_head action

### DIFF
--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -57,10 +57,8 @@ function amp_post_template_add_fonts( $amp_template ) {
 
 /**
  * Add block styles for core blocks and third-party blocks.
- *
- * @param AMP_Post_Template $amp_template Template.
  */
-function amp_post_template_add_block_styles( $amp_template ) {
+function amp_post_template_add_block_styles() {
 
 	add_theme_support( 'wp-block-styles' );
 

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -59,9 +59,7 @@ function amp_post_template_add_fonts( $amp_template ) {
  * Add block styles for core blocks and third-party blocks.
  */
 function amp_post_template_add_block_styles() {
-
 	add_theme_support( 'wp-block-styles' );
-
 	wp_common_block_scripts_and_styles();
 	wp_styles()->do_items();
 }

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -57,6 +57,8 @@ function amp_post_template_add_fonts( $amp_template ) {
 
 /**
  * Add block styles for core blocks and third-party blocks.
+ *
+ * @since 1.5.0
  */
 function amp_post_template_add_block_styles() {
 	add_theme_support( 'wp-block-styles' );

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -62,7 +62,7 @@ function amp_post_template_add_fonts( $amp_template ) {
  */
 function amp_post_template_add_block_styles( $amp_template ) {
 
-	current_theme_supports( 'wp-block-styles' );
+	add_theme_supports( 'wp-block-styles' );
 
 	wp_common_block_scripts_and_styles();
 	wp_styles()->do_items();

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -62,7 +62,7 @@ function amp_post_template_add_fonts( $amp_template ) {
  */
 function amp_post_template_add_block_styles( $amp_template ) {
 
-	add_theme_supports( 'wp-block-styles' );
+	add_theme_support( 'wp-block-styles' );
 
 	wp_common_block_scripts_and_styles();
 	wp_styles()->do_items();

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -62,7 +62,9 @@ function amp_post_template_add_fonts( $amp_template ) {
  */
 function amp_post_template_add_block_styles() {
 	add_theme_support( 'wp-block-styles' );
-	wp_common_block_scripts_and_styles();
+	if ( function_exists( 'wp_common_block_scripts_and_styles' ) ) {
+		wp_common_block_scripts_and_styles();
+	}
 	wp_styles()->do_items();
 }
 

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -15,6 +15,7 @@ function amp_post_template_init_hooks() {
 	add_action( 'amp_post_template_head', 'amp_print_schemaorg_metadata' );
 	add_action( 'amp_post_template_head', 'amp_add_generator_metadata' );
 	add_action( 'amp_post_template_head', 'wp_generator' );
+	add_action( 'amp_post_template_head', 'amp_post_template_add_block_styles' );
 	add_action( 'amp_post_template_css', 'amp_post_template_add_styles', 99 );
 	add_action( 'amp_post_template_data', 'amp_post_template_add_analytics_script' );
 	add_action( 'amp_post_template_footer', 'amp_post_template_add_analytics_data' );
@@ -52,6 +53,20 @@ function amp_post_template_add_fonts( $amp_template ) {
 	foreach ( $font_urls as $slug => $url ) {
 		printf( '<link rel="stylesheet" href="%s">', esc_url( esc_url( $url ) ) ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 	}
+}
+
+/**
+ * Add block styles for core blocks and third-party blocks.
+ *
+ * @param AMP_Post_Template $amp_template Template.
+ */
+function amp_post_template_add_block_styles( $amp_template ) {
+	global $wp_styles;
+
+	current_theme_supports( 'wp-block-styles' );
+
+	wp_common_block_scripts_and_styles();
+	$wp_styles->do_items();
 }
 
 /**

--- a/includes/amp-post-template-functions.php
+++ b/includes/amp-post-template-functions.php
@@ -61,12 +61,11 @@ function amp_post_template_add_fonts( $amp_template ) {
  * @param AMP_Post_Template $amp_template Template.
  */
 function amp_post_template_add_block_styles( $amp_template ) {
-	global $wp_styles;
 
 	current_theme_supports( 'wp-block-styles' );
 
 	wp_common_block_scripts_and_styles();
-	$wp_styles->do_items();
+	wp_styles()->do_items();
 }
 
 /**

--- a/includes/templates/reader-template-loader.php
+++ b/includes/templates/reader-template-loader.php
@@ -32,16 +32,5 @@ do_action( 'pre_amp_render_post', get_queried_object_id() );
 require_once AMP__DIR__ . '/includes/amp-post-template-functions.php';
 amp_post_template_init_hooks();
 
-// Support and load Core block styles.
-current_theme_supports( 'wp-block-styles' );
-add_action(
-	'amp_post_template_head',
-	static function () {
-		global $wp_styles;
-		wp_common_block_scripts_and_styles();
-		$wp_styles->do_items();
-	}
-);
-
 $amp_post_template = new AMP_Post_Template( get_queried_object_id() );
 $amp_post_template->load();

--- a/includes/templates/reader-template-loader.php
+++ b/includes/templates/reader-template-loader.php
@@ -32,5 +32,16 @@ do_action( 'pre_amp_render_post', get_queried_object_id() );
 require_once AMP__DIR__ . '/includes/amp-post-template-functions.php';
 amp_post_template_init_hooks();
 
+// Support and load Core block styles.
+current_theme_supports( 'wp-block-styles' );
+add_action(
+	'amp_post_template_head',
+	static function () {
+		global $wp_styles;
+		wp_common_block_scripts_and_styles();
+		$wp_styles->do_items();
+	}
+);
+
 $amp_post_template = new AMP_Post_Template( get_queried_object_id() );
 $amp_post_template->load();

--- a/templates/style.php
+++ b/templates/style.php
@@ -264,15 +264,18 @@ blockquote p:last-child {
 	max-width: 100%;
 }
 
-.amp-wp-article-content amp-img {
+.amp-wp-article-content amp-img,
+.amp-wp-article-content .wp-block-cover {
 	margin: 0 auto;
 }
 
-.amp-wp-article-content amp-img.alignright {
+.amp-wp-article-content amp-img.alignright,
+.amp-wp-article-content .wp-block-cover.alignright {
 	margin: 0 0 1em 16px;
 }
 
-.amp-wp-article-content amp-img.alignleft {
+.amp-wp-article-content amp-img.alignleft,
+.amp-wp-article-content .wp-block-cover.alignleft {
 	margin: 0 16px 1em 0;
 }
 

--- a/templates/style.php
+++ b/templates/style.php
@@ -28,8 +28,21 @@ $border_color            = $this->get_customizer_setting( 'border_color' );
 $link_color              = $this->get_customizer_setting( 'link_color' );
 $header_background_color = $this->get_customizer_setting( 'header_background_color' );
 $header_color            = $this->get_customizer_setting( 'header_color' );
+
+$alignwide_max = $content_max_width > 0 ? $content_max_width * 2 : 1920
 ?>
 /* Generic WP styling */
+
+.alignnone,
+.aligncenter,
+.alignleft,
+.alignright,
+.alignwide {
+	margin-top: 1em;
+	margin-right: auto;
+	margin-bottom: 1em;
+	margin-left: auto;
+}
 
 .alignright {
 	float: right;
@@ -44,6 +57,35 @@ $header_color            = $this->get_customizer_setting( 'header_color' );
 	text-align: center;
 	margin-left: auto;
 	margin-right: auto;
+}
+
+.alignwide {
+	width: 100%;
+}
+
+@media (min-width: calc(840px - 48px)) {
+	.alignwide {
+		width: calc(100vw - 48px);
+		max-width: calc(100vw - 48px);
+		margin-left: calc(50% - 50vw + 24px);
+		margin-right: calc(50% - 50vw + 24px);
+	}
+}
+
+@media (min-width: calc(<?php echo sprintf( '%dpx', $alignwide_max ); ?>)) {
+	.alignwide {
+		width: calc(<?php echo sprintf( '%dpx', $alignwide_max ); ?> - 48px);
+		max-width: calc(<?php echo sprintf( '%dpx', $alignwide_max ); ?> - 48px);
+		margin-left: calc(calc(50% - <?php echo sprintf( '%dpx', $alignwide_max ); ?> / 2) + 24px);
+		margin-right: calc(calc(50% - <?php echo sprintf( '%dpx', $alignwide_max ); ?> / 2) + 24px);
+	}
+}
+
+.alignfull {
+	width: 100vw;
+	max-width: 100vw;
+	margin-left: calc(50% - 50vw);
+	margin-right: calc(50% - 50vw);
 }
 
 .amp-wp-enforced-sizes {
@@ -264,8 +306,7 @@ blockquote p:last-child {
 	max-width: 100%;
 }
 
-.amp-wp-article-content amp-img,
-.amp-wp-article-content .wp-block-cover {
+.amp-wp-article-content amp-img {
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
Load block styles in Reader mode

## Summary

This PR loads block styles in Reader mode via the `'amp_post_template_head'` action:

It also adds the theme support for `'wp-block-styles'`.

The styles are directly printed. Scripts are ignored, as they wouldn't be used in AMP anyway.

Fixes #4297

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).