### PR TITLE
Update labels for stylesheet information panel

### DIFF
--- a/assets/css/src/amp-validation-error-taxonomy.css
+++ b/assets/css/src/amp-validation-error-taxonomy.css
@@ -27,7 +27,7 @@ td.column-error_code .error-code {
 	font-family: Consolas, Monaco, monospace;
 }
 
-th.column-status {
+th.column-included {
 	width: 15%;
 }
 
@@ -467,7 +467,7 @@ body.taxonomy-amp_validation_error .wp-list-table .new th.check-column input {
 	text-align: right;
 }
 
-#amp_stylesheets .column-stylesheet_status {
+#amp_stylesheets .column-stylesheet_included {
 	width: 5%;
 	white-space: nowrap;
 	text-align: center;

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2136,12 +2136,12 @@ class AMP_Validated_URL_Post_Type {
 			<tr>
 				<th class="column-stylesheet_expand"></th>
 				<th class="column-stylesheet_order"><?php esc_html_e( 'Order', 'amp' ); ?></th>
-				<th class="column-original_size"><?php esc_html_e( 'Original', 'amp' ); ?></th>
+				<th class="column-original_size"><?php esc_html_e( 'Original(B)', 'amp' ); ?></th>
 				<th class="column-minified"><?php esc_html_e( 'Minified', 'amp' ); ?></th>
-				<th class="column-final_size"><?php esc_html_e( 'Final', 'amp' ); ?></th>
+				<th class="column-final_size"><?php esc_html_e( 'Final(B)', 'amp' ); ?></th>
 				<th class="column-percentage"><?php esc_html_e( 'Percent', 'amp' ); ?></th>
 				<th class="column-priority"><?php esc_html_e( 'Priority', 'amp' ); ?></th>
-				<th class="column-stylesheet_status"><?php esc_html_e( 'Status', 'amp' ); ?></th>
+				<th class="column-stylesheet_included"><?php esc_html_e( 'Included', 'amp' ); ?></th>
 				<th class="column-markup"><?php esc_html_e( 'Markup', 'amp' ); ?></th>
 				<th class="column-sources_with_invalid_output"><?php esc_html_e( 'Sources', 'amp' ); ?></th>
 			</tr>
@@ -2198,7 +2198,6 @@ class AMP_Validated_URL_Post_Type {
 					<td class="column-original_size">
 						<?php
 						echo esc_html( number_format_i18n( $stylesheet['original_size'] ) );
-						echo '<small>B</small>';
 						?>
 					</td>
 					<td class="column-minified">
@@ -2213,7 +2212,6 @@ class AMP_Validated_URL_Post_Type {
 					<td class="column-final_size">
 						<?php
 						echo esc_html( number_format_i18n( $stylesheet['final_size'] ) );
-						echo '<small>B</small>';
 						?>
 					</td>
 					<td class="column-percentage">
@@ -2227,7 +2225,7 @@ class AMP_Validated_URL_Post_Type {
 					<td class="column-priority">
 						<?php echo esc_html( $stylesheet['priority'] ); ?>
 					</td>
-					<td class="column-stylesheet_status">
+					<td class="column-stylesheet_included">
 						<?php
 						$emoji_style = sprintf( 'font-family: %s;', Fonts::getEmojiFontFamilyValue() );
 						switch ( $stylesheet['status'] ) {

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2052,7 +2052,8 @@ class AMP_Validated_URL_Post_Type {
 					<?php esc_html_e( 'Total CSS size prior to minification:', 'amp' ); ?>
 				</th>
 				<td>
-					<?php echo esc_html( number_format_i18n( $included_original_size + $excluded_original_size ) ); ?><small>B</small>
+					<?php echo esc_html( number_format_i18n( $included_original_size + $excluded_original_size ) ); ?>
+					<abbr title="<?php esc_attr_e( 'bytes', 'amp' ); ?>"><?php echo esc_attr_x( 'B', 'abbreviation for bytes', 'amp' ); ?></abbr>
 				</td>
 			</tr>
 			<tr>
@@ -2060,7 +2061,8 @@ class AMP_Validated_URL_Post_Type {
 					<?php esc_html_e( 'Total CSS size after minification:', 'amp' ); ?>
 				</th>
 				<td>
-					<?php echo esc_html( number_format_i18n( $included_final_size + $excluded_final_size ) ); ?><small>B</small>
+					<?php echo esc_html( number_format_i18n( $included_final_size + $excluded_final_size ) ); ?>
+					<abbr title="<?php esc_attr_e( 'bytes', 'amp' ); ?>"><?php echo esc_attr_x( 'B', 'abbreviation for bytes', 'amp' ); ?></abbr>
 				</td>
 			</tr>
 			<tr>
@@ -2107,7 +2109,8 @@ class AMP_Validated_URL_Post_Type {
 					?>
 				</th>
 				<td>
-					<?php echo esc_html( number_format_i18n( $excluded_final_size ) ); ?><small>B</small>
+					<?php echo esc_html( number_format_i18n( $excluded_final_size ) ); ?>
+					<abbr title="<?php esc_attr_e( 'bytes', 'amp' ); ?>"><?php echo esc_attr_x( 'B', 'abbreviation for bytes', 'amp' ); ?></abbr>
 				</td>
 			</tr>
 		</table>

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -2136,9 +2136,15 @@ class AMP_Validated_URL_Post_Type {
 			<tr>
 				<th class="column-stylesheet_expand"></th>
 				<th class="column-stylesheet_order"><?php esc_html_e( 'Order', 'amp' ); ?></th>
-				<th class="column-original_size"><?php esc_html_e( 'Original(B)', 'amp' ); ?></th>
+				<th class="column-original_size">
+					<?php esc_html_e( 'Original', 'amp' ); ?>
+					(<abbr title="<?php esc_attr_e( 'bytes', 'amp' ); ?>"><?php echo esc_attr_x( 'B', 'abbreviation for bytes', 'amp' ); ?></abbr>)
+				</th>
 				<th class="column-minified"><?php esc_html_e( 'Minified', 'amp' ); ?></th>
-				<th class="column-final_size"><?php esc_html_e( 'Final(B)', 'amp' ); ?></th>
+				<th class="column-final_size">
+					<?php esc_html_e( 'Final', 'amp' ); ?>
+					(<abbr title="<?php esc_attr_e( 'bytes', 'amp' ); ?>"><?php echo esc_attr_x( 'B', 'abbreviation for bytes', 'amp' ); ?></abbr>)
+				</th>
 				<th class="column-percentage"><?php esc_html_e( 'Percent', 'amp' ); ?></th>
 				<th class="column-priority"><?php esc_html_e( 'Priority', 'amp' ); ?></th>
 				<th class="column-stylesheet_included"><?php esc_html_e( 'Included', 'amp' ); ?></th>


### PR DESCRIPTION
## Summary
Improve on semantic clarity of labels in stylesheets evaluation panel. 

Fixes #4294

Before | After
-------|------
![image](https://user-images.githubusercontent.com/134745/77123857-8740c500-69fe-11ea-97a3-36c20139e670.png) | ![image](https://user-images.githubusercontent.com/134745/77123878-958ee100-69fe-11ea-9c9b-82e6d8557037.png)


## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
