### PR TITLE
Move eligible `@keyframes` rules to `styel[amp-keyframes]`

### DIFF
--- a/src/Component/Keyframes.php
+++ b/src/Component/Keyframes.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Class Keyframes.
+ *
+ * @package Amp\AmpWP
+ */
+
+namespace Amp\AmpWP\Component;
+
+use Sabberworm\CSS\Parser;
+use Sabberworm\CSS\Rule\Rule;
+use Sabberworm\CSS\Settings;
+
+/**
+ * Class Keyframes
+ *
+ * Gets @keyframes rules that can be moved to style[amp-custom], and removes them from the stylesheet.
+ *
+ * @internal
+ * @since 1.5.0
+ */
+final class Keyframes {
+
+	/**
+	 * The stylesheet.
+	 *
+	 * @var string
+	 */
+	private $stylesheet;
+
+	/**
+	 * The whitelist of allowed properties.
+	 *
+	 * @var string[] The allowed properties in the @keyframes rule.
+	 */
+	private $property_whitelist;
+
+	/**
+	 * The @keyframes rules that were removed
+	 *
+	 * @var string
+	 */
+	private $removed_keyframes = '';
+
+	/**
+	 * The index in the stylesheet to start a search for keyframes at.
+	 *
+	 * @var string
+	 */
+	private $pointer = 0;
+
+	/**
+	 * Instantiates the class.
+	 *
+	 * @param string   $stylesheet         The stylesheet to look for the @keyframes in.
+	 * @param string[] $property_whitelist The properties that are allowed in the @keyframes rules.
+	 */
+	public function __construct( $stylesheet, $property_whitelist ) {
+		$this->stylesheet         = $stylesheet;
+		$this->property_whitelist = $property_whitelist;
+	}
+
+	/**
+	 * Gets the eligible removed keyframes.
+	 *
+	 * @return string The removed keyframes that are eligible to be in the style[amp-keyframes].
+	 */
+	public function get_removed_keyframes() {
+		return $this->removed_keyframes;
+	}
+
+	/**
+	 * Gets the stylesheet, which may have eligible @keyframes rules removed.
+	 *
+	 * @return string The stylesheet.
+	 */
+	public function get_stylesheet() {
+		return $this->stylesheet;
+	}
+
+	/**
+	 * Removes @keyframes rules in a stylesheet, if they would be valid in style[amp-keyframes].
+	 *
+	 * To avoid exceeding the limit of the style[amp-custom],
+	 * this removes and returns eligible @keyframes rules to add those to style[amp-keyframes].
+	 * But the style[amp-keyframes] has fewer allowed style properties, so this only removes @keyframes that would be valid.
+	 */
+	public function remove_eligible_keyframes() {
+		while( preg_match( '/@keyframes[^{]+({)/', substr( $this->stylesheet, $this->pointer ), $matches, PREG_OFFSET_CAPTURE ) ) {
+			$keyframes_position     = $matches[0][1];
+			$first_bracket_position = $matches[1][1];
+			$this->possibly_remove_keyframes_at_index( $keyframes_position, $first_bracket_position );
+		}
+
+	}
+
+	/**
+	 * Gets @keyframes rules in a stylesheet, if they exist.
+	 *
+	 * @todo: This should be reworked to parse the stylesheet with Sabberworm, as @keyframes can be nested in @media queries.
+	 * @param int $keyframes_index       The position of the @keyframe in the stylesheet.
+	 * @param int $opening_bracket_index The position of the opening { after @keyframes.
+	 */
+	private function possibly_remove_keyframes_at_index( $keyframes_index, $opening_bracket_index ) {
+		$bracket_count     = 0;
+		$stylesheet_length = strlen( $this->stylesheet );
+		for ( $closing_bracket_index = $opening_bracket_index; $closing_bracket_index < $stylesheet_length; $closing_bracket_index++ ) {
+			$character = substr( $this->stylesheet, $closing_bracket_index, 1 );
+			if ( '{' === $character ) {
+				$bracket_count++;
+			} elseif ( '}' === $character ) {
+				$bracket_count--;
+			}
+
+			if ( 0 === $bracket_count ) {
+				break;
+			}
+		}
+
+		$length    = 1 + $closing_bracket_index - $keyframes_index;
+		$keyframes = substr( $this->stylesheet, $keyframes_index, $length );
+
+		// Conditionally remove the @keyframes rule from the stylesheet.
+		if ( $this->is_valid( $keyframes ) ) {
+			$this->removed_keyframes .= $keyframes;
+			$this->stylesheet         = trim( substr_replace( $this->stylesheet, '', $keyframes_index, $length ) );
+		} else {
+			// Since this @keyframes wasn't valid, move the pointer so that the next search doesn't examine this again.
+			$this->pointer = $closing_bracket_index;
+		}
+	}
+
+	/**
+	 * Gets whether a stylesheet part with @keyframes{ ... } would be valid if moved to the style[amp-keyframes].
+	 *
+	 * @param string $stylesheet_part The part of the stylesheet with @keyframes { ... }.
+	 * @return bool Whether it passes validation to be in the style[amp-keyframes].
+	 */
+	private function is_valid( $stylesheet_part ) {
+		$parser_settings = Settings::create();
+		$css_parser      = new Parser( $stylesheet_part, $parser_settings );
+		$css_document    = $css_parser->parse();
+
+		foreach ( $css_document->getContents() as $css_item ) {
+			foreach ( $css_item->getContents() as $rules ) {
+				$properties = $rules->getRules();
+				if ( ! $this->are_properties_valid( $properties ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets whether all of the properties are in the whitelist.
+	 *
+	 * @param Rule[] $properties The CSS properties.
+	 * @return bool Whether all of the properties are in the whitelist.
+	 */
+	private function are_properties_valid( $properties ) {
+		foreach ( $properties as $property ) {
+			$property_name_without_vendor = preg_replace( '/^-\w+-/', '', $property->getRule() );
+			if ( ! in_array( $property_name_without_vendor, $this->property_whitelist, true ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}

--- a/tests/php/test-amp-keyframes.php
+++ b/tests/php/test-amp-keyframes.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Tests for Keyframes class.
+ *
+ * @package AMP
+ */
+
+use Amp\AmpWP\Component\Keyframes;
+
+/**
+ * Tests for Keyframes class.
+ *
+ * @covers \Amp\AmpWP\Component\Keyframes
+ */
+class Test_Keyframes extends \WP_UnitTestCase {
+
+	/**
+	 * Gets the data for test_remove_eligible_keyframes().
+	 *
+	 * @return array[] The testing data.
+	 */
+	public function get_keyframes_data() {
+		$default_property_whitelist = [
+			'animation-timing-function',
+			'offset-distance',
+			'opacity',
+			'transform',
+			'visibility',
+		];
+
+		return [
+			'eligible_keyframes_moved_to_amp_keyframes' => [
+				'@keyframes visible { from { visibility: visible; } to { visibility: hidden } }',
+				$default_property_whitelist,
+				'',
+				null,
+			],
+			'complex_and_eligible_keyframes'            => [
+				'@keyframes offset { 0% { offset-distance: 0%; } 50% { offset-distance: 50%; opacity: 50%; } 100% { offset-distance: 100%; opacity: 80%; } }',
+				$default_property_whitelist,
+				'',
+				null,
+			],
+			'multiple_keyframes_moved_to_amp_keyframes' => [
+				'@keyframes scale { from { transform: scaleX(0.5); } to { transform: scaleX(1); } } @keyframes rotate { from { transform: rotateY(10deg); } to { transform: rotateY(20deg); } }',
+				$default_property_whitelist,
+				'',
+				'@keyframes scale { from { transform: scaleX(0.5); } to { transform: scaleX(1); } }@keyframes rotate { from { transform: rotateY(10deg); } to { transform: rotateY(20deg); } }',
+			],
+			'non_eligible_keyframes_not_moved'          => [
+				'@keyframes wider { from { width: 20px } to { width: 40px } }',
+				$default_property_whitelist,
+				null,
+				'',
+			],
+			'empty_property_whitelist'                  => [
+				'@keyframes visible { from { visibility: visible } to { visibility: hidden } }',
+				[],
+				null,
+				'',
+			],
+			'non_keyframes_remain_in_stylesheet_while_keyframes_removed' => [
+				'@media screen and ( max-width: 800px; ) { #baz{ background-color #ffffff; } } @keyframes visible { from { visibility: visible; } to { visibility: hidden; } } .foo { margin-bottom: 20px; }',
+				$default_property_whitelist,
+				'@media screen and ( max-width: 800px; ) { #baz{ background-color #ffffff; } }  .foo { margin-bottom: 20px; }',
+				'@keyframes visible { from { visibility: visible; } to { visibility: hidden; } }',
+			],
+		];
+	}
+
+	/**
+	 * Test remove_eligible_keyframes.
+	 *
+	 * @dataProvider get_keyframes_data
+	 * @covers \Amp\AmpWP\Component\Keyframes::remove_eligible_keyframes()
+	 *
+	 * @param string $stylesheet          Stylesheet to evaluate for keyframes.
+	 * @param array  $property_whitelist  Properties that are allowed in the keyframes.
+	 * @param string $expected_stylesheet Expected final stylesheet.
+	 * @param string $expected_keyframes  Expected keyframes that were removed from the stylesheet.
+	 */
+	public function test_remove_eligible_keyframes( $stylesheet, $property_whitelist, $expected_stylesheet, $expected_keyframes ) {
+		if ( null === $expected_stylesheet ) {
+			$expected_stylesheet = $stylesheet;
+		}
+		if ( null === $expected_keyframes ) {
+			$expected_keyframes = $stylesheet;
+		}
+
+		$keyframes = new Keyframes( $stylesheet, $property_whitelist );
+		$keyframes->remove_eligible_keyframes();
+
+		$this->assertEquals( $expected_stylesheet, $keyframes->get_stylesheet() );
+		$this->assertEquals( $expected_keyframes, $keyframes->get_removed_keyframes() );
+	}
+}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -170,10 +170,24 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'allowed_at_rules_retained' => [
-				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } } @keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
+				'<style>@media screen and ( max-width: 640px ) { body { font-size: small; } } @font-face { font-family: "Open Sans"; src: url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2"); } @supports (display: grid) { div { display: grid; } } @-moz-keyframes appear { from { opacity: 0.0; } to { opacity: 1.0; } }</style><div></div>',
 				'<div></div>',
 				[
-					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}@keyframes appear{from{opacity:0}to{opacity:1}}',
+					'@media screen and ( max-width: 640px ){body{font-size:small}}@font-face{font-family:"Open Sans";src:url("/fonts/OpenSans-Regular-webfont.woff2") format("woff2")}@supports (display: grid){div{display:grid}}@-moz-keyframes appear{from{opacity:0}to{opacity:1}}',
+				],
+			],
+
+			'keyframes_eligible_for_style_amp_keyframes_removed' => [
+				'<style>@keyframes offset { 0% { offset-distance: 0% } 50% { offset-distance: 50% } 100% { offset-distance: 100% } }</style><div></div>',
+				'<div></div>',
+				[ '' ],
+			],
+
+			'keyframes_not_eligible_for_style_amp_keyframes_not_removed' => [
+				'<style>@keyframes border { from { border-bottom: 0 } to { border-bottom: 20px } }</style><div></div>',
+				'<div></div>',
+				[
+					'@keyframes border{from{border-bottom:0}to{border-bottom:20px}}',
 				],
 			],
 
@@ -699,10 +713,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'audio{border:solid 1px yellow}',
 				'amp-audio{border:solid 1px yellow}',
 			],
-			'keyframes' => [
+			'keyframes_eligible_for_style_amp_keyframes_removed' => [
 				'<div>test</div>',
 				'span {color:red;} @keyframes foo { from: { opacity:0; } 50% {opacity:0.5} 75%,80% { opacity:0.6 } to { opacity:1 }  }',
-				'@keyframes foo{from:{opacity:0}50%{opacity:.5}75%,80%{opacity:.6}to{opacity:1}}',
+				'',
+			],
+			'keyframes_not_eligible_for_style_amp_custom_not_removed' => [
+				'<div>test</div>',
+				'span {color:red;} @keyframes margin { from: { margin-top:0 } 50% { margin-top:10px } 75%,80% { margin-top:16px } to { margin-top:20px } }',
+				'@keyframes margin{from:{margin-top:0}50%{margin-top:10px}75%,80%{margin-top:16px}to{margin-top:20px}}',
 			],
 			'type_class_names' => [
 				'<audio src="https://example.org/foo.mp3" width="100" height="100" class="audio iframe video img form">',


### PR DESCRIPTION

## Summary
* When a `@keyframes` rule has [valid properties](https://github.com/ampproject/amphtml/blob/c0454f7095a2a07d99e626b9c320f7b302d8541a/validator/validator-main.protoascii#L1560-L1564) for the `style[amp-custom]`, this moves it there.

* Still, this need to be reworked to consider `@media` queries. If a `@keyframes` is wrapped in a `@media` query, it should also be wrapped in it when it's moved to the `style[amp-keyframes]`.

Fixes #1626 

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
