### PR TITLE
Add PHPStan config files to libraries

### DIFF
--- a/lib/common/composer.json
+++ b/lib/common/composer.json
@@ -58,7 +58,7 @@
       "@cs",
       "@analyze"
     ],
-    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze src -l3 --ansi; fi",
+    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze --ansi; fi",
     "unit": "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi"
   }
 }

--- a/lib/common/phpstan.neon.dist
+++ b/lib/common/phpstan.neon.dist
@@ -1,0 +1,10 @@
+includes:
+	# @see https://github.com/phpstan/phpstan-src/blob/master/conf/bleedingEdge.neon
+	- phar://phpstan.phar/conf/bleedingEdge.neon
+parameters:
+	level: 3
+	inferPrivatePropertyTypeFromConstructor: true
+	paths:
+		- %currentWorkingDirectory%/src/
+	autoload_files:
+		- %currentWorkingDirectory%/vendor/autoload.php

--- a/lib/optimizer/composer.json
+++ b/lib/optimizer/composer.json
@@ -71,7 +71,7 @@
       "@cs",
       "@analyze"
     ],
-    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze src -l3 --ansi; fi",
+    "analyze": "if [ -z $TEST_SKIP_PHPSTAN ]; then phpstan analyze --ansi; fi",
     "unit": "if [ -z $TEST_SKIP_PHPUNIT ]; then phpunit --colors=always; fi"
   }
 }

--- a/lib/optimizer/phpstan.neon.dist
+++ b/lib/optimizer/phpstan.neon.dist
@@ -1,0 +1,10 @@
+includes:
+	# @see https://github.com/phpstan/phpstan-src/blob/master/conf/bleedingEdge.neon
+	- phar://phpstan.phar/conf/bleedingEdge.neon
+parameters:
+	level: 3
+	inferPrivatePropertyTypeFromConstructor: true
+	paths:
+		- %currentWorkingDirectory%/src/
+	autoload_files:
+		- %currentWorkingDirectory%/vendor/autoload.php


### PR DESCRIPTION
## Summary

To make the libraries behave in the same way and with the same expectations than the plugin, this PR adds a `phpstan.neon.dist` configuration file to the `ampproject/common` and `ampproject/optimizer` libraries and adapts the Composer file so that it gets its source folder and level from the configuration.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).