### PR TITLE
Change notice label from 'Remove Element' to 'Remove Block'

### DIFF
--- a/assets/src/block-validation/components/higher-order/with-validation-error-notice/index.js
+++ b/assets/src/block-validation/components/higher-order/with-validation-error-notice/index.js
@@ -41,7 +41,7 @@ export default createHigherOrderComponent(
 
 			const actions = [
 				{
-					label: __( 'Remove Element', 'amp' ),
+					label: __( 'Remove Block', 'amp' ),
 					onClick: () => onReplace( [] ),
 				},
 			];


### PR DESCRIPTION


## Summary
* Changes action label in the notice from 'Remove Element' to 'Remove Block'
* As mentioned in #3822, this really removes the block, not just the invalid element.
![remove-block](https://user-images.githubusercontent.com/4063887/76816135-16629880-67c5-11ea-9203-8e4e49f9cebd.png)

Fixes #3822 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
