### PR TITLE
Remove post-processor cache

### DIFF
--- a/includes/options/class-amp-options-menu.php
+++ b/includes/options/class-amp-options-menu.php
@@ -101,19 +101,6 @@ class AMP_Options_Menu {
 			]
 		);
 
-		if ( wp_using_ext_object_cache() ) {
-			add_settings_field(
-				'caching',
-				__( 'Caching', 'amp' ),
-				[ $this, 'render_caching' ],
-				AMP_Options_Manager::OPTION_NAME,
-				'general',
-				[
-					'class' => 'amp-caching-field',
-				]
-			);
-		}
-
 		$submenus = [
 			new AMP_Analytics_Options_Submenu( AMP_Options_Manager::OPTION_NAME ),
 		];
@@ -371,34 +358,6 @@ class AMP_Options_Menu {
 				})( jQuery );
 			</script>
 		<?php endif; ?>
-		<?php
-	}
-
-	/**
-	 * Render the caching settings section.
-	 *
-	 * @since 1.0
-	 *
-	 * @todo Change the messaging and description to be user-friendly and helpful.
-	 */
-	public function render_caching() {
-		?>
-		<fieldset>
-			<?php if ( AMP_Options_Manager::show_response_cache_disabled_notice() ) : ?>
-				<div class="notice notice-info notice-alt inline">
-					<p><?php esc_html_e( 'The post-processor cache was disabled due to detecting randomly generated content found on', 'amp' ); ?> <a href="<?php echo esc_url( get_option( AMP_Theme_Support::CACHE_MISS_URL_OPTION, '' ) ); ?>"><?php esc_html_e( 'on this web page.', 'amp' ); ?></a></p>
-					<p><?php esc_html_e( 'Randomly generated content was detected on this web page.  To avoid filling up the cache with unusable content, the AMP plugin\'s post-processor cache was automatically disabled.', 'amp' ); ?>
-						<a href="<?php echo esc_url( 'https://github.com/ampproject/amp-wp/wiki/Post-Processor-Cache' ); ?>"><?php esc_html_e( 'Read more', 'amp' ); ?></a>.</p>
-				</div>
-			<?php endif; ?>
-			<p>
-				<label for="enable_response_caching">
-					<input id="enable_response_caching" type="checkbox" name="<?php echo esc_attr( AMP_Options_Manager::OPTION_NAME . '[enable_response_caching]' ); ?>" <?php checked( AMP_Options_Manager::get_option( 'enable_response_caching' ) ); ?>>
-					<?php esc_html_e( 'Enable post-processor caching.', 'amp' ); ?>
-				</label>
-			</p>
-			<p class="description"><?php esc_html_e( 'This will enable post-processor caching to speed up processing an AMP response after WordPress renders a template.', 'amp' ); ?></p>
-		</fieldset>
 		<?php
 	}
 

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -2016,7 +2016,7 @@ class AMP_Validation_Manager {
 				$validation_url,
 				[
 					'cookies'     => wp_unslash( $_COOKIE ), // Pass along cookies so private pages and drafts can be accessed.
-					'timeout'     => 15, // Increase from default of 5 to give extra time for the plugin to identify the sources for any given validation errors; also, response caching is disabled when validating.
+					'timeout'     => 15, // Increase from default of 5 to give extra time for the plugin to identify the sources for any given validation errors.
 					'sslverify'   => false,
 					'redirection' => 0, // Because we're in a loop for redirection.
 					'headers'     => [

--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -64,7 +64,7 @@ final class SiteHealth {
 				'label' => esc_html__( 'AMP', 'amp' ),
 				'color' => $is_using_object_cache ? 'green' : 'orange',
 			],
-			'description' => esc_html__( 'The AMP plugin performs at its best when persistent object cache is enabled. Object caching is used to more effectively store image dimensions and parsed CSS. It also allows for post-processor caching to be used.', 'amp' ),
+			'description' => esc_html__( 'The AMP plugin performs at its best when persistent object cache is enabled. Object caching is used to more effectively store image dimensions and parsed CSS.', 'amp' ),
 			'actions'     => sprintf(
 				'<p><a href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
 				'https://codex.wordpress.org/Class_Reference/WP_Object_Cache#Persistent_Caching',

--- a/tests/e2e/specs/amp-options.js
+++ b/tests/e2e/specs/amp-options.js
@@ -10,12 +10,6 @@ describe( 'AMP Settings Screen', () => {
 		await expect( page ).toMatchElement( '.amp-welcome-notice h2', { text: 'Welcome to AMP for WordPress' } );
 	} );
 
-	it( 'should display a warning about missing object cache', async () => {
-		await visitAdminPage( 'admin.php', 'page=amp-options' );
-
-		await expect( page ).toMatchElement( '.notice-warning p', { text: 'The AMP plugin performs at its best when persistent object cache is enabled' } );
-	} );
-
 	it( 'should display a message about theme compatibility', async () => {
 		await visitAdminPage( 'admin.php', 'page=amp-options' );
 

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -2340,7 +2340,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$this->assertStringStartsWith( 'Redirecting to non-AMP version', $sanitized_html );
 		$this->assertCount( 4, $redirects );
 		$this->assertEquals( home_url( '/?amp_validation_errors=1' ), $redirects[0] );
-		$this->assertEquals( 4, AMP_Theme_Support_Sanitizer_Counter::$count, 'Expected sanitizer to not be invoked again since although validation results are cached.' );
+		$this->assertEquals( 4, AMP_Theme_Support_Sanitizer_Counter::$count, 'Expected sanitizer to be invoked again although validation results are cached.' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This PR removes code related to the post-processor cache, which includes:

- Removing the `ETag` HTTP header and the support for sending 304 `Not Modified` responses
- Removing the 'Caching' section and option on the settings page
  - Remove the `enable_response_caching` option upon upgrade to v1.5.0
- Removing all notices related to object caching and post-processor cache 

<!-- Please reference the issue this PR addresses. -->
Fixes #4178

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
