### PR TITLE
Ensure display:block images in Twenty Twenty are not overridden to be inline-block

### DIFF
--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -724,7 +724,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * Add style rule with a selector of higher specificity than just `img` to make `amp-img` have `display:block` rather than `display:inline-block`.
 	 *
 	 * This is needed to override the AMP core stylesheet which has a more specific selector `.i-amphtml-layout-intrinsic` which
-	 * is given a `display: line-block`; this display value prevents margins from collapsing with surrounding block elements,
+	 * is given a `display: inline-block`; this display value prevents margins from collapsing with surrounding block elements,
 	 * resulting in larger margins in AMP than expected.
 	 *
 	 * @since 1.5

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -94,7 +94,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'add_twentytwenty_toggles'         => [],
 					'add_nav_menu_styles'              => [],
 					'add_twentytwenty_masthead_styles' => [],
-					'add_img_display_block_fix' => [],
+					'add_img_display_block_fix'        => [],
 					'add_twentytwenty_current_page_awareness' => [],
 				];
 
@@ -730,16 +730,17 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 	 * @since 1.5
 	 */
 	public static function add_img_display_block_fix() {
+		// Note that wp_add_inline_style() is not used because this stylesheet needs to be added _before_ style.css so
+		// that any subsequent style rules for images will continue to override.
 		add_action(
-			'wp_enqueue_scripts',
+			'wp_print_styles',
 			static function() {
-				wp_add_inline_style(
-					get_template() . '-style',
+				printf(
+					'<style data-src="AMP_Core_Theme_Sanitizer::add_img_display_block_fix">%s</style>',
 					// The selector is targeting an attribute that can never appear. It is purely present to increase specificity.
 					'amp-img:not([_]) { display: block }'
 				);
-			},
-			11
+			}
 		);
 	}
 

--- a/includes/sanitizers/class-amp-core-theme-sanitizer.php
+++ b/includes/sanitizers/class-amp-core-theme-sanitizer.php
@@ -94,6 +94,7 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 					'add_twentytwenty_toggles'         => [],
 					'add_nav_menu_styles'              => [],
 					'add_twentytwenty_masthead_styles' => [],
+					'add_img_display_block_fix' => [],
 					'add_twentytwenty_current_page_awareness' => [],
 				];
 
@@ -714,6 +715,29 @@ class AMP_Core_Theme_Sanitizer extends AMP_Base_Sanitizer {
 				<?php
 				$styles = str_replace( [ '<style>', '</style>' ], '', ob_get_clean() );
 				wp_add_inline_style( get_template() . '-style', $styles );
+			},
+			11
+		);
+	}
+
+	/**
+	 * Add style rule with a selector of higher specificity than just `img` to make `amp-img` have `display:block` rather than `display:inline-block`.
+	 *
+	 * This is needed to override the AMP core stylesheet which has a more specific selector `.i-amphtml-layout-intrinsic` which
+	 * is given a `display: line-block`; this display value prevents margins from collapsing with surrounding block elements,
+	 * resulting in larger margins in AMP than expected.
+	 *
+	 * @since 1.5
+	 */
+	public static function add_img_display_block_fix() {
+		add_action(
+			'wp_enqueue_scripts',
+			static function() {
+				wp_add_inline_style(
+					get_template() . '-style',
+					// The selector is targeting an attribute that can never appear. It is purely present to increase specificity.
+					'amp-img:not([_]) { display: block }'
+				);
 			},
 			11
 		);

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -238,4 +238,19 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $actual );
 	}
+
+	/**
+	 * Tests add_img_display_block_fix.
+	 *
+	 * @covers AMP_Core_Theme_Sanitizer::add_img_display_block_fix()
+	 */
+	public function test_add_img_display_block_fix() {
+		$handle = get_template() . '-style';
+		wp_register_style( $handle, get_stylesheet_uri(), [], '0.1' );
+
+		$this->assertEmpty( wp_styles()->print_inline_style( $handle, false ) );
+		AMP_Core_Theme_Sanitizer::add_img_display_block_fix();
+		wp_enqueue_scripts();
+		$this->assertRegExp( '/amp-img.+display.+block/s', wp_styles()->print_inline_style( $handle, false ) );
+	}
 }

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -245,12 +245,10 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 	 * @covers AMP_Core_Theme_Sanitizer::add_img_display_block_fix()
 	 */
 	public function test_add_img_display_block_fix() {
-		$handle = get_template() . '-style';
-		wp_register_style( $handle, get_stylesheet_uri(), [], '0.1' );
-
-		$this->assertEmpty( wp_styles()->print_inline_style( $handle, false ) );
 		AMP_Core_Theme_Sanitizer::add_img_display_block_fix();
-		wp_enqueue_scripts();
-		$this->assertRegExp( '/amp-img.+display.+block/s', wp_styles()->print_inline_style( $handle, false ) );
+		ob_start();
+		wp_print_styles();
+		$output = ob_get_clean();
+		$this->assertRegExp( '/amp-img.+display.+block/s', $output );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #4419

### Before

> ![image](https://user-images.githubusercontent.com/134745/77362008-7ac5b080-6d0d-11ea-81f3-df3cba43bd42.png)

### After

> ![image](https://user-images.githubusercontent.com/134745/77362067-8f09ad80-6d0d-11ea-885e-f80676b86bca.png)

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
