### PR TITLE
Remove amp-source-stack comments from script and style elements

### DIFF
--- a/includes/class-amp-theme-support.php
+++ b/includes/class-amp-theme-support.php
@@ -2001,6 +2001,10 @@ class AMP_Theme_Support {
 
 		$dom = Document::fromHtml( $response );
 
+		if ( AMP_Validation_Manager::$is_validate_request ) {
+			AMP_Validation_Manager::remove_illegal_source_stack_comments( $dom );
+		}
+
 		AMP_HTTP::send_server_timing( 'amp_dom_parse', -$dom_parse_start, 'AMP DOM Parse' );
 
 		// Make sure scripts from the body get moved to the head.

--- a/includes/validation/class-amp-validation-manager.php
+++ b/includes/validation/class-amp-validation-manager.php
@@ -1860,6 +1860,32 @@ class AMP_Validation_Manager {
 	}
 
 	/**
+	 * Remove source stack comments which appear inside of script and style tags.
+	 *
+	 * HTML comments that appear inside of script and style elements get parsed as text content. AMP does not allow
+	 * such HTML comments to appear inside of CDATA, resulting in validation errors to be emitted when validating a
+	 * page that happens to have source stack comments output when generating JSON data (e.g. All in One SEO).
+	 * Additionally, when source stack comments are output inside of style elements the result can either be CSS
+	 * parse errors or incorrect stylesheet sizes being reported due to the presence of the source stack comments.
+	 * So to prevent these issues from occurring, the source stack comments need to be removed from the document prior
+	 * to sanitizing.
+	 *
+	 * @since 1.5
+	 *
+	 * @param Document $dom Document.
+	 */
+	public static function remove_illegal_source_stack_comments( Document $dom ) {
+		/**
+		 * Script element.
+		 *
+		 * @var DOMText $text
+		 */
+		foreach ( $dom->xpath->query( '//text()[ contains( ., "<!--amp-source-stack" ) ][ parent::script or parent::style ]' ) as $text ) {
+			$text->nodeValue = preg_replace( '#<!--/?amp-source-stack.*?-->#s', '', $text->nodeValue );
+		}
+	}
+
+	/**
 	 * Finalize validation.
 	 *
 	 * @see AMP_Validation_Manager::add_admin_bar_menu_items()


### PR DESCRIPTION
## Summary

HTML comments that appear inside of script and style elements get parsed as text content. AMP does not allow such HTML comments to appear inside of CDATA, resulting in validation errors to be emitted when validating a page that happens to have source stack comments output when generating JSON data (e.g. All in One SEO). Additionally, when source stack comments are output inside of style elements the result can either be CSS parse errors or incorrect stylesheet sizes being reported due to the presence of the source stack comments. So to prevent these issues from occurring, the source stack comments need to be removed from the document prior to sanitizing.

Fixes #4420.

### Before

<img width="1506" alt="Screen Shot 2020-03-23 at 17 11 28" src="https://user-images.githubusercontent.com/134745/77375832-ea4a9880-6d2b-11ea-82e3-05db88216e06.png">

### After

In addition to the absence of validation errors, note the total CSS size is different due to the removal of the source stack comments (which prevents parse errors).

<img width="1514" alt="Screen Shot 2020-03-23 at 17 11 46" src="https://user-images.githubusercontent.com/134745/77375851-f59dc400-6d2b-11ea-8687-df33eb625f9e.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
