### PR TITLE
Remove dotenv config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,6 @@
 
 module.exports = function( grunt ) {
 	'use strict';
-	require( 'dotenv' ).config();
 
 	// Root paths to include in the plugin build ZIP when running `npm run build`.
 	const productionIncludedRootFiles = [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,8 +41,6 @@ module.exports = function( grunt ) {
 		'vendor/*/*/tests',
 		'vendor/ampproject/optimizer/bin',
 		'vendor/bin',
-		'vendor/ampproject/common/vendor',
-		'vendor/ampproject/optimizer/vendor',
 	];
 
 	grunt.initConfig( {
@@ -75,6 +73,8 @@ module.exports = function( grunt ) {
 				command: [
 					'if [ ! -e build ]; then echo "Run grunt build first."; exit 1; fi',
 					'cd build',
+					'if [ -d vendor/ampproject/common/vendor ]; then rm -r vendor/ampproject/common/vendor; fi',
+					'if [ -d vendor/ampproject/optimizer/vendor ]; then rm -r vendor/ampproject/optimizer/vendor; fi',
 					'composer install --no-dev -o',
 					'for symlinksource in $(find vendor/ampproject -type l); do symlinktarget=$(readlink "$symlinksource") && rm "$symlinksource" && cp -r "vendor/ampproject/$symlinktarget" "$symlinksource"; done',
 					'composer remove cweagans/composer-patches --update-no-dev -o',


### PR DESCRIPTION
Amends #4315 for something that was missed in 318d78d4232dd4e7df0896bf3f63740a0c949f31.

Without this change, I get an error when doing `npm run build`:

```
Loading "Gruntfile.js" tasks...ERROR
>> Error: Cannot find module 'dotenv'
>> Require stack:
>> - /app/public/content/plugins/amp/Gruntfile.js
>> - /app/public/content/plugins/amp/node_modules/grunt/lib/grunt/task.js
>> - /app/public/content/plugins/amp/node_modules/grunt/lib/grunt.js
>> - /app/public/content/plugins/amp/node_modules/grunt/node_modules/grunt-cli/bin/grunt
>> - /app/public/content/plugins/amp/node_modules/grunt/bin/grunt
```

With the line removed, the build succeeds.