### PR TITLE
Prevent any vendor .git directories from being added to build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,6 +29,7 @@ module.exports = function( grunt ) {
 		'composer.*',
 		'patches',
 		'vendor/*/*/.editorconfig',
+		'vendor/*/*/.git',
 		'vendor/*/*/.gitignore',
 		'vendor/*/*/composer.*',
 		'vendor/*/*/Doxyfile',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,7 @@ module.exports = function( grunt ) {
 		'vendor/*/*/*.yml',
 		'vendor/*/*/.*.yml',
 		'vendor/*/*/tests',
+		'vendor/bin',
 	];
 
 	grunt.initConfig( {


### PR DESCRIPTION
I noticed when doing `npm run build` that the `build` directory was unexpectedly getting `vendor/sabberworm/php-css-parser/.git` added to it. This PR prevents that from happening.

This may be related to #4300.