### PR TITLE
Remove registration of Facebook embed handler

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,9 @@ module.exports = function( grunt ) {
 		'vendor/*/*/*.yml',
 		'vendor/*/*/.*.yml',
 		'vendor/*/*/tests',
+		'vendor/ampproject/common/phpstan.neon.dist',
 		'vendor/ampproject/optimizer/bin',
+		'vendor/ampproject/optimizer/phpstan.neon.dist',
 		'vendor/bin',
 	];
 

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -11,15 +11,6 @@ use AmpProject\Dom\Document;
  * Class AMP_Facebook_Embed_Handler
  */
 class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
-	const URL_PATTERN = '#https?://(www\.)?facebook\.com/.*#i';
-
-	/**
-	 * Default width.
-	 *
-	 * @var int
-	 */
-	protected $DEFAULT_WIDTH = 600;
-
 	/**
 	 * Default height.
 	 *
@@ -45,57 +36,14 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Registers embed.
 	 */
 	public function register_embed() {
-		wp_embed_register_handler( $this->amp_tag, self::URL_PATTERN, [ $this, 'oembed' ], -1 );
+		// Not implemented.
 	}
 
 	/**
 	 * Unregisters embed.
 	 */
 	public function unregister_embed() {
-		wp_embed_unregister_handler( $this->amp_tag, -1 );
-	}
-
-	/**
-	 * WordPress OEmbed rendering callback.
-	 *
-	 * @param array  $matches URL pattern matches.
-	 * @param array  $attr    Matched attributes.
-	 * @param string $url     Matched URL.
-	 * @return string HTML markup for rendered embed.
-	 */
-	public function oembed( $matches, $attr, $url ) {
-		return $this->render( [ 'url' => $url ] );
-	}
-
-	/**
-	 * Gets the rendered embed markup.
-	 *
-	 * @param array $args Embed rendering arguments.
-	 * @return string HTML markup for rendered embed.
-	 */
-	public function render( $args ) {
-		$args = wp_parse_args(
-			$args,
-			[
-				'url' => false,
-			]
-		);
-
-		if ( empty( $args['url'] ) ) {
-			return '';
-		}
-
-		$this->did_convert_elements = true;
-
-		return AMP_HTML_Utils::build_tag(
-			$this->amp_tag,
-			[
-				'data-href' => $args['url'],
-				'layout'    => 'responsive',
-				'width'     => $this->args['width'],
-				'height'    => $this->args['height'],
-			]
-		);
+		// Not implemented.
 	}
 
 	/**
@@ -136,7 +84,13 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 				$scripts[] = $script;
 			}
 			foreach ( $scripts as $script ) {
-				$script->parentNode->removeChild( $script );
+				$parent_node = $script->parentNode;
+				$parent_node->removeChild( $script );
+
+				// Remove parent node if it is an empty <p> tag.
+				if ( 'p' === $parent_node->tagName && null === $parent_node->firstChild ) {
+					$parent_node->parentNode->removeChild( $parent_node );
+				}
 			}
 			$fb_root->parentNode->removeChild( $fb_root );
 		}

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -79,11 +79,13 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 		 */
 		$fb_root = $dom->getElementById( 'fb-root' );
 		if ( $fb_root ) {
-			$scripts = [];
-			foreach ( $dom->xpath->query( '//script[ starts-with( @src, "https://connect.facebook.net" ) and contains( @src, "sdk.js" ) ]' ) as $script ) {
-				$scripts[] = $script;
-			}
-			foreach ( $scripts as $script ) {
+			/**
+			 * Script.
+			 *
+			 * @var DOMElement $script
+			 */
+			$script_query = $dom->xpath->query( '//script[ starts-with( @src, "https://connect.facebook.net" ) and contains( @src, "sdk.js" ) ]' );
+			foreach ( $script_query as $script ) {
 				$parent_node = $script->parentNode;
 				$parent_node->removeChild( $script );
 

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -94,7 +94,12 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 					$parent_node->parentNode->removeChild( $parent_node );
 				}
 			}
-			$fb_root->parentNode->removeChild( $fb_root );
+
+			// Remove other instances of <div id="fb-root">.
+			$fb_root_query = $dom->xpath->query( '//div[ @id = "fb-root" ]' );
+			foreach ( $fb_root_query as $fb_root ) {
+				$fb_root->parentNode->removeChild( $fb_root );
+			}
 		}
 	}
 

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -88,7 +88,7 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 				$parent_node->removeChild( $script );
 
 				// Remove parent node if it is an empty <p> tag.
-				if ( 'p' === $parent_node->tagName && null === $parent_node->firstChild ) {
+				if ( 'p' === $parent_node->nodeName && null === $parent_node->firstChild ) {
 					$parent_node->parentNode->removeChild( $parent_node );
 				}
 			}

--- a/includes/embeds/class-amp-facebook-embed.php
+++ b/includes/embeds/class-amp-facebook-embed.php
@@ -82,7 +82,7 @@ class AMP_Facebook_Embed_Handler extends AMP_Base_Embed_Handler {
 			/**
 			 * Script.
 			 *
-			 * @var DOMElement $script
+			 * @var DOMElement $script_query
 			 */
 			$script_query = $dom->xpath->query( '//script[ starts-with( @src, "https://connect.facebook.net" ) and contains( @src, "sdk.js" ) ]' );
 			foreach ( $script_query as $script ) {

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -13,60 +13,6 @@
 class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 
 	/**
-	 * Data provider for test__conversion.
-	 *
-	 * @return array Data.
-	 */
-	public function get_conversion_data() {
-		return [
-			'no_embed'         => [
-				'<p>Hello world.</p>',
-				'<p>Hello world.</p>' . PHP_EOL,
-			],
-			'simple_url_https' => [
-				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				'<p><amp-facebook data-href="https://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			],
-			'simple_url_http'  => [
-				'http://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				'<p><amp-facebook data-href="http://www.facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			],
-			'no_dubdubdub'     => [
-				'https://facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
-				'<p><amp-facebook data-href="https://facebook.com/zuck/posts/10102593740125791" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			],
-			'notes_url'        => [
-				'https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/' . PHP_EOL,
-				'<p><amp-facebook data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			],
-			'photo_url'        => [
-				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
-				'<p><amp-facebook data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			],
-			'notes_url2'       => [
-				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
-				'<p><amp-facebook data-href="https://www.facebook.com/zuck/videos/10102509264909801/" layout="responsive" width="600" height="400"></amp-facebook></p>' . PHP_EOL,
-			],
-
-		];
-	}
-
-	/**
-	 * Test conversion.
-	 *
-	 * @dataProvider get_conversion_data
-	 * @param string $source   Source.
-	 * @param string $expected Expected.
-	 */
-	public function test__conversion( $source, $expected ) {
-		$embed = new AMP_Facebook_Embed_Handler();
-		$embed->register_embed();
-		$filtered_content = apply_filters( 'the_content', $source );
-
-		$this->assertEqualMarkup( $expected, $filtered_content );
-	}
-
-	/**
 	 * Get scripts data.
 	 *
 	 * @return array Scripts.
@@ -94,9 +40,12 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	public function test__get_scripts( $source, $expected ) {
 		$embed = new AMP_Facebook_Embed_Handler();
 		$embed->register_embed();
-		$source = apply_filters( 'the_content', $source );
 
-		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( AMP_DOM_Utils::get_dom_from_content( $source ) );
+		$filtered_content = apply_filters( 'the_content', $source );
+		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
+		$embed->sanitize_raw_embeds( $dom );
+
+		$whitelist_sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
 		$whitelist_sanitizer->sanitize();
 
 		$scripts = array_merge(
@@ -114,21 +63,79 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	 */
 	public function get_raw_embed_dataset() {
 		return [
-			'no_embed_blockquote'   => [
+			'no_embed_blockquote'        => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>',
 			],
-			'div_without_instagram' => [
+
+			'div_without_facebook_embed' => [
 				'<div>lorem ipsum</div>',
 				'<div>lorem ipsum</div>',
 			],
 
-			'post_embed'            => [
+			'simple_url_https'           => [
+				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
+				'
+					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102593740125791" data-embed-as="post" layout="responsive">
+						<blockquote cite="https://www.facebook.com/zuck/posts/10102593740125791" class="fb-xfbml-parse-ignore" fallback="">
+							<p>February 4 is Facebook’s 12th birthday!</p>
+							<p>Our anniversary has a lot of meaning to me as an opportunity to reflect on how…</p>
+							<p>Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on <a href="https://www.facebook.com/zuck/posts/10102593740125791">Tuesday, January 12, 2016</a></p>
+						</blockquote>
+					</amp-facebook>
+				' . PHP_EOL,
+			],
+
+			'notes_url'                  => [
+				'https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/' . PHP_EOL,
+				'
+					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive">
+						<blockquote cite="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" class="fb-xfbml-parse-ignore" fallback="">
+							<p>Posted by <a href="https://www.facebook.com/Engineering/">Facebook Engineering</a> on <a href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/">Saturday, December 8, 2012</a></p>
+						</blockquote>
+					</amp-facebook>
+				' . PHP_EOL,
+			],
+
+			'photo_url'                  => [
+				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
+				'
+					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" data-embed-as="post" layout="responsive">
+						<blockquote cite="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231&amp;type=3" class="fb-xfbml-parse-ignore" fallback="">
+							<p>Meanwhile, Beast turned to the dark side.</p>
+							<p>Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on <a href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231&amp;type=3">Friday, December 18, 2015</a></p>
+						</blockquote>
+					</amp-facebook>
+				' . PHP_EOL,
+			],
+
+			'video_url'                  => [
+				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
+				'
+					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/videos/10102509264909801/" data-embed-as="video" layout="responsive">
+						<blockquote cite="https://www.facebook.com/zuck/videos/10102509264909801/" class="fb-xfbml-parse-ignore" fallback="">
+							<p><a href="https://www.facebook.com/zuck/videos/10102509264909801/"></a></p>
+							<p>I want to share a few more thoughts on the Chan Zuckerberg Initiative before I just start posting photos of me and Max for a while 🙂</p>
+							<p>I hope one idea comes through: that we as a society should make investments now to ensure this world is much better for the next generation.</p>
+							<p>I don\'t think we do enough of this right now. </p>
+							<p>Sure, there are many areas where investment now will solve problems for today and also improve the world for the future. We do muster the will to solve some of those.</p>
+							<p>But for the problems that will truly take decades of investment before we see any major return, we are dramatically underinvested.</p>
+							<p>One example is basic science research to cure disease. Another is developing clean energy to protect the world for the future. Another is the slow and steady improvement to modernize schools. Others are systematic issues around poverty and justice. There is a long list of these opportunities.</p>
+							<p>The role of philanthropy is to invest in important areas that companies and governments aren\'t funding — either because they may not be profitable for companies or because they are too long term for people to want to invest now.</p>
+							<p>In the case of disease, basic research often needs to be funded before biotech or pharma companies can create drugs to help people. If we invest more in science, we can make faster progress towards curing disease.</p>
+							<p>Our investment in the Chan Zuckerberg Initiative is small compared to what the world can invest in solving these great challenges. My hope is that our work inspires more people to invest in these longer term issues. If we can do that, then we can all really make a difference together.</p>
+							<p>Posted by <a href="https://www.facebook.com/zuck">Mark Zuckerberg</a> on Friday, December 4, 2015</p>
+						</blockquote>
+					</amp-facebook>
+				' . PHP_EOL,
+			],
+
+			'post_embed'                 => [
 				'<div class="fb-post" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"></div>',
 				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive"></amp-facebook>',
 			],
 
-			'post_with_fallbacks'   => [
+			'post_with_fallbacks'        => [
 				'
 					<div class="fb-post" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/" data-width="500" data-show-text="true">
 						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore">
@@ -139,18 +146,18 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'
 					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/"  data-show-text="true" data-embed-as="post" layout="responsive">
 						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore" fallback="">
-							Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on <a href="https://developers.facebook.com/20531316728/posts/10154009990506729/">Thursday, August 27, 2015</a>
+							<p> Posted by <a href="https://www.facebook.com/facebook/">Facebook</a> on <a href="https://developers.facebook.com/20531316728/posts/10154009990506729/">Thursday, August 27, 2015</a></p>
 						</blockquote>
 					</amp-facebook>
 				',
 			],
 
-			'video_embed'           => [
+			'video_embed'                => [
 				'<div class="fb-video" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false"></div>',
 				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video" layout="responsive"></amp-facebook>',
 			],
 
-			'page_embed'            => [
+			'page_embed'                 => [
 				'
 					<div class="fb-page" data-href="https://www.facebook.com/xwp.co/" data-width="340" data-height="432" data-hide-cover="true" data-show-facepile="true" data-show-posts="false">
 						<div class="fb-xfbml-parse-ignore">
@@ -161,13 +168,15 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'
 					<amp-facebook-page width="340" height="432" data-href="https://www.facebook.com/xwp.co/" data-hide-cover="true" data-show-facepile="true" data-show-posts="false" layout="responsive">
 						<div class="fb-xfbml-parse-ignore" fallback="">
-							<blockquote cite="https://www.facebook.com/xwp.co/"><a href="https://www.facebook.com/xwp.co/">Like Us</a></blockquote>
+							<blockquote cite="https://www.facebook.com/xwp.co/">
+								<p><a href="https://www.facebook.com/xwp.co/">Like Us</a></p>
+							</blockquote>
 						</div>
 					</amp-facebook-page>
 				',
 			],
 
-			'like'                  => [
+			'like'                       => [
 				'
 					<div class="fb-like" data-href="https://developers.facebook.com/docs/plugins/" data-width="400" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true"></div>
 				',
@@ -177,35 +186,35 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				',
 			],
 
-			'comments'              => [
+			'comments'                   => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="responsive"></amp-facebook-comments>',
 			],
 
-			'comments_full_width'   => [
+			'comments_full_width'        => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
 			],
 
-			'comments_full_width_2' => [
+			'comments_full_width_2'      => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-height="123" data-width="100%" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments width="auto" height="123" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
 			],
 
-			'comment_embed'         => [
+			'comment_embed'              => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
 				',
 				'<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment" layout="responsive"></amp-facebook>',
 			],
 
-			'remove_fb_root'        => [
+			'remove_fb_root'             => [
 				'<div id="fb-root"></div><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 				'',
 			],
@@ -221,9 +230,11 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	 * @covers AMP_Facebook_Embed_Handler::sanitize_raw_embeds()
 	 */
 	public function test__raw_embed_sanitizer( $source, $expected ) {
-		$dom   = AMP_DOM_Utils::get_dom_from_content( $source );
 		$embed = new AMP_Facebook_Embed_Handler();
+		$embed->register_embed();
 
+		$filtered_content = apply_filters( 'the_content', $source );
+		$dom              = AMP_DOM_Utils::get_dom_from_content( $filtered_content );
 		$embed->sanitize_raw_embeds( $dom );
 
 		$layout_sanitizer = new AMP_Layout_Sanitizer( $dom );

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -219,6 +219,11 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				'',
 			],
 
+			'remove_multiple_fb_root'       => [
+				str_repeat( '<div id="fb-root"></div>', 5 ) . str_repeat( '<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', 5 ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				'',
+			],
+
 			'remove_empty_p_tag'            => [
 				'<p><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script></p><div id="fb-root"></div>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 				'',

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -63,17 +63,17 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 	 */
 	public function get_raw_embed_dataset() {
 		return [
-			'no_embed_blockquote'        => [
+			'no_embed_blockquote'           => [
 				'<p>Hello world.</p>',
 				'<p>Hello world.</p>',
 			],
 
-			'div_without_facebook_embed' => [
+			'div_without_facebook_embed'    => [
 				'<div>lorem ipsum</div>',
 				'<div>lorem ipsum</div>',
 			],
 
-			'simple_url_https'           => [
+			'simple_url_https'              => [
 				'https://www.facebook.com/zuck/posts/10102593740125791' . PHP_EOL,
 				'
 					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102593740125791" data-embed-as="post" layout="responsive">
@@ -86,7 +86,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				' . PHP_EOL,
 			],
 
-			'notes_url'                  => [
+			'notes_url'                     => [
 				'https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/' . PHP_EOL,
 				'
 					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive">
@@ -97,7 +97,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				' . PHP_EOL,
 			],
 
-			'photo_url'                  => [
+			'photo_url'                     => [
 				'https://www.facebook.com/photo.php?fbid=10102533316889441&set=a.529237706231.2034669.4&type=3&theater' . PHP_EOL,
 				'
 					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/photo.php?fbid=10102533316889441&amp;set=a.529237706231.2034669.4&amp;type=3&amp;theater" data-embed-as="post" layout="responsive">
@@ -109,7 +109,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				' . PHP_EOL,
 			],
 
-			'video_url'                  => [
+			'video_url'                     => [
 				'https://www.facebook.com/zuck/videos/10102509264909801/' . PHP_EOL,
 				'
 					<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/videos/10102509264909801/" data-embed-as="video" layout="responsive">
@@ -130,12 +130,12 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				' . PHP_EOL,
 			],
 
-			'post_embed'                 => [
+			'post_embed'                    => [
 				'<div class="fb-post" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/"></div>',
 				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/notes/facebook-engineering/under-the-hood-the-javascript-sdk-truly-asynchronous-loading/10151176218703920/" data-embed-as="post" layout="responsive"></amp-facebook>',
 			],
 
-			'post_with_fallbacks'        => [
+			'post_with_fallbacks'           => [
 				'
 					<div class="fb-post" data-href="https://www.facebook.com/20531316728/posts/10154009990506729/" data-width="500" data-show-text="true">
 						<blockquote cite="https://developers.facebook.com/20531316728/posts/10154009990506729/" class="fb-xfbml-parse-ignore">
@@ -152,12 +152,12 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				',
 			],
 
-			'video_embed'                => [
+			'video_embed'                   => [
 				'<div class="fb-video" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false"></div>',
 				'<amp-facebook width="600" height="400" data-href="https://www.facebook.com/amanda.orr.56/videos/10212156330049017/" data-show-text="false" data-embed-as="video" layout="responsive"></amp-facebook>',
 			],
 
-			'page_embed'                 => [
+			'page_embed'                    => [
 				'
 					<div class="fb-page" data-href="https://www.facebook.com/xwp.co/" data-width="340" data-height="432" data-hide-cover="true" data-show-facepile="true" data-show-posts="false">
 						<div class="fb-xfbml-parse-ignore">
@@ -176,7 +176,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				',
 			],
 
-			'like'                       => [
+			'like'                          => [
 				'
 					<div class="fb-like" data-href="https://developers.facebook.com/docs/plugins/" data-width="400" data-layout="standard" data-action="like" data-size="small" data-show-faces="true" data-share="true"></div>
 				',
@@ -186,37 +186,47 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 				',
 			],
 
-			'comments'                   => [
+			'comments'                      => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments width="600" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="responsive"></amp-facebook-comments>',
 			],
 
-			'comments_full_width'        => [
+			'comments_full_width'           => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-width="100%" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments width="auto" height="400" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
 			],
 
-			'comments_full_width_2'      => [
+			'comments_full_width_2'         => [
 				'
 					<div class="fb-comments" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-height="123" data-width="100%" data-numposts="5"></div>
 				',
 				'<amp-facebook-comments width="auto" height="123" data-href="https://developers.facebook.com/docs/plugins/comments#configurator" data-numposts="5" layout="fixed-height"></amp-facebook-comments>',
 			],
 
-			'comment_embed'              => [
+			'comment_embed'                 => [
 				'
 					<div class="fb-comment-embed" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-width="500"></div>
 				',
 				'<amp-facebook width="500" height="400" data-href="https://www.facebook.com/zuck/posts/10102735452532991?comment_id=1070233703036185" data-embed-as="comment" layout="responsive"></amp-facebook>',
 			],
 
-			'remove_fb_root'             => [
+			'remove_fb_root'                => [
 				'<div id="fb-root"></div>' . str_repeat( '<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', 5 ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 				'',
+			],
+
+			'remove_empty_p_tag'            => [
+				'<p><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script></p><div id="fb-root"></div>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				'',
+			],
+
+			'keep_p_tag_if_it_has_children' => [
+				'<p><span id="foo-bar"></span><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script></p><div id="fb-root"></div>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				'<p><span id="foo-bar"></span></p>',
 			],
 		];
 	}

--- a/tests/php/test-amp-facebook-embed.php
+++ b/tests/php/test-amp-facebook-embed.php
@@ -215,7 +215,7 @@ class AMP_Facebook_Embed_Test extends WP_UnitTestCase {
 			],
 
 			'remove_fb_root'             => [
-				'<div id="fb-root"></div><script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+				'<div id="fb-root"></div>' . str_repeat( '<script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>', 5 ), // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 				'',
 			],
 		];


### PR DESCRIPTION
## Summary

This PR removes the custom WordPress embed handler for Facebook and instead relies on `\AMP_Facebook_Embed_Handler::sanitize_raw_embeds` to convert such embeds to their appropriate AMP components.

<!-- Please reference the issue this PR addresses. -->
Fixes #4358.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
