### PR TITLE
Improve security of external href (make it harder for malicious people).

### DIFF
--- a/includes/options/class-amp-options-manager.php
+++ b/includes/options/class-amp-options-manager.php
@@ -413,7 +413,7 @@ class AMP_Options_Manager {
 			<h2><?php esc_html_e( 'Welcome to AMP for WordPress', 'amp' ); ?></h2>
 			<h3><?php esc_html_e( 'Bring the speed and features of the open source AMP project to your site, complete with the tools to support content authoring and website development.', 'amp' ); ?></h3>
 			<h3><?php esc_html_e( 'From granular controls that help you create AMP content, to Core Gutenberg support, to a sanitizer that only shows visitors error-free pages, to a full error workflow for developers, this release enables rich, performant experiences for your WordPress site.', 'amp' ); ?></h3>
-			<a href="https://amp-wp.org/getting-started/" target="_blank" class="button button-primary"><?php esc_html_e( 'Learn More', 'amp' ); ?></a>
+			<a href="https://amp-wp.org/getting-started/" target="_blank" rel="noopener noreferrer" class="button button-primary"><?php esc_html_e( 'Learn More', 'amp' ); ?></a>
 		</div>
 
 		<script>


### PR DESCRIPTION
Initially I reported this via the Google Seucrity program (in
https://issuetracker.google.com/issues/151134576), but it was
rejected with this explanation:
https://sites.google.com/site/bughunteruniversity/nonvuln/phishing-with-window-opener

While the change may not fix all possible attack vectors, it at least
takes care about one (window.opener). It adds one more layer to the
security onion, and makes it one step harder for malicious people.

The probability that this issues can be exploitet is low, as amp-wp.org
needs to be compromised, and an admin of an wordpress installation needs
to click on the getting started link.

The security impact is medium, as a breach can theoretically affect a
lot of websites (currently 400.000+ installations counted on the
wordpress plugin page for this plugin) and there are other ways to
do malicious things which are not prevented by this change.

There are also static security scanners (commercial and open source)
which flag this as a blocking security issue. Adding this change will
make that this is not showing up as an issue in such scans, which may
make a difference for companies where such scans are mandatory to not
show up security issues.

All in all this is a security related improvement, but not a big security
hole.

## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
