### PR TITLE
Move eligible viewport rules to `meta[name="viewport"]`

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -261,23 +261,12 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * Get the acceptable validation errors.
 	 *
 	 * @since 1.0
+	 * @deprecated Now unused.
 	 *
-	 * @param string $template Template.
 	 * @return array Acceptable errors.
 	 */
-	public static function get_acceptable_errors( $template ) {
-		if ( in_array( $template, self::$supported_themes, true ) ) {
-			return [
-				AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE => [
-					[
-						'at_rule' => 'viewport',
-					],
-					[
-						'at_rule' => '-ms-viewport',
-					],
-				],
-			];
-		}
+	public static function get_acceptable_errors() {
+		_deprecated_function( __METHOD__, '1.5' );
 		return [];
 	}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -261,7 +261,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * Get the acceptable validation errors.
 	 *
 	 * @since 1.0
-	 * @deprecated Now unused.
+	 * @deprecated Now unused because viewport CSS at-rules are extracted from stylesheets into meta[name=viewport] tags.
 	 *
 	 * @return array Acceptable errors.
 	 */

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -135,10 +135,8 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 	 * The viewport defaults to 'width=device-width', which is the bare minimum that AMP requires.
 	 */
 	protected function ensure_viewport_is_present() {
-		$viewport_rules = $this->get_valid_viewport_rules( AMP_Style_Sanitizer::get_extracted_viewport_rules() );
-
 		if ( empty( $this->meta_tags[ self::TAG_VIEWPORT ] ) ) {
-			$this->meta_tags[ self::TAG_VIEWPORT ][] = $this->create_viewport_element( $viewport_rules );
+			$this->meta_tags[ self::TAG_VIEWPORT ][] = $this->create_viewport_element( static::AMP_VIEWPORT );
 		}
 		// @todo: In an else block, add $viewport rules to the existing meta[name="viewport"], prioritizing the existing ones.
 	}

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -139,7 +139,9 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 			$this->meta_tags[ self::TAG_VIEWPORT ][] = $this->create_viewport_element( static::AMP_VIEWPORT );
 		} else {
 			$parsed_rules = [];
-			foreach ( $this->meta_tags[ self::TAG_VIEWPORT ] as $meta_viewport ) {
+
+			// Reverse the meta[name="viewport"] tags, so original meta[name="viewport"] tags have precedence @viewport style rules.
+			foreach ( array_reverse( $this->meta_tags[ self::TAG_VIEWPORT ] ) as $meta_viewport ) {
 				$viewport_content = explode( ',', $meta_viewport->getAttribute( 'content' ) );
 				foreach ( $viewport_content as $rule ) {
 					list( $name, $value )          = explode( '=', $rule, 2 );
@@ -155,7 +157,7 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 	/**
 	 * Gets the viewport rules that would be valid in meta[name="viewport"].
 	 *
-	 * @link https://github.com/ampproject/amphtml/blob/5f75efe35b734a4fcf0884d373315d
+	 * @link https://github.com/ampproject/amphtml/blob/6b439aec75c1d9b52ba19435f6730b27a457bf42/validator/validator-main.protoascii#L436-L445
 	 *
 	 * @param array $rules The rules to evaluate, an associative array of $rule_name => $rule_value.
 	 * @return string The rules of those that are valid.

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -180,7 +180,7 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 		}
 
 		if ( ! isset( $allowed_meta_spec ) ) {
-			return '';
+			return static::AMP_VIEWPORT;
 		}
 
 		$valid_rules = [];

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -147,12 +147,12 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( array_reverse( $this->meta_tags[ self::TAG_VIEWPORT ] ) as $meta_viewport ) {
 				$viewport_content = explode( ',', $meta_viewport->getAttribute( 'content' ) );
 				foreach ( $viewport_content as $rule ) {
-					$exploded_rules = explode( '=', $rule, 2 );
-					if ( ! isset( $exploded_rules[1] ) ) {
+					$exploded_rule = explode( '=', $rule, 2 );
+					if ( ! isset( $exploded_rule[1] ) ) {
 						continue;
 					}
 
-					list( $name, $value )          = $exploded_rules;
+					list( $name, $value )          = $exploded_rule;
 					$parsed_rules[ trim( $name ) ] = trim( $value );
 				}
 			}
@@ -189,7 +189,7 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
-			// If the spec for the attribute has a mandatory value, like width="device-width", ensure it has that value.
+			// If the spec for the attribute has a mandatory value, like width="device-width", ensure it has the right value.
 			if ( isset( $allowed_meta_spec[ $rule_name ]['value'] ) && $rule_value !== $allowed_meta_spec[ $rule_name ]['value'] ) {
 				continue;
 			}

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -147,7 +147,12 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 			foreach ( array_reverse( $this->meta_tags[ self::TAG_VIEWPORT ] ) as $meta_viewport ) {
 				$viewport_content = explode( ',', $meta_viewport->getAttribute( 'content' ) );
 				foreach ( $viewport_content as $rule ) {
-					list( $name, $value )          = explode( '=', $rule, 2 );
+					$exploded_rules = explode( '=', $rule, 2 );
+					if ( ! isset( $exploded_rules[1] ) ) {
+						continue;
+					}
+
+					list( $name, $value )          = $exploded_rules;
 					$parsed_rules[ trim( $name ) ] = trim( $value );
 				}
 			}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1444,7 +1444,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$parsed      = null;
 		$cache_key   = null;
 		$cached      = true;
-		$cache_group = 'amp-parsed-stylesheet-v26'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
+		$cache_group = 'amp-parsed-stylesheet-v27'; // This should be bumped whenever the PHP-CSS-Parser is updated or parsed format is updated.
 
 		$cache_impacting_options = array_merge(
 			wp_array_slice_assoc(
@@ -3309,6 +3309,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param array      $viewport_rules An associative array of $rule_name => $rule_value.
 	 */
 	private function create_meta_viewport( DOMElement $element, $viewport_rules ) {
+		if ( empty( $viewport_rules ) ) {
+			return;
+		}
 		$viewport_meta = $this->dom->createElement( 'meta' );
 		$viewport_meta->setAttribute( 'name', 'viewport' );
 		$viewport_meta->setAttribute(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -2031,17 +2031,19 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			} elseif ( $css_item instanceof Import ) {
 				$imported_stylesheet = $this->splice_imported_stylesheet( $css_item, $css_list, $options );
 
-				if ( ! empty( $imported_stylesheet['imported_font_urls'] ) ) {
+				if ( isset( $imported_stylesheet['imported_font_urls'] ) ) {
 					$imported_font_urls = array_merge(
 						$imported_font_urls,
 						$imported_stylesheet['imported_font_urls']
 					);
 				}
 
-				$results = array_merge(
-					$results,
-					$imported_stylesheet['validation_errors']
-				);
+				if ( isset( $imported_stylesheet['validation_errors'] ) ) {
+					$results = array_merge(
+						$results,
+						$imported_stylesheet['validation_errors']
+					);
+				}
 			} elseif ( $css_item instanceof AtRuleSet ) {
 				if ( in_array( $css_item->atRuleName(), $this->allowed_viewport_rules, true ) ) {
 					$output_format = new OutputFormat();

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -297,13 +297,6 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	private $selector_mappings = [];
 
 	/**
-	 * The allowed viewport rules that can be extracted and moved to meta[name="viewport"].
-	 *
-	 * @var array
-	 */
-	private $allowed_viewport_rules = [ 'viewport', '-ms-viewport', '-o-viewport' ];
-
-	/**
 	 * Elements in extensions which use the video-manager, and thus the video-autoplay.css.
 	 *
 	 * @var array
@@ -2016,7 +2009,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				$imported_font_urls  = array_merge( $imported_font_urls, $imported_stylesheet['imported_font_urls'] );
 				$validation_errors   = array_merge( $validation_errors, $imported_stylesheet['validation_errors'] );
 			} elseif ( $css_item instanceof AtRuleSet ) {
-				if ( in_array( $css_item->atRuleName(), $this->allowed_viewport_rules, true ) ) {
+				if ( preg_match( '/^(-.+-)?viewport$/', $css_item->atRuleName() ) ) {
 					$output_format = new OutputFormat();
 					foreach ( $css_item->getRules() as $rule ) {
 						$rule_value = $rule->getValue();

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1212,7 +1212,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			]
 		);
 
-		$this->maybe_create_meta_viewport( $element, $parsed['viewport_rules'] );
+		if ( $parsed['viewport_rules'] ) {
+			$this->create_meta_viewport( $element, $parsed['viewport_rules'] );
+		}
 
 		$this->pending_stylesheets[] = [
 			'group'              => $is_keyframes ? self::STYLE_AMP_KEYFRAMES_GROUP_INDEX : self::STYLE_AMP_CUSTOM_GROUP_INDEX,
@@ -1310,7 +1312,9 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			]
 		);
 
-		$this->maybe_create_meta_viewport( $element, $parsed['viewport_rules'] );
+		if ( $parsed['viewport_rules'] ) {
+			$this->create_meta_viewport( $element, $parsed['viewport_rules'] );
+		}
 
 		$this->pending_stylesheets[] = [
 			'group'              => self::STYLE_AMP_CUSTOM_GROUP_INDEX,
@@ -3300,11 +3304,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 	 * @param DOMElement $element        An element.
 	 * @param array      $viewport_rules An associative array of $rule_name => $rule_value.
 	 */
-	private function maybe_create_meta_viewport( $element, $viewport_rules ) {
-		if ( empty( $viewport_rules ) ) {
-			return;
-		}
-
+	private function create_meta_viewport( DOMElement $element, $viewport_rules ) {
 		$viewport_meta = $this->dom->createElement( 'meta' );
 		$viewport_meta->setAttribute( 'name', 'viewport' );
 		$viewport_meta->setAttribute(

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -1539,7 +1539,7 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		// Prevent importing something that has already been imported, and avoid infinite recursion.
 		if ( isset( $this->processed_imported_stylesheet_urls[ $import_stylesheet_url ] ) ) {
 			$css_list->remove( $item );
-			return [];
+			return compact( 'validation_errors', 'imported_font_urls' );
 		}
 		$this->processed_imported_stylesheet_urls[ $import_stylesheet_url ] = true;
 
@@ -2014,15 +2014,8 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 			} elseif ( $css_item instanceof Import ) {
 				$imported_stylesheet = $this->splice_imported_stylesheet( $css_item, $css_list, $options );
 
-				$imported_font_urls = array_merge(
-					$imported_font_urls,
-					$imported_stylesheet['imported_font_urls']
-				);
-
-				$results = array_merge(
-					$results,
-					$imported_stylesheet['validation_errors']
-				);
+				$imported_font_urls = array_merge( $imported_font_urls, $imported_stylesheet['imported_font_urls'] );
+				$results            = array_merge( $results, $imported_stylesheet['validation_errors'] );
 			} elseif ( $css_item instanceof AtRuleSet ) {
 				if ( in_array( $css_item->atRuleName(), $this->allowed_viewport_rules, true ) ) {
 					$output_format = new OutputFormat();

--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -257,8 +257,6 @@ class AMP_Validation_Error_Taxonomy {
 		if ( is_admin() ) {
 			self::add_admin_hooks();
 		}
-
-		self::accept_validation_errors( AMP_Core_Theme_Sanitizer::get_acceptable_errors( get_template() ) );
 	}
 
 	/**
@@ -488,7 +486,6 @@ class AMP_Validation_Error_Taxonomy {
 	 * Automatically (forcibly) accept validation errors that arise (that is, remove the invalid markup causing the validation errors).
 	 *
 	 * @since 1.0
-	 * @see AMP_Core_Theme_Sanitizer::get_acceptable_errors()
 	 *
 	 * @param array|true $acceptable_errors Acceptable validation errors, where keys are codes and values are either `true` or sparse array to check as subset. If just true, then all validation errors are accepted.
 	 */

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2679,11 +2679,5 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$content = $dom->saveHTML( $dom->documentElement );
 		$this->assertEquals( $expected, $content );
-
-		// Reset the static property.
-		$reflection = new \ReflectionObject( $style_sanitizer );
-		$property   = $reflection->getProperty( 'extracted_viewport_rules' );
-		$property->setAccessible( true );
-		$property->setValue( [] );
 	}
 }

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2663,6 +2663,18 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<style amp-custom>@viewport{ viewport-fit: auto; height: 10em }</style>',
 				'<meta name="viewport" content="viewport-fit=auto,height=10em,width=device-width">',
 			],
+			'ms_vendor_prefix_recognized' => [
+				'<style amp-custom>@-ms-viewport{ initial-scale: .8 }</style>',
+				'<meta name="viewport" content="initial-scale=.8,width=device-width">',
+			],
+			'o_vendor_prefix_recognized' => [
+				'<style amp-custom>@-o-viewport{ height: 80% }</style>',
+				'<meta name="viewport" content="height=80%,width=device-width">',
+			],
+			'invalid_vendor_prefix_not_recognized' => [
+				'<style amp-custom>@-baz-viewport{ height: 400px }</style>',
+				'<meta name="viewport" content="width=device-width">',
+			],
 			'initial_meta_tag_has_precendence_over_viewport_style_rule' => [
 				'<meta name="viewport" content="height=20em"><style amp-custom>@viewport{ height: 30em }</style>',
 				'<meta name="viewport" content="height=20em,width=device-width">',

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -162,7 +162,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 			'illegal_at_rules_removed' => [
 				'<style>@charset "utf-8"; @namespace svg url(http://www.w3.org/2000/svg); @page { margin: 1cm; } @viewport { width: device-width; } @counter-style thumbs { system: cyclic; symbols: "\1F44D"; suffix: " "; } body { color: black; }</style>',
-				'',
+				'<meta name="viewport" content="width=device-width">',
 				[
 					'@page{margin:1cm}body{color:black}',
 				],
@@ -2647,11 +2647,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			],
 			'valid_initial_scale_moved' => [
 				'<html amp><head><meta charset="utf-8"><style amp-custom>@viewport{ initial-scale: .9; }</style>' . $amp_boilerplate . '</head><body></body></html>',
-				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="initial-scale=.9, width=device-width">' . $amp_boilerplate . '</head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="initial-scale=.9,width=device-width">' . $amp_boilerplate . '</head><body></body></html>',
 			],
 			'single_valid_viewport_rule_moved' => [
 				'<html amp><head><meta charset="utf-8"><style amp-custom>@viewport{ viewport-fit: auto; }</style>' . $amp_boilerplate . '</head><body></body></html>',
-				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="viewport-fit=auto, width=device-width">' . $amp_boilerplate . '</head><body></body></html>',
+				'<html amp><head><meta charset="utf-8"><meta name="viewport" content="viewport-fit=auto,width=device-width">' . $amp_boilerplate . '</head><body></body></html>',
 			],
 		];
 	}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -166,7 +166,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[
 					'@page{margin:1cm}body{color:black}',
 				],
-				[ AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE, AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE, AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE ],
+				[ AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE, AMP_Style_Sanitizer::CSS_SYNTAX_INVALID_AT_RULE ],
 			],
 
 			'allowed_at_rules_retained' => [

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2639,49 +2639,17 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			'existing_meta_viewport_remains_when_no_style_rule' => [
 				'<meta name="viewport" content="width=device-width">',
 			],
-			'width_other_than_1_not_moved' => [
-				'<style amp-custom>@viewport{ width: 80vw; }</style>',
+			'viewport_rule_converted_to_meta_viewport' => [
+				'<style>@viewport{ width: device-width; }</style>',
 				'<meta name="viewport" content="width=device-width">',
 			],
-			'invalid_zoom_rule_not_moved' => [
-				'<style amp-custom>@viewport{ zoom: 1.2 }</style>',
+			'vendor_prefixed_viewport_rule_converted_to_meta_viewport' => [
+				'<style>@-moz-viewport{ width: device-width; }</style>',
 				'<meta name="viewport" content="width=device-width">',
 			],
-			'invalid_rule_not_moved_and_valid_rule_moved' => [
-				'<style amp-custom>@viewport{ zoom: auto; viewport-fit: contain }</style>',
-				'<meta name="viewport" content="viewport-fit=contain,width=device-width">',
-			],
-			'valid_initial_scale_moved' => [
-				'<style amp-custom>@viewport{ initial-scale: .9; }</style>',
-				'<meta name="viewport" content="initial-scale=.9,width=device-width">',
-			],
-			'single_valid_viewport_rule_moved' => [
-				'<style amp-custom>@viewport{ viewport-fit: auto; }</style>',
-				'<meta name="viewport" content="viewport-fit=auto,width=device-width">',
-			],
-			'two_valid_viewport_rules_moved' => [
-				'<style amp-custom>@viewport{ viewport-fit: auto; height: 10em }</style>',
-				'<meta name="viewport" content="viewport-fit=auto,height=10em,width=device-width">',
-			],
-			'ms_vendor_prefix_recognized' => [
-				'<style amp-custom>@-ms-viewport{ initial-scale: .8 }</style>',
-				'<meta name="viewport" content="initial-scale=.8,width=device-width">',
-			],
-			'o_vendor_prefix_recognized' => [
-				'<style amp-custom>@-o-viewport{ height: 80% }</style>',
-				'<meta name="viewport" content="height=80%,width=device-width">',
-			],
-			'invalid_vendor_prefix_not_recognized' => [
-				'<style amp-custom>@-baz-viewport{ height: 400px }</style>',
-				'<meta name="viewport" content="width=device-width">',
-			],
-			'initial_meta_tag_has_precendence_over_viewport_style_rule' => [
-				'<meta name="viewport" content="height=20em"><style amp-custom>@viewport{ height: 30em }</style>',
-				'<meta name="viewport" content="height=20em,width=device-width">',
-			],
-			'meta_tag_with_no_content_gets_width_added' => [
-				'<meta name="viewport">',
-				'<meta name="viewport" content="width=device-width">',
+			'viewport_merged_rules' => [
+				'<meta name="viewport" content="width=device-width,user-scalable=no"><style>@viewport{ initial-scale: 1; }</style><style>@-moz-viewport{ user-scalable: yes; }</style><style>@-o-viewport { minimum-scale: 0.5; }</style><style>@-baz-viewport { unrecognized: 1; }</style>',
+				'<meta name="viewport" content="width=device-width,user-scalable=yes,initial-scale=1,minimum-scale=.5,unrecognized=1">',
 			],
 		];
 	}
@@ -2692,6 +2660,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 * @dataProvider get_viewport_data
 	 * @covers AMP_Style_Sanitizer::sanitize()
 	 * @covers AMP_Meta_Sanitizer::sanitize()
+	 * @covers AMP_Meta_Sanitizer::ensure_viewport_is_present()
 	 *
 	 * @param string $markup   The markup to sanitize.
 	 * @param string $expected The expected result after sanitizing.

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2691,6 +2691,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 	 *
 	 * @dataProvider get_viewport_data
 	 * @covers AMP_Style_Sanitizer::sanitize()
+	 * @covers AMP_Meta_Sanitizer::sanitize()
 	 *
 	 * @param string $markup   The markup to sanitize.
 	 * @param string $expected The expected result after sanitizing.

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -2679,6 +2679,10 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				'<meta name="viewport" content="height=20em"><style amp-custom>@viewport{ height: 30em }</style>',
 				'<meta name="viewport" content="height=20em,width=device-width">',
 			],
+			'meta_tag_with_no_content_gets_width_added' => [
+				'<meta name="viewport">',
+				'<meta name="viewport" content="width=device-width">',
+			],
 		];
 	}
 

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -165,21 +165,6 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_acceptable_errors().
-	 *
-	 * @covers AMP_Core_Theme_Sanitizer::get_acceptable_errors()
-	 *
-	 * @dataProvider get_templates
-	 *
-	 * @param string $template Template name.
-	 * @param array $expected Expected acceptable errors.
-	 */
-	public function test_get_acceptable_errors( $template, $expected ) {
-		$actual = AMP_Core_Theme_Sanitizer::get_acceptable_errors( $template );
-		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
 	 * Test add_has_header_video_body_class().
 	 *
 	 * @covers AMP_Core_Theme_Sanitizer::add_has_header_video_body_class()


### PR DESCRIPTION
## Summary
- [x] Prevent validation errors for `@viewport` rules and other vendor prefixes
- [x] When those rules would be valid in `meta[name="viewport"]`, move them there
- [x] When there is an existing `meta[name="viewport"]`, consider the rules that already has, and merge the style `@viewport` rules with those

<!-- Please reference the issue this PR addresses. -->
Fixes #4118

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
