### PR TITLE
Simplify Stories removal notice text

### DIFF
--- a/includes/admin/class-amp-admin-pointers.php
+++ b/includes/admin/class-amp-admin-pointers.php
@@ -82,7 +82,7 @@ class AMP_Admin_Pointers {
 					'description'     => implode(
 						' ',
 						[
-							esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
+							esc_html__( 'The Stories experience is being extracted into a standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
 							sprintf(
 								'<a href="%s" target="_blank">%s</a>',
 								esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),

--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -593,7 +593,7 @@ class AMP_Options_Manager {
 		) {
 			printf(
 				'<div class="notice notice-warning"><p>%s %s</p></div>',
-				esc_html__( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
+				esc_html__( 'The Stories experience is being extracted into a standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ),
 				sprintf(
 					'<a href="%s" target="_blank">%s</a>',
 					esc_url( 'https://amp-wp.org/documentation/amp-stories/exporting-stories/' ),
@@ -603,7 +603,7 @@ class AMP_Options_Manager {
 		} elseif ( ! self::is_stories_experience_enabled() && 'toplevel_page_' . self::OPTION_NAME === get_current_screen()->id ) {
 			printf(
 				'<div class="notice notice-info"><p>%s</p></div>',
-				esc_html__( 'The Stories experience has been removed from the AMP plugin. This beta feature is being split into a separate standalone plugin which will be available for installation soon.', 'amp' )
+				esc_html__( 'The Stories experience is being extracted into a standalone plugin which will be available soon.', 'amp' )
 			);
 		}
 	}
@@ -628,7 +628,7 @@ class AMP_Options_Manager {
 						    }
 						);
 					} )( window.wp );",
-			wp_json_encode( __( 'The Stories experience is being extracted from the AMP plugin into a separate standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) ),
+			wp_json_encode( __( 'The Stories experience is being extracted into a standalone plugin which will be available soon. Please back up or export your existing Stories as they will not be available in the next version of the AMP plugin.', 'amp' ) ),
 			wp_json_encode( __( 'View how to export your Stories', 'amp' ) )
 		);
 


### PR DESCRIPTION
## Summary

Simplify the message given to users after the Stories experience has been removed. This is the case for users that did not have stories created prior to the removal. 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
