### PR TITLE
Update allowed tags/attributes from spec in amphtml 2003031842100

### DIFF
--- a/bin/amphtml-update.py
+++ b/bin/amphtml-update.py
@@ -787,10 +787,10 @@ def GetMandatoryOf( attr, constraint ):
 	Returns:
 		A list of attributes that have that constraint name.
 	"""
-	attributes = []
+	attributes = set()
 	for attr_spec in attr:
 		if attr_spec.HasField(constraint):
-			attributes.append(
+			attributes.add(
 				# Convert something like [src] to data-amp-bind-src.
 				re.sub(
 					"^\[(\S+)\]$",
@@ -799,8 +799,7 @@ def GetMandatoryOf( attr, constraint ):
 				)
 			)
 
-	attributes.sort()
-	return attributes
+	return sorted(attributes)
 
 def Phpize(data, indent=0):
 	"""Helper function to convert JSON-serializable data into PHP literals.

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -13,10 +13,110 @@
  */
 class AMP_Allowed_Tags_Generated {
 
-	private static $spec_file_revision = 961;
+	private static $spec_file_revision = 1012;
 	private static $minimum_validator_revision_required = 375;
 
 	private static $descendant_tag_lists = array(
+		'amp-mega-menu-allowed-descendants' => array(
+			'a',
+			'amp-ad',
+			'amp-carousel',
+			'amp-embed',
+			'amp-img',
+			'amp-lightbox',
+			'amp-list',
+			'amp-video',
+			'b',
+			'br',
+			'button',
+			'col',
+			'colgroup',
+			'div',
+			'em',
+			'fieldset',
+			'form',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'i',
+			'input',
+			'label',
+			'li',
+			'mark',
+			'nav',
+			'ol',
+			'option',
+			'p',
+			'path',
+			'section',
+			'span',
+			'strike',
+			'strong',
+			'sub',
+			'sup',
+			'svg',
+			'table',
+			'tbody',
+			'td',
+			'template',
+			'th',
+			'time',
+			'title',
+			'tr',
+			'u',
+			'ul',
+		),
+		'amp-nested-menu-allowed-descendants' => array(
+			'a',
+			'amp-accordion',
+			'amp-img',
+			'amp-list',
+			'b',
+			'br',
+			'button',
+			'col',
+			'colgroup',
+			'div',
+			'em',
+			'fieldset',
+			'form',
+			'h1',
+			'h2',
+			'h3',
+			'h4',
+			'h5',
+			'h6',
+			'i',
+			'input',
+			'label',
+			'li',
+			'mark',
+			'nav',
+			'ol',
+			'option',
+			'p',
+			'path',
+			'section',
+			'span',
+			'strike',
+			'strong',
+			'sub',
+			'sup',
+			'svg',
+			'table',
+			'tbody',
+			'td',
+			'template',
+			'th',
+			'time',
+			'title',
+			'tr',
+			'u',
+			'ul',
+		),
 		'amp-story-bookend-allowed-descendants' => array(
 			'script',
 		),
@@ -107,6 +207,7 @@ class AMP_Allowed_Tags_Generated {
 			'small',
 			'solidcolor',
 			'span',
+			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -138,7 +239,6 @@ class AMP_Allowed_Tags_Generated {
 			'amp-experiment',
 			'amp-fit-text',
 			'amp-font',
-			'amp-gfycat',
 			'amp-gist',
 			'amp-google-vrview-image',
 			'amp-img',
@@ -234,6 +334,7 @@ class AMP_Allowed_Tags_Generated {
 			'solidcolor',
 			'source',
 			'span',
+			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -288,11 +389,8 @@ class AMP_Allowed_Tags_Generated {
 			'amp-fx-collection',
 			'amp-fx-flying-carpet',
 			'amp-gfycat',
-			'amp-gfycat',
-			'amp-gist',
 			'amp-gist',
 			'amp-google-document-embed',
-			'amp-google-vrview-image',
 			'amp-google-vrview-image',
 			'amp-hulu',
 			'amp-ima-video',
@@ -304,8 +402,6 @@ class AMP_Allowed_Tags_Generated {
 			'amp-jwplayer',
 			'amp-kaltura-player',
 			'amp-list',
-			'amp-list',
-			'amp-live-list',
 			'amp-live-list',
 			'amp-mathml',
 			'amp-megaphone',
@@ -417,6 +513,7 @@ class AMP_Allowed_Tags_Generated {
 			'solidcolor',
 			'source',
 			'span',
+			'stop',
 			'strong',
 			'sub',
 			'sup',
@@ -467,9 +564,11 @@ class AMP_Allowed_Tags_Generated {
 								'maps',
 								'bip',
 								'bbmi',
+								'chrome',
 								'itms-services',
 								'fb-me',
 								'fb-messenger',
+								'feed',
 								'intent',
 								'line',
 								'skype',
@@ -508,6 +607,7 @@ class AMP_Allowed_Tags_Generated {
 					'type' => array(
 						'value_casei' => array(
 							'text/html',
+							'application/rss+xml',
 						),
 					),
 				),
@@ -1326,6 +1426,7 @@ class AMP_Allowed_Tags_Generated {
 				'attr_spec_list' => array(
 					'data-amp-bind-src' => array(),
 					'filter' => array(
+						'mandatory' => true,
 						'value_casei' => array(
 							'custom',
 							'fuzzy',
@@ -1342,6 +1443,7 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'filter-value' => array(),
 					'highlight-user-entry' => array(),
+					'inline' => array(),
 					'items' => array(),
 					'max-entries' => array(),
 					'media' => array(),
@@ -1351,6 +1453,7 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'query' => array(),
 					'src' => array(
 						'value_url' => array(
 							'allow_relative' => true,
@@ -1686,6 +1789,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'data-video' => array(
 						'value_regex' => '[0-9]+',
+					),
+					'dock' => array(
+						'requires_extension' => array(
+							'amp-video-docking',
+						),
 					),
 					'media' => array(),
 					'noloading' => array(
@@ -2294,6 +2402,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'hide-keyboard-shortcuts-panel' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'highlighted' => array(),
 					'input-selector' => array(),
 					'locale' => array(),
@@ -2382,6 +2495,11 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-6]',
 					),
 					'format' => array(),
+					'hide-keyboard-shortcuts-panel' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'highlighted' => array(),
 					'input-selector' => array(),
 					'locale' => array(),
@@ -2474,6 +2592,11 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'format' => array(),
 					'fullscreen' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'hide-keyboard-shortcuts-panel' => array(
 						'value' => array(
 							'',
 						),
@@ -2575,6 +2698,11 @@ class AMP_Allowed_Tags_Generated {
 						'value_regex' => '[0-6]',
 					),
 					'format' => array(),
+					'hide-keyboard-shortcuts-panel' => array(
+						'value' => array(
+							'',
+						),
+					),
 					'highlighted' => array(),
 					'locale' => array(),
 					'max' => array(),
@@ -3523,6 +3651,130 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-inline-gallery' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							5,
+						),
+					),
+					'requires_extension' => array(
+						'amp-inline-gallery',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+				),
+			),
+		),
+		'amp-inline-gallery-pagination' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
+					'mandatory_ancestor' => 'amp-inline-gallery',
+					'requires_extension' => array(
+						'amp-inline-gallery',
+					),
+					'spec_name' => 'amp-inline-gallery-pagination',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'inset' => array(
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							1,
+						),
+					),
+					'mandatory_ancestor' => 'amp-inline-gallery',
+					'requires_extension' => array(
+						'amp-inline-gallery',
+					),
+					'spec_name' => 'amp-inline-gallery-pagination [inset]',
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+				),
+			),
+		),
+		'amp-inline-gallery-thumbnails' => array(
+			array(
+				'attr_spec_list' => array(
+					'aspect-ratio-height' => array(
+						'blacklisted_value_regex' => '^0+(\\.0+)?$',
+						'value_regex' => '\\d+(\\.\\d+)?',
+					),
+					'aspect-ratio-width' => array(
+						'blacklisted_value_regex' => '^0+(\\.0+)?$',
+						'value_regex' => '\\d+(\\.\\d+)?',
+					),
+					'loop' => array(
+						'value' => array(
+							'true',
+							'false',
+						),
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+							2,
+							3,
+							7,
+							9,
+							1,
+							4,
+						),
+					),
+					'mandatory_ancestor' => 'amp-inline-gallery',
+					'requires_extension' => array(
+						'amp-inline-gallery',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-inline-gallery',
+				),
+			),
+		),
 		'amp-instagram' => array(
 			array(
 				'attr_spec_list' => array(
@@ -3784,7 +4036,6 @@ class AMP_Allowed_Tags_Generated {
 					'credentials' => array(),
 					'data-amp-bind-is-layout-container' => array(),
 					'data-amp-bind-src' => array(),
-					'data-amp-bind-state' => array(),
 					'diffable' => array(
 						'value' => array(
 							'',
@@ -3823,6 +4074,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'template' => array(),
+					'xssi-prefix' => array(),
 				),
 				'tag_spec' => array(
 					'amp_layout' => array(
@@ -3836,6 +4088,7 @@ class AMP_Allowed_Tags_Generated {
 						),
 					),
 					'mandatory_anyof' => array(
+						'data-amp-bind-src',
 						'data-amp-bind-src',
 						'src',
 					),
@@ -3961,6 +4214,47 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-mega-menu' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							3,
+						),
+					),
+					'child_tags' => array(
+						'child_tag_name_oneof' => array(
+							'nav',
+							'amp-list',
+						),
+						'mandatory_num_child_tags' => 1,
+					),
+					'descendant_tag_list' => 'amp-mega-menu-allowed-descendants',
+					'reference_points' => array(
+						'AMP-MEGA-MENU > AMP-LIST' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+						'AMP-MEGA-MENU > NAV' => array(
+							'mandatory' => false,
+							'unique' => false,
+						),
+					),
+					'requires_extension' => array(
+						'amp-mega-menu',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-mega-menu',
+				),
+			),
+		),
 		'amp-megaphone' => array(
 			array(
 				'attr_spec_list' => array(
@@ -4057,8 +4351,8 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'curated',
-							'specific',
 							'semantic',
+							'specific',
 						),
 					),
 					'data-minimum-date-factor' => array(),
@@ -4087,11 +4381,11 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'amp_layout' => array(
 						'supported_layouts' => array(
-							4,
 							6,
 							2,
 							3,
 							7,
+							4,
 						),
 					),
 					'requires_extension' => array(
@@ -4132,17 +4426,59 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-nested-menu' => array(
+			array(
+				'attr_spec_list' => array(
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+					'side' => array(
+						'value' => array(
+							'left',
+							'right',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							6,
+						),
+					),
+					'descendant_tag_list' => 'amp-nested-menu-allowed-descendants',
+					'mandatory_ancestor' => 'amp-sidebar',
+					'requires_extension' => array(
+						'amp-sidebar',
+					),
+					'spec_url' => 'https://amp.dev/documentation/components/amp-nested-menu',
+				),
+			),
+		),
 		'amp-next-page' => array(
 			array(
-				'attr_spec_list' => array(),
+				'attr_spec_list' => array(
+					'deep-parsing' => array(),
+					'max-pages' => array(),
+				),
 				'tag_spec' => array(
 					'reference_points' => array(
-						'AMP-NEXT-PAGE > [separator]' => array(
+						'AMP-NEXT-PAGE > SCRIPT[type=application/json]' => array(
+							'mandatory' => true,
+							'unique' => true,
+						),
+						'AMP-NEXT-PAGE > [footer]' => array(
 							'mandatory' => false,
 							'unique' => true,
 						),
-						'amp-next-page extension .json configuration' => array(
-							'mandatory' => true,
+						'AMP-NEXT-PAGE > [recommendation-box]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'AMP-NEXT-PAGE > [separator]' => array(
+							'mandatory' => false,
 							'unique' => true,
 						),
 					),
@@ -4156,6 +4492,8 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'deep-parsing' => array(),
+					'max-pages' => array(),
 					'src' => array(
 						'blacklisted_value_regex' => '__amp_source_origin',
 						'mandatory' => true,
@@ -4166,9 +4504,22 @@ class AMP_Allowed_Tags_Generated {
 							),
 						),
 					),
+					'xssi-prefix' => array(),
 				),
 				'tag_spec' => array(
 					'reference_points' => array(
+						'AMP-NEXT-PAGE > SCRIPT[type=application/json]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'AMP-NEXT-PAGE > [footer]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'AMP-NEXT-PAGE > [recommendation-box]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
 						'AMP-NEXT-PAGE > [separator]' => array(
 							'mandatory' => false,
 							'unique' => true,
@@ -4190,6 +4541,8 @@ class AMP_Allowed_Tags_Generated {
 					'data-slot' => array(
 						'mandatory' => true,
 					),
+					'deep-parsing' => array(),
+					'max-pages' => array(),
 					'type' => array(
 						'mandatory' => true,
 						'value' => array(
@@ -4199,6 +4552,18 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(
 					'reference_points' => array(
+						'AMP-NEXT-PAGE > SCRIPT[type=application/json]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'AMP-NEXT-PAGE > [footer]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
+						'AMP-NEXT-PAGE > [recommendation-box]' => array(
+							'mandatory' => false,
+							'unique' => true,
+						),
 						'AMP-NEXT-PAGE > [separator]' => array(
 							'mandatory' => false,
 							'unique' => true,
@@ -4677,6 +5042,37 @@ class AMP_Allowed_Tags_Generated {
 				),
 			),
 		),
+		'amp-redbull-player' => array(
+			array(
+				'attr_spec_list' => array(
+					'data-param-videoid' => array(
+						'mandatory' => true,
+					),
+					'media' => array(),
+					'noloading' => array(
+						'value' => array(
+							'',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'amp_layout' => array(
+						'supported_layouts' => array(
+							2,
+							3,
+							4,
+							6,
+							7,
+							8,
+							9,
+						),
+					),
+					'requires_extension' => array(
+						'amp-redbull-player',
+					),
+				),
+			),
+		),
 		'amp-reddit' => array(
 			array(
 				'attr_spec_list' => array(
@@ -4785,6 +5181,7 @@ class AMP_Allowed_Tags_Generated {
 							2,
 							3,
 							7,
+							9,
 							1,
 							4,
 						),
@@ -4893,6 +5290,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-sidebar',
 					),
+					'spec_name' => 'amp-sidebar',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-sidebar',
 				),
 			),
@@ -5291,7 +5689,6 @@ class AMP_Allowed_Tags_Generated {
 							'amp-geo',
 							'amp-pixel',
 							'amp-sidebar',
-							'amp-story-access',
 							'amp-story-auto-ads',
 							'amp-story-bookend',
 							'amp-story-page',
@@ -5301,30 +5698,6 @@ class AMP_Allowed_Tags_Generated {
 					'mandatory_parent' => 'body',
 					'requires_extension' => array(
 						'amp-story',
-					),
-				),
-			),
-		),
-		'amp-story-access' => array(
-			array(
-				'attr_spec_list' => array(
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'type' => array(
-						'value' => array(
-							'blocking',
-							'notification',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'amp-story',
-					'requires_extension' => array(
-						'amp-access',
 					),
 				),
 			),
@@ -5460,6 +5833,7 @@ class AMP_Allowed_Tags_Generated {
 						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
 						'mandatory' => true,
 					),
+					'next-page-no-ad' => array(),
 				),
 				'tag_spec' => array(
 					'child_tags' => array(
@@ -5628,41 +6002,6 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-twitter',
 					),
-				),
-			),
-		),
-		'amp-user-location' => array(
-			array(
-				'attr_spec_list' => array(
-					'id' => array(
-						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
-						'mandatory' => true,
-					),
-					'media' => array(),
-					'noloading' => array(
-						'value' => array(
-							'',
-						),
-					),
-					'src' => array(
-						'value_url' => array(
-							'allow_relative' => false,
-							'protocol' => array(
-								'https',
-							),
-						),
-					),
-				),
-				'tag_spec' => array(
-					'amp_layout' => array(
-						'supported_layouts' => array(
-							1,
-						),
-					),
-					'requires_extension' => array(
-						'amp-user-location',
-					),
-					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
 				),
 			),
 		),
@@ -6742,6 +7081,16 @@ class AMP_Allowed_Tags_Generated {
 					'spec_name' => 'amp-list-load-more button[load-more-clickable]',
 				),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'button amp-nested-menu',
+				),
+			),
 		),
 		'canvas' => array(
 			array(
@@ -7281,6 +7630,25 @@ class AMP_Allowed_Tags_Generated {
 				'tag_spec' => array(
 					'mandatory_ancestor' => 'amp-list',
 					'spec_name' => 'AMP-LIST DIV [fetch-error]',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu' => array(),
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'disallowed_ancestor' => array(
+						'amp-accordion',
+					),
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'mandatory_oneof' => array(
+						'amp-nested-submenu',
+						'amp-nested-submenu-close',
+						'amp-nested-submenu-open',
+					),
+					'spec_name' => 'div amp-nested-menu',
 				),
 			),
 		),
@@ -8470,6 +8838,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h2 amp-nested-menu',
+				),
+			),
 		),
 		'h3' => array(
 			array(
@@ -8477,6 +8855,16 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h3 amp-nested-menu',
+				),
 			),
 		),
 		'h4' => array(
@@ -8486,6 +8874,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h4 amp-nested-menu',
+				),
+			),
 		),
 		'h5' => array(
 			array(
@@ -8494,6 +8892,16 @@ class AMP_Allowed_Tags_Generated {
 				),
 				'tag_spec' => array(),
 			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h5 amp-nested-menu',
+				),
+			),
 		),
 		'h6' => array(
 			array(
@@ -8501,6 +8909,16 @@ class AMP_Allowed_Tags_Generated {
 					'align' => array(),
 				),
 				'tag_spec' => array(),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'h6 amp-nested-menu',
+				),
 			),
 		),
 		'head' => array(
@@ -8840,7 +9258,7 @@ class AMP_Allowed_Tags_Generated {
 					'step' => array(),
 					'tabindex' => array(),
 					'type' => array(
-						'blacklisted_value_regex' => '(^|\\s)(button|file|image|password|)(\\s|$)',
+						'blacklisted_value_regex' => '(^|\\s)(file|image|password|)(\\s|$)',
 					),
 					'value' => array(),
 					'width' => array(),
@@ -11503,6 +11921,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'src' => array(
 						'dispatch_key' => 2,
@@ -11524,9 +11947,50 @@ class AMP_Allowed_Tags_Generated {
 					),
 				),
 				'tag_spec' => array(
-					'mandatory' => true,
+					'mandatory_alternatives' => 'amphtml engine v0.js script',
 					'mandatory_parent' => 'head',
 					'spec_name' => 'amphtml engine v0.js script',
+					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'src' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'https://cdn.ampproject.org/lts/v0.js',
+						),
+					),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'contents',
+						'regex' => '.',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_alternatives' => 'amphtml engine v0.js script',
+					'mandatory_parent' => 'head',
+					'spec_name' => 'amphtml engine v0.js lts script',
 					'spec_url' => 'https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup',
 					'unique' => true,
 				),
@@ -11610,6 +12074,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11635,6 +12104,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11658,6 +12132,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11689,6 +12168,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11717,6 +12201,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11743,6 +12232,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11802,6 +12296,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11827,6 +12326,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11850,6 +12354,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11878,6 +12387,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11904,6 +12418,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -11927,6 +12446,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -11980,6 +12504,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12003,6 +12532,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12055,6 +12589,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12078,6 +12617,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12105,6 +12649,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12130,6 +12679,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12153,6 +12707,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12205,6 +12764,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12230,6 +12794,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12253,6 +12822,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12308,6 +12882,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12331,6 +12910,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12358,6 +12942,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12381,6 +12970,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12408,6 +13002,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12431,6 +13030,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12459,6 +13063,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12482,6 +13091,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12535,6 +13149,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12558,6 +13177,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12585,6 +13209,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12608,6 +13237,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12635,6 +13269,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12658,6 +13297,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12685,6 +13329,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12708,6 +13357,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12761,6 +13415,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12784,6 +13443,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12811,6 +13475,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12834,6 +13503,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12861,6 +13535,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12884,6 +13563,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12911,6 +13595,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12934,6 +13623,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -12961,6 +13655,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -12984,6 +13683,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13037,6 +13741,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13060,6 +13769,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13087,6 +13801,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13110,6 +13829,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13137,6 +13861,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13160,6 +13889,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13187,6 +13921,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13210,6 +13949,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13237,6 +13981,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13260,6 +14009,41 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-inline-gallery',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13287,6 +14071,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13310,6 +14099,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13337,6 +14131,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13360,6 +14159,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13387,6 +14191,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13410,6 +14219,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13437,6 +14251,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13460,6 +14279,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13512,6 +14336,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13535,6 +14364,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13564,6 +14398,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13587,6 +14426,41 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-mega-menu',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13614,6 +14488,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13637,6 +14516,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13664,6 +14548,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13684,6 +14573,9 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'id' => array(
+						'blacklisted_value_regex' => '(^|\\s)(__amp_\\S*|__count__|__defineGetter__|__defineSetter__|__lookupGetter__|__lookupSetter__|__noSuchMethod__|__parent__|__proto__|__AMP_\\S*|\\$p|\\$proxy|acceptCharset|addEventListener|appendChild|assignedSlot|attachShadow|AMP|baseURI|checkValidity|childElementCount|childNodes|classList|className|clientHeight|clientLeft|clientTop|clientWidth|compareDocumentPosition|computedName|computedRole|contentEditable|createShadowRoot|enqueAction|firstChild|firstElementChild|getAnimations|getAttribute|getAttributeNS|getAttributeNode|getAttributeNodeNS|getBoundingClientRect|getClientRects|getDestinationInsertionPoints|getElementsByClassName|getElementsByTagName|getElementsByTagNameNS|getRootNode|hasAttribute|hasAttributeNS|hasAttributes|hasChildNodes|hasPointerCapture|i-amphtml-\\S*|innerHTML|innerText|inputMode|insertAdjacentElement|insertAdjacentHTML|insertAdjacentText|isContentEditable|isDefaultNamespace|isEqualNode|isSameNode|lastChild|lastElementChild|lookupNamespaceURI|namespaceURI|nextElementSibling|nextSibling|nodeName|nodeType|nodeValue|offsetHeight|offsetLeft|offsetParent|offsetTop|offsetWidth|outerHTML|outerText|ownerDocument|parentElement|parentNode|previousElementSibling|previousSibling|querySelector|querySelectorAll|releasePointerCapture|removeAttribute|removeAttributeNS|removeAttributeNode|removeChild|removeEventListener|replaceChild|reportValidity|requestPointerLock|scrollHeight|scrollIntoView|scrollIntoViewIfNeeded|scrollLeft|scrollWidth|setAttribute|setAttributeNS|setAttributeNode|setAttributeNodeNS|setPointerCapture|shadowRoot|styleMap|tabIndex|tagName|textContent|toString|valueOf|(webkit|ms|moz|o)dropzone|(webkit|moz|ms|o)MatchesSelector|(webkit|moz|ms|o)RequestFullScreen|(webkit|moz|ms|o)RequestFullscreen)(\\s|$)',
+					),
 					'nonce' => array(),
 					'template' => array(
 						'dispatch_key' => 2,
@@ -13728,6 +14620,41 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-nested-menu',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13741,6 +14668,7 @@ class AMP_Allowed_Tags_Generated {
 						'requires_usage' => true,
 						'version' => array(
 							'0.1',
+							'1.0',
 						),
 					),
 				),
@@ -13760,7 +14688,7 @@ class AMP_Allowed_Tags_Generated {
 					'requires_extension' => array(
 						'amp-next-page',
 					),
-					'spec_name' => 'amp-next-page extension .json configuration',
+					'spec_name' => 'AMP-NEXT-PAGE > SCRIPT[type=application/json]',
 					'spec_url' => 'https://amp.dev/documentation/components/amp-next-page',
 				),
 			),
@@ -13770,6 +14698,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13797,6 +14730,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13820,6 +14758,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13847,6 +14790,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13870,6 +14818,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13897,6 +14850,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13920,6 +14878,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13947,6 +14910,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -13970,6 +14938,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -13997,6 +14970,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14020,6 +14998,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14047,6 +15030,41 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
+					'nonce' => array(),
+					'type' => array(
+						'value_casei' => array(
+							'text/javascript',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'extension_spec' => array(
+						'name' => 'amp-redbull-player',
+						'requires_usage' => true,
+						'version' => array(
+							'0.1',
+						),
+					),
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'async' => array(
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14072,6 +15090,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14095,6 +15118,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14159,6 +15187,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14182,6 +15215,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14209,6 +15247,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14232,6 +15275,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14259,6 +15307,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14282,6 +15335,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14309,6 +15367,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14332,6 +15395,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14358,6 +15426,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14409,6 +15482,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14507,6 +15585,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14564,6 +15647,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14586,10 +15674,68 @@ class AMP_Allowed_Tags_Generated {
 			),
 			array(
 				'attr_spec_list' => array(
+					'cryptokeys' => array(
+						'dispatch_key' => 2,
+						'mandatory' => true,
+						'value' => array(
+							'',
+						),
+					),
+					'sha-256-hash' => array(
+						'mandatory' => true,
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/json',
+						),
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_parent' => 'head',
+					'requires_extension' => array(
+						'amp-subscriptions',
+					),
+					'spec_name' => 'cryptokeys .json script',
+					'unique' => true,
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'ciphertext' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+					),
+					'type' => array(
+						'mandatory' => true,
+						'value_casei' => array(
+							'application/octet-stream',
+						),
+					),
+				),
+				'cdata' => array(
+					'blacklisted_cdata_regex' => array(
+						'error_message' => 'html comments',
+						'regex' => '<!--',
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'body',
+					'mandatory_parent' => 'subscriptions-section content swg_amp_cache_nonce',
+					'spec_name' => 'subscriptions script ciphertext',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
 					'async' => array(
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14617,6 +15763,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14640,6 +15791,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14667,55 +15823,9 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
-					'nonce' => array(),
-					'type' => array(
-						'value_casei' => array(
-							'text/javascript',
-						),
-					),
-				),
-				'tag_spec' => array(
-					'extension_spec' => array(
-						'name' => 'amp-user-location',
-						'requires_usage' => true,
-						'version' => array(
-							'0.1',
-						),
-					),
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'nonce' => array(),
-					'type' => array(
-						'dispatch_key' => 3,
-						'mandatory' => true,
-						'value_casei' => array(
-							'application/json',
-						),
-					),
-				),
-				'cdata' => array(
-					'blacklisted_cdata_regex' => array(
-						'error_message' => 'html comments',
-						'regex' => '<!--',
-					),
-				),
-				'tag_spec' => array(
-					'mandatory_parent' => 'amp-user-location',
-					'requires_extension' => array(
-						'amp-user-location',
-					),
-					'spec_name' => 'amp-user-location extension .json script',
-					'spec_url' => 'https://amp.dev/documentation/components/amp-user-location',
-				),
-			),
-			array(
-				'attr_spec_list' => array(
-					'async' => array(
-						'mandatory' => true,
+					'crossorigin' => array(
 						'value' => array(
-							'',
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14741,6 +15851,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14769,6 +15884,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14792,6 +15912,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14820,6 +15945,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14843,6 +15973,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14870,6 +16005,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14893,6 +16033,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14920,6 +16065,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14943,6 +16093,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -14970,6 +16125,11 @@ class AMP_Allowed_Tags_Generated {
 							'',
 						),
 					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
+						),
+					),
 					'nonce' => array(),
 					'type' => array(
 						'value_casei' => array(
@@ -14994,6 +16154,11 @@ class AMP_Allowed_Tags_Generated {
 						'mandatory' => true,
 						'value' => array(
 							'',
+						),
+					),
+					'crossorigin' => array(
+						'value' => array(
+							'anonymous',
 						),
 					),
 					'nonce' => array(),
@@ -15058,6 +16223,26 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'mandatory_parent' => 'amp-accordion',
 					'spec_name' => 'amp-accordion > section',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'encrypted' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+					),
+					'subscriptions-section' => array(
+						'value_casei' => array(
+							'content',
+						),
+					),
+					'swg_amp_cache_nonce' => array(
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'body',
+					'spec_name' => 'subscriptions-section content swg_amp_cache_nonce',
 				),
 			),
 		),
@@ -15333,6 +16518,31 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(),
 				'tag_spec' => array(),
+			),
+			array(
+				'attr_spec_list' => array(
+					'amp-nested-submenu-close' => array(),
+					'amp-nested-submenu-open' => array(),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'amp-nested-menu',
+					'spec_name' => 'span amp-nested-menu',
+				),
+			),
+			array(
+				'attr_spec_list' => array(
+					'swg_amp_cache_nonce' => array(
+						'dispatch_key' => 1,
+						'mandatory' => true,
+					),
+				),
+				'tag_spec' => array(
+					'mandatory_ancestor' => 'body',
+					'requires_extension' => array(
+						'amp-subscriptions',
+					),
+					'spec_name' => 'span swg_amp_cache_nonce',
+				),
 			),
 		),
 		'stop' => array(
@@ -16229,6 +17439,11 @@ class AMP_Allowed_Tags_Generated {
 			array(
 				'attr_spec_list' => array(
 					'datetime' => array(),
+					'pubdate' => array(
+						'value' => array(
+							'',
+						),
+					),
 				),
 				'tag_spec' => array(),
 			),
@@ -17155,6 +18370,16 @@ class AMP_Allowed_Tags_Generated {
 		'itemscope' => array(),
 		'itemtype' => array(),
 		'lang' => array(),
+		'next-page-hide' => array(
+			'requires_extension' => array(
+				'amp-next-page',
+			),
+		),
+		'next-page-replace' => array(
+			'requires_extension' => array(
+				'amp-next-page',
+			),
+		),
 		'on' => array(),
 		'overflow' => array(),
 		'placeholder' => array(
@@ -17240,6 +18465,7 @@ class AMP_Allowed_Tags_Generated {
 				'rangeUnderflow',
 				'stepMismatch',
 				'tooLong',
+				'tooShort',
 				'typeMismatch',
 				'valueMissing',
 			),
@@ -17343,6 +18569,166 @@ class AMP_Allowed_Tags_Generated {
 			'tag_spec' => array(
 				'spec_name' => 'AMP-LIVE-LIST [update]',
 				'spec_url' => 'https://amp.dev/documentation/components/amp-live-list#update',
+			),
+		),
+		'AMP-MEGA-MENU > AMP-LIST' => array(
+			'attr_spec_list' => array(
+				'data-amp-bind-src' => array(),
+				'src' => array(),
+			),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'template',
+					),
+					'mandatory_num_child_tags' => 1,
+				),
+				'mandatory_anyof' => array(
+					'data-amp-bind-src',
+					'src',
+				),
+				'reference_points' => array(
+					'AMP-MEGA-MENU > AMP-LIST > TEMPLATE' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU > AMP-LIST',
+			),
+		),
+		'AMP-MEGA-MENU > AMP-LIST > TEMPLATE' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'nav',
+					),
+					'mandatory_num_child_tags' => 1,
+				),
+				'mandatory_parent' => 'amp-list',
+				'reference_points' => array(
+					'AMP-MEGA-MENU > NAV' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU > AMP-LIST > TEMPLATE',
+			),
+		),
+		'AMP-MEGA-MENU > NAV' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'ol',
+						'ul',
+					),
+					'mandatory_num_child_tags' => 1,
+				),
+				'reference_points' => array(
+					'AMP-MEGA-MENU NAV > UL/OL' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU > NAV',
+			),
+		),
+		'AMP-MEGA-MENU NAV > UL/OL' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'li',
+					),
+					'mandatory_min_num_child_tags' => 1,
+				),
+				'mandatory_parent' => 'nav',
+				'reference_points' => array(
+					'AMP-MEGA-MENU NAV > UL/OL > LI' => array(
+						'mandatory' => false,
+						'unique' => false,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU NAV > UL/OL',
+			),
+		),
+		'AMP-MEGA-MENU NAV > UL/OL > LI' => array(
+			'attr_spec_list' => array(),
+			'tag_spec' => array(
+				'child_tags' => array(
+					'child_tag_name_oneof' => array(
+						'a',
+						'button',
+						'div',
+						'h1',
+						'h2',
+						'h3',
+						'h4',
+						'h5',
+						'h6',
+						'span',
+					),
+					'mandatory_min_num_child_tags' => 1,
+				),
+				'reference_points' => array(
+					'AMP-MEGA-MENU item-content' => array(
+						'mandatory' => false,
+						'unique' => true,
+					),
+					'AMP-MEGA-MENU item-heading' => array(
+						'mandatory' => true,
+						'unique' => true,
+					),
+				),
+				'spec_name' => 'AMP-MEGA-MENU NAV > UL/OL > LI',
+			),
+		),
+		'AMP-MEGA-MENU item-content' => array(
+			'attr_spec_list' => array(
+				'role' => array(
+					'mandatory' => true,
+					'value' => array(
+						'dialog',
+					),
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-MEGA-MENU item-content',
+			),
+		),
+		'AMP-MEGA-MENU item-heading' => array(
+			'attr_spec_list' => array(
+				'role' => array(
+					'value' => array(
+						'button',
+					),
+				),
+			),
+			'tag_spec' => array(
+				'spec_name' => 'AMP-MEGA-MENU item-heading',
+			),
+		),
+		'AMP-NEXT-PAGE > [footer]' => array(
+			'attr_spec_list' => array(
+				'footer' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'mandatory_parent' => 'amp-next-page',
+				'spec_name' => 'AMP-NEXT-PAGE > [footer]',
+			),
+		),
+		'AMP-NEXT-PAGE > [recommendation-box]' => array(
+			'attr_spec_list' => array(
+				'recommendation-box' => array(
+					'mandatory' => true,
+				),
+			),
+			'tag_spec' => array(
+				'mandatory_parent' => 'amp-next-page',
+				'spec_name' => 'AMP-NEXT-PAGE > [recommendation-box]',
 			),
 		),
 		'AMP-NEXT-PAGE > [separator]' => array(

--- a/includes/sanitizers/class-amp-allowed-tags-generated.php
+++ b/includes/sanitizers/class-amp-allowed-tags-generated.php
@@ -4089,7 +4089,6 @@ class AMP_Allowed_Tags_Generated {
 					),
 					'mandatory_anyof' => array(
 						'data-amp-bind-src',
-						'data-amp-bind-src',
 						'src',
 					),
 					'requires_extension' => array(

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -2224,7 +2224,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 	 *
 	 * @since 0.5
 	 *
-	 * @todo It would be more robust if the the actual tag spec were looked up and then matched against the parent, but this is currently overkill.
+	 * @todo It would be more robust if the the actual tag spec were looked up (see https://github.com/ampproject/amp-wp/pull/3817) and then matched against the parent. This is needed to support the spec 'subscriptions script ciphertext'.
 	 *
 	 * @param DOMElement $node             Node.
 	 * @param string     $parent_spec_name Parent spec name, for example 'body' or 'form [method=post]'.

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -570,9 +570,9 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'brid-player'                                  => [
-				'<amp-brid-player data-dynamic="abc" data-partner="264" data-player="4144" data-video="13663" layout="responsive" width="480" height="270"></amp-brid-player>',
+				'<amp-brid-player data-dynamic="abc" data-partner="264" data-player="4144" data-video="13663" layout="responsive" width="480" height="270" dock></amp-brid-player>',
 				null,
-				[ 'amp-brid-player' ],
+				[ 'amp-brid-player', 'amp-video-docking' ],
 			],
 
 			'brightcove'                                   => [
@@ -718,6 +718,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						'<a href="webcal:foo">Click me.</a>',
 						'<a href="whatsapp:foo">Click me.</a>',
 						'<a href="web+mastodon:follow/@handle@instance">Click me.</a>',
+						'<a href="feed://blog.amp.dev/feed/" type="application/rss+xml">Click me.</a>',
 					]
 				),
 			],
@@ -2039,7 +2040,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			'amp-autocomplete'                             => [
 				'
 					<form method="post" action-xhr="/form/echo-json/post" target="_blank" on="submit-success:AMP.setState({result: event.response})">
-						<amp-autocomplete id="autocomplete" filter="substring" min-characters="0">
+						<amp-autocomplete id="autocomplete" filter="substring" min-characters="0" inline="@">
 							<input type="text" id="input">
 							<script type="application/json" id="script">
 							{ "items" : ["apple", "banana", "orange"] }
@@ -2051,6 +2052,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						<script type="application/json" id="script">
 						{ "items" : ["red", "green", "blue"] }
 						</script>
+					</amp-autocomplete>
+					<amp-autocomplete
+						filter="prefix"
+						src="https://example.com/articles.json?ref=CANONICAL_URL"
+						query="q">
+						<input>
 					</amp-autocomplete>
 				',
 				null,
@@ -2283,6 +2290,79 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				',
 				null,
 				[ 'amp-base-carousel', 'amp-inline-gallery', 'amp-lightbox-gallery' ],
+			],
+
+			'amp-mega-menu'                                => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+					<nav>
+						<ul>
+							<li>
+								<span role="button">Image</span>
+								<div role="dialog">
+									<amp-img
+											src="/static/inline-examples/images/image1.jpg"
+											width="300"
+											height="200"></amp-img>
+								</div>
+							</li>
+							<li>
+								<span role="button">List</span>
+								<div role="dialog">
+									<ol>
+										<li>item 1</li>
+										<li>item 2</li>
+										<li>item 3</li>
+									</ol>
+								</div>
+							</li>
+							<li>
+								<a href="https://amp.dev/">Link</a>
+							</li>
+						</ul>
+					</nav>
+				</amp-mega-menu>
+				',
+				null,
+				[ 'amp-mega-menu' ],
+			],
+
+			'amp-nested-menu'                              => [
+				'
+				<button on="tap:sidebar1">Open Sidebar</button>
+				<amp-sidebar id="sidebar1" layout="nodisplay" style="width:300px">
+					<amp-nested-menu layout="fill">
+						<ul>
+							<li>
+								<h4 amp-nested-submenu-open>Open Sub-Menu</h4>
+								<div amp-nested-submenu>
+									<ul>
+										<li>
+											<h4 amp-nested-submenu-close>go back</h4>
+										</li>
+										<li>
+											<h4 amp-nested-submenu-open>Open Another Sub-Menu</h4>
+											<div amp-nested-submenu>
+												<h4 amp-nested-submenu-close>go back</h4>
+												<amp-img
+														src="/static/inline-examples/images/image1.jpg"
+														layout="responsive"
+														width="450"
+														height="300"></amp-img>
+											</div>
+										</li>
+									</ul>
+								</div>
+							</li>
+							<li>
+								<a href="https://amp.dev/">Link</a>
+							</li>
+						</ul>
+					</amp-nested-menu>
+				</amp-sidebar>
+				',
+				null,
+				[ 'amp-sidebar' ],
 			],
 		];
 	}

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2437,6 +2437,85 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-mega-menu' ],
 			],
 
+			'amp-mega-menu-with-template'                  => [
+				'
+				<amp-mega-menu height="60" layout="fixed-height">
+				  <amp-list
+				    height="350"
+				    layout="fixed-height"
+				    src="/static/samples/json/product-single-item.json"
+				    single-item>
+				    <template type="amp-mustache">
+				      <nav>
+				        <ul>
+				{{#values}}          <li>
+				            <h4 role="button">{{name}}</h4>
+				            <div role="dialog">
+				              <amp-img
+				                src="{{img}}"
+				                width="320"
+				                height="213"></amp-img>
+				              <p>Price: $<b>{{price}}</b></p>
+				            </div>
+				          </li>
+				{{/values}}        </ul>
+				      </nav>
+				    </template>
+				  </amp-list>
+				</amp-mega-menu>
+				',
+				null,
+				[ 'amp-mega-menu', 'amp-list', 'amp-mustache' ],
+			],
+
+			'amp-mega-menu-disallowed-descendants'         => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+					<nav>
+						<ul>
+							<li>
+								<span role="button">List</span>
+								<div role="dialog">
+									<details><summary>Not</summary> allowed</details>
+								</div>
+							</li>
+							<li>
+								<a href="https://amp.dev/">Link</a>
+							</li>
+						</ul>
+					</nav>
+				</amp-mega-menu>
+				',
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+					<nav>
+						<ul>
+							<li>
+								<span role="button">List</span>
+								<div role="dialog"></div>
+							</li>
+							<li>
+								<a href="https://amp.dev/">Link</a>
+							</li>
+						</ul>
+					</nav>
+				</amp-mega-menu>
+				',
+				[ 'amp-mega-menu' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_DESCENDANT_TAG ],
+			],
+
+			'amp-mega-menu-invalid-child'                  => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+					<div>Not allowed</div>
+				</amp-mega-menu>
+				',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
+			],
+
 			'amp-nested-menu'                              => [
 				'
 				<button on="tap:sidebar1">Open Sidebar</button>

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2248,6 +2248,42 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<amp-img src="/img1.png" layout="fill"></amp-img>',
 				null,
 			],
+
+			'amp-inline-gallery'                           => [
+				'
+				<amp-inline-gallery layout="container">
+					<amp-base-carousel
+							class="gallery"
+							layout="responsive"
+							width="3.6"
+							height="2"
+							snap-align="center"
+							loop="true"
+							visible-count="1.2"
+							lightbox>
+						<amp-img
+								src="/static/inline-examples/images/image1.jpg"
+								layout="responsive"
+								width="450"
+								height="300"></amp-img>
+						<amp-img
+								src="/static/inline-examples/images/image2.jpg"
+								layout="responsive"
+								width="450"
+								height="300"></amp-img>
+						<amp-img
+								src="/static/inline-examples/images/image3.jpg"
+								layout="responsive"
+								width="450"
+								height="300"></amp-img>
+					</amp-base-carousel>
+					<amp-inline-gallery-pagination layout="nodisplay" inset>
+					</amp-inline-gallery-pagination>
+				</amp-inline-gallery>
+				',
+				null,
+				[ 'amp-base-carousel', 'amp-inline-gallery', 'amp-lightbox-gallery' ],
+			],
 		];
 	}
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2402,6 +2402,65 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-base-carousel', 'amp-inline-gallery', 'amp-lightbox-gallery' ],
 			],
 
+			'amp-inline-gallery-with-thumbs'               => [
+				'
+				<amp-inline-gallery layout="container">
+				  <!--
+				    The amp-layout with layout="container" is used to display the pagination on
+				    top of the carousel instead of the thumbnails. You can also use a div with
+				    `position: relative;`
+				  -->
+				  <amp-layout layout="container">
+				    <amp-base-carousel
+				      class="gallery"
+				      layout="responsive"
+				      width="3"
+				      height="2"
+				      snap-align="center"
+				      loop="true">
+				      <amp-img
+				        class="slide"
+				        layout="flex-item"
+				        src="https://picsum.photos/id/779/600/400"
+				        srcset="https://picsum.photos/id/779/150/100 150w,
+				                https://picsum.photos/id/779/600/400 600w,
+				                https://picsum.photos/id/779/1200/800 1200w">
+				      </amp-img>
+				      <amp-img
+				        class="slide"
+				        layout="flex-item"
+				        src="https://picsum.photos/id/1048/600/400"
+				        srcset="https://picsum.photos/id/1048/150/100 150w,
+				                https://picsum.photos/id/1048/600/400 600w,
+				                https://picsum.photos/id/1048/1200/800 1200w">
+				      </amp-img>
+				      <amp-img
+				        class="slide"
+				        layout="flex-item"
+				        src="https://picsum.photos/id/108/600/400"
+				        srcset="https://picsum.photos/id/108/150/100 150w,
+				                https://picsum.photos/id/108/600/400 600w,
+				                https://picsum.photos/id/108/1200/800 1200w">
+				      </amp-img>
+				    </amp-base-carousel>
+				    <!--
+				        If using fewer than 8 slides, consider adding something
+				        like media="(max-width: 799px)".
+				      -->
+				    <amp-inline-gallery-pagination layout="nodisplay" inset>
+				    </amp-inline-gallery-pagination>
+				  </amp-layout>
+				  <amp-inline-gallery-thumbnails
+				    media="(min-width: 800px)"
+				    layout="fixed-height"
+				    height="96">
+				  </amp-inline-gallery-thumbnails>
+				</amp-inline-gallery>
+				',
+				null,
+				[ 'amp-base-carousel', 'amp-inline-gallery' ],
+			],
+
 			'amp-mega-menu'                                => [
 				'
 				<amp-mega-menu height="30" layout="fixed-height">

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2516,6 +2516,65 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
 			],
 
+			'amp-mega-menu-invalid-grandchild'             => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+				  <nav>
+				    <div>
+				      Not allowed
+				    </div>
+				  </nav>
+				</amp-mega-menu>
+				',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
+			],
+
+			'amp-mega-menu-missing-grandchild'             => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+				  <nav></nav>
+				</amp-mega-menu>
+				',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
+			],
+
+			'amp-mega-menu-missing-great-grandchild'       => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+				  <nav><ul></ul></nav>
+				</amp-mega-menu>
+				',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
+			],
+
+			'amp-mega-menu-missing-great-great-grandchild' => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+				  <nav><ul><li></li></ul></nav>
+				</amp-mega-menu>
+				',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
+			],
+
+			'amp-mega-menu-invalid-great-great-grandchild' => [
+				'
+				<amp-mega-menu height="30" layout="fixed-height">
+				  <nav><ul><li><section></section></li></ul></nav>
+				</amp-mega-menu>
+				',
+				'',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
+			],
+
 			'amp-nested-menu'                              => [
 				'
 				<button on="tap:sidebar1">Open Sidebar</button>

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -71,6 +71,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG_ANCESTOR ],
 			],
 
+			'amp-script-intrinsic'                         => [
+				'
+				<amp-script src="https://example.com/hello-world.js" layout="intrinsic" width="200" height="123">
+					<button>Hello amp-script!</button>
+				</amp-script>
+				',
+				null,
+				[ 'amp-script' ],
+			],
+
 			'bad-svg-stop'                                 => [
 				'<stop offset="5%" stop-color="gold" />',
 				'',
@@ -399,11 +409,56 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				],
 			],
 
-			// AMP-NEXT-PAGE > [separator].
-			'reference-point-amp-next-page-separator'      => [
-				'<amp-next-page src="https://example.com/config.json"><div separator><h1>Keep reading</h1></div></amp-next-page>',
+			'amp-next-page-example'                        => [
+				'
+				<amp-next-page deep-parsing="false" max-pages="5">
+				 <script type="application/json">
+				   [
+				     {
+				       "image": "https://example.com/image1.jpg",
+				       "title": "This article shows first",
+				       "url": "https://example.com/article1.amp.html"
+				     }
+				   ]
+				 </script>
+				</amp-next-page>
+				',
 				null,
 				[ 'amp-next-page' ],
+			],
+
+			// AMP-NEXT-PAGE > [separator].
+			'reference-point-amp-next-page-separator'      => [
+				'<amp-next-page src="https://example.com/config.json" xssi-prefix=")]}"><div separator><h1>Keep reading</h1></div></amp-next-page>',
+				null,
+				[ 'amp-next-page' ],
+			],
+
+			// AMP-NEXT-PAGE > [footer].
+			'reference-point-amp-next-page-footer'         => [
+				'<amp-next-page src="https://example.com/config.json"><div footer>The footer</div></amp-next-page>',
+				null,
+				[ 'amp-next-page' ],
+			],
+
+			// AMP-NEXT-PAGE > [recommendation-box].
+			'reference-point-amp-next-page-recommendation' => [
+				'
+				<amp-next-page src="https://example.com/config.json">
+				  <div recommendation-box class="my-custom-recommendation-box">
+				    Here are a few more articles:
+				    <template type="amp-mustache">
+				      <div class="recommendation-box-content">
+				{{#pages}}        <span class="title">{{title}}</span>
+				        <span class="url">{{url}}</span>
+				        <span class="image">{{image}}</span>
+				{{/pages}}      </div>
+				    </template>
+				  </div>
+				</amp-next-page>
+				',
+				null,
+				[ 'amp-next-page', 'amp-mustache' ],
 			],
 
 			// amp-next-page extension .json configuration.
@@ -1489,7 +1544,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'amp_date_picker'                              => [
-				'<amp-date-picker id="simple-date-picker" type="single" mode="overlay" layout="container" on="select:AMP.setState({date1: event.date, dateType1: event.id})" format="Y-MM-DD" open-after-select input-selector="[name=date1]" class="mr1 ml1 flex picker"><div class="ampstart-input inline-block mt1"><input class="border-none p0" name="date1" placeholder="Pick a date"></div><button class="ampstart-btn m1 caps" on="tap: simple-date-picker.clear">Clear</button></amp-date-picker>',
+				'<amp-date-picker id="simple-date-picker" type="single" mode="overlay" layout="container" on="select:AMP.setState({date1: event.date, dateType1: event.id})" format="Y-MM-DD" open-after-select input-selector="[name=date1]" class="mr1 ml1 flex picker" hide-keyboard-shortcuts-panel><div class="ampstart-input inline-block mt1"><input class="border-none p0" name="date1" placeholder="Pick a date"></div><button class="ampstart-btn m1 caps" on="tap: simple-date-picker.clear">Clear</button></amp-date-picker>',
 				null, // No change.
 				[ 'amp-date-picker' ],
 			],
@@ -1845,7 +1900,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 					[ "\n", "\t" ],
 					'',
 					'
-						<amp-list load-more="auto" src="https://www.load.more.example.com/" width="400" height="800">
+						<amp-list load-more="auto" src="https://www.load.more.example.com/" width="400" height="800" xssi-prefix=")]}\'">
 							<amp-list-load-more load-more-button>
 								<template type="amp-mustache">
 									Showing {{#count}} out of {{#total}} items
@@ -2363,6 +2418,20 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				',
 				null,
 				[ 'amp-sidebar' ],
+			],
+
+			'amp-redbull-player'                           => [
+				'
+				<amp-redbull-player
+				  id="rbvideo"
+				  data-param-videoid="rrn:content:videos:3965a26c-052e-575f-a28b-ded6bee23ee1:en-INT"
+				  data-param-skinid="com"
+				  data-param-locale="en"
+				  height="360"
+				  width="640"></amp-redbull-player>
+				',
+				null,
+				[ 'amp-redbull-player' ],
 			],
 		];
 	}

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -427,6 +427,19 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-next-page' ],
 			],
 
+			'amp-next-page-hide-and-replace'               => [
+				'
+				<header class="my-header" next-page-hide>
+					<h2>Text here.</h2>
+				</header>
+				<div class="sticky" next-page-replace="sticky-123">
+					<h2>The second sticky will replace me once you scroll past my page</h2>
+				</div>
+				',
+				null,
+				[ 'amp-next-page' ],
+			],
+
 			// AMP-NEXT-PAGE > [separator].
 			'reference-point-amp-next-page-separator'      => [
 				'<amp-next-page src="https://example.com/config.json" xssi-prefix=")]}"><div separator><h1>Keep reading</h1></div></amp-next-page>',
@@ -717,6 +730,48 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'form'                                         => [
 				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"><input type="button" value="Open Lightbox" on="tap:lb1.open"></fieldset></form>',
+				null,
+				[ 'amp-form' ],
+			],
+
+			'form-visible-when-invalid'                    => [
+				'
+				<form method="post"
+				    action-xhr="https://example.com/subscribe"
+				    custom-validation-reporting="show-all-on-submit" target="_blank">
+				    <fieldset>
+				      <label>
+				        <span>Name:</span>
+				        <input type="text"
+				          name="name"
+				          id="name5"
+				          required
+				          pattern="\w+\s\w+">
+				        <span visible-when-invalid="valueMissing"
+				          validation-for="name5"></span>
+				        <span visible-when-invalid="patternMismatch"
+				          validation-for="name5">
+				          Please enter your first and last name separated by a space (e.g. Jane Miller)
+				        </span>
+				      </label>
+				      <br>
+				      <label>
+				        <span>Email:</span>
+				        <input type="email"
+				          name="email"
+				          id="email5"
+				          required>
+				        <span visible-when-invalid="valueMissing"
+				          validation-for="email5"></span>
+				        <span visible-when-invalid="typeMismatch"
+				          validation-for="email5"></span>
+				      </label>
+				      <br>
+				      <input type="submit"
+				        value="Subscribe">
+				    </fieldset>
+				  </form>
+				',
 				null,
 				[ 'amp-form' ],
 			],

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2554,6 +2554,39 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-sidebar' ],
 			],
 
+			'amp-nested-menu-with-amp-list'                => [
+				'
+				<button on="tap:sidebar2">Open Sidebar</button>
+				<amp-sidebar id="sidebar2" layout="nodisplay" style="width:300px">
+				  <amp-list
+				    layout="fill"
+				    src="/static/inline-examples/data/amp-list-data.json"
+				    items="."
+				    single-item>
+				    <template type="amp-mustache">
+				      <amp-nested-menu layout="fill">
+				        <ul>
+				{{#items}}          <li>
+				            <h3 amp-nested-submenu-open>{{title}}</h3>
+				            <div amp-nested-submenu>
+				              <button amp-nested-submenu-close>close</button>
+				              <amp-img
+				                src="{{imageUrl}}"
+				                layout="responsive"
+				                width="400"
+				                height="300"></amp-img>
+				            </div>
+				          </li>
+				{{/items}}        </ul>
+				      </amp-nested-menu>
+				    </template>
+				  </amp-list>
+				</amp-sidebar>
+				',
+				null,
+				[ 'amp-sidebar', 'amp-list', 'amp-mustache' ],
+			],
+
 			'amp-redbull-player'                           => [
 				'
 				<amp-redbull-player

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -499,7 +499,7 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 						'',
 						'
 						<amp-story standalone live-story-disabled supports-landscape title="My Story" publisher="The AMP Team" publisher-logo-src="https://example.com/logo/1x1.png" poster-portrait-src="https://example.com/my-story/poster/3x4.jpg" poster-square-src="https://example.com/my-story/poster/1x1.jpg" poster-landscape-src="https://example.com/my-story/poster/4x3.jpg" background-audio="my.mp3">
-							<amp-story-page id="my-first-page">
+							<amp-story-page id="my-first-page" next-page-no-ad>
 								<amp-story-grid-layer template="fill">
 									<amp-img id="object1" animate-in="rotate-in-left" src="https://example.ampproject.org/helloworld/bg1.jpg" width="900" height="1600">
 									</amp-img>
@@ -716,8 +716,8 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 			],
 
 			'form'                                         => [
-				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"></fieldset></form>',
-				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"></fieldset></form>',
+				'<form method="get" action="/form/search-html/get" target="_blank"><fieldset><label><span>Search for</span><input type="search" placeholder="test" name="term" required></label><input type="submit" value="Search"><input type="button" value="Open Lightbox" on="tap:lb1.open"></fieldset></form>',
+				null,
 				[ 'amp-form' ],
 			],
 
@@ -2687,6 +2687,16 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				'<html><head><meta charset="utf-8"></head><body></body></html>',
 				[],
 				[ AMP_Tag_And_Attribute_Sanitizer::MANDATORY_CDATA_MISSING_OR_INCORRECT ],
+			],
+			'amp_runtime'                             => [
+				'<html><head><meta charset="utf-8"><script async src="https://cdn.ampproject.org/v0.js" crossorigin="anonymous"></script></head><body></body></html>',
+				null,
+				[],
+			],
+			'amp_runtime_lts'                         => [
+				'<html><head><meta charset="utf-8"><script async src="https://cdn.ampproject.org/lts/v0.js" crossorigin="anonymous"></script></head><body></body></html>',
+				null,
+				[],
 			],
 		];
 

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2075,16 +2075,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-truncate-text' ],
 			],
 
-			'amp-user-location'                            => [
-				'
-					<button on="tap: location.request()">Use my location</button>
-					<amp-user-location id="location" on="approve:AMP.setState({located: true})" layout="nodisplay">
-					</amp-user-location>
-				',
-				null,
-				[ 'amp-user-location' ],
-			],
-
 			'amp-megaphone'                                => [
 				'<amp-megaphone height="166" layout="fixed-height" data-episode="OSC7749686951" data-light></amp-megaphone>',
 				null,

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2753,6 +2753,25 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				null,
 				[],
 			],
+			'amp-subscriptions'                       => [
+				// @todo The <script ciphertext type="application/octet-stream">...</script> but it is not yet supported. Support depends on todo in \AMP_Tag_And_Attribute_Sanitizer::has_parent().
+				'
+					<html>
+						<head>
+							<meta charset="utf-8">
+							<script cryptokeys sha-256-hash type="application/json">{}</script>
+						</head>
+						<body>
+							<section subscriptions-section="content" encrypted swg_amp_cache_nonce="NONCE">
+								...
+							</section>
+							<span swg_amp_cache_nonce="NONCE"></span>
+						</body>
+					</html>
+				',
+				null,
+				[ 'amp-subscriptions' ],
+			],
 		];
 
 		$bad_dev_mode_document = sprintf(

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2516,65 +2516,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
 			],
 
-			'amp-mega-menu-invalid-grandchild'             => [
-				'
-				<amp-mega-menu height="30" layout="fixed-height">
-				  <nav>
-				    <div>
-				      Not allowed
-				    </div>
-				  </nav>
-				</amp-mega-menu>
-				',
-				'',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
-			],
-
-			'amp-mega-menu-missing-grandchild'             => [
-				'
-				<amp-mega-menu height="30" layout="fixed-height">
-				  <nav></nav>
-				</amp-mega-menu>
-				',
-				'',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
-			],
-
-			'amp-mega-menu-missing-great-grandchild'       => [
-				'
-				<amp-mega-menu height="30" layout="fixed-height">
-				  <nav><ul></ul></nav>
-				</amp-mega-menu>
-				',
-				'',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
-			],
-
-			'amp-mega-menu-missing-great-great-grandchild' => [
-				'
-				<amp-mega-menu height="30" layout="fixed-height">
-				  <nav><ul><li></li></ul></nav>
-				</amp-mega-menu>
-				',
-				'',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
-			],
-
-			'amp-mega-menu-invalid-great-great-grandchild' => [
-				'
-				<amp-mega-menu height="30" layout="fixed-height">
-				  <nav><ul><li><section></section></li></ul></nav>
-				</amp-mega-menu>
-				',
-				'',
-				[],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_CHILD_TAG ],
-			],
-
 			'amp-nested-menu'                              => [
 				'
 				<button on="tap:sidebar1">Open Sidebar</button>


### PR DESCRIPTION
Previously #3619.

- [x] Run `./bin/amphtml-update.sh` (`lando ssh -c 'bash ./bin/amphtml-update.sh vendor/amphtml'`)
- [x] Examine diff for changelog
- [x] Update spec generator as needed based on spec format changes.
- [x] Modify validating sanitizer based on changes to spec, if needed.
- [x] Add tests for key changes

# Changelog

* Add component: `amp-inline-gallery`, including `amp-inline-gallery-pagination` and `amp-inline-gallery-thumbnails`.
* Add component: `amp-mega-menu`. 
* Add component: `amp-nested-menu`.  Added `amp-nested-submenu-close` and `amp-nested-submenu-open` attributes to nested `button` elements, as well as adding attributes to `div`, `span`, and each level of heading elements (`h2`–`h6`).
* New link protocols: `chrome` and `feed`. Allowing type of `application/rss+xml`.
* Updates to what are allowed in `amp-story-page-attachment` and `amp-story-grid-layer`.
* Update attributes for `amp-autocomplete`, allowing `inline` and `query` attributes, and making `filter` mandatory.
* Add `dock` support to `amp-brid-player`.
* Add `hide-keyboard-shortcuts-panel` to `amp-date-picker`.
* Update `amp-list`, removing `[state]` attribute and adding `xssi-prefix`.
* Update `amp-next-page`, adding attributes for `deep-parsing` and `max-pages`, and adding reference points.
* Add component: `amp-redbull-player`.
* Add `intrinsic` layout to `amp-script`.
* Remove `amp-story-access` component.
* Add `next-page-no-ad` attribute to `amp-story-page`.
* Remove `amp-user-location` component.
* Allow `input[type=button]` element.
* Update `script[type=text/plain][template=amp-mustache]` to accept an `id` attribute.
* Add `subscriptions script ciphertext` and `cryptokeys .json script`.
* Update `time` to allow `pubdate` attribute.
* Update global attribute list to include `next-page-hide` and `next-page-replace`. 
* Update `visible-when-invalid` global attribute to add `tooShort` value.
* Add recognition of of LTS release channel. Full support including opt-in will come with https://github.com/ampproject/amp-wp/pull/4403.
* Allow `crossorigin=anonymous` attribute to `script` and `link` elements. Will become the default with https://github.com/ampproject/amp-wp/pull/4403.
* Add reference points for:
  * `amp-mega-menu` — note these do not currently enforce validation, as can be seen in the failing and now-reverted commit 7550879d04412a26f348deacf1520fa44ba1ef19. Work will need to be done later to improve validation for reference points. The most important thing is that valid AMP is not being treated as invalid.
    * `AMP-MEGA-MENU > AMP-LIST`
    * `AMP-MEGA-MENU > AMP-LIST > TEMPLATE`
    * `AMP-MEGA-MENU > NAV`
    * `AMP-MEGA-MENU NAV > UL/OL`
    * `AMP-MEGA-MENU NAV > UL/OL > LI`
    * `AMP-MEGA-MENU item-content`
    * `AMP-MEGA-MENU item-heading`
  * `AMP-NEXT-PAGE > [footer]`
  * `AMP-NEXT-PAGE > [recommendation-box]`

# Details

```bash
(
    PREV_VERSION=1910161528000;
    THIS_VERSION=2003031842100; 
    git checkout $THIS_VERSION;
    git diff $PREV_VERSION...$THIS_VERSION -w -- $( git ls-files | grep '.protoascii' );
    git checkout - > /dev/null
)
```


<details>
<summary>Compare 1910161528000..2003031842100</summary>

```diff
diff --git a/extensions/amp-access/validator-amp-access.protoascii b/extensions/amp-access/validator-amp-access.protoascii
index cf6966c76..2226348dd 100644
--- a/extensions/amp-access/validator-amp-access.protoascii
+++ b/extensions/amp-access/validator-amp-access.protoascii
@@ -20,7 +20,7 @@ tags: {  # amp-access
     name: "amp-access"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-accordion/validator-amp-accordion.protoascii b/extensions/amp-accordion/validator-amp-accordion.protoascii
index c646ff1a8..c1f007a2a 100644
--- a/extensions/amp-accordion/validator-amp-accordion.protoascii
+++ b/extensions/amp-accordion/validator-amp-accordion.protoascii
@@ -22,7 +22,7 @@ tags: {  # amp-accordion
     name: "amp-accordion"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
@@ -35,7 +35,7 @@ tags: {  # amp-accordion
     name: "amp-accordion"
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-ad/validator-amp-ad.protoascii b/extensions/amp-ad/validator-amp-ad.protoascii
index 67cce32bb..4cae8ec1b 100644
--- a/extensions/amp-ad/validator-amp-ad.protoascii
+++ b/extensions/amp-ad/validator-amp-ad.protoascii
@@ -38,7 +38,7 @@ tags: {  # amp-ad
     name: "amp-ad"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-analytics/validator-amp-analytics.protoascii b/extensions/amp-analytics/validator-amp-analytics.protoascii
index b63d599a5..b59d28352 100644
--- a/extensions/amp-analytics/validator-amp-analytics.protoascii
+++ b/extensions/amp-analytics/validator-amp-analytics.protoascii
@@ -24,7 +24,7 @@ tags: {  # amp-analytics
     name: "amp-analytics"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-anim/validator-amp-anim.protoascii b/extensions/amp-anim/validator-amp-anim.protoascii
index 56cbfae06..b6656fbfd 100644
--- a/extensions/amp-anim/validator-amp-anim.protoascii
+++ b/extensions/amp-anim/validator-amp-anim.protoascii
@@ -23,7 +23,7 @@ tags: {  # amp-anim
     name: "amp-anim"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-apester-media/validator-amp-apester-media.protoascii b/extensions/amp-apester-media/validator-amp-apester-media.protoascii
index c923f8e8d..1ecb27d54 100644
--- a/extensions/amp-apester-media/validator-amp-apester-media.protoascii
+++ b/extensions/amp-apester-media/validator-amp-apester-media.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-apester-media
     name: "amp-apester-media"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-audio/validator-amp-audio.protoascii b/extensions/amp-audio/validator-amp-audio.protoascii
index 8592a2f64..b35a10c7c 100644
--- a/extensions/amp-audio/validator-amp-audio.protoascii
+++ b/extensions/amp-audio/validator-amp-audio.protoascii
@@ -22,7 +22,7 @@ tags: {  # amp-audio
     version: "0.1"
     version: "latest"
     deprecated_allow_duplicates: true
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
index 803ec9a2c..4d51a7403 100644
--- a/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
+++ b/extensions/amp-autocomplete/validator-amp-autocomplete.protoascii
@@ -41,14 +41,24 @@ tags: {  # <amp-autocomplete>
       if_value_regex: "custom"
       also_requires_attr: "filter-expr"
     }
+    mandatory: true
   }
   attrs: {
     name: "filter-expr"
     requires_extension: "amp-bind"
   }
   attrs: { name: "filter-value" }
+  attrs: { name: "highlight-user-entry" }
+  attrs: { name: "inline" }
+  attrs: { name: "items" }
   attrs: { name: "max-entries" }
   attrs: { name: "min-characters" }
+  attrs: {
+    name: "query"
+    trigger: {
+      also_requires_attr: "src"
+    }
+  }
   attrs: {
     name: "src"
     value_url: {
@@ -59,13 +69,8 @@ tags: {  # <amp-autocomplete>
   attrs: { name: "submit-on-enter" }
   attrs: {
     name: "suggest-first"
-    trigger: {
-      also_requires_attr: "filter"
-    }
   }
-  attrs: { name: "highlight-user-entry" }
   attrs: { name: "template" }
-  attrs: { name: "items" }
   # amp-bind
   attrs: {
     name: "[src]"
diff --git a/extensions/amp-bind/validator-amp-bind.protoascii b/extensions/amp-bind/validator-amp-bind.protoascii
index 67b4208d1..13e7b36c5 100644
--- a/extensions/amp-bind/validator-amp-bind.protoascii
+++ b/extensions/amp-bind/validator-amp-bind.protoascii
@@ -24,7 +24,7 @@ tags: {  # amp-bind
     version: "latest"
     # amp-bind has no associated tag which indicates usage of the extension.
     # TODO(gregable): Implement a mechanism to associate attributes with
-    # extension usage and then set this to GRANDFATHERED or ERROR.
+    # extension usage and then set this to EXEMPTED or ERROR.
     requires_usage: NONE
   }
   attr_lists: "common-extension-attrs"
@@ -39,7 +39,7 @@ tags: {  # amp-bind
     version: "0.1"
     # amp-bind has no associated tag which indicates usage of the extension.
     # TODO(gregable): Implement a mechanism to associate attributes with
-    # extension usage and then set this to GRANDFATHERED or ERROR.
+    # extension usage and then set this to EXEMPTED or ERROR.
     requires_usage: NONE
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-brid-player/validator-amp-brid-player.protoascii b/extensions/amp-brid-player/validator-amp-brid-player.protoascii
index 0a6ed37b7..e00484b0c 100644
--- a/extensions/amp-brid-player/validator-amp-brid-player.protoascii
+++ b/extensions/amp-brid-player/validator-amp-brid-player.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-brid-player
     name: "amp-brid-player"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
@@ -60,6 +60,10 @@ tags: {  # <amp-brid-player>
     mandatory_oneof: "['data-outstream', 'data-playlist', 'data-video']"
     value_regex: "[0-9]+"
   }
+  attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-brid-player"
   amp_layout: {
diff --git a/extensions/amp-brightcove/validator-amp-brightcove.protoascii b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
index 872fc4303..c9079d25c 100644
--- a/extensions/amp-brightcove/validator-amp-brightcove.protoascii
+++ b/extensions/amp-brightcove/validator-amp-brightcove.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-brightcove
     name: "amp-brightcove"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii b/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii
index 48be5dea9..86e50ee96 100644
--- a/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii
+++ b/extensions/amp-call-tracking/validator-amp-call-tracking.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-call-tracking
     name: "amp-call-tracking"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-carousel/validator-amp-carousel.protoascii b/extensions/amp-carousel/validator-amp-carousel.protoascii
index 11b1e55ab..f94eefebe 100644
--- a/extensions/amp-carousel/validator-amp-carousel.protoascii
+++ b/extensions/amp-carousel/validator-amp-carousel.protoascii
@@ -24,7 +24,7 @@ tags: {  # amp-carousel
     version: "0.1"
     version: "0.2"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii b/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
index 28959b2ac..c66072a02 100644
--- a/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
+++ b/extensions/amp-dailymotion/validator-amp-dailymotion.protoascii
@@ -20,7 +20,7 @@ tags: {  # amp-dailymotion
     name: "amp-dailymotion"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-date-picker/validator-amp-date-picker.protoascii b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
index 07633ddae..4379338e2 100644
--- a/extensions/amp-date-picker/validator-amp-date-picker.protoascii
+++ b/extensions/amp-date-picker/validator-amp-date-picker.protoascii
@@ -170,6 +170,10 @@ attr_lists: {
     name: "open-after-select"
     value: ""
   }
+  attrs: {
+    name: "hide-keyboard-shortcuts-panel"
+    value: ""
+  }
   attrs: {
     name: "src"
     value_url: {
diff --git a/extensions/amp-experiment/validator-amp-experiment.protoascii b/extensions/amp-experiment/validator-amp-experiment.protoascii
index 02316d0ee..4c35444db 100644
--- a/extensions/amp-experiment/validator-amp-experiment.protoascii
+++ b/extensions/amp-experiment/validator-amp-experiment.protoascii
@@ -24,7 +24,7 @@ tags: {  # amp-experiment
     version: "0.1"
     version: "1.0"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-facebook/validator-amp-facebook.protoascii b/extensions/amp-facebook/validator-amp-facebook.protoascii
index 72330802e..100c4e8ad 100644
--- a/extensions/amp-facebook/validator-amp-facebook.protoascii
+++ b/extensions/amp-facebook/validator-amp-facebook.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-facebook
     name: "amp-facebook"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-fit-text/validator-amp-fit-text.protoascii b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
index c29376537..203e1b554 100644
--- a/extensions/amp-fit-text/validator-amp-fit-text.protoascii
+++ b/extensions/amp-fit-text/validator-amp-fit-text.protoascii
@@ -17,30 +17,26 @@
 tags: {  # amp-fit-text
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-fit-text"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # amp-fit-text
-  html_format: AMP
-  html_format: AMP4ADS
+tags: {  # amp-fit-text (AMP4EMAIL)
   html_format: AMP4EMAIL
-  html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "SCRIPT[custom-element=amp-fit-text] (AMP4EMAIL)"
   extension_spec: {
     name: "amp-fit-text"
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-font/validator-amp-font.protoascii b/extensions/amp-font/validator-amp-font.protoascii
index 735900db3..7b375a3e3 100644
--- a/extensions/amp-font/validator-amp-font.protoascii
+++ b/extensions/amp-font/validator-amp-font.protoascii
@@ -23,7 +23,7 @@ tags: {  # amp-font
     name: "amp-font"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-form/validator-amp-form.protoascii b/extensions/amp-form/validator-amp-form.protoascii
index e06e18b78..3c6558b1a 100644
--- a/extensions/amp-form/validator-amp-form.protoascii
+++ b/extensions/amp-form/validator-amp-form.protoascii
@@ -25,7 +25,7 @@ tags: {  # amp-form
     version: "0.1"
     version: "latest"
     deprecated_allow_duplicates: true
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
@@ -38,7 +38,7 @@ tags: {  # amp-form
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
     deprecated_allow_duplicates: true
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-fx-flying-carpet/validator-amp-fx-flying-carpet.protoascii b/extensions/amp-fx-flying-carpet/validator-amp-fx-flying-carpet.protoascii
index a6332b6a9..1b853a862 100644
--- a/extensions/amp-fx-flying-carpet/validator-amp-fx-flying-carpet.protoascii
+++ b/extensions/amp-fx-flying-carpet/validator-amp-fx-flying-carpet.protoascii
@@ -20,7 +20,7 @@ tags: {  # <script custom-element="amp-fx-flying-carpet">
     name: "amp-fx-flying-carpet"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-gfycat/validator-amp-gfycat.protoascii b/extensions/amp-gfycat/validator-amp-gfycat.protoascii
index a1a2836df..4e5fa19b2 100644
--- a/extensions/amp-gfycat/validator-amp-gfycat.protoascii
+++ b/extensions/amp-gfycat/validator-amp-gfycat.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-gfycat
     name: "amp-gfycat"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-iframe/validator-amp-iframe.protoascii b/extensions/amp-iframe/validator-amp-iframe.protoascii
index 5b4c88fba..13dc48ce8 100644
--- a/extensions/amp-iframe/validator-amp-iframe.protoascii
+++ b/extensions/amp-iframe/validator-amp-iframe.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-iframe
     name: "amp-iframe"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
index 238852928..43c62d817 100644
--- a/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
+++ b/extensions/amp-image-lightbox/validator-amp-image-lightbox.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-image-lightbox
     name: "amp-image-lightbox"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
new file mode 100644
index 000000000..24d4fdffc
--- /dev/null
+++ b/extensions/amp-inline-gallery/validator-amp-inline-gallery.protoascii
@@ -0,0 +1,110 @@
+#
+# Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+
+tags: {  # amp-inline-gallery
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-inline-gallery"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-inline-gallery>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY"
+  requires_extension: "amp-inline-gallery"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  amp_layout: {
+    supported_layouts: CONTAINER
+  }
+}
+tags: {  # <amp-inline-gallery-pagination>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY-PAGINATION"
+  spec_name: "amp-inline-gallery-pagination"
+  requires_extension: "amp-inline-gallery"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  mandatory_ancestor: "AMP-INLINE-GALLERY"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
+tags: {  # <amp-inline-gallery-pagination inset>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY-PAGINATION"
+  spec_name: "amp-inline-gallery-pagination [inset]"
+  requires_extension: "amp-inline-gallery"
+  attrs: {
+    name: "inset"
+    mandatory: true
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  mandatory_ancestor: "AMP-INLINE-GALLERY"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+}
+tags: {  # <amp-inline-gallery-thumbnails>
+  html_format: AMP
+  tag_name: "AMP-INLINE-GALLERY-THUMBNAILS"
+  requires_extension: "amp-inline-gallery"
+  attrs: {
+    name: "aspect-ratio-height"
+    # Non-zero number
+    value_regex: "\\d+(\\.\\d+)?"
+    blacklisted_value_regex: "^0+(\\.0+)?$"
+    trigger: {
+      also_requires_attr: "aspect-ratio-width"
+    }
+  }
+  attrs: {
+    name: "aspect-ratio-width"
+    # Non-zero number
+    value_regex: "\\d+(\\.\\d+)?"
+    blacklisted_value_regex: "^0+(\\.0+)?$"
+    trigger: {
+      also_requires_attr: "aspect-ratio-height"
+    }
+  }
+  attrs: {
+    name: "loop"
+    value: "true"
+    value: "false"
+  }
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-inline-gallery"
+  mandatory_ancestor: "AMP-INLINE-GALLERY"
+  amp_layout: {
+    supported_layouts: FILL
+    supported_layouts: FIXED
+    supported_layouts: FIXED_HEIGHT
+    supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
+    supported_layouts: NODISPLAY
+    supported_layouts: RESPONSIVE
+  }
+}
diff --git a/extensions/amp-inputmask/validator-amp-inputmask.protoascii b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
index b1fff7a0b..c4b1b4d99 100644
--- a/extensions/amp-inputmask/validator-amp-inputmask.protoascii
+++ b/extensions/amp-inputmask/validator-amp-inputmask.protoascii
@@ -22,7 +22,7 @@ tags: {  # amp-inputmask
     version: "latest"
     # amp-inputmask has no associated tag which indicates usage of the extension.
     # TODO(gregable): Implement a mechanism to associate attributes with
-    # extension usage and then set this to GRANDFATHERED or ERROR.
+    # extension usage and then set this to EXEMPTED or ERROR.
     requires_usage: NONE
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-instagram/validator-amp-instagram.protoascii b/extensions/amp-instagram/validator-amp-instagram.protoascii
index e8deeaa31..4a462662c 100644
--- a/extensions/amp-instagram/validator-amp-instagram.protoascii
+++ b/extensions/amp-instagram/validator-amp-instagram.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-instagram
     name: "amp-instagram"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-install-serviceworker/validator-amp-install-serviceworker.protoascii b/extensions/amp-install-serviceworker/validator-amp-install-serviceworker.protoascii
index 87aae591b..d0d20ad06 100644
--- a/extensions/amp-install-serviceworker/validator-amp-install-serviceworker.protoascii
+++ b/extensions/amp-install-serviceworker/validator-amp-install-serviceworker.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-install-serviceworker
     name: "amp-install-serviceworker"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-izlesene/validator-amp-izlesene.protoascii b/extensions/amp-izlesene/validator-amp-izlesene.protoascii
index 7c56262f5..4dc56f819 100644
--- a/extensions/amp-izlesene/validator-amp-izlesene.protoascii
+++ b/extensions/amp-izlesene/validator-amp-izlesene.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-izlesene
     name: "amp-izlesene"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
index fe0af650d..600dd84eb 100644
--- a/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
+++ b/extensions/amp-jwplayer/validator-amp-jwplayer.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-jwplayer
     name: "amp-jwplayer"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-kaltura-player/validator-amp-kaltura-player.protoascii b/extensions/amp-kaltura-player/validator-amp-kaltura-player.protoascii
index fd15c0b08..168f857a8 100644
--- a/extensions/amp-kaltura-player/validator-amp-kaltura-player.protoascii
+++ b/extensions/amp-kaltura-player/validator-amp-kaltura-player.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-kaltura-player
     name: "amp-kaltura-player"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-lightbox/validator-amp-lightbox.protoascii b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
index afb77bd7d..308668f21 100644
--- a/extensions/amp-lightbox/validator-amp-lightbox.protoascii
+++ b/extensions/amp-lightbox/validator-amp-lightbox.protoascii
@@ -22,7 +22,7 @@ tags: {  # amp-lightbox
     name: "amp-lightbox"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
@@ -65,7 +65,10 @@ tags: {  # <amp-lightbox>
   }
   attrs: { name: "controls" }
   attrs: { name: "from" }
-  attrs: { name: "scrollable" }
+  attrs: {
+    name: "scrollable"
+    disabled_by: "amp4email"
+  }
   # <amp-bind>
   attrs: { name: "[open]" }
   attr_lists: "extended-amp-global"
diff --git a/extensions/amp-list/validator-amp-list.protoascii b/extensions/amp-list/validator-amp-list.protoascii
index 267713a0f..0d36870e2 100644
--- a/extensions/amp-list/validator-amp-list.protoascii
+++ b/extensions/amp-list/validator-amp-list.protoascii
@@ -20,7 +20,7 @@ tags: {  # amp-list
     name: "amp-list"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
@@ -64,6 +64,10 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     value: "refresh"
   }
   attrs: { name: "credentials" }
+  attrs: {
+    name: "data-amp-bind-src"
+    mandatory_anyof: "['src','[src]','data-amp-bind-src']"
+  }
   attrs: {
     name: "diffable"
     value: ""
@@ -88,9 +92,10 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
     value: "fetch"
   }
   attrs: { name: "single-item" }
+  attrs: { name: "xssi-prefix" }
   attrs: {
     name: "src"
-    mandatory_anyof: "['src','[src]']"
+    mandatory_anyof: "['src','[src]','data-amp-bind-src']"
     value_url: {
       protocol: "https"
       allow_relative: true  # Will be set to false at a future date.
@@ -107,11 +112,7 @@ tags: {  # <amp-list> with mandatory src and/or [src] attr
   }
   attrs: {
     name: "[src]"
-    mandatory_anyof: "['src','[src]']"
-  }
-  attrs: {
-    name: "[state]"
-    deprecation: "[src]"
+    mandatory_anyof: "['src','[src]','data-amp-bind-src']"
   }
   attr_lists: "extended-amp-global"
   amp_layout: {
@@ -233,6 +234,10 @@ tags: {  # <amp-list>
     name: "template"
     value_oneof_set: TEMPLATE_IDS
   }
+  # <amp-bind>
+  attrs: {
+    name: "[is-layout-container]"
+  }
   attr_lists: "extended-amp-global"
   amp_layout: {
     supported_layouts: FILL
@@ -281,7 +286,7 @@ tags: {  # <amp-list>
   attrs: { name: "single-item" }
   attrs: {
     name: "src"
-    mandatory_anyof: "['src','[src]']"
+    mandatory_anyof: "['src','[src]','data-amp-bind-src']"
     value_url: {
       protocol: "https"
       allow_relative: true
@@ -292,7 +297,7 @@ tags: {  # <amp-list>
   # <amp-bind>
   attrs: {
     name: "[src]"
-    mandatory_anyof: "['src','[src]']"
+    mandatory_anyof: "['src','[src]','data-amp-bind-src']"
   }
   attrs: {
     name: "[state]"
diff --git a/extensions/amp-live-list/validator-amp-live-list.protoascii b/extensions/amp-live-list/validator-amp-live-list.protoascii
index 330da465c..abda4a5c3 100644
--- a/extensions/amp-live-list/validator-amp-live-list.protoascii
+++ b/extensions/amp-live-list/validator-amp-live-list.protoascii
@@ -23,7 +23,7 @@ tags: {  # amp-live-list
     name: "amp-live-list"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii b/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
new file mode 100644
index 000000000..392a1aafc
--- /dev/null
+++ b/extensions/amp-mega-menu/validator-amp-mega-menu.protoascii
@@ -0,0 +1,215 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+tags: {  # amp-mega-menu
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-mega-menu"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # <amp-mega-menu>
+  html_format: AMP
+  tag_name: "AMP-MEGA-MENU"
+  requires_extension: "amp-mega-menu"
+  attr_lists: "extended-amp-global"
+  spec_url: "https://amp.dev/documentation/components/amp-mega-menu"
+  descendant_tag_list: "amp-mega-menu-allowed-descendants"
+  # We want to support both of the cases below:
+  # <amp-mega-menu> > <nav> > ... and
+  # <amp-mega-menu> > <amp-list> > <template> > <nav> > ...
+  # The latter is needed for dynamic template rendering.
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "NAV"
+    child_tag_name_oneof: "AMP-LIST"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU > AMP-LIST"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU > NAV"
+  }
+  amp_layout: {
+    supported_layouts: FIXED_HEIGHT
+  }
+}
+tags: {  # <amp-mega-menu> <nav>
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU > NAV"
+  siblings_disallowed: true
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "OL"
+    child_tag_name_oneof: "UL"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU NAV > UL/OL"
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU > AMP-LIST"
+  # Include mandatory amp-list attrs so that <amp-mega-menu> > <nav>
+  # does not match to this tag.
+  attrs: {
+    name: "src"
+    mandatory_anyof: "['src','[src]']"
+  }
+  attrs: {
+    name: "[src]"
+    mandatory_anyof: "['src','[src]']"
+  }
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "TEMPLATE"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU > AMP-LIST > TEMPLATE"
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU > AMP-LIST > TEMPLATE"
+  mandatory_parent: "AMP-LIST"
+  child_tags: {
+    mandatory_num_child_tags: 1
+    child_tag_name_oneof: "NAV"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU > NAV"
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU NAV > UL/OL"
+  mandatory_parent: "NAV"
+  child_tags: {
+    mandatory_min_num_child_tags: 1
+    child_tag_name_oneof: "LI"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU NAV > UL/OL > LI"
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU NAV > UL/OL > LI"
+  child_tags: {
+    mandatory_min_num_child_tags: 1
+    child_tag_name_oneof: "A"
+    child_tag_name_oneof: "BUTTON"
+    child_tag_name_oneof: "DIV"
+    child_tag_name_oneof: "H1"
+    child_tag_name_oneof: "H2"
+    child_tag_name_oneof: "H3"
+    child_tag_name_oneof: "H4"
+    child_tag_name_oneof: "H5"
+    child_tag_name_oneof: "H6"
+    child_tag_name_oneof: "SPAN"
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU item-content"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-MEGA-MENU item-heading"
+    mandatory: true
+    unique: true
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU item-heading"
+  attrs: {
+    name: "role"
+    value: "button"
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-MEGA-MENU item-content"
+  # Disallow role=menu until supported by implementation.
+  attrs: {
+    name: "role"
+    value: "dialog"
+    mandatory: true
+  }
+}
+descendant_tag_list {
+  # Purposefully being restrictive when whitelisting child components;
+  # On demand, add more components to this list after manual testing.
+  name: "amp-mega-menu-allowed-descendants"
+  tag: "A"
+  tag: "AMP-AD"
+  tag: "AMP-CAROUSEL"
+  tag: "AMP-EMBED"
+  tag: "AMP-IMG"
+  tag: "AMP-LIGHTBOX"
+  tag: "AMP-LIST"
+  tag: "AMP-VIDEO"
+  tag: "B"
+  tag: "BR"
+  tag: "BUTTON"
+  tag: "COL"
+  tag: "COLGROUP"
+  tag: "DIV"
+  tag: "EM"
+  tag: "FIELDSET"
+  tag: "FORM"
+  tag: "H1"
+  tag: "H2"
+  tag: "H3"
+  tag: "H4"
+  tag: "H5"
+  tag: "H6"
+  tag: "I"
+  tag: "INPUT"
+  tag: "LABEL"
+  tag: "LI"
+  tag: "MARK"
+  tag: "NAV"
+  tag: "OL"
+  tag: "OPTION"
+  tag: "P"
+  tag: "PATH"
+  tag: "SECTION"
+  tag: "SPAN"
+  tag: "STRIKE"
+  tag: "STRONG"
+  tag: "SUB"
+  tag: "SUP"
+  tag: "SVG"
+  tag: "TABLE"
+  tag: "TBODY"
+  tag: "TD"
+  tag: "TEMPLATE"
+  tag: "TH"
+  tag: "TIME"
+  tag: "TITLE"
+  tag: "TR"
+  tag: "U"
+  tag: "UL"
+}
diff --git a/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
index 9dbfa2e67..156a0ce30 100644
--- a/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
+++ b/extensions/amp-minute-media-player/validator-amp-minute-media-player.protoascii
@@ -29,18 +29,15 @@ tags: {  # <amp-minute-media-player>
   tag_name: "AMP-MINUTE-MEDIA-PLAYER"
   requires_extension: "amp-minute-media-player"
   attrs: { name: "autoplay" }
-  attrs: {
-    name: "dock"
-    requires_extension: "amp-video-docking"
-  }
+  attrs: { name: "data-content-id" }
   attrs: {
     name: "data-content-type"
     mandatory: true
     value: "curated"
-    value: "specific"
     value: "semantic"
+    value: "specific"
   }
-  attrs: { name: "data-content-id" }
+  attrs: { name: "data-minimum-date-factor" }
   attrs: { name: "data-scanned-element" }
   attrs: {
     name: "data-scanned-element-type"
@@ -48,17 +45,19 @@ tags: {  # <amp-minute-media-player>
     value: "id"
     value: "tag"
   }
-  attrs: { name: "data-tags" }
-  attrs: { name: "data-minimum-date-factor" }
   attrs: { name: "data-scoped-keywords" }
-
+  attrs: { name: "data-tags" }
+  attrs: {
+    name: "dock"
+    requires_extension: "amp-video-docking"
+  }
   attr_lists: "extended-amp-global"
   spec_url: "https://amp.dev/documentation/components/amp-minute-media-player"
   amp_layout: {
-    supported_layouts: RESPONSIVE
     supported_layouts: FILL
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
+    supported_layouts: RESPONSIVE
   }
 }
diff --git a/extensions/amp-mustache/validator-amp-mustache.protoascii b/extensions/amp-mustache/validator-amp-mustache.protoascii
index 8f310f62d..bca89f9b1 100644
--- a/extensions/amp-mustache/validator-amp-mustache.protoascii
+++ b/extensions/amp-mustache/validator-amp-mustache.protoascii
@@ -29,7 +29,7 @@ tags: {  # amp-mustache
     version: "0.2"
     version: "latest"
     deprecated_version: "0.1"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
@@ -77,6 +77,132 @@ tags: {
   disallowed_ancestor: "FORM DIV [submitting][template]"
   disallowed_ancestor: "FORM DIV [verify-error][template]"
   requires_extension: "amp-mustache"
+  attrs: {
+    name: "id"
+    add_value_to_set: TEMPLATE_IDS
+    # When updating this blacklisted_value_regex, also update elsewhere in this
+    # file, and in mandatory-id-attr and $GLOBAL_ATTRS in
+    # validator-main.protoascii, and validator-amp-script.protoascii.
+    blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "__amp_\\S*|"
+        "__count__|"
+        "__defineGetter__|"
+        "__defineSetter__|"
+        "__lookupGetter__|"
+        "__lookupSetter__|"
+        "__noSuchMethod__|"
+        "__parent__|"
+        "__proto__|"
+        "__AMP_\\S*|"
+        "\\$p|"
+        "\\$proxy|"
+        "acceptCharset|"
+        "addEventListener|"
+        "appendChild|"
+        "assignedSlot|"
+        "attachShadow|"
+        "AMP|"
+        "baseURI|"
+        "checkValidity|"
+        "childElementCount|"
+        "childNodes|"
+        "classList|"
+        "className|"
+        "clientHeight|"
+        "clientLeft|"
+        "clientTop|"
+        "clientWidth|"
+        "compareDocumentPosition|"
+        "computedName|"
+        "computedRole|"
+        "contentEditable|"
+        "createShadowRoot|"
+        "enqueAction|"
+        "firstChild|"
+        "firstElementChild|"
+        "getAnimations|"
+        "getAttribute|"
+        "getAttributeNS|"
+        "getAttributeNode|"
+        "getAttributeNodeNS|"
+        "getBoundingClientRect|"
+        "getClientRects|"
+        "getDestinationInsertionPoints|"
+        "getElementsByClassName|"
+        "getElementsByTagName|"
+        "getElementsByTagNameNS|"
+        "getRootNode|"
+        "hasAttribute|"
+        "hasAttributeNS|"
+        "hasAttributes|"
+        "hasChildNodes|"
+        "hasPointerCapture|"
+        "i-amphtml-\\S*|"
+        "innerHTML|"
+        "innerText|"
+        "inputMode|"
+        "insertAdjacentElement|"
+        "insertAdjacentHTML|"
+        "insertAdjacentText|"
+        "isContentEditable|"
+        "isDefaultNamespace|"
+        "isEqualNode|"
+        "isSameNode|"
+        "lastChild|"
+        "lastElementChild|"
+        "lookupNamespaceURI|"
+        "namespaceURI|"
+        "nextElementSibling|"
+        "nextSibling|"
+        "nodeName|"
+        "nodeType|"
+        "nodeValue|"
+        "offsetHeight|"
+        "offsetLeft|"
+        "offsetParent|"
+        "offsetTop|"
+        "offsetWidth|"
+        "outerHTML|"
+        "outerText|"
+        "ownerDocument|"
+        "parentElement|"
+        "parentNode|"
+        "previousElementSibling|"
+        "previousSibling|"
+        "querySelector|"
+        "querySelectorAll|"
+        "releasePointerCapture|"
+        "removeAttribute|"
+        "removeAttributeNS|"
+        "removeAttributeNode|"
+        "removeChild|"
+        "removeEventListener|"
+        "replaceChild|"
+        "reportValidity|"
+        "requestPointerLock|"
+        "scrollHeight|"
+        "scrollIntoView|"
+        "scrollIntoViewIfNeeded|"
+        "scrollLeft|"
+        "scrollWidth|"
+        "setAttribute|"
+        "setAttributeNS|"
+        "setAttributeNode|"
+        "setAttributeNodeNS|"
+        "setPointerCapture|"
+        "shadowRoot|"
+        "styleMap|"
+        "tabIndex|"
+        "tagName|"
+        "textContent|"
+        "toString|"
+        "valueOf|"
+        "(webkit|ms|moz|o)dropzone|"
+        "(webkit|moz|ms|o)MatchesSelector|"
+        "(webkit|moz|ms|o)RequestFullScreen|"
+        "(webkit|moz|ms|o)RequestFullscreen"
+        ")(\\s|$)"
+  }
   attrs: {
     name: "type"
     mandatory: true
@@ -114,6 +240,132 @@ tags: {
   # AMP4EMAIL addition.
   disallowed_ancestor: "FORM DIV [submitting]"
   requires_extension: "amp-mustache"
+  attrs: {
+    name: "id"
+    add_value_to_set: TEMPLATE_IDS
+    # When updating this blacklisted_value_regex, also update elsewhere in this
+    # file, and in mandatory-id-attr and $GLOBAL_ATTRS in
+    # validator-main.protoascii, and validator-amp-script.protoascii.
+    blacklisted_value_regex: "(^|\\s)("  # Values are space separated
+        "__amp_\\S*|"
+        "__count__|"
+        "__defineGetter__|"
+        "__defineSetter__|"
+        "__lookupGetter__|"
+        "__lookupSetter__|"
+        "__noSuchMethod__|"
+        "__parent__|"
+        "__proto__|"
+        "__AMP_\\S*|"
+        "\\$p|"
+        "\\$proxy|"
+        "acceptCharset|"
+        "addEventListener|"
+        "appendChild|"
+        "assignedSlot|"
+        "attachShadow|"
+        "AMP|"
+        "baseURI|"
+        "checkValidity|"
+        "childElementCount|"
+        "childNodes|"
+        "classList|"
+        "className|"
+        "clientHeight|"
+        "clientLeft|"
+        "clientTop|"
+        "clientWidth|"
+        "compareDocumentPosition|"
+        "computedName|"
+        "computedRole|"
+        "contentEditable|"
+        "createShadowRoot|"
+        "enqueAction|"
+        "firstChild|"
+        "firstElementChild|"
+        "getAnimations|"
+        "getAttribute|"
+        "getAttributeNS|"
+        "getAttributeNode|"
+        "getAttributeNodeNS|"
+        "getBoundingClientRect|"
+        "getClientRects|"
+        "getDestinationInsertionPoints|"
+        "getElementsByClassName|"
+        "getElementsByTagName|"
+        "getElementsByTagNameNS|"
+        "getRootNode|"
+        "hasAttribute|"
+        "hasAttributeNS|"
+        "hasAttributes|"
+        "hasChildNodes|"
+        "hasPointerCapture|"
+        "i-amphtml-\\S*|"
+        "innerHTML|"
+        "innerText|"
+        "inputMode|"
+        "insertAdjacentElement|"
+        "insertAdjacentHTML|"
+        "insertAdjacentText|"
+        "isContentEditable|"
+        "isDefaultNamespace|"
+        "isEqualNode|"
+        "isSameNode|"
+        "lastChild|"
+        "lastElementChild|"
+        "lookupNamespaceURI|"
+        "namespaceURI|"
+        "nextElementSibling|"
+        "nextSibling|"
+        "nodeName|"
+        "nodeType|"
+        "nodeValue|"
+        "offsetHeight|"
+        "offsetLeft|"
+        "offsetParent|"
+        "offsetTop|"
+        "offsetWidth|"
+        "outerHTML|"
+        "outerText|"
+        "ownerDocument|"
+        "parentElement|"
+        "parentNode|"
+        "previousElementSibling|"
+        "previousSibling|"
+        "querySelector|"
+        "querySelectorAll|"
+        "releasePointerCapture|"
+        "removeAttribute|"
+        "removeAttributeNS|"
+        "removeAttributeNode|"
+        "removeChild|"
+        "removeEventListener|"
+        "replaceChild|"
+        "reportValidity|"
+        "requestPointerLock|"
+        "scrollHeight|"
+        "scrollIntoView|"
+        "scrollIntoViewIfNeeded|"
+        "scrollLeft|"
+        "scrollWidth|"
+        "setAttribute|"
+        "setAttributeNS|"
+        "setAttributeNode|"
+        "setAttributeNodeNS|"
+        "setPointerCapture|"
+        "shadowRoot|"
+        "styleMap|"
+        "tabIndex|"
+        "tagName|"
+        "textContent|"
+        "toString|"
+        "valueOf|"
+        "(webkit|ms|moz|o)dropzone|"
+        "(webkit|moz|ms|o)MatchesSelector|"
+        "(webkit|moz|ms|o)RequestFullScreen|"
+        "(webkit|moz|ms|o)RequestFullscreen"
+        ")(\\s|$)"
+  }
   attrs: {
     name: "type"
     mandatory: true
@@ -156,8 +408,9 @@ tags: {
   attrs: {
     name: "id"
     add_value_to_set: TEMPLATE_IDS
-    # When updating this blacklisted_value_regex, also update below, and in
-    # mandatory-id-attr and $GLOBAL_ATTRS in validator-main.protoascii.
+    # When updating this blacklisted_value_regex, also update elsewhere in this
+    # file, and in mandatory-id-attr and $GLOBAL_ATTRS in
+    # validator-main.protoascii, and validator-amp-script.protoascii.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
@@ -308,8 +561,9 @@ tags: {
   attrs: {
     name: "id"
     add_value_to_set: TEMPLATE_IDS
-    # When updating this blacklisted_value_regex, also update above, and in
-    # mandatory-id-attr and $GLOBAL_ATTRS in validator-main.protoascii.
+    # When updating this blacklisted_value_regex, also update elsewhere in this
+    # file, and in mandatory-id-attr and $GLOBAL_ATTRS in
+    # validator-main.protoascii, and validator-amp-script.protoascii.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
diff --git a/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
new file mode 100644
index 000000000..d944fec2a
--- /dev/null
+++ b/extensions/amp-nested-menu/validator-amp-nested-menu.protoascii
@@ -0,0 +1,175 @@
+#
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the license.
+#
+tags: {  # amp-nested-menu
+  html_format: AMP
+  tag_name: "SCRIPT"
+  extension_spec: {
+    name: "amp-nested-menu"
+    version: "0.1"
+    version: "latest"
+  }
+  attr_lists: "common-extension-attrs"
+}
+tags: {  # amp-nested-menu
+  html_format: AMP
+  tag_name: "AMP-NESTED-MENU"
+  # nested menu can be lazy loaded by sidebar.
+  requires_extension: "amp-sidebar"
+  mandatory_ancestor: "AMP-SIDEBAR"
+  attrs: {
+    name: "side"
+    value: "left"
+    value: "right"
+  }
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: FILL
+  }
+  descendant_tag_list: "amp-nested-menu-allowed-descendants"
+  spec_url: "https://amp.dev/documentation/components/amp-nested-menu"
+}
+tags: {  # <amp-nested-menu> <div amp-nested-submenu(-open/-close)>
+  html_format: AMP
+  tag_name: "DIV"
+  spec_name: "div amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  # submenus inside accordion do not display correctly due to styling of <amp-accordion>.
+  disallowed_ancestor: "AMP-ACCORDION"
+  attrs: {
+    name: "amp-nested-submenu"
+    mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu', 'amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+
+attr_lists {
+  name: "amp-nested-menu-actions"
+  attrs: {
+    name: "amp-nested-submenu-close"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+  attrs: {
+    name: "amp-nested-submenu-open"
+    mandatory_oneof: "['amp-nested-submenu-close', 'amp-nested-submenu-open']"
+  }
+}
+tags: {  # <amp-nested-menu> <button amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "BUTTON"
+  spec_name: "button amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+tags: {  # <amp-nested-menu> <h2 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H2"
+  spec_name: "h2 amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+tags: {  # <amp-nested-menu> <h3 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H3"
+  spec_name: "h3 amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+tags: {  # <amp-nested-menu> <h4 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H4"
+  spec_name: "h4 amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+tags: {  # <amp-nested-menu> <h5 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H5"
+  spec_name: "h5 amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+tags: {  # <amp-nested-menu> <h6 amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "H6"
+  spec_name: "h6 amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+tags: {  # <amp-nested-menu> <span amp-nested-submenu-open/close>
+  html_format: AMP
+  tag_name: "SPAN"
+  spec_name: "span amp-nested-menu"
+  mandatory_ancestor: "AMP-NESTED-MENU"
+  attr_lists: "amp-nested-menu-actions"
+}
+descendant_tag_list {
+  # Purposefully being restrictive when whitelisting child components;
+  # On demand, add more components to this list after manual testing.
+  name: "amp-nested-menu-allowed-descendants"
+  tag: "A"
+  tag: "AMP-ACCORDION"
+  tag: "AMP-IMG"
+  tag: "AMP-LIST"
+  tag: "B"
+  tag: "BR"
+  tag: "BUTTON"
+  tag: "COL"
+  tag: "COLGROUP"
+  tag: "DIV"
+  tag: "EM"
+  tag: "FIELDSET"
+  tag: "FORM"
+  tag: "H1"
+  tag: "H2"
+  tag: "H3"
+  tag: "H4"
+  tag: "H5"
+  tag: "H6"
+  tag: "I"
+  tag: "INPUT"
+  tag: "LABEL"
+  tag: "LI"
+  tag: "MARK"
+  tag: "NAV"
+  tag: "OL"
+  tag: "OPTION"
+  tag: "P"
+  tag: "PATH"
+  tag: "SECTION"
+  tag: "SPAN"
+  tag: "STRIKE"
+  tag: "STRONG"
+  tag: "SUB"
+  tag: "SUP"
+  tag: "SVG"
+  tag: "TABLE"
+  tag: "TBODY"
+  tag: "TD"
+  tag: "TEMPLATE"
+  tag: "TH"
+  tag: "TIME"
+  tag: "TITLE"
+  tag: "TR"
+  tag: "U"
+  tag: "UL"
+}
diff --git a/extensions/amp-next-page/validator-amp-next-page.protoascii b/extensions/amp-next-page/validator-amp-next-page.protoascii
index 63b5403ad..beb38f5b9 100644
--- a/extensions/amp-next-page/validator-amp-next-page.protoascii
+++ b/extensions/amp-next-page/validator-amp-next-page.protoascii
@@ -19,14 +19,15 @@ tags: {  # amp-next-page
   extension_spec: {
     name: "amp-next-page"
     version: "0.1"
+    version: "1.0"
     version: "latest"
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # amp-next-page: json config
+tags: {  # amp-next-page: JSON Config
   html_format: AMP
   tag_name: "SCRIPT"
-  spec_name: "amp-next-page extension .json configuration"
+  spec_name: "AMP-NEXT-PAGE > SCRIPT[type=application/json]"
   requires_extension: "amp-next-page"
   mandatory_parent: "AMP-NEXT-PAGE"
   attrs: {
@@ -47,18 +48,51 @@ tags: {
     mandatory: true
   }
 }
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-NEXT-PAGE > [recommendation-box]"
+  mandatory_parent: "AMP-NEXT-PAGE"
+  attrs: {
+    name: "recommendation-box"
+    mandatory: true
+  }
+}
+tags: {
+  html_format: AMP
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "AMP-NEXT-PAGE > [footer]"
+  mandatory_parent: "AMP-NEXT-PAGE"
+  attrs: {
+    name: "footer"
+    mandatory: true
+  }
+}
 tags: {  # <amp-next-page>
   html_format: AMP
   tag_name: "AMP-NEXT-PAGE"
   spec_name: "amp-next-page with inline config"
   unique: true
   requires_extension: "amp-next-page"
+  ### TODO(wassgha) Uncomment after deprecating 0.1
+  # mandatory_parent: "BODY"
+  # mandatory_last_child: true
+  attrs: { name: "deep-parsing" }
+  attrs: { name: "max-pages" }
   reference_points: {
     tag_spec_name: "AMP-NEXT-PAGE > [separator]"
     unique: true
   }
   reference_points: {
-    tag_spec_name: "amp-next-page extension .json configuration"
+    tag_spec_name: "AMP-NEXT-PAGE > [recommendation-box]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [footer]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > SCRIPT[type=application/json]"
     mandatory: true
     unique: true
   }
@@ -70,6 +104,11 @@ tags: {  # <amp-next-page src>
   spec_name: "amp-next-page with src attribute"
   unique: true
   requires_extension: "amp-next-page"
+  ### TODO(wassgha) Uncomment after deprecating 0.1
+  # mandatory_parent: "BODY"
+  # mandatory_last_child: true
+  attrs: { name: "deep-parsing" }
+  attrs: { name: "max-pages" }
   attrs: {
     name: "src"
     mandatory: true
@@ -79,10 +118,23 @@ tags: {  # <amp-next-page src>
     }
     blacklisted_value_regex: "__amp_source_origin"
   }
+  attrs: { name: "xssi-prefix" }
   reference_points: {
     tag_spec_name: "AMP-NEXT-PAGE > [separator]"
     unique: true
   }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [recommendation-box]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [footer]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > SCRIPT[type=application/json]"
+    unique: true
+  }
   spec_url: "https://amp.dev/documentation/components/amp-next-page"
 }
 tags: {  # <amp-next-page type="adsense">
@@ -91,6 +143,9 @@ tags: {  # <amp-next-page type="adsense">
   spec_name: "amp-next-page [type=adsense]"
   unique: true
   requires_extension: "amp-next-page"
+  ### TODO(wassgha) Uncomment after deprecating 0.1
+  # mandatory_parent: "BODY"
+  # mandatory_last_child: true
   attrs: {
     name: "data-client"
     mandatory: true
@@ -99,6 +154,8 @@ tags: {  # <amp-next-page type="adsense">
     name: "data-slot"
     mandatory: true
   }
+  attrs: { name: "deep-parsing" }
+  attrs: { name: "max-pages" }
   attrs: {
     name: "type"
     mandatory: true
@@ -108,5 +165,17 @@ tags: {  # <amp-next-page type="adsense">
     tag_spec_name: "AMP-NEXT-PAGE > [separator]"
     unique: true
   }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [recommendation-box]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > [footer]"
+    unique: true
+  }
+  reference_points: {
+    tag_spec_name: "AMP-NEXT-PAGE > SCRIPT[type=application/json]"
+    unique: true
+  }
   spec_url: "https://amp.dev/documentation/components/amp-next-page"
 }
diff --git a/extensions/amp-o2-player/validator-amp-o2-player.protoascii b/extensions/amp-o2-player/validator-amp-o2-player.protoascii
index 8542604b8..07cd62b14 100644
--- a/extensions/amp-o2-player/validator-amp-o2-player.protoascii
+++ b/extensions/amp-o2-player/validator-amp-o2-player.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-o2-player
     name: "amp-o2-player"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-pinterest/validator-amp-pinterest.protoascii b/extensions/amp-pinterest/validator-amp-pinterest.protoascii
index 36b61f92b..3dafb56e6 100644
--- a/extensions/amp-pinterest/validator-amp-pinterest.protoascii
+++ b/extensions/amp-pinterest/validator-amp-pinterest.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-pinterest
     name: "amp-pinterest"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-reach-player/validator-amp-reach-player.protoascii b/extensions/amp-reach-player/validator-amp-reach-player.protoascii
index 9e78ce5e9..93a6ffd83 100644
--- a/extensions/amp-reach-player/validator-amp-reach-player.protoascii
+++ b/extensions/amp-reach-player/validator-amp-reach-player.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-reach-player
     name: "amp-reach-player"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-izlesene/validator-amp-izlesene.protoascii b/extensions/amp-redbull-player/validator-amp-redbull-player.protoascii
similarity index 75%
copy from extensions/amp-izlesene/validator-amp-izlesene.protoascii
copy to extensions/amp-redbull-player/validator-amp-redbull-player.protoascii
index 7c56262f5..8ee98822d 100644
--- a/extensions/amp-izlesene/validator-amp-izlesene.protoascii
+++ b/extensions/amp-redbull-player/validator-amp-redbull-player.protoascii
@@ -1,5 +1,5 @@
 #
-# Copyright 2017 The AMP HTML Authors. All Rights Reserved.
+# Copyright 2019 The AMP HTML Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,32 +14,32 @@
 # limitations under the license.
 #
 
-tags: {  # amp-izlesene
+tags: {  # amp-redbull-player
   html_format: AMP
   tag_name: "SCRIPT"
   extension_spec: {
-    name: "amp-izlesene"
+    name: "amp-redbull-player"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-izlesene>
+tags: {  # <amp-redbull-player>
   html_format: AMP
-  tag_name: "AMP-IZLESENE"
-  requires_extension: "amp-izlesene"
+  tag_name: "AMP-REDBULL-PLAYER"
+  requires_extension: "amp-redbull-player"
   attrs: {
-    name: "data-videoid"
+    name: "data-param-videoid"
     mandatory: true
-    value_regex: "[0-9]+"
   }
   attr_lists: "extended-amp-global"
   amp_layout: {
-    supported_layouts: FILL
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
-    supported_layouts: FLEX_ITEM
     supported_layouts: RESPONSIVE
+    supported_layouts: FILL
+    supported_layouts: FLEX_ITEM
+    supported_layouts: FLUID
+    supported_layouts: INTRINSIC
   }
 }
diff --git a/extensions/amp-script/validator-amp-script.protoascii b/extensions/amp-script/validator-amp-script.protoascii
index c0f6d5c69..9725ae2e2 100644
--- a/extensions/amp-script/validator-amp-script.protoascii
+++ b/extensions/amp-script/validator-amp-script.protoascii
@@ -33,6 +33,9 @@ tags: {  # <amp-script> (local script)
     name: "id"
     add_value_to_set: AMP_SCRIPT_IDS
     mandatory: true
+    # When updating this blacklisted_value_regex, also update for
+    # mandatory-id-attr and $GLOBAL_ATTRS in validator-main.protoascii, and
+    # validator-amp-mustache.protoascii.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
@@ -211,6 +214,7 @@ tags: {  # <amp-script>
     supported_layouts: FIXED
     supported_layouts: FIXED_HEIGHT
     supported_layouts: FLEX_ITEM
+    supported_layouts: INTRINSIC
     supported_layouts: NODISPLAY
     supported_layouts: RESPONSIVE
   }
diff --git a/extensions/amp-selector/validator-amp-selector.protoascii b/extensions/amp-selector/validator-amp-selector.protoascii
index 82d7e6b2b..1c6580e19 100644
--- a/extensions/amp-selector/validator-amp-selector.protoascii
+++ b/extensions/amp-selector/validator-amp-selector.protoascii
@@ -15,13 +15,14 @@
 #
 tags: {
   html_format: AMP
+  html_format: AMP4ADS
   html_format: ACTIONS
   tag_name: "SCRIPT"
   extension_spec: {
     name: "amp-selector"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
@@ -34,12 +35,13 @@ tags: {
     name: "amp-selector"
     # AMP4EMAIL doesn't allow version: "latest".
     version: "0.1"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
 tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
   html_format: AMP
+  html_format: AMP4ADS
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "AMP-SELECTOR"
@@ -93,6 +95,7 @@ tags: {  # <amp-selector> for AMP (autoplay attribute allowed)
 # always match, we want to prefer 'option' when both of them match.
 tags: {
   html_format: AMP
+  html_format: AMP4ADS
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "$REFERENCE_POINT"
@@ -113,6 +116,7 @@ tags: {
 }
 tags: {
   html_format: AMP
+  html_format: AMP4ADS
   html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "$REFERENCE_POINT"
diff --git a/extensions/amp-sidebar/validator-amp-sidebar.protoascii b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
index b4e5f7605..5c3df0a18 100644
--- a/extensions/amp-sidebar/validator-amp-sidebar.protoascii
+++ b/extensions/amp-sidebar/validator-amp-sidebar.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-sidebar
     name: "amp-sidebar"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
@@ -37,11 +37,11 @@ tags: {  # amp-sidebar
   }
   attr_lists: "common-extension-attrs"
 }
-tags: {  # <amp-sidebar> not in amp-story
+tags: {  # <amp-sidebar> not in amp-story or email
   html_format: AMP
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "AMP-SIDEBAR"
+  spec_name: "amp-sidebar"
   # There is an alternate spec for amp-sidebar in amp-story.
   disallowed_ancestor: "AMP-STORY"
   requires_extension: "amp-sidebar"
@@ -59,6 +59,22 @@ tags: {  # <amp-sidebar> not in amp-story
   }
   spec_url: "https://amp.dev/documentation/components/amp-sidebar"
 }
+tags: {  # <amp-sidebar> in email
+  html_format: AMP4EMAIL
+  tag_name: "AMP-SIDEBAR"
+  spec_name: "amp-sidebar (AMP4EMAIL)"
+  requires_extension: "amp-sidebar"
+  attrs: {
+    name: "side"
+    value: "left"
+    value: "right"
+  }
+  attr_lists: "extended-amp-global"
+  amp_layout: {
+    supported_layouts: NODISPLAY
+  }
+  spec_url: "https://amp.dev/documentation/components/amp-sidebar"
+}
 tags: { # <amp-sidebar> in amp-story
   html_format: AMP
   tag_name: "AMP-SIDEBAR"
diff --git a/extensions/amp-social-share/validator-amp-social-share.protoascii b/extensions/amp-social-share/validator-amp-social-share.protoascii
index d74f62d4e..73711c0c9 100644
--- a/extensions/amp-social-share/validator-amp-social-share.protoascii
+++ b/extensions/amp-social-share/validator-amp-social-share.protoascii
@@ -22,7 +22,7 @@ tags: {  # amp-social-share
     name: "amp-social-share"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii b/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
index 84081d8c0..d72b5a18c 100644
--- a/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
+++ b/extensions/amp-soundcloud/validator-amp-soundcloud.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-soundcloud
     name: "amp-soundcloud"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-springboard-player/validator-amp-springboard-player.protoascii b/extensions/amp-springboard-player/validator-amp-springboard-player.protoascii
index 6a887086d..1bd1ed641 100644
--- a/extensions/amp-springboard-player/validator-amp-springboard-player.protoascii
+++ b/extensions/amp-springboard-player/validator-amp-springboard-player.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-springboard-player
     name: "amp-springboard-player"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-sticky-ad/validator-amp-sticky-ad.protoascii b/extensions/amp-sticky-ad/validator-amp-sticky-ad.protoascii
index b12deae1c..4f45ed63d 100644
--- a/extensions/amp-sticky-ad/validator-amp-sticky-ad.protoascii
+++ b/extensions/amp-sticky-ad/validator-amp-sticky-ad.protoascii
@@ -22,7 +22,7 @@ tags: {  # <script custom-element="amp-sticky-ad">
     version: "1.0"
     version: "latest"
     deprecated_version: "0.1"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
   }
   attr_lists: "common-extension-attrs"
 }
diff --git a/extensions/amp-story/validator-amp-story.protoascii b/extensions/amp-story/validator-amp-story.protoascii
index 94c57912f..627571eb0 100644
--- a/extensions/amp-story/validator-amp-story.protoascii
+++ b/extensions/amp-story/validator-amp-story.protoascii
@@ -104,7 +104,6 @@ tags: {  # <amp-story>
     child_tag_name_oneof: "AMP-GEO"
     child_tag_name_oneof: "AMP-PIXEL"
     child_tag_name_oneof: "AMP-SIDEBAR"
-    child_tag_name_oneof: "AMP-STORY-ACCESS"
     child_tag_name_oneof: "AMP-STORY-AUTO-ADS"
     child_tag_name_oneof: "AMP-STORY-BOOKEND"
     child_tag_name_oneof: "AMP-STORY-PAGE"
@@ -124,6 +123,7 @@ tags: {  # <amp-story-page>
       protocol: "https"
     }
   }
+  attrs: { name: "next-page-no-ad" }
   attr_lists: "mandatory-id-attr"
   child_tags: {
     child_tag_name_oneof: "AMP-ANALYTICS"
@@ -342,18 +342,6 @@ tags: {
   }
   spec_url: "https://amp.dev/documentation/components/amp-story"
 }
-tags: {  # <amp-story-access>
-  html_format: AMP
-  tag_name: "AMP-STORY-ACCESS"
-  requires_extension: "amp-access"
-  mandatory_parent: "AMP-STORY"
-  attrs: {
-    name: "type"
-    value: "blocking"
-    value: "notification"
-  }
-  attr_lists: "extended-amp-global"
-}
 tags: {  # <amp-story-bookend>
   html_format: AMP
   tag_name: "AMP-STORY-BOOKEND"
@@ -604,6 +592,7 @@ descendant_tag_list: {
   tag: "SMALL"
   tag: "SOLIDCOLOR"
   tag: "SPAN"
+  tag: "STOP"
   tag: "STRONG"
   tag: "SUB"
   tag: "SUP"
@@ -636,7 +625,6 @@ descendant_tag_list: {
   tag: "AMP-EXPERIMENT"
   tag: "AMP-FIT-TEXT"
   tag: "AMP-FONT"
-  tag: "AMP-GFYCAT"
   tag: "AMP-GIST"
   tag: "AMP-GOOGLE-VRVIEW-IMAGE"
   tag: "AMP-IMG"
@@ -733,6 +721,7 @@ descendant_tag_list: {
   tag: "SOLIDCOLOR"
   tag: "SOURCE"
   tag: "SPAN"
+  tag: "STOP"
   tag: "STRONG"
   tag: "SUB"
   tag: "SUP"
@@ -808,12 +797,9 @@ descendant_tag_list {
   tag: "AMP-FX-COLLECTION"
   tag: "AMP-FX-FLYING-CARPET"
   tag: "AMP-GFYCAT"
-  tag: "AMP-GFYCAT"
-  tag: "AMP-GIST"
   tag: "AMP-GIST"
   tag: "AMP-GOOGLE-DOCUMENT-EMBED"
   tag: "AMP-GOOGLE-VRVIEW-IMAGE"
-  tag: "AMP-GOOGLE-VRVIEW-IMAGE"
   tag: "AMP-HULU"
   tag: "AMP-IMA-VIDEO"
   tag: "AMP-IMAGE-SLIDER"
@@ -824,8 +810,6 @@ descendant_tag_list {
   tag: "AMP-JWPLAYER"
   tag: "AMP-KALTURA-PLAYER"
   tag: "AMP-LIST"
-  tag: "AMP-LIST"
-  tag: "AMP-LIVE-LIST"
   tag: "AMP-LIVE-LIST"
   tag: "AMP-MATHML"
   tag: "AMP-MEGAPHONE"
@@ -938,6 +922,7 @@ descendant_tag_list {
   tag: "SOLIDCOLOR"
   tag: "SOURCE"
   tag: "SPAN"
+  tag: "STOP"
   tag: "STRONG"
   tag: "SUB"
   tag: "SUP"
diff --git a/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii b/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii
index 0c49ab3c2..925a7796d 100644
--- a/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii
+++ b/extensions/amp-subscriptions/validator-amp-subscriptions.protoascii
@@ -65,4 +65,85 @@ tags: {  # amp-subscriptions-google
   requires_extension: "amp-subscriptions"
   attr_lists: "common-extension-attrs"
 }
+tags: {  # <script cryptokeys sha-256-hash>
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "cryptokeys .json script"
+  unique: true
+  mandatory_parent: "HEAD"
+  requires_extension: "amp-subscriptions"
+  attrs: {
+    name: "cryptokeys"
+    mandatory: true
+    value: ""
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  attrs: {
+    name: "sha-256-hash"
+    mandatory: true
+  }
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
+  }
+}
+tags: {  # <section subscriptions-section="content" swg_amp_cache_nonce="NONCE">
+  html_format: AMP
+  tag_name: "SECTION"
+  spec_name: "subscriptions-section content swg_amp_cache_nonce"
+  requires: "span swg_amp_cache_nonce"
+  satisfies: "subscriptions-section content swg_amp_cache_nonce"
+  mandatory_ancestor: "BODY"
+  attrs: {
+    name: "encrypted"
+    mandatory: true
+    dispatch_key: NAME_DISPATCH
+  }
+  attrs: {
+    name: "subscriptions-section"
+    value_casei: "content"
+  }
+  attrs: {
+    name: "swg_amp_cache_nonce"
+    mandatory: true
+  }
+}
+tags: {  # <script type="application/octet-stream" ciphertext>
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "subscriptions script ciphertext"
+  mandatory_parent: "subscriptions-section content swg_amp_cache_nonce"
+  mandatory_ancestor: "BODY"
+  attrs: {
+    name: "ciphertext"
+    dispatch_key: NAME_DISPATCH
+    mandatory: true
+  }
+  attrs: {
+    name: "type"
+    value_casei: "application/octet-stream"
+    mandatory: true
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "<!--"
+      error_message: "html comments"
+    }
+  }
+}
+tags: {  # <span swg_amp_cache_nonce="NONCE">
+  html_format: AMP
+  tag_name: "SPAN"
+  spec_name: "span swg_amp_cache_nonce"
+  requires: "subscriptions-section content swg_amp_cache_nonce"
+  satisfies: "span swg_amp_cache_nonce"
+  mandatory_ancestor: "BODY"
+  requires_extension: "amp-subscriptions"
+  attrs: {
+    name: "swg_amp_cache_nonce"
+    mandatory: true
+    dispatch_key: NAME_DISPATCH
+  }
+}
 # related attributes are listed in validator-main.protoascii
diff --git a/extensions/amp-twitter/validator-amp-twitter.protoascii b/extensions/amp-twitter/validator-amp-twitter.protoascii
index 02ec95854..8922ff7ae 100644
--- a/extensions/amp-twitter/validator-amp-twitter.protoascii
+++ b/extensions/amp-twitter/validator-amp-twitter.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-twitter
     name: "amp-twitter"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-user-notification/validator-amp-user-notification.protoascii b/extensions/amp-user-notification/validator-amp-user-notification.protoascii
index 2ddd0341f..87bccf634 100644
--- a/extensions/amp-user-notification/validator-amp-user-notification.protoascii
+++ b/extensions/amp-user-notification/validator-amp-user-notification.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-user-notification
     name: "amp-user-notification"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-vimeo/validator-amp-vimeo.protoascii b/extensions/amp-vimeo/validator-amp-vimeo.protoascii
index 640d4fbda..50eeeadac 100644
--- a/extensions/amp-vimeo/validator-amp-vimeo.protoascii
+++ b/extensions/amp-vimeo/validator-amp-vimeo.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-vimeo
     name: "amp-vimeo"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-vine/validator-amp-vine.protoascii b/extensions/amp-vine/validator-amp-vine.protoascii
index 7d60cd28d..37cc42dc0 100644
--- a/extensions/amp-vine/validator-amp-vine.protoascii
+++ b/extensions/amp-vine/validator-amp-vine.protoascii
@@ -21,7 +21,7 @@ tags: {  # amp-vine
     name: "amp-vine"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/extensions/amp-youtube/validator-amp-youtube.protoascii b/extensions/amp-youtube/validator-amp-youtube.protoascii
index b87d55b5f..3923f0fd1 100644
--- a/extensions/amp-youtube/validator-amp-youtube.protoascii
+++ b/extensions/amp-youtube/validator-amp-youtube.protoascii
@@ -22,7 +22,7 @@ tags: {  # amp-youtube
     name: "amp-youtube"
     version: "0.1"
     version: "latest"
-    requires_usage: GRANDFATHERED
+    requires_usage: EXEMPTED
     deprecated_allow_duplicates: true
   }
   attr_lists: "common-extension-attrs"
diff --git a/validator/java/src/test/resources/validator-all-test.protoascii b/validator/java/src/test/resources/validator-all-test.protoascii
new file mode 100644
index 000000000..1fb79c027
--- /dev/null
+++ b/validator/java/src/test/resources/validator-all-test.protoascii
@@ -0,0 +1,61 @@
+tags: {
+  html_format: AMP4EMAIL
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "test_satisfies"
+  satisfies: "amp-app-banner button[open-button]"
+  mandatory_alternatives: "alternative"
+  siblings_disallowed: true
+}
+
+descendant_tag_list: {
+      name: "satisfies-allowed-descendants"
+      tag: "A"
+      tag: "ABBR"
+}
+
+tags: {
+  html_format: AMP4EMAIL
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "test_satisfies_parent_head"
+  descendant_tag_list: "satisfies-allowed-descendants"
+  attrs: {
+      name: "href"
+      mandatory: true
+      alternative_names: "href"
+      value_url: {
+        protocol: "https"
+      }
+      blacklisted_value_regex: "__amp_source_origin"
+    }
+    mark_descendants {
+        marker: AUTOSCROLL
+      }
+    siblings_disallowed: true
+    mandatory_last_child: true
+    named_id: STYLE_AMP_CUSTOM
+
+}
+
+tags: {
+  html_format: AMP4EMAIL
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "SCRIPT"
+  attrs: {
+    name: "type"
+    mandatory: true
+    value_casei: "application/json"
+  }
+}
+
+tags: {
+  html_format: AMP4EMAIL
+  tag_name: "$REFERENCE_POINT"
+  spec_name: "test_parent"
+  satisfies: "amp-app-banner button[open-button]"
+  mandatory_alternatives: "alternative"
+  siblings_disallowed: true
+  child_tags: {
+      mandatory_num_child_tags: 1
+      first_child_tag_name_oneof: "AMP-AD"
+  }
+}
\ No newline at end of file
diff --git a/validator/validator-main.protoascii b/validator/validator-main.protoascii
index f9b75ec6e..1157fb364 100644
--- a/validator/validator-main.protoascii
+++ b/validator/validator-main.protoascii
@@ -26,14 +26,14 @@ min_validator_revision_required: 375
 # newer versions of the spec file. This is currently a Google internal
 # mechanism, validator.js does not use this facility. However, any
 # change to this file (validator-main.js) requires updating this revision id.
-spec_file_revision: 961
+spec_file_revision: 1012
 
 styles_spec_url: "https://amp.dev/documentation/guides-and-tutorials/develop/style_and_layout/style_pages"
 script_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#html-tags"
 
 css_length_spec: {
   html_format: AMP
-  max_bytes: 50000
+  max_bytes: 75000
   max_bytes_per_inline_style: 1000
   spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
 }
@@ -1058,7 +1058,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
     value_casei: "text/css"
   }
   cdata: {
-    max_bytes: 50000
+    max_bytes: 75000
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
       at_rule_spec: {
@@ -1176,7 +1176,7 @@ tags: {  # Special custom 'author' spreadsheet for transformed AMP
     value_casei: "text/css"
   }
   cdata: {
-    max_bytes: 50000
+    max_bytes: 75000
     url_bytes_included: false
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
@@ -1257,7 +1257,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP4ADS
     value_casei: "text/css"
   }
   cdata: {
-    max_bytes: 20000  # Smaller than AMP, which is 50,000.
+    max_bytes: 20000  # Smaller than AMP, which is 75,000.
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/a4a_spec#css"
     css_spec: {
       at_rule_spec: {
@@ -1346,7 +1346,7 @@ tags: {  # Special custom 'author' spreadsheet for AMP
   }
   # TODO(b/68756045): Whitelist CSS properties allowed in Dynamic Mail.
   cdata: {
-    max_bytes: 50000
+    max_bytes: 75000
     max_bytes_spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#maximum-size"
     css_spec: {
       at_rule_spec: {
@@ -1623,12 +1623,17 @@ attr_lists: {
 tags: {
   html_format: AMP
   html_format: AMP4ADS
-  html_format: AMP4EMAIL
   html_format: ACTIONS
   tag_name: "SECTION"
   disallowed_ancestor: "AMP-ACCORDION"
   attr_lists: "poool-access-attrs"
 }
+tags: {
+  html_format: AMP4EMAIL
+  tag_name: "SECTION"
+  spec_name: "section (AMP4EMAIL)"
+  disallowed_ancestor: "AMP-ACCORDION"
+}
 # 4.3.4 The nav element
 tags: {
   html_format: AMP
@@ -1890,11 +1895,13 @@ tags: {
       # Blackberry messenger
       # (http://devblog.blackberry.com/2015/02/cross-platform-sharing-with-bbm/)
       protocol: "bbmi"
+      protocol: "chrome"
       # IOS over-the-air app installation
       # (https://github.com/nifcblm/AHPP-iOS-App/wiki/How-to-distribute-enterprise-iOS-App)
       protocol: "itms-services"
       protocol: "fb-me"
       protocol: "fb-messenger"
+      protocol: "feed"
       protocol: "intent"
       # Line messenger (https://media.line.me/howto/en/)
       protocol: "line"
@@ -1962,6 +1969,7 @@ tags: {
   attrs: {
     name: "type"
     value_casei: "text/html"
+    value_casei: "application/rss+xml"
   }
   attr_lists: "name-attr"
   # <amp-bind>
@@ -2104,6 +2112,10 @@ tags: {
   attrs: {
     name: "datetime"
   }
+  attrs: {
+    name: "pubdate"
+    value: ""
+  }
 }
 # 4.5.12 The code element
 tags: {
@@ -4410,7 +4422,10 @@ attr_lists: {
   attrs: { name: "accept" }
   attrs: { name: "accesskey" }
   attrs: { name: "autocomplete" }
-  attrs: { name: "autofocus" }
+  attrs: {
+    disabled_by: "amp4email"
+    name: "autofocus"
+  }
   attrs: { name: "checked" }
   attrs: { name: "disabled" }
   attrs: { name: "height" }
@@ -4503,7 +4518,6 @@ tags: {
   attrs: {
     name: "type"
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated.
-        "button|"
         "file|"
         "image|"
         "password|"
@@ -4852,30 +4866,89 @@ tags: {
 # description are allowed.
 # Note that the type TEXT/PLAIN description is define in
 # validator-amp-mustache.protoascii.
+
+# The three tagspecs below all handle the runtime engine v0.js script. They
+# enforce that exactly one runtime script must be included. This tagspec is
+# for the standard runtime, while the one below it is an identical spec but for
+# the LTS runtime, with the only difference being the src attribute. The third
+# is the corresponding spec for AMP4EMAIL and ACTIONS.
+attr_lists: {
+  name: "amphtml-engine-attrs"
+  attrs: {
+    name: "async"
+    mandatory: true
+    value: ""
+  }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
+  attrs: {
+    name: "type"
+    value_casei: "text/javascript"
+  }
+}
 tags: {
   html_format: AMP
-  html_format: AMP4EMAIL
-  html_format: ACTIONS
   tag_name: "SCRIPT"
   spec_name: "amphtml engine v0.js script"
-  mandatory: true
+  mandatory_alternatives: "amphtml engine v0.js script"
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
+  attr_lists: "amphtml-engine-attrs"
   attrs: {
-    name: "async"
+    name: "src"
     mandatory: true
-    value: ""
+    value: "https://cdn.ampproject.org/v0.js"
+    dispatch_key: NAME_VALUE_DISPATCH
+  }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
     }
+  }
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+}
+tags: {
+  html_format: AMP
+  tag_name: "SCRIPT"
+  spec_name: "amphtml engine v0.js lts script"
+  mandatory_alternatives: "amphtml engine v0.js script"
+  unique: true
+  mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
+  attr_lists: "amphtml-engine-attrs"
   attrs: {
     name: "src"
     mandatory: true
-    value: "https://cdn.ampproject.org/v0.js"
+    value: "https://cdn.ampproject.org/lts/v0.js"
     dispatch_key: NAME_VALUE_DISPATCH
   }
+  cdata: {
+    blacklisted_cdata_regex: {
+      regex: "."
+      error_message: "contents"
+    }
+  }
+  spec_url: "https://amp.dev/documentation/guides-and-tutorials/learn/spec/amphtml#required-markup"
+}
+tags: {
+  html_format: AMP4EMAIL
+  html_format: ACTIONS
+  tag_name: "SCRIPT"
+  spec_name: "amphtml engine v0.js script [AMP4EMAIL,ACTIONS]"
+  mandatory: true
+  unique: true
+  mandatory_parent: "HEAD"
+  attr_lists: "nonce-attr"
+  attr_lists: "amphtml-engine-attrs"
   attrs: {
-    name: "type"
-    value_casei: "text/javascript"
+    name: "src"
+    mandatory: true
+    value: "https://cdn.ampproject.org/v0.js"
+    dispatch_key: NAME_VALUE_DISPATCH
   }
   cdata: {
     blacklisted_cdata_regex: {
@@ -4893,21 +4966,13 @@ tags: {
   unique: true
   mandatory_parent: "HEAD"
   attr_lists: "nonce-attr"
-  attrs: {
-    name: "async"
-    mandatory: true
-    value: ""
-  }
+  attr_lists: "amphtml-engine-attrs"
   attrs: {
     name: "src"
     mandatory: true
     value: "https://cdn.ampproject.org/amp4ads-v0.js"
     dispatch_key: NAME_VALUE_DISPATCH
   }
-  attrs: {
-    name: "type"
-    value_casei: "text/javascript"
-  }
   cdata: {
     blacklisted_cdata_regex: {
       regex: "."
@@ -5307,9 +5372,11 @@ tags: {
   html_format: ACTIONS
   enabled_by: "transformed"
   tag_name: "I-AMPHTML-SIZER"
+  spec_name: "I-AMPHTML-SIZER-RESPONSIVE"
   explicit_attrs_only: true
   attrs: {
     name: "style"
+    dispatch_key: NAME_DISPATCH
     mandatory: true
     blacklisted_value_regex: "!\\s*important"
     css_declaration: {
@@ -5320,6 +5387,49 @@ tags: {
   }
 }
 
+tags: {
+  html_format: AMP
+  html_format: ACTIONS
+  enabled_by: "transformed"
+  tag_name: "I-AMPHTML-SIZER"
+  spec_name: "I-AMPHTML-SIZER-INTRINSIC"
+  explicit_attrs_only: true
+  attrs: {
+    name: "class"
+    value: "i-amphtml-sizer"
+    mandatory: true
+    dispatch_key: NAME_DISPATCH
+  }
+}
+
+tags: {
+  html_format: AMP
+  enabled_by: "transformed"
+  tag_name: "IMG"
+  spec_name: "IMG-I-AMPHTML-INTRINSIC-SIZER"
+  mandatory_parent: "I-AMPHTML-SIZER-INTRINSIC"
+  attrs: {
+    name: "alt"
+    value: ""
+    mandatory: true
+  }
+  attrs: {
+    name: "aria-hidden"
+    value: "true"
+    mandatory: true
+  }
+  attrs: {
+    name: "role"
+    value: "presentation"
+    mandatory: true
+  }
+  attrs: {
+    name: "src"
+    value_regex: "data:image\\/svg\\+xml;charset=utf-8,<svg height=\"\\d+\" width=\"\\d+\" xmlns=\"http:\\/\\/www\\.w3\\.org\\/2000\\/svg\" version=\"1\\.1\"\\/>|data:image\\/svg\\+xml;charset=utf-8,<svg height='100' width='300' xmlns='http:\\/\\/www\\.w3\\.org\\/2000\\/svg' version='1\\.1'\\/>"
+    mandatory: true
+  }
+}
+
 # AMP Layout attributes: implied for TagSpecs with amp_layout field
 # set. Note that while these attributes are defined as optional here,
 # depending on amp layout the validator will examine these fields and
@@ -5361,6 +5471,10 @@ attr_lists: {
     mandatory: true
     value: ""
   }
+  attrs: {
+    name: "crossorigin"
+    value: "anonymous"
+  }
   attrs: {
     disabled_by: "transformed"
     disabled_by: "amp4email"
@@ -5379,7 +5493,8 @@ attr_lists: {
     name: "id"
     mandatory: true
     # When updating this blacklisted_value_regex, also update the entry for
-    # "id" in $GLOBAL_ATTRS and "id" in "amp-script extension local script".
+    # "id" in $GLOBAL_ATTRS, and also validator-amp-script.protoascii and
+    # validator-amp-mustache.protoascii.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
@@ -6411,7 +6526,8 @@ attr_lists: {
   attrs: {
     name: "id"
     # When updating this blacklisted_value_regex, also update for
-    # mandatory-id-attr and validator-amp-mustache.protoascii.
+    # mandatory-id-attr, validator-amp-script.protoascii, and
+    # validator-amp-mustache.protoascii.
     blacklisted_value_regex: "(^|\\s)("  # Values are space separated
         "__amp_\\S*|"
         "__count__|"
@@ -6622,6 +6738,7 @@ attr_lists: {
     value: "rangeUnderflow"
     value: "stepMismatch"
     value: "tooLong"
+    value: "tooShort"
     value: "typeMismatch"
     value: "valueMissing"
     trigger: {
@@ -6693,6 +6810,16 @@ attr_lists: {
     name: "subscriptions-service"
     requires_extension: "amp-subscriptions"
   }
+  # amp-next-page specific attributes, see
+  # https://amp.dev/documentation/components/amp-next-page
+  attrs: {
+    name: "next-page-hide"
+    requires_extension: "amp-next-page"
+  }
+  attrs: {
+    name: "next-page-replace"
+    requires_extension: "amp-next-page"
+  }
   # <amp-bind>
   attrs: { name: "[aria-activedescendant]" }
   attrs: { name: "[aria-atomic]" }
@@ -6762,156 +6889,162 @@ error_specificity { code: WARNING_TAG_REQUIRED_BY_MISSING specificity: 14 }
 error_specificity { code: EXTENSION_UNUSED specificity: 15 }
 error_specificity { code: WARNING_EXTENSION_UNUSED specificity: 16 }
 error_specificity { code: WARNING_EXTENSION_DEPRECATED_VERSION specificity: 17 }
-error_specificity { code: DISALLOWED_TAG specificity: 18 }
-error_specificity { code: DISALLOWED_ATTR specificity: 19 }
-error_specificity { code: INVALID_ATTR_VALUE specificity: 20 }
-error_specificity { code: DUPLICATE_ATTRIBUTE specificity: 21 }
-error_specificity { code: ATTR_VALUE_REQUIRED_BY_LAYOUT specificity: 22 }
-error_specificity { code: MANDATORY_ATTR_MISSING specificity: 23 }
-error_specificity { code: MANDATORY_ONEOF_ATTR_MISSING specificity: 24 }
-error_specificity { code: MANDATORY_ANYOF_ATTR_MISSING specificity: 25 }
-error_specificity { code: ATTR_REQUIRED_BUT_MISSING specificity: 26 }
-error_specificity { code: DUPLICATE_UNIQUE_TAG specificity: 27 }
-error_specificity { code: DUPLICATE_UNIQUE_TAG_WARNING specificity: 28 }
-error_specificity { code: STYLESHEET_TOO_LONG specificity: 29 }
-error_specificity { code: STYLESHEET_AND_INLINE_STYLE_TOO_LONG specificity: 30 }
-error_specificity { code: INLINE_STYLE_TOO_LONG specificity: 31 }
-error_specificity { code: CSS_SYNTAX_INVALID_AT_RULE specificity: 32 }
+error_specificity { code: NON_LTS_SCRIPT_AFTER_LTS specificity: 18 }
+error_specificity { code: LTS_SCRIPT_AFTER_NON_LTS specificity: 19 }
+error_specificity { code: DISALLOWED_TAG specificity: 20 }
+error_specificity { code: DISALLOWED_ATTR specificity: 21 }
+error_specificity { code: INVALID_ATTR_VALUE specificity: 22 }
+error_specificity { code: DUPLICATE_ATTRIBUTE specificity: 23 }
+error_specificity { code: ATTR_VALUE_REQUIRED_BY_LAYOUT specificity: 24 }
+error_specificity { code: MANDATORY_ATTR_MISSING specificity: 25 }
+error_specificity { code: MANDATORY_ONEOF_ATTR_MISSING specificity: 26 }
+error_specificity { code: MANDATORY_ANYOF_ATTR_MISSING specificity: 27 }
+error_specificity { code: ATTR_REQUIRED_BUT_MISSING specificity: 28 }
+error_specificity { code: DUPLICATE_UNIQUE_TAG specificity: 29 }
+error_specificity { code: DUPLICATE_UNIQUE_TAG_WARNING specificity: 30 }
+error_specificity { code: STYLESHEET_TOO_LONG specificity: 31 }
+error_specificity { code: STYLESHEET_AND_INLINE_STYLE_TOO_LONG specificity: 32 }
+error_specificity { code: INLINE_STYLE_TOO_LONG specificity: 33 }
+error_specificity { code: CSS_SYNTAX_INVALID_AT_RULE specificity: 34 }
 error_specificity {
-  code: MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE specificity: 33
-}
-error_specificity { code: INVALID_PROPERTY_VALUE_IN_ATTR_VALUE specificity: 34 }
-error_specificity { code: DISALLOWED_PROPERTY_IN_ATTR_VALUE specificity: 35 }
-error_specificity { code: MUTUALLY_EXCLUSIVE_ATTRS specificity: 36 }
-error_specificity { code: UNESCAPED_TEMPLATE_IN_ATTR_VALUE specificity: 37 }
-error_specificity { code: TEMPLATE_PARTIAL_IN_ATTR_VALUE specificity: 38 }
-error_specificity { code: TEMPLATE_IN_ATTR_NAME specificity: 39 }
+  code: MANDATORY_PROPERTY_MISSING_FROM_ATTR_VALUE specificity: 35
+}
+error_specificity { code: INVALID_PROPERTY_VALUE_IN_ATTR_VALUE specificity: 36 }
+error_specificity { code: DISALLOWED_PROPERTY_IN_ATTR_VALUE specificity: 37 }
+error_specificity { code: MUTUALLY_EXCLUSIVE_ATTRS specificity: 38 }
+error_specificity { code: UNESCAPED_TEMPLATE_IN_ATTR_VALUE specificity: 39 }
+error_specificity { code: TEMPLATE_PARTIAL_IN_ATTR_VALUE specificity: 40 }
+error_specificity { code: TEMPLATE_IN_ATTR_NAME specificity: 41 }
 error_specificity {
-  code: INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT specificity: 40
-}
-error_specificity { code: MISSING_LAYOUT_ATTRIBUTES specificity: 41 }
-error_specificity { code: IMPLIED_LAYOUT_INVALID specificity: 42 }
-error_specificity { code: SPECIFIED_LAYOUT_INVALID specificity: 43 }
-error_specificity { code: ATTR_DISALLOWED_BY_IMPLIED_LAYOUT specificity: 44 }
-error_specificity { code: ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT specificity: 45 }
-error_specificity { code: DUPLICATE_DIMENSION specificity: 46 }
-error_specificity { code: DISALLOWED_RELATIVE_URL specificity: 47 }
-error_specificity { code: MISSING_URL specificity: 48 }
-error_specificity { code: DISALLOWED_DOMAIN specificity: 49 }
-error_specificity { code: INVALID_URL_PROTOCOL specificity: 50 }
-error_specificity { code: INVALID_URL specificity: 51 }
-error_specificity { code: DISALLOWED_STYLE_ATTR specificity: 52 }
-error_specificity { code: CSS_SYNTAX_STRAY_TRAILING_BACKSLASH specificity: 53 }
-error_specificity { code: CSS_SYNTAX_UNTERMINATED_COMMENT specificity: 54 }
-error_specificity { code: CSS_SYNTAX_UNTERMINATED_STRING specificity: 55 }
-error_specificity { code: CSS_SYNTAX_BAD_URL specificity: 56 }
+  code: INCONSISTENT_UNITS_FOR_WIDTH_AND_HEIGHT specificity: 42
+}
+error_specificity { code: MISSING_LAYOUT_ATTRIBUTES specificity: 43 }
+error_specificity { code: IMPLIED_LAYOUT_INVALID specificity: 44 }
+error_specificity { code: SPECIFIED_LAYOUT_INVALID specificity: 45 }
+error_specificity { code: ATTR_DISALLOWED_BY_IMPLIED_LAYOUT specificity: 46 }
+error_specificity { code: ATTR_DISALLOWED_BY_SPECIFIED_LAYOUT specificity: 47 }
+error_specificity { code: DUPLICATE_DIMENSION specificity: 48 }
+error_specificity { code: DISALLOWED_RELATIVE_URL specificity: 49 }
+error_specificity { code: MISSING_URL specificity: 50 }
+error_specificity { code: DISALLOWED_DOMAIN specificity: 51 }
+error_specificity { code: INVALID_URL_PROTOCOL specificity: 52 }
+error_specificity { code: INVALID_URL specificity: 53 }
+error_specificity { code: DISALLOWED_STYLE_ATTR specificity: 54 }
+error_specificity { code: CSS_SYNTAX_STRAY_TRAILING_BACKSLASH specificity: 55 }
+error_specificity { code: CSS_SYNTAX_UNTERMINATED_COMMENT specificity: 56 }
+error_specificity { code: CSS_SYNTAX_UNTERMINATED_STRING specificity: 57 }
+error_specificity { code: CSS_SYNTAX_BAD_URL specificity: 58 }
 error_specificity {
-  code: CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE specificity: 57
+  code: CSS_SYNTAX_EOF_IN_PRELUDE_OF_QUALIFIED_RULE specificity: 59
 }
-error_specificity { code: CSS_SYNTAX_INVALID_DECLARATION specificity: 58 }
-error_specificity { code: CSS_SYNTAX_INCOMPLETE_DECLARATION specificity: 59 }
-error_specificity { code: CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR specificity: 60 }
-error_specificity { code: CSS_SYNTAX_MISSING_SELECTOR specificity: 61 }
-error_specificity { code: CSS_SYNTAX_NOT_A_SELECTOR_START specificity: 62 }
+error_specificity { code: CSS_SYNTAX_INVALID_DECLARATION specificity: 60 }
+error_specificity { code: CSS_SYNTAX_INCOMPLETE_DECLARATION specificity: 61 }
+error_specificity { code: CSS_SYNTAX_ERROR_IN_PSEUDO_SELECTOR specificity: 62 }
+error_specificity { code: CSS_SYNTAX_MISSING_SELECTOR specificity: 63 }
+error_specificity { code: CSS_SYNTAX_NOT_A_SELECTOR_START specificity: 64 }
 error_specificity {
-  code: CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR specificity: 63
-}
-error_specificity { code: CSS_SYNTAX_MISSING_URL specificity: 64 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_DOMAIN specificity: 65 }
-error_specificity { code: CSS_SYNTAX_INVALID_URL specificity: 66 }
-error_specificity { code: CSS_SYNTAX_INVALID_URL_PROTOCOL specificity: 67 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_RELATIVE_URL specificity: 68 }
-error_specificity { code: INCORRECT_NUM_CHILD_TAGS specificity: 69 }
-error_specificity { code: DISALLOWED_CHILD_TAG_NAME specificity: 70 }
-error_specificity { code: DISALLOWED_FIRST_CHILD_TAG_NAME specificity: 71 }
-error_specificity { code: CSS_SYNTAX_INVALID_ATTR_SELECTOR specificity: 72 }
+  code: CSS_SYNTAX_UNPARSED_INPUT_REMAINS_IN_SELECTOR specificity: 65
+}
+error_specificity { code: CSS_SYNTAX_MISSING_URL specificity: 66 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_DOMAIN specificity: 67 }
+error_specificity { code: CSS_SYNTAX_INVALID_URL specificity: 68 }
+error_specificity { code: CSS_SYNTAX_INVALID_URL_PROTOCOL specificity: 69 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_RELATIVE_URL specificity: 70 }
+error_specificity { code: INCORRECT_NUM_CHILD_TAGS specificity: 71 }
+error_specificity { code: DISALLOWED_CHILD_TAG_NAME specificity: 72 }
+error_specificity { code: DISALLOWED_FIRST_CHILD_TAG_NAME specificity: 73 }
+error_specificity { code: CSS_SYNTAX_INVALID_ATTR_SELECTOR specificity: 74 }
 error_specificity {
-  code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT specificity: 73
+  code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT specificity: 75
 }
-error_specificity { code: MANDATORY_REFERENCE_POINT_MISSING specificity: 74 }
-error_specificity { code: DUPLICATE_REFERENCE_POINT specificity: 75 }
-error_specificity { code: TAG_REFERENCE_POINT_CONFLICT specificity: 76 }
+error_specificity { code: MANDATORY_REFERENCE_POINT_MISSING specificity: 76 }
+error_specificity { code: DUPLICATE_REFERENCE_POINT specificity: 77 }
+error_specificity { code: TAG_REFERENCE_POINT_CONFLICT specificity: 78 }
 error_specificity {
   code: CHILD_TAG_DOES_NOT_SATISFY_REFERENCE_POINT_SINGULAR
-  specificity: 77
+  specificity: 79
 }
-error_specificity { code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE specificity: 78 }
+error_specificity { code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE specificity: 80 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_PROPERTY_VALUE_WITH_HINT
-  specificity: 79
+  specificity: 81
 }
 error_specificity {
   code: CSS_SYNTAX_PROPERTY_DISALLOWED_WITHIN_AT_RULE
-  specificity: 80
+  specificity: 82
 }
 error_specificity {
   code: CSS_SYNTAX_PROPERTY_DISALLOWED_TOGETHER_WITH
-  specificity: 81
+  specificity: 83
 }
 error_specificity {
   code: CSS_SYNTAX_PROPERTY_REQUIRES_QUALIFICATION
-  specificity: 82
+  specificity: 84
 }
 error_specificity {
   code: BASE_TAG_MUST_PRECEED_ALL_URLS
-  specificity: 83
-}
-error_specificity { code: DISALLOWED_SCRIPT_TAG specificity: 100 }
-error_specificity { code: GENERAL_DISALLOWED_TAG specificity: 101 }
-error_specificity { code: DEPRECATED_ATTR specificity: 102 }
-error_specificity { code: DEPRECATED_TAG specificity: 103 }
-error_specificity { code: DISALLOWED_MANUFACTURED_BODY specificity: 104 }
-error_specificity { code: DOCUMENT_TOO_COMPLEX specificity: 105 }
-error_specificity { code: INCORRECT_MIN_NUM_CHILD_TAGS specificity: 106 }
-error_specificity { code: TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS specificity: 107 }
-error_specificity { code: MANDATORY_LAST_CHILD_TAG specificity: 108 }
+  specificity: 85
+}
+error_specificity { code: DISALLOWED_SCRIPT_TAG specificity: 102 }
+error_specificity { code: GENERAL_DISALLOWED_TAG specificity: 103 }
+error_specificity { code: DEPRECATED_ATTR specificity: 104 }
+error_specificity { code: DEPRECATED_TAG specificity: 105 }
+error_specificity { code: DISALLOWED_MANUFACTURED_BODY specificity: 106 }
+error_specificity { code: DOCUMENT_TOO_COMPLEX specificity: 107 }
+error_specificity { code: INCORRECT_MIN_NUM_CHILD_TAGS specificity: 108 }
+error_specificity { code: TAG_NOT_ALLOWED_TO_HAVE_SIBLINGS specificity: 109 }
+error_specificity { code: MANDATORY_LAST_CHILD_TAG specificity: 110 }
 error_specificity {
   code: CSS_SYNTAX_INVALID_PROPERTY
-  specificity: 109
+  specificity: 111
 }
 error_specificity {
   code: CSS_SYNTAX_INVALID_PROPERTY_NOLIST
-  specificity: 110
+  specificity: 112
 }
 error_specificity {
   code: CSS_SYNTAX_QUALIFIED_RULE_HAS_NO_DECLARATIONS
-  specificity: 111
+  specificity: 113
 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_QUALIFIED_RULE_MUST_BE_INSIDE_KEYFRAME
-  specificity: 112
+  specificity: 114
 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_KEYFRAME_INSIDE_KEYFRAME
-  specificity: 113
+  specificity: 115
 }
 error_specificity {
   code: CSS_SYNTAX_MALFORMED_MEDIA_QUERY
-  specificity: 115
+  specificity: 117
 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_MEDIA_TYPE
-  specificity: 116
+  specificity: 118
 }
 error_specificity {
   code: CSS_SYNTAX_DISALLOWED_MEDIA_FEATURE
-  specificity: 117
+  specificity: 119
 }
 error_specificity {
   code: INVALID_UTF8
-  specificity: 118
+  specificity: 120
 }
 error_specificity {
   code: CSS_EXCESSIVELY_NESTED
-  specificity: 119
+  specificity: 121
 }
 error_specificity {
   code: DOCUMENT_SIZE_LIMIT_EXCEEDED
-  specificity: 120
+  specificity: 122
 }
 error_specificity {
   code: VALUE_SET_MISMATCH
-  specificity: 121
+  specificity: 123
+}
+error_specificity {
+  code: INVALID_DOCTYPE_HTML
+  specificity: 124
 }
 error_specificity {
   code: DEV_MODE_ONLY
@@ -6926,6 +7059,11 @@ error_formats {
   code: UNKNOWN_CODE
   format: "Unknown error."
 }
+error_formats {
+  code: INVALID_DOCTYPE_HTML
+  format: "Invalid or missing doctype declaration. Should be <!doctype html>. "
+          "See https://amp.dev/documentation/guides-and-tutorials/start/create/basic_markup/"
+}
 error_formats {
   code: MANDATORY_TAG_MISSING
   format: "The mandatory tag '%1' is missing or incorrect."
@@ -6960,6 +7098,17 @@ error_formats {
           "extension. This may become an error in the future."
 }
 
+error_formats {
+  code: NON_LTS_SCRIPT_AFTER_LTS
+  format: "'%1' must use the LTS version to correspond with the first script "
+          "in the page, which uses LTS."
+}
+error_formats {
+  code: LTS_SCRIPT_AFTER_NON_LTS
+  format: "'%1' must use the non-LTS version to correspond with the first "
+          "script in the page, which does not use LTS."
+}
+
 error_formats {
   code: ATTR_REQUIRED_BUT_MISSING
   format: "The attribute '%1' in tag '%2' is missing or incorrect, but "
```