### PR TITLE
Fix tag-built release process

### DIFF
--- a/bin/tag-built.sh
+++ b/bin/tag-built.sh
@@ -30,7 +30,7 @@ mkdir built
 git clone . built/
 cd built
 git checkout $tag
-git rm -r $(git ls-files)
+git rm -r $(git ls-files | sed 's:/.*::' | sort | uniq)
 rsync -avz ../build/ ./
 git add -A .
 git commit -m "Build $tag" --no-verify

--- a/contributing/engineering.md
+++ b/contributing/engineering.md
@@ -306,7 +306,7 @@ This will create an `amp.zip` in the plugin directory which you can install. The
     1. Make sure “Pre-release” is checked.
 1. Publish GitHub release.
 1. Create built release tag (from the just-created `build` directory):
-    1. do `git fetch --tags && ./bin/tag-built.sh`
+    1. Do `git fetch origin --tags && ./bin/tag-built.sh`
     1. Add link from release notes.
 1. Make announcements on Twitter and the #amp-wp channel on AMP Slack, linking to release post or GitHub release.
 1. Bump version in release branch, e.g. `…-alpha` to `…-beta1` and `…-beta2` to `…-RC1`
@@ -334,7 +334,7 @@ Contributors who want to make a new release, follow these steps:
 1. Run `npm run deploy` to commit the plugin to WordPress.org.
 1. Confirm the release is available on WordPress.org; try installing it on a WordPress install and confirm it works.
 1. Create built release tag (from the just-created `build` directory):
-    1. do `git fetch --tags && ./bin/tag-built.sh`
+    1. Do `git fetch origin --tags && ./bin/tag-built.sh`
     1. Add link from release notes.
 1. For new major releases, create a release branch from the tag. Patch versions are made from the release branch.
 1. For minor releases, bump `Stable tag` in the `readme.txt`/`readme.md` in `develop`. Cherry-pick other changes as necessary.


### PR DESCRIPTION
## Summary

I was getting an error when attempting to run `tag-built.sh` so this PR fixes that.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
