### PR TITLE
Limit blank lines to max 1 via PHPCS

### DIFF
--- a/amp.php
+++ b/amp.php
@@ -238,6 +238,7 @@ function _amp_incorrect_plugin_slug_admin_notice() {
 	</div>
 	<?php
 }
+
 if ( 'amp' !== basename( AMP__DIR__ ) ) {
 	add_action( 'admin_notices', '_amp_incorrect_plugin_slug_admin_notice' );
 }
@@ -261,6 +262,7 @@ function _amp_xdebug_admin_notice() {
 	</div>
 	<?php
 }
+
 if ( extension_loaded( 'xdebug' ) ) {
 	add_action( 'admin_notices', '_amp_xdebug_admin_notice' );
 }

--- a/includes/admin/class-amp-post-meta-box.php
+++ b/includes/admin/class-amp-post-meta-box.php
@@ -422,5 +422,4 @@ class AMP_Post_Meta_Box {
 
 		return $link;
 	}
-
 }

--- a/includes/amp-helper-functions.php
+++ b/includes/amp-helper-functions.php
@@ -1646,6 +1646,7 @@ function amp_generate_script_hash( $script ) {
  * @license   http://opensource.org/licenses/MIT MIT
  */
 if ( ! function_exists( 'array_column' ) ) {
+
 	/**
 	 * Returns the values from a single column of the input array, identified by
 	 * the $columnKey.

--- a/includes/embeds/class-amp-playlist-embed-handler.php
+++ b/includes/embeds/class-amp-playlist-embed-handler.php
@@ -330,5 +330,4 @@ class AMP_Playlist_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return '';
 	}
-
 }

--- a/includes/embeds/class-amp-scribd-embed-handler.php
+++ b/includes/embeds/class-amp-scribd-embed-handler.php
@@ -74,5 +74,4 @@ class AMP_Scribd_Embed_Handler extends AMP_Base_Embed_Handler {
 			$html
 		);
 	}
-
 }

--- a/includes/embeds/class-amp-tumblr-embed-handler.php
+++ b/includes/embeds/class-amp-tumblr-embed-handler.php
@@ -55,6 +55,5 @@ class AMP_Tumblr_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return $cache;
 	}
-
 }
 

--- a/includes/embeds/class-amp-vimeo-embed.php
+++ b/includes/embeds/class-amp-vimeo-embed.php
@@ -175,5 +175,4 @@ class AMP_Vimeo_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return $this->render( compact( 'video_id' ) );
 	}
-
 }

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -206,5 +206,4 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		return $this->render( compact( 'video_id' ), $url );
 	}
-
 }

--- a/includes/sanitizers/class-amp-o2-player-sanitizer.php
+++ b/includes/sanitizers/class-amp-o2-player-sanitizer.php
@@ -133,5 +133,4 @@ class AMP_O2_Player_Sanitizer extends AMP_Base_Sanitizer {
 		}
 		return [];
 	}
-
 }

--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -2098,7 +2098,6 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		);
 	}
 
-
 	/**
 	 * Check if attribute has valid properties.
 	 *

--- a/includes/utils/class-amp-dom-utils.php
+++ b/includes/utils/class-amp-dom-utils.php
@@ -187,7 +187,6 @@ class AMP_DOM_Utils {
 		);
 	}
 
-
 	/**
 	 * Return valid HTML content extracted from the DOMNode passed as a parameter.
 	 *

--- a/includes/utils/class-amp-image-dimension-extractor.php
+++ b/includes/utils/class-amp-image-dimension-extractor.php
@@ -273,7 +273,6 @@ class AMP_Image_Dimension_Extractor {
 		}
 	}
 
-
 	/**
 	 * Get default user agent
 	 *

--- a/includes/validation/class-amp-validated-url-post-type.php
+++ b/includes/validation/class-amp-validated-url-post-type.php
@@ -259,6 +259,7 @@ class AMP_Validated_URL_Post_Type {
 			}
 		);
 	}
+
 	/**
 	 * Enqueue style.
 	 */
@@ -2826,7 +2827,6 @@ class AMP_Validated_URL_Post_Type {
 
 		return $views;
 	}
-
 
 	/**
 	 * Filters messages displayed after bulk updates.

--- a/includes/widgets/class-amp-widget-archives.php
+++ b/includes/widgets/class-amp-widget-archives.php
@@ -107,5 +107,4 @@ class AMP_Widget_Archives extends WP_Widget_Archives {
 		endif;
 		echo wp_kses_post( $args['after_widget'] );
 	}
-
 }

--- a/includes/widgets/class-amp-widget-categories.php
+++ b/includes/widgets/class-amp-widget-categories.php
@@ -89,5 +89,4 @@ class AMP_Widget_Categories extends WP_Widget_Categories {
 		endif;
 		echo wp_kses_post( $args['after_widget'] );
 	}
-
 }

--- a/includes/widgets/class-amp-widget-text.php
+++ b/includes/widgets/class-amp-widget-text.php
@@ -27,7 +27,6 @@ if ( class_exists( 'WP_Widget_Text' ) ) {
 			}
 			return parent::inject_video_max_width_style( $matches );
 		}
-
 	}
 
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -91,6 +91,15 @@
 		<include-pattern>src/*</include-pattern>
 	</rule>
 
+	<!-- Limit max. consecutive blank lines to 1 instead of 2. -->
+	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
+		<properties>
+			<property name="spacing" value="1"/>
+			<property name="spacingBeforeFirst" value="1"/>
+			<property name="spacingAfterLast" value="0"/>
+		</properties>
+	</rule>
+
 	<!-- Include sniffs for PHP cross-version compatibility. -->
 	<config name="testVersion" value="5.6-"/>
 	<rule ref="PHPCompatibilityWP">

--- a/src/Component/HasCaption.php
+++ b/src/Component/HasCaption.php
@@ -14,6 +14,7 @@ namespace AmpProject\AmpWP\Component;
  * @since 1.5.0
  */
 interface HasCaption {
+
 	/**
 	 * Gets the caption.
 	 *

--- a/tests/php/src/StubSanitizer.php
+++ b/tests/php/src/StubSanitizer.php
@@ -10,6 +10,7 @@ use AMP_Base_Sanitizer;
  * Stub class for AMP_Base_Sanitizer, since it is an abstract class.
  */
 class StubSanitizer extends AMP_Base_Sanitizer {
+
 	public function sanitize() {
 		return $this->dom;
 	}

--- a/tests/php/test-amp-analytics-options.php
+++ b/tests/php/test-amp-analytics-options.php
@@ -294,5 +294,4 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 		$this->assertStringStartsWith( '<amp-analytics', $output );
 		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
 	}
-
 }

--- a/tests/php/test-amp-dailymotion-embed.php
+++ b/tests/php/test-amp-dailymotion-embed.php
@@ -1,6 +1,7 @@
 <?php
 
 class AMP_DailyMotion_Embed_Test extends WP_UnitTestCase {
+
 	public function get_conversion_data() {
 		return [
 			'no_embed'       => [

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -258,7 +258,6 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertEquals( 'https://example.com/foo/?blaz', amp_remove_endpoint( 'https://example.com/foo/amp/?blaz' ) );
 	}
 
-
 	/**
 	 * Test that hook is added.
 	 *

--- a/tests/php/test-amp-image-dimension-extractor.php
+++ b/tests/php/test-amp-image-dimension-extractor.php
@@ -11,6 +11,7 @@
  * @covers AMP_Image_Dimension_Extractor
  */
 class AMP_Image_Dimension_Extractor_Extract_Test extends WP_UnitTestCase {
+
 	/**
 	 * Set up.
 	 */

--- a/tests/php/test-amp-instagram-embed.php
+++ b/tests/php/test-amp-instagram-embed.php
@@ -1,6 +1,7 @@
 <?php
 
 class AMP_Instagram_Embed_Test extends WP_UnitTestCase {
+
 	public function get_conversion_data() {
 		return [
 			'no_embed'      => [

--- a/tests/php/test-amp-pinterest-embed.php
+++ b/tests/php/test-amp-pinterest-embed.php
@@ -1,6 +1,7 @@
 <?php
 
 class AMP_Pinterest_Embed_Test extends WP_UnitTestCase {
+
 	public function get_conversion_data() {
 		return [
 			'no_embed'         => [

--- a/tests/php/test-amp-playbuzz-sanitizer.php
+++ b/tests/php/test-amp-playbuzz-sanitizer.php
@@ -63,7 +63,6 @@ class AMP_Playbuzz_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $content );
 	}
 
-
 	public function test_get_scripts__data_item_or_data_game_required() {
 		$source   = '<div class="pb_feed"></div>';
 		$expected = [];

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -1,6 +1,7 @@
 <?php
 
 class AMP_Render_Post_Test extends WP_UnitTestCase {
+
 	/**
 	 * @expectedDeprecated amp_render_post
 	 */

--- a/tests/php/test-amp-scribd-embed-handler.php
+++ b/tests/php/test-amp-scribd-embed-handler.php
@@ -166,5 +166,4 @@ class AMP_Scribd_Embed_Handler_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $scripts );
 	}
-
 }

--- a/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
+++ b/tests/php/test-amp-tag-and-attribute-sanitizer-private-methods.php
@@ -654,7 +654,6 @@ class AMP_Tag_And_Attribute_Sanitizer_Attr_Spec_Rules_Test extends WP_UnitTestCa
 		$this->assertEquals( $expected, $got, sprintf( "using source: %s\n%s", $data['source'], wp_json_encode( $data ) ) );
 	}
 
-
 	public function get_replace_node_with_children_data() {
 		return [
 			'text_child' => [

--- a/tests/php/test-amp-vine-embed.php
+++ b/tests/php/test-amp-vine-embed.php
@@ -1,6 +1,7 @@
 <?php
 
 class AMP_Vine_Embed_Test extends WP_UnitTestCase {
+
 	public function get_conversion_data() {
 		return [
 			'no_embed'   => [

--- a/tests/php/test-class-amp-dom-utils.php
+++ b/tests/php/test-class-amp-dom-utils.php
@@ -430,7 +430,6 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $element->getAttribute( 'on' ) );
 	}
 
-
 	public function get_merge_amp_actions_data() {
 		return [
 			// Both empty.

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -42,7 +42,6 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		parent::tearDown();
 	}
 
-
 	/**
 	 * Test init.
 	 *
@@ -377,5 +376,4 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		$_POST['amp-preview'] = 'do-preview';
 		$this->assertEquals( 'https://foo.bar?' . amp_get_slug() . '=1', $this->instance->preview_post_link( $link ) );
 	}
-
 }

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -237,7 +237,6 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( $id, $entries );
 	}
 
-
 	public function get_test_get_options_defaults_data() {
 		return [
 			'reader'                               => [

--- a/tests/php/test-class-amp-playlist-embed-handler.php
+++ b/tests/php/test-class-amp-playlist-embed-handler.php
@@ -335,5 +335,4 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		}
 		return $ids;
 	}
-
 }

--- a/tests/php/test-class-amp-schema-org-metadata.php
+++ b/tests/php/test-class-amp-schema-org-metadata.php
@@ -15,7 +15,6 @@ use AmpProject\Optimizer\ErrorCollection;
  */
 class AmpSchemaOrgMetadataTest extends WP_UnitTestCase {
 
-
 	/**
 	 * Data provider for test_transform.
 	 *

--- a/tests/php/test-class-amp-service-worker.php
+++ b/tests/php/test-class-amp-service-worker.php
@@ -248,5 +248,4 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		// Go back home to clean up 🤷!
 		$this->go_to( home_url() );
 	}
-
 }

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -1850,6 +1850,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 	public function test_start_output_buffering() {
 		wp();
 		if ( ! function_exists( 'newrelic_disable_autorum ' ) ) {
+
 			/**
 			 * Define newrelic_disable_autorum to allow passing line.
 			 */

--- a/tests/php/test-class-amp-widget-archives.php
+++ b/tests/php/test-class-amp-widget-archives.php
@@ -80,5 +80,4 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 		$this->assertContains( 'on="change:AMP.navigateTo(url=event.value)"', $output );
 		$this->assertNotContains( 'onchange=', $output );
 	}
-
 }

--- a/tests/php/test-class-amp-widget-categories.php
+++ b/tests/php/test-class-amp-widget-categories.php
@@ -80,5 +80,4 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 		$this->assertContains( 'on="change:', $output );
 		$this->assertNotContains( '<script type=', $output );
 	}
-
 }

--- a/tests/php/test-class-amp-widget-text.php
+++ b/tests/php/test-class-amp-widget-text.php
@@ -61,5 +61,4 @@ class Test_AMP_Widget_Text extends WP_UnitTestCase {
 		$this->assertEquals( $video_only_width, $this->widget->inject_video_max_width_style( [ $video_only_width ] ) );
 		$this->assertEquals( '', $this->widget->inject_video_max_width_style( [ '' ] ) );
 	}
-
 }

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -214,5 +214,4 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, $scripts );
 	}
-
 }

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -1634,7 +1634,6 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( '%s validated URLs unforgotten.', $filtered_messages['post']['untrashed'] );
 	}
 
-
 	/**
 	 * Gets mock errors for tests.
 	 *

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -2366,7 +2366,6 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::reset_validation_results();
 	}
 
-
 	/**
 	 * Add a nonce to the $_REQUEST, so that is_authorized() returns true.
 	 *


### PR DESCRIPTION
## Summary

PHPCS default configuration uses 2 blank lines to separate functions, as that is the code standard of PHPCS itself.

This was constantly reintroducing 2 blank lines at the beginning of a class under some circumstances when running `phpcbf`.

This PR changes the default configuration to use max. 1 blank line between functions, 1 blank line before functions and no blank line after functions.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).