### PR TITLE
Prevent failed attempts to override the reply-title heading in comment form

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -1130,7 +1130,7 @@ class AMP_Theme_Support {
 		add_action( 'template_redirect', [ __CLASS__, 'start_output_buffering' ], $priority );
 
 		// Commenting hooks.
-		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ] );
+		add_filter( 'comment_form_defaults', [ __CLASS__, 'filter_comment_form_defaults' ], PHP_INT_MAX );
 		add_filter( 'comment_reply_link', [ __CLASS__, 'filter_comment_reply_link' ], 10, 4 );
 		add_filter( 'cancel_comment_reply_link', [ __CLASS__, 'filter_cancel_comment_reply_link' ], 10, 3 );
 		add_action( 'comment_form', [ __CLASS__, 'amend_comment_form' ], 100 );
@@ -1338,29 +1338,48 @@ class AMP_Theme_Support {
 	 * @since 0.7
 	 * @see comment_form()
 	 *
-	 * @param array $args Comment form args.
+	 * @param array $default_args Comment form arg defaults.
 	 * @return array Filtered comment form args.
 	 */
-	public static function filter_comment_form_defaults( $args ) {
-		$state_id = self::get_comment_form_state_id( get_the_ID() );
+	public static function filter_comment_form_defaults( $default_args ) {
 
+		// Obtain the actual args provided to the comment_form() function since it is not available in the filter.
+		$args      = [];
+		$backtrace = debug_backtrace(); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- Due to limitation in WordPress core.
+		foreach ( $backtrace as $call ) {
+			if ( 'comment_form' === $call['function'] ) {
+				$args = isset( $call['args'][0] ) ? $call['args'][0] : [];
+				break;
+			}
+		}
+
+		// Abort if the comment_form() was called with arguments which we cannot override the defaults for.
+		// @todo This and the debug_backtrace() call above would be unnecessary if WordPress had a comment_form_args filter.
+		$overridden_keys = [ 'cancel_reply_before', 'title_reply', 'title_reply_before', 'title_reply_to' ];
+		foreach ( $overridden_keys as $key ) {
+			if ( array_key_exists( $key, $args ) && array_key_exists( $key, $default_args ) && $default_args[ $key ] !== $args[ $key ] ) {
+				return $default_args;
+			}
+		}
+
+		$state_id     = self::get_comment_form_state_id( get_the_ID() );
 		$text_binding = sprintf(
 			'%s.replyToName ? %s : %s',
 			$state_id,
 			str_replace(
 				'%s',
 				sprintf( '" + %s.replyToName + "', $state_id ),
-				wp_json_encode( $args['title_reply_to'], JSON_UNESCAPED_UNICODE )
+				wp_json_encode( $default_args['title_reply_to'], JSON_UNESCAPED_UNICODE )
 			),
-			wp_json_encode( $args['title_reply'], JSON_UNESCAPED_UNICODE )
+			wp_json_encode( $default_args['title_reply'], JSON_UNESCAPED_UNICODE )
 		);
 
-		$args['title_reply_before'] .= sprintf(
+		$default_args['title_reply_before'] .= sprintf(
 			'<span [text]="%s">',
 			esc_attr( $text_binding )
 		);
-		$args['cancel_reply_before'] = '</span>' . $args['cancel_reply_before'];
-		return $args;
+		$default_args['cancel_reply_before'] = '</span>' . $default_args['cancel_reply_before'];
+		return $default_args;
 	}
 
 	/**

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1068,7 +1068,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$priority = defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX; // phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 		$this->assertEquals( $priority, has_action( 'template_redirect', [ self::TESTED_CLASS, 'start_output_buffering' ] ) );
 
-		$this->assertEquals( 10, has_filter( 'comment_form_defaults', [ self::TESTED_CLASS, 'filter_comment_form_defaults' ] ) );
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'comment_form_defaults', [ self::TESTED_CLASS, 'filter_comment_form_defaults' ] ) );
 		$this->assertEquals( 10, has_filter( 'comment_reply_link', [ self::TESTED_CLASS, 'filter_comment_reply_link' ] ) );
 		$this->assertEquals( 10, has_filter( 'cancel_comment_reply_link', [ self::TESTED_CLASS, 'filter_cancel_comment_reply_link' ] ) );
 		$this->assertEquals( 100, has_action( 'comment_form', [ self::TESTED_CLASS, 'amend_comment_form' ] ) );


### PR DESCRIPTION
## Summary

This is a short-term fix to prevent attempting to integrate amp-bind with the  “Leave a Reply” heading in the comment form. Because WordPress only provides a `comment_form_defaults` filter for the `comment_form()` function, and not a filter like `comment_form_args` to modify the actual args passed in, we cannot use the `comment_form_defaults` filter to inject amp-bind logic into the form.

Longer-term solutions would be to introduce the `comment_form_args` filter to core, or even better to not use amp-bind and instead use amp-script for this.

The effect of this PR is that the “Leave a Reply” heading will remain unchanged in Twenty Nineteen and Twenty Twenty when you enter a comment or click a “Reply” link in the comments list. In Twenty Seventeen, which does not pass any arguments to `comment_form()`, the heading will change from “Leave a Reply” to “Leave a Reply to John Smith” when clicking the reply link. In all themes, the “Cancel Reply” link should still appear regardless of the heading changing.

Additionally, this PR prevents the amp-bind warning message from appearing:

> `Default value () does not match first result (Leave a Reply) for <SPAN [text]="commentform_post_2013.replyToName ? "Leave a Reply to " + commentform_post_2013.replyToName + "" : "Leave a Reply"">. We recommend writing expressions with matching default values, but this can be safely ignored if intentional.`

Fixes #2489.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
