### PR TITLE
Add DevMode helper and keep devmode nodes during optimization

### DIFF
--- a/includes/sanitizers/class-amp-audio-sanitizer.php
+++ b/includes/sanitizers/class-amp-audio-sanitizer.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
+
 /**
  * Class AMP_Audio_Sanitizer
  *
@@ -61,7 +63,7 @@ class AMP_Audio_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback, or it has a dev mode exemption.
-			if ( $this->is_inside_amp_noscript( $node ) || $this->has_dev_mode_exemption( $node ) ) {
+			if ( $this->is_inside_amp_noscript( $node ) || DevMode::hasExemptionForNode( $node ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
 use AmpProject\Dom\Document;
 
 /**
@@ -412,12 +413,13 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @since 1.3
 	 *
+	 * @deprecated Use AmpProject\DevMode::isActiveForDocument( $document ) instead.
+	 *
 	 * @return bool Whether the document is in dev mode.
 	 */
 	protected function is_document_in_dev_mode() {
-		return $this->dom->documentElement->hasAttribute(
-			AMP_Rule_Spec::DEV_MODE_ATTRIBUTE
-		);
+		_deprecated_function( 'AMP_Base_Sanitizer::is_document_in_dev_mode', '1.5', 'AmpProject\DevMode::isActiveForDocument' );
+		return DevMode::isActiveForDocument( $this->dom );
 	}
 
 	/**
@@ -425,25 +427,27 @@ abstract class AMP_Base_Sanitizer {
 	 *
 	 * @since 1.3
 	 *
+	 * @deprecated Use AmpProject\DevMode::hasExemptionForNode( $node ) instead.
+	 *
 	 * @param DOMNode $node Node to check.
 	 * @return bool Whether the node should be exempt during dev mode.
 	 */
 	protected function has_dev_mode_exemption( DOMNode $node ) {
-		if ( ! $node instanceof DOMElement ) {
-			return false;
-		}
-
-		return $node->hasAttribute( AMP_Rule_Spec::DEV_MODE_ATTRIBUTE );
+		_deprecated_function( 'AMP_Base_Sanitizer::has_dev_mode_exemption', '1.5', 'AmpProject\DevMode::hasExemptionForNode' );
+		return DevMode::hasExemptionForNode( $node );
 	}
 
 	/**
 	 * Check whether a certain node should be exempt from validation.
 	 *
+	 * @deprecated Use AmpProject\DevMode::isExemptFromValidation( $node ) instead.
+	 *
 	 * @param DOMNode $node Node to check.
 	 * @return bool Whether the node should be exempt from validation.
 	 */
 	protected function is_exempt_from_validation( DOMNode $node ) {
-		return $this->is_document_in_dev_mode() && $this->has_dev_mode_exemption( $node );
+		_deprecated_function( 'AMP_Base_Sanitizer::is_exempt_from_validation', '1.5', 'AmpProject\DevMode::isExemptFromValidation' );
+		return DevMode::isExemptFromValidation( $node );
 	}
 
 	/**

--- a/includes/sanitizers/class-amp-base-sanitizer.php
+++ b/includes/sanitizers/class-amp-base-sanitizer.php
@@ -463,7 +463,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @return bool Whether the node should have been removed, that is, that the node was sanitized for validity.
 	 */
 	public function remove_invalid_child( $node, $validation_error = [] ) {
-		if ( $this->is_exempt_from_validation( $node ) ) {
+		if ( DevMode::isExemptFromValidation( $node ) ) {
 			return false;
 		}
 
@@ -496,7 +496,7 @@ abstract class AMP_Base_Sanitizer {
 	 * @return bool Whether the node should have been removed, that is, that the node was sanitized for validity.
 	 */
 	public function remove_invalid_attribute( $element, $attribute, $validation_error = [], $attr_spec = [] ) {
-		if ( $this->is_exempt_from_validation( $element ) ) {
+		if ( DevMode::isExemptFromValidation( $element ) ) {
 			return false;
 		}
 

--- a/includes/sanitizers/class-amp-form-sanitizer.php
+++ b/includes/sanitizers/class-amp-form-sanitizer.php
@@ -6,6 +6,8 @@
  * @since 0.7
  */
 
+use AmpProject\DevMode;
+
 /**
  * Class AMP_Form_Sanitizer
  *
@@ -46,7 +48,7 @@ class AMP_Form_Sanitizer extends AMP_Base_Sanitizer {
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
-			if ( ! $node instanceof DOMElement || $this->has_dev_mode_exemption( $node ) ) {
+			if ( ! $node instanceof DOMElement || DevMode::hasExemptionForNode( $node ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-iframe-sanitizer.php
+++ b/includes/sanitizers/class-amp-iframe-sanitizer.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
+
 /**
  * Class AMP_Iframe_Sanitizer
  *
@@ -94,7 +96,7 @@ class AMP_Iframe_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback, or if it has a dev mode exemption.
-			if ( $this->is_inside_amp_noscript( $node ) || $this->has_dev_mode_exemption( $node ) ) {
+			if ( $this->is_inside_amp_noscript( $node ) || DevMode::hasExemptionForNode( $node ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-img-sanitizer.php
+++ b/includes/sanitizers/class-amp-img-sanitizer.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
+
 /**
  * Class AMP_Img_Sanitizer
  *
@@ -97,7 +99,7 @@ class AMP_Img_Sanitizer extends AMP_Base_Sanitizer {
 
 		for ( $i = $num_nodes - 1; $i >= 0; $i-- ) {
 			$node = $nodes->item( $i );
-			if ( ! $node instanceof DOMElement || $this->has_dev_mode_exemption( $node ) ) {
+			if ( ! $node instanceof DOMElement || DevMode::hasExemptionForNode( $node ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-script-sanitizer.php
+++ b/includes/sanitizers/class-amp-script-sanitizer.php
@@ -6,6 +6,8 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
+
 /**
  * Class AMP_Script_Sanitizer
  *
@@ -39,7 +41,7 @@ class AMP_Script_Sanitizer extends AMP_Base_Sanitizer {
 			 * Skip noscript elements inside of amp-img or other AMP components for fallbacks.
 			 * See \AMP_Img_Sanitizer::adjust_and_replace_node(). Also skip if the element has dev mode.
 			 */
-			if ( 'amp-' === substr( $noscript->parentNode->nodeName, 0, 4 ) || $this->has_dev_mode_exemption( $noscript ) ) {
+			if ( 'amp-' === substr( $noscript->parentNode->nodeName, 0, 4 ) || DevMode::hasExemptionForNode( $noscript ) ) {
 				continue;
 			}
 

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
 use AmpProject\Dom\Document;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\CSSList\CSSList;
@@ -811,7 +812,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		 */
 
 		$dev_mode_predicate = '';
-		if ( $this->is_document_in_dev_mode() ) {
+		if ( DevMode::isActiveForDocument( $this->dom ) ) {
 			$dev_mode_predicate = sprintf( ' and not ( @%s )', AMP_Rule_Spec::DEV_MODE_ATTRIBUTE );
 		}
 

--- a/includes/sanitizers/class-amp-video-sanitizer.php
+++ b/includes/sanitizers/class-amp-video-sanitizer.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+use AmpProject\DevMode;
+
 /**
  * Class AMP_Video_Sanitizer
  *
@@ -70,7 +72,7 @@ class AMP_Video_Sanitizer extends AMP_Base_Sanitizer {
 			$node = $nodes->item( $i );
 
 			// Skip element if already inside of an AMP element as a noscript fallback, or if the element is in dev mode.
-			if ( $this->is_inside_amp_noscript( $node ) || $this->has_dev_mode_exemption( $node ) ) {
+			if ( $this->is_inside_amp_noscript( $node ) || DevMode::hasExemptionForNode( $node ) ) {
 				continue;
 			}
 

--- a/lib/common/src/DevMode.php
+++ b/lib/common/src/DevMode.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace AmpProject;
+
+use AmpProject\Dom\Document;
+use DOMDocument;
+use DOMElement;
+use DOMNode;
+
+/**
+ * Helper functionality to deal with AMP dev-mode.
+ *
+ * @link    https://github.com/ampproject/amphtml/issues/20974
+ *
+ * @package ampproject/common
+ */
+final class DevMode
+{
+
+    /**
+     * Attribute name for AMP dev mode.
+     *
+     * @var string
+     */
+    const DEV_MODE_ATTRIBUTE = 'data-ampdevmode';
+
+    /**
+     * Check whether the provided document is in dev mode.
+     *
+     * @param DOMDocument $document Document for which to check whether dev mode is active.
+     * @return bool Whether the document is in dev mode.
+     */
+    public static function isActiveForDocument(DOMDocument $document)
+    {
+        if (! $document instanceof Document) {
+            $document = Document::fromNode($document);
+        }
+
+        return $document->documentElement->hasAttribute(self::DEV_MODE_ATTRIBUTE);
+    }
+
+    /**
+     * Check whether a node is exempt from validation during dev mode.
+     *
+     * @param DOMNode $node Node to check.
+     * @return bool Whether the node should be exempt during dev mode.
+     */
+    public static function hasExemptionForNode(DOMNode $node)
+    {
+        if (! $node instanceof DOMElement) {
+            return false;
+        }
+
+        return $node->hasAttribute(self::DEV_MODE_ATTRIBUTE);
+    }
+
+    /**
+     * Check whether a certain node should be exempt from validation.
+     *
+     * @param DOMNode $node Node to check.
+     * @return bool Whether the node should be exempt from validation.
+     */
+    public static function isExemptFromValidation(DOMNode $node)
+    {
+        $document = $node instanceof Document ? $node : $node->ownerDocument;
+
+        if (! $document) {
+            return false;
+        }
+
+        return self::isActiveForDocument($document) && self::hasExemptionForNode($node);
+    }
+}

--- a/lib/common/tests/DevModeTest.php
+++ b/lib/common/tests/DevModeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace AmpProject\Common;
+
+use AmpProject\DevMode;
+use AmpProject\Dom\Document;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for AmpProject\DevMode.
+ *
+ * @covers  \AmpProject\DevMode
+ * @package ampproject/common
+ */
+class DevModeTest extends TestCase
+{
+
+    public function dataIsActiveForDocument()
+    {
+        return [
+            [ '<html><body></body></html>', false ],
+            [ '<html data-ampdevmode><body></body></html>', true ],
+        ];
+    }
+
+    /** @dataProvider dataIsActiveForDocument */
+    public function testIsActiveForDocument($html, $expected)
+    {
+        $document = Document::fromHtml($html);
+        $this->assertEquals($expected, DevMode::isActiveForDocument($document));
+    }
+
+    public function dataHasExemptionForNode()
+    {
+        return [
+            [ '<html><body id="node_to_test"><div data-ampdevmode></div></body></html>', false ],
+            [ '<html><body><div id="node_to_test" data-ampdevmode></div></body></html>', true ],
+        ];
+    }
+
+    /** @dataProvider dataHasExemptionForNode */
+    public function testHasExemptionForNode($html, $expected)
+    {
+        $document = Document::fromHtml($html);
+        $node = $document->xpath->query('//*[@id="node_to_test"]')->item(0);
+        $this->assertEquals($expected, DevMode::hasExemptionForNode($node));
+    }
+
+    public function dataIsExemptFromValidation()
+    {
+        return [
+            [ '<html><body id="node_to_test"><div data-ampdevmode></div></body></html>', false ],
+            [ '<html><body><div id="node_to_test" data-ampdevmode></div></body></html>', false ],
+            [ '<html data-ampdevmode><body id="node_to_test"><div data-ampdevmode></div></body></html>', false ],
+            [ '<html data-ampdevmode><body><div id="node_to_test" data-ampdevmode></div></body></html>', true ],
+        ];
+    }
+
+    /** @dataProvider dataIsExemptFromValidation */
+    public function testIsExemptFromValidation($html, $expected)
+    {
+        $document = Document::fromHtml($html);
+        $node = $document->xpath->query('//*[@id="node_to_test"]')->item(0);
+        $this->assertEquals($expected, DevMode::isExemptFromValidation($node));
+    }
+}

--- a/lib/optimizer/src/Transformer/AmpBoilerplate.php
+++ b/lib/optimizer/src/Transformer/AmpBoilerplate.php
@@ -4,6 +4,7 @@ namespace AmpProject\Optimizer\Transformer;
 
 use AmpProject\Amp;
 use AmpProject\Attribute;
+use AmpProject\DevMode;
 use AmpProject\Dom\Document;
 use AmpProject\Optimizer\ErrorCollection;
 use AmpProject\Optimizer\Transformer;
@@ -74,9 +75,10 @@ final class AmpBoilerplate implements Transformer
     private function removeStyleAndNoscriptTags(Document $document)
     {
         $headNode = $document->head->firstChild;
+        $devMode = DevMode::isActiveForDocument($document);
         while ($headNode) {
             $nextSibling = $headNode->nextSibling;
-            if ($headNode instanceof DOMElement) {
+            if ($headNode instanceof DOMElement && (! $devMode || ! DevMode::hasExemptionForNode($headNode))) {
                 switch ($headNode->tagName) {
                     case Tag::STYLE:
                         if (! $headNode->hasAttribute(Attribute::AMP_CUSTOM)) {

--- a/lib/optimizer/tests/Transformer/AmpBoilerplateTest.php
+++ b/lib/optimizer/tests/Transformer/AmpBoilerplateTest.php
@@ -106,6 +106,16 @@ final class AmpBoilerplateTest extends TestCase
                 $inputWithoutBoilerplate('<html ⚡4email>'),
                 $expected('<html ⚡4email>', $amp4EmailBoilerplate),
             ],
+
+            'keeps devmode nodes when in devmode' => [
+                $inputWithBoilerplate('<html ⚡ data-ampdevmode>', '<style data-ampdevmode>h1: red;</style>' . $ampBoilerplate),
+                $expected('<html ⚡ data-ampdevmode>', '<style data-ampdevmode>h1: red;</style>' . $ampBoilerplate),
+            ],
+
+            'removes devmode nodes when not in devmode' => [
+                $inputWithBoilerplate('<html ⚡>', '<style data-ampdevmode>h1: red;</style>' . $ampBoilerplate),
+                $expected('<html ⚡>', $ampBoilerplate),
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary

This PR makes the following changes:

- Adds a new `AmpProject\DevMode` helper class (with tests);
- Deprecates the devmode-related methods in `AMP_Base_Sanitizer`;
- Moves usage of the deprecated `AMP_Base_Sanitizer` methods over to the new `AmpProject\DevMode` helper class;
- Ensures that the `AmpBoilerplate` transformer does not remove nodes that are marked as being in devmode.

The `AmpProject\DevMode` helper class was introduced (and the `AMP_BaseSanitizer` code deprecated) because the `ampproject/optimizer` cannot have a dependency pointing to the plugin package. Dependencies can only ever be allowed the other way around.

Fixes #4369

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).