### PR TITLE
Use get_term() instead of term_exists()

### DIFF
--- a/includes/admin/class-amp-story-templates.php
+++ b/includes/admin/class-amp-story-templates.php
@@ -286,8 +286,10 @@ class AMP_Story_Templates {
 				'meta_box_cb'           => false,
 			]
 		);
+		
+		$located_term = get_term( self::TEMPLATES_TERM, self::TEMPLATES_TAXONOMY );
 
-		if ( ! term_exists( self::TEMPLATES_TERM, self::TEMPLATES_TAXONOMY ) ) {
+		if ( null === $located_term || is_wp_error( $located_term ) ) {
 			wp_insert_term(
 				__( 'Story Template', 'amp' ),
 				self::TEMPLATES_TAXONOMY,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #4337

## Checklist

- [X] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
 -- guidelines link is 404