### PR TITLE
Show correct PHP requirement message to users

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -34,7 +34,7 @@ if ( version_compare( phpversion(), '5.6', '<' ) ) {
 		sprintf(
 			/* translators: %s: required PHP version */
 			__( 'The AMP plugin requires PHP %s. Please contact your host to update your PHP version.', 'amp' ),
-			'5.4+'
+			'5.6+'
 		)
 	);
 }


### PR DESCRIPTION
## Summary

Although we bumped the minimum version of PHP from 5.4 to 5.6, we didn't adapt the version number in the error message that users are shown.

So users with PHP 5.4 or PHP 5.5 would be shown an error message saying they'd require 5.4, instead of 5.6.

This PR fixes the version used to display the error message.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).