### PR TITLE
Fix warning icon no longer appears as emoji in macOS Catalina

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -12,6 +12,7 @@ use AmpProject\AmpWP\Transformer;
 use AmpProject\Attribute;
 use AmpProject\Dom\Document;
 use AmpProject\Extension;
+use AmpProject\Fonts;
 use AmpProject\Optimizer;
 use AmpProject\RemoteRequest\CurlRemoteGetRequest;
 use AmpProject\RemoteRequest\FallbackRemoteGetRequest;
@@ -1450,6 +1451,8 @@ class AMP_Theme_Support {
 			if ( amp_is_dev_mode() ) {
 				$data .= 'html:not(#_) > body { position:unset !important; }';
 			}
+
+			$data .= sprintf( '#amp-admin-bar-item-status-icon { font-family: %s; }', Fonts::getEmojiFontFamilyValue() );
 
 			wp_add_inline_style( 'admin-bar', $data );
 		}

--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -7,6 +7,7 @@
 
 use AmpProject\DevMode;
 use AmpProject\Dom\Document;
+use AmpProject\Fonts;
 use Sabberworm\CSS\RuleSet\DeclarationBlock;
 use Sabberworm\CSS\CSSList\CSSList;
 use Sabberworm\CSS\Property\Selector;
@@ -2914,14 +2915,20 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 		$css_usage_percentage = ceil( ( $total_size / $this->style_custom_cdata_spec['max_bytes'] ) * 100 );
 		$menu_item_text       = __( 'CSS Usage', 'amp' ) . ': ';
 		$menu_item_text      .= $css_usage_percentage . '%';
+		$stylesheets_a_element->appendChild( $this->dom->createTextNode( $menu_item_text ) );
 
 		if ( $css_usage_percentage > 100 ) {
-			$menu_item_text .= ' 🚫';
+			$emoji = '🚫';
 		} elseif ( $css_usage_percentage >= self::CSS_BUDGET_WARNING_PERCENTAGE ) {
-			$menu_item_text .= ' ⚠️';
+			$emoji = '⚠️';
 		}
-
-		$stylesheets_a_element->appendChild( $this->dom->createTextNode( $menu_item_text ) );
+		if ( isset( $emoji ) ) {
+			$stylesheets_a_element->appendChild( $this->dom->createTextNode( ' ' ) );
+			$span = $this->dom->createElement( 'span' );
+			$span->setAttribute( 'style', sprintf( 'font-family: %s;', Fonts::getEmojiFontFamilyValue() ) );
+			$span->appendChild( $this->dom->createTextNode( $emoji ) );
+			$stylesheets_a_element->appendChild( $span );
+		}
 
 		$validity_li_element->parentNode->insertBefore( $stylesheets_li_element, $validity_li_element->nextSibling );
 	}

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -5,6 +5,8 @@
  * @package AMP
  */
 
+use AmpProject\Fonts;
+
 /**
  * Class AMP_Validated_URL_Post_Type
  *
@@ -2078,6 +2080,9 @@ class AMP_Validated_URL_Post_Type {
 					$percentage_budget_used = ( ( $included_final_size + $excluded_final_size ) / $style_custom_cdata_spec['max_bytes'] ) * 100;
 
 					printf( '%.1f%% ', $percentage_budget_used ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
+					<span style="font-family: <?php echo esc_attr( Fonts::getEmojiFontFamilyValue() ); ?>">
+					<?php
 					if ( $percentage_budget_used > 100 ) {
 						echo '🚫';
 					} elseif ( $percentage_budget_used >= AMP_Style_Sanitizer::CSS_BUDGET_WARNING_PERCENTAGE ) {
@@ -2086,6 +2091,7 @@ class AMP_Validated_URL_Post_Type {
 						echo '✅';
 					}
 					?>
+					</span>
 				</td>
 			</tr>
 			<tr>
@@ -2223,15 +2229,16 @@ class AMP_Validated_URL_Post_Type {
 					</td>
 					<td class="column-stylesheet_status">
 						<?php
+						$emoji_style = sprintf( 'font-family: %s;', Fonts::getEmojiFontFamilyValue() );
 						switch ( $stylesheet['status'] ) {
 							case $included_status:
-								printf( '<span title="%s">✅</span>', esc_attr__( 'Stylesheet included', 'amp' ) );
+								printf( '<span title="%s" style="%s">✅</span>', esc_attr__( 'Stylesheet included', 'amp' ), esc_attr( $emoji_style ) );
 								break;
 							case $excessive_status:
-								printf( '<span title="%s">⚠️</span>', esc_attr__( 'Stylesheet overruns CSS budget yet it is still included on page', 'amp' ) );
+								printf( '<span title="%s" style="%s">⚠️</span>', esc_attr__( 'Stylesheet overruns CSS budget yet it is still included on page', 'amp' ), esc_attr( $emoji_style ) );
 								break;
 							case $excluded_status:
-								printf( '<span title="%s">🚫</span>', esc_attr__( 'Stylesheet excluded due to exceeding CSS budget', 'amp' ) );
+								printf( '<span title="%s" style="%s">🚫</span>', esc_attr__( 'Stylesheet excluded due to exceeding CSS budget', 'amp' ), esc_attr( $emoji_style ) );
 								break;
 						}
 						?>

--- a/lib/common/src/Fonts.php
+++ b/lib/common/src/Fonts.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AmpProject;
+
+/**
+ * Class for fonts.
+ *
+ * @package ampproject/common
+ */
+final class Fonts
+{
+
+    const EMOJI_FONT_STACK = [
+        'Apple Color Emoji',
+        'Android Emoji',
+        'Segoe UI Emoji',
+        'Noto Color Emoji',
+        'EmojiSymbols',
+        'Symbola',
+        'Segoe UI Symbol',
+        'emoji',
+    ];
+
+    /**
+     * Get emoji font family property value.
+     *
+     * @return string Font-family property value.
+     */
+    public static function getEmojiFontFamilyValue()
+    {
+        return implode(
+            ', ',
+            array_map(
+                static function ($font) {
+                    return '"' . $font . '"';
+                },
+                self::EMOJI_FONT_STACK
+            )
+        );
+    }
+}

--- a/lib/common/src/Fonts.php
+++ b/lib/common/src/Fonts.php
@@ -33,14 +33,20 @@ final class Fonts
      */
     public static function getEmojiFontFamilyValue()
     {
-        return implode(
-            ', ',
-            array_map(
-                static function ($font) {
-                    return '"' . $font . '"';
-                },
-                self::EMOJI_FONT_STACK
-            )
-        );
+        static $fontFamilyValue = null;
+
+        if ($fontFamilyValue === null) {
+            $fontFamilyValue = implode(
+                ', ',
+                array_map(
+                    static function ($font) {
+                        return '"' . $font . '"';
+                    },
+                    self::EMOJI_FONT_STACK
+                )
+            );
+        }
+
+        return $fontFamilyValue;
     }
 }

--- a/lib/common/src/Fonts.php
+++ b/lib/common/src/Fonts.php
@@ -10,6 +10,11 @@ namespace AmpProject;
 final class Fonts
 {
 
+    /**
+     * Font stack to cycle through for displaying emojis reliably.
+     *
+     * @var string[]
+     */
     const EMOJI_FONT_STACK = [
         'Apple Color Emoji',
         'Android Emoji',

--- a/lib/common/tests/FontsTest.php
+++ b/lib/common/tests/FontsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AmpProject\Common;
+
+use AmpProject\Fonts;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for AmpProject\Fonts.
+ *
+ * @covers Amp
+ * @package ampproject/common
+ */
+class FontsTest extends TestCase
+{
+
+    /**
+     * Test the check for an AMP runtime method.
+     *
+     * @covers       Fonts::getEmojiFontFamilyValue()
+     */
+    public function testGetEmojiFontFamilyValue()
+    {
+        $value = Fonts::getEmojiFontFamilyValue();
+        $this->assertContains('Apple Color Emoji', $value);
+        $this->assertContains(',', $value);
+    }
+}

--- a/lib/common/tests/FontsTest.php
+++ b/lib/common/tests/FontsTest.php
@@ -17,7 +17,7 @@ class FontsTest extends TestCase
     use AssertContainsCompatibility;
 
     /**
-     * Test the check for an AMP runtime method.
+     * Test retrieval of the emoji-specific font-family stack.
      *
      * @covers Fonts::getEmojiFontFamilyValue()
      */

--- a/lib/common/tests/FontsTest.php
+++ b/lib/common/tests/FontsTest.php
@@ -3,6 +3,7 @@
 namespace AmpProject\Common;
 
 use AmpProject\Fonts;
+use AmpProject\Tests\AssertContainsCompatibility;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -13,16 +14,17 @@ use PHPUnit\Framework\TestCase;
  */
 class FontsTest extends TestCase
 {
+    use AssertContainsCompatibility;
 
     /**
      * Test the check for an AMP runtime method.
      *
-     * @covers       Fonts::getEmojiFontFamilyValue()
+     * @covers Fonts::getEmojiFontFamilyValue()
      */
     public function testGetEmojiFontFamilyValue()
     {
         $value = Fonts::getEmojiFontFamilyValue();
-        $this->assertContains('Apple Color Emoji', $value);
-        $this->assertContains(',', $value);
+        $this->assertStringContains('Apple Color Emoji', $value);
+        $this->assertStringContains(',', $value);
     }
 }


### PR DESCRIPTION
## Summary

Upon upgrading to macOS Catalina, I noticed the ⚠️ emoji was no longer appearing as color but rather as:

![image](https://user-images.githubusercontent.com/134745/76643284-fbb4c900-6511-11ea-98e1-6f3b5d92f59a.png)

This PR ensures that color emoji fonts are used when emoji are added to the page. Originally reported at https://github.com/ampproject/amp-wp/issues/3726#issuecomment-594341592.

Before | After
-------|-------
<img alt="Screen Shot 2020-03-13 at 09 30 49" src="https://user-images.githubusercontent.com/134745/76643457-49c9cc80-6512-11ea-8a34-9a33c6f13332.png"> | <img alt="Screen Shot 2020-03-13 at 09 37 43" src="https://user-images.githubusercontent.com/134745/76643465-4d5d5380-6512-11ea-92e4-45c4748a0d9c.png">
![image](https://user-images.githubusercontent.com/134745/76643503-60702380-6512-11ea-8766-457a3e9f0211.png) | ![image](https://user-images.githubusercontent.com/134745/76643527-6d8d1280-6512-11ea-8433-fee8183f9aed.png)
![image](https://user-images.githubusercontent.com/134745/76643547-7da4f200-6512-11ea-9030-34b0f5f77068.png) | ![image](https://user-images.githubusercontent.com/134745/76643572-8eedfe80-6512-11ea-92a1-693b5101b345.png)


## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
