### PR TITLE
Exclude processing style attributes inside of Mustache templates

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2523,15 +2523,15 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @note Uses recursion to traverse down the tree of Dom\Document nodes.
 	 *
-	 * @param DOMElement $element Node.
+	 * @param DOMElement $element Element with a style attribute.
 	 */
-	private function collect_inline_styles( $element ) {
-		$style_attribute = $element->getAttributeNode( 'style' );
-		if ( empty( $style_attribute ) ) {
+	private function collect_inline_styles( DOMElement $element ) {
+		$attr_node = $element->getAttributeNode( 'style' );
+		if ( ! $attr_node ) {
 			return;
 		}
 
-		$value = trim( $style_attribute->nodeValue );
+		$value = trim( $attr_node->nodeValue );
 		if ( empty( $value ) ) {
 			return;
 		}
@@ -2546,7 +2546,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 
 		$class = 'amp-wp-' . substr( md5( $value ), 0, 7 );
 		$root  = ':root' . str_repeat( ':not(#_)', self::INLINE_SPECIFICITY_MULTIPLIER );
-		$rule  = sprintf( '%s .%s { %s }', $root, $class, $style_attribute->nodeValue );
+		$rule  = sprintf( '%s .%s { %s }', $root, $class, $value );
 
 		$this->set_current_node( $element ); // And sources when needing to be located.
 
@@ -2570,7 +2570,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				'element'       => $element,
 				'origin'        => 'style_attribute',
 				'sources'       => $this->current_sources,
-				'priority'      => $this->get_stylesheet_priority( $style_attribute ),
+				'priority'      => $this->get_stylesheet_priority( $attr_node ),
 				'tokens'        => $parsed['tokens'],
 				'hash'          => $parsed['hash'],
 				'parse_time'    => $parsed['parse_time'],

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -1238,7 +1238,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 
 			// Check the context to see if we are currently within a template tag.
 			// If this is the case and the attribute value contains a template placeholder, we skip sanitization.
-			if ( ! empty( $this->open_elements['template'] ) && preg_match( '/{{.*?}}/', $attr_node->nodeValue ) ) {
+			if ( ! empty( $this->open_elements['template'] ) && preg_match( '/{{[^}]+?}}/', $attr_node->nodeValue ) ) {
 				continue;
 			}
 

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -68,10 +68,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'span_two_styles_reversed' => [
-				'<span style="color: #00ff00; background-color: #000; ">This is green.</span>',
-				'<span data-amp-original-style="color: #00ff00; background-color: #000; " class="amp-wp-c71affe">This is green.</span>',
+				'<span style="color: #00ff00; background-color: #000;">This is green.</span>',
+				'<span data-amp-original-style="color: #00ff00; background-color: #000;" class="amp-wp-be0c539">This is green.</span>',
 				[
-					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-c71affe{color:#0f0;background-color:#000}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-be0c539{color:#0f0;background-color:#000}',
 				],
 			],
 
@@ -247,6 +247,39 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					'@media (max-width: 450px){.sidebar{padding:0}}.sidebar{margin:0 auto}',
 				],
 			],
+			'with_mustache_template' => [
+				'
+				<style>
+				.custom-population { color: red; }
+				</style>
+				<form id="myform" role="search" class="search-form" method="get" action="https://example.com/" target="_top" style="color: blue">
+					<amp-autocomplete filter="substring" items="." filter-value="title" max-entries="6" min-characters="2" submit-on-enter="" src="https://example.com/autocomplete/">
+						<template type="amp-mustache" id="amp-template-custom">
+							<div class="city-item" data-value="{{city}}, {{state}}">
+								<div style="color: {{regionColor}}">{{city}}, {{state}}</div>
+								<div class="custom-population">Population: {{population}}</div>
+							</div>
+						</template>
+					</amp-autocomplete>
+				</form>
+				',
+				'
+				<form id="myform" role="search" class="search-form amp-wp-f2a1aff" method="get" action="https://example.com/" target="_top" data-amp-original-style="color: blue">
+					<amp-autocomplete filter="substring" items="." filter-value="title" max-entries="6" min-characters="2" submit-on-enter="" src="https://example.com/autocomplete/">
+						<template type="amp-mustache" id="amp-template-custom">
+							<div class="city-item" data-value="{{city}}, {{state}}">
+								<div style="color: {{regionColor}}">{{city}}, {{state}}</div>
+								<div class="custom-population">Population: {{population}}</div>
+							</div>
+						</template>
+					</amp-autocomplete>
+				</form>
+				',
+				[
+					'.custom-population{color:red}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-f2a1aff{color:blue}',
+				],
+			],
 		];
 	}
 
@@ -274,8 +307,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		// Test content.
 		$content = AMP_DOM_Utils::get_content_from_dom( $dom );
-		$content = preg_replace( '/(?<=>)\s+(?=<)/', '', $content );
-		$this->assertEquals( $expected_content, $content );
+		$this->assertEqualMarkup( $expected_content, $content );
 
 		// Test stylesheet.
 		$this->assertEquals( $expected_stylesheets, array_values( $sanitizer->get_stylesheets() ) );
@@ -2576,5 +2608,23 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	public function test_get_styles() {
 		$sanitizer = new AMP_Style_Sanitizer( new Document() );
 		$this->assertEquals( [], $sanitizer->get_styles() );
+	}
+
+	/**
+	 * Assert markup is equal.
+	 *
+	 * @param string $expected Expected markup.
+	 * @param string $actual   Actual markup.
+	 */
+	public function assertEqualMarkup( $expected, $actual ) {
+		$actual   = preg_replace( '/\s+/', ' ', $actual );
+		$expected = preg_replace( '/\s+/', ' ', $expected );
+		$actual   = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $actual ) );
+		$expected = preg_replace( '/(?<=>)\s+(?=<)/', '', trim( $expected ) );
+
+		$this->assertEquals(
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $expected, -1, PREG_SPLIT_DELIM_CAPTURE ) ),
+			array_filter( preg_split( '#(<[^>]+>|[^<>]+)#', $actual, -1, PREG_SPLIT_DELIM_CAPTURE ) )
+		);
 	}
 }

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -255,7 +255,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				<form id="myform" role="search" class="search-form" method="get" action="https://example.com/" target="_top" style="color: blue">
 					<amp-autocomplete filter="substring" items="." filter-value="title" max-entries="6" min-characters="2" submit-on-enter="" src="https://example.com/autocomplete/">
 						<template type="amp-mustache" id="amp-template-custom">
-							<div class="city-item" data-value="{{city}}, {{state}}">
+							<div class="city-item" data-value="{{city}}, {{state}}" style="outline: solid 1px black;">
 								<div style="color: {{regionColor}}">{{city}}, {{state}}</div>
 								<div class="custom-population">Population: {{population}}</div>
 							</div>
@@ -267,7 +267,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				<form id="myform" role="search" class="search-form amp-wp-f2a1aff" method="get" action="https://example.com/" target="_top" data-amp-original-style="color: blue">
 					<amp-autocomplete filter="substring" items="." filter-value="title" max-entries="6" min-characters="2" submit-on-enter="" src="https://example.com/autocomplete/">
 						<template type="amp-mustache" id="amp-template-custom">
-							<div class="city-item" data-value="{{city}}, {{state}}">
+							<div class="city-item amp-wp-d4ea4c7" data-value="{{city}}, {{state}}" data-amp-original-style="outline: solid 1px black;">
 								<div style="color: {{regionColor}}">{{city}}, {{state}}</div>
 								<div class="custom-population">Population: {{population}}</div>
 							</div>
@@ -278,6 +278,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'.custom-population{color:red}',
 					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-f2a1aff{color:blue}',
+					':root:not(#_):not(#_):not(#_):not(#_):not(#_) .amp-wp-d4ea4c7{outline:solid 1px black}',
 				],
 			],
 		];


### PR DESCRIPTION
## Summary

As reported in a [support topic](https://wordpress.org/support/topic/amp-autocomplete-inline-style-not-rendering/) by @artneo7, there is an issue with the style sanitizer in how it handles inline `style` attributes that appear inside of Mustache `template` elements. Consider this markup:

```html
<form id="myform" role="search" class="search-form" method="get" action="https://example.com/" target="_top">
	<amp-autocomplete filter="substring" items="." filter-value="title" max-entries="6" min-characters="2" submit-on-enter="" src="https://example.com/autocomplete/">
		<template type="amp-mustache" id="amp-template-custom">
			<div class="city-item" data-value="{{city}}, {{state}}">
				<div style="color: {{regionColor}}">{{city}}, {{state}}</div>
				<div class="custom-population">Population: {{population}}</div>
			</div>
		</template>
	</amp-autocomplete>
</form>
```

Note specifically `<div style="color: {{regionColor}}">{{city}}, {{state}}</div>`.

At the moment, the AMP plugin is trying to extract this inline `style` to be added to the `amp-custom` stylesheet, leaving behind a CSS class:

```html
<form id="myform" role="search" class="search-form" method="get" action="https://example.com/" target="_top">
	<amp-autocomplete filter="substring" items="." filter-value="title" max-entries="6" min-characters="2" submit-on-enter="" src="https://example.com/autocomplete/">
		<template type="amp-mustache" id="amp-template-custom">
			<div class="city-item" data-value="{{city}}, {{state}}">
				<div class="amp-wp-88b51c5">{{city}}, {{state}}</div>
				<div class="custom-population">Population: {{population}}</div>
			</div>
		</template>
	</amp-autocomplete>
</form>
```

But no CSS rule for `.amp-wp-88b51c5 { color:: {{regionColor}} }` appears in `style[amp-custom]`, which of course it shouldn't be cause: (1) it's a syntax error and (2) it doesn't make sense outside of a mustache `template` anyway.

In this special case, the style sanitizer needs to prevent converting inline `style` attributes to be part of `style[amp-custom]`. The reality is that AMP now allows for inline `style` attributes as long as they aren't `!important`. (See also #1313.) Since we can't move the style to `style[amp-custom]` it's fine to leave it in place. The reason for always moving inline `style` elements even when not `!important` is to preserve the relative CSS cascade (see https://github.com/ampproject/amp-wp/issues/1313#issuecomment-535731938), but in the case of styles appearing in Mustache templates the concern is minimized because the author already indicates they are writing AMP markup, and so it will be up to them to ensure the inline `style` is fine to have the final word.

With the changes in this PR, inline `style` attributes that contain Mustache variable tags are left unchanged.

Relates to #4276 and #3137.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
