### PR TITLE
Introduce AssertContainsCompatibility trait

### DIFF
--- a/tests/php/src/AssertContainsCompatibility.php
+++ b/tests/php/src/AssertContainsCompatibility.php
@@ -27,7 +27,7 @@ trait AssertContainsCompatibility {
 	 * @param string $haystack Haystack to search through.
 	 * @param string $message  Message to show in case the assert fails.
 	 */
-	public function assertStringContains( $needle, $haystack, $message = '' ) {
+	public function assertStringContains( $needle, $haystack, $message = '' ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 		if ( method_exists( $this, 'assertStringContainsString' ) ) {
 			$this->assertStringContainsString( $needle, $haystack, $message );
 		} else {
@@ -47,7 +47,7 @@ trait AssertContainsCompatibility {
 	 * @param string $haystack Haystack to search through.
 	 * @param string $message  Message to show in case the assert fails.
 	 */
-	public function assertStringNotContains( $needle, $haystack, $message = '' ) {
+	public function assertStringNotContains( $needle, $haystack, $message = '' ) { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName
 		if ( method_exists( $this, 'assertStringNotContainsString' ) ) {
 			$this->assertStringNotContainsString( $needle, $haystack, $message );
 		} else {

--- a/tests/php/src/AssertContainsCompatibility.php
+++ b/tests/php/src/AssertContainsCompatibility.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Trait AssertContainsCompatibility.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+namespace AmpProject\AmpWP\Tests;
+
+/**
+ * Compatibility trait for assertStringContainsString support.
+ *
+ * @package AmpProject\AmpWP
+ */
+
+trait AssertContainsCompatibility {
+
+	/**
+	 * Assert that a string contains a given substring.
+	 *
+	 * This indirection (and non-conflicting naming) is needed to keep compatible across PHPUnit versions without the
+	 * following deprecation notice:
+	 * Using assertContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor
+	 * your test to use assertStringContainsString() or assertStringContainsStringIgnoringCase() instead.
+	 *
+	 * @param string $needle   Needle to look for.
+	 * @param string $haystack Haystack to search through.
+	 * @param string $message  Message to show in case the assert fails.
+	 */
+	public function assertStringContains( $needle, $haystack, $message = '' ) {
+		if ( method_exists( $this, 'assertStringContainsString' ) ) {
+			$this->assertStringContainsString( $needle, $haystack, $message );
+		} else {
+			$this->assertContains( $needle, $haystack, $message );
+		}
+	}
+
+	/**
+	 * Assert that a string doesn't contains a given substring.
+	 *
+	 * This indirection (and non-conflicting naming) is needed to keep compatible across PHPUnit versions without the
+	 * following deprecation notice:
+	 * Using assertNotContains() with string haystacks is deprecated and will not be supported in PHPUnit 9. Refactor
+	 * your test to use assertStringNotContainsString() or assertStringNotContainsStringIgnoringCase() instead.
+	 *
+	 * @param string $needle   Needle to look for.
+	 * @param string $haystack Haystack to search through.
+	 * @param string $message  Message to show in case the assert fails.
+	 */
+	public function assertStringNotContains( $needle, $haystack, $message = '' ) {
+		if ( method_exists( $this, 'assertStringNotContainsString' ) ) {
+			$this->assertStringNotContainsString( $needle, $haystack, $message );
+		} else {
+			$this->assertNotContains( $needle, $haystack, $message );
+		}
+	}
+}

--- a/tests/php/test-amp-analytics-options.php
+++ b/tests/php/test-amp-analytics-options.php
@@ -1,8 +1,11 @@
 <?php
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\Dom\Document;
 
 class AMP_Analytics_Options_Test extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Set up.
@@ -251,7 +254,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 		$this->assertEquals( 1, $trigger_count );
 
 		$this->assertStringStartsWith( '<amp-analytics', $output );
-		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
+		$this->assertStringContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
 
 		remove_action(
 			'amp_print_analytics',
@@ -270,7 +273,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 
 		$output = get_echo( 'amp_print_analytics', [ $analytics ] );
 
-		$this->assertContains( 'data-include="_till_responded"', $output );
+		$this->assertStringContains( 'data-include="_till_responded"', $output );
 	}
 
 	/**
@@ -292,7 +295,7 @@ class AMP_Analytics_Options_Test extends WP_UnitTestCase {
 		);
 		$output = get_echo( 'amp_print_analytics', [ '' ] );
 		$this->assertStringStartsWith( '<amp-analytics', $output );
-		$this->assertContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
+		$this->assertStringContains( 'type="googleanalytics"><script type="application/json">{"requests":{"event":', $output );
 	}
 
 }

--- a/tests/php/test-amp-helper-functions.php
+++ b/tests/php/test-amp-helper-functions.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\HandleValidation;
 
 /**
@@ -12,6 +13,7 @@ use AmpProject\AmpWP\Tests\HandleValidation;
  */
 class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use HandleValidation;
 
 	/**
@@ -133,12 +135,12 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$url = amp_get_permalink( $published_post );
-		$this->assertContains( 'current_filter=amp_pre_get_permalink', $url );
-		$this->assertContains( 'url=0', $url );
+		$this->assertStringContains( 'current_filter=amp_pre_get_permalink', $url );
+		$this->assertStringContains( 'url=0', $url );
 
 		remove_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10 );
 		$url = amp_get_permalink( $published_post );
-		$this->assertContains( 'current_filter=amp_get_permalink', $url );
+		$this->assertStringContains( 'current_filter=amp_get_permalink', $url );
 		remove_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ] );
 
 		// Now check with theme support added (in transitional mode).
@@ -147,9 +149,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $drafted_post ) );
 		$this->assertStringEndsWith( '&amp', amp_get_permalink( $published_page ) );
 		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
-		$this->assertNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
+		$this->assertStringNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
-		$this->assertNotContains( 'current_filter=amp_pre_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
+		$this->assertStringNotContains( 'current_filter=amp_pre_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 	}
 
 	/**
@@ -198,12 +200,12 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
 		$url = amp_get_permalink( $published_post );
-		$this->assertContains( 'current_filter=amp_pre_get_permalink', $url );
-		$this->assertContains( 'url=0', $url );
+		$this->assertStringContains( 'current_filter=amp_pre_get_permalink', $url );
+		$this->assertStringContains( 'url=0', $url );
 
 		remove_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10 );
 		$url = amp_get_permalink( $published_post );
-		$this->assertContains( 'current_filter=amp_get_permalink', $url );
+		$this->assertStringContains( 'current_filter=amp_get_permalink', $url );
 		remove_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10 );
 
 		// Now check with theme support added (in transitional mode).
@@ -212,9 +214,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_post ) );
 		$this->assertStringEndsWith( '?amp', amp_get_permalink( $published_page ) );
 		add_filter( 'amp_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
-		$this->assertNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
+		$this->assertStringNotContains( 'current_filter=amp_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 		add_filter( 'amp_pre_get_permalink', [ $this, 'return_example_url' ], 10, 2 );
-		$this->assertNotContains( 'current_filter=amp_pre_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
+		$this->assertStringNotContains( 'current_filter=amp_pre_get_permalink', amp_get_permalink( $published_post ) ); // Filter does not apply.
 
 		// Make sure that if permalink has anchor that it is persists.
 		add_filter( 'post_link', $add_anchor_fragment );
@@ -480,7 +482,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				$canonical_url
 			);
 			$this->assertNotInstanceOf( 'WP_Error', $invalid_url_post_id );
-			$this->assertContains( '<!--', $get_amp_html_link() );
+			$this->assertStringContains( '<!--', $get_amp_html_link() );
 
 			// Allow the URL when the errors are forcibly sanitized.
 			add_filter( 'amp_validation_error_sanitized', '__return_true' );
@@ -648,7 +650,7 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 	public function test_amp_get_boilerplate_code() {
 		$boilerplate_code = amp_get_boilerplate_code();
 		$this->assertStringStartsWith( '<style amp-boilerplate>', $boilerplate_code );
-		$this->assertContains( '<noscript><style amp-boilerplate>', $boilerplate_code );
+		$this->assertStringContains( '<noscript><style amp-boilerplate>', $boilerplate_code );
 	}
 
 	/**
@@ -660,8 +662,8 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		$stylesheets = amp_get_boilerplate_stylesheets();
 		$this->assertInternalType( 'array', $stylesheets );
 		$this->assertCount( 2, $stylesheets );
-		$this->assertContains( 'body{-webkit-animation:-amp-start', $stylesheets[0] );
-		$this->assertContains( 'body{-webkit-animation:none', $stylesheets[1] );
+		$this->assertStringContains( 'body{-webkit-animation:-amp-start', $stylesheets[0] );
+		$this->assertStringContains( 'body{-webkit-animation:none', $stylesheets[1] );
 	}
 
 	/**
@@ -677,21 +679,21 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 		};
 
 		$output = $get_generator_tag();
-		$this->assertContains( 'mode=reader', $output );
-		$this->assertContains( 'v' . AMP__VERSION, $output );
+		$this->assertStringContains( 'mode=reader', $output );
+		$this->assertStringContains( 'v' . AMP__VERSION, $output );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => true ] );
 		$output = $get_generator_tag();
-		$this->assertContains( 'mode=transitional', $output );
-		$this->assertContains( 'v' . AMP__VERSION, $output );
+		$this->assertStringContains( 'mode=transitional', $output );
+		$this->assertStringContains( 'v' . AMP__VERSION, $output );
 
 		add_theme_support( AMP_Theme_Support::SLUG, [ AMP_Theme_Support::PAIRED_FLAG => false ] );
 		$output = $get_generator_tag();
-		$this->assertContains( 'mode=standard', $output );
-		$this->assertContains( 'v' . AMP__VERSION, $output );
+		$this->assertStringContains( 'mode=standard', $output );
+		$this->assertStringContains( 'v' . AMP__VERSION, $output );
 
 		$output = $get_generator_tag();
-		$this->assertContains( 'mode=standard', $output );
+		$this->assertStringContains( 'mode=standard', $output );
 	}
 
 	/**
@@ -723,9 +725,9 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 
 		$output = get_echo( 'wp_print_scripts' );
 
-		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0.js\' async></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mathml-0.1.js\' async custom-element="amp-mathml"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mustache-latest.js\' async custom-template="amp-mustache"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0.js\' async></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mathml-0.1.js\' async custom-element="amp-mathml"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mustache-latest.js\' async custom-template="amp-mustache"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		// Try rendering via amp_render_scripts() instead of amp_render_scripts(), which is how component scripts get added normally.
 		$output = amp_render_scripts(
@@ -735,14 +737,14 @@ class Test_AMP_Helper_Functions extends WP_UnitTestCase {
 				'amp-accordion' => true,
 			]
 		);
-		$this->assertNotContains( 'amp-mathml', $output, 'The amp-mathml component was already printed above.' );
-		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mustache-2.0.js\' async custom-element="amp-carousel"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
-		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-accordion-0.1.js\' async custom-element="amp-accordion"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringNotContains( 'amp-mathml', $output, 'The amp-mathml component was already printed above.' );
+		$this->assertStringContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-mustache-2.0.js\' async custom-element="amp-carousel"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-accordion-0.1.js\' async custom-element="amp-accordion"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 
 		// Try some experimental component to ensure expected script attributes are added.
 		wp_register_script( 'amp-foo', 'https://cdn.ampproject.org/v0/amp-foo-0.1.js', [ 'amp-runtime' ], null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NotInFooter, WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		$output = get_echo( 'wp_print_scripts', [ 'amp-foo' ] );
-		$this->assertContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-foo-0.1.js\' async custom-element="amp-foo"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringContains( '<script type=\'text/javascript\' src=\'https://cdn.ampproject.org/v0/amp-foo-0.1.js\' async custom-element="amp-foo"></script>', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
 
 	/**

--- a/tests/php/test-amp-render-post.php
+++ b/tests/php/test-amp-render-post.php
@@ -1,6 +1,11 @@
 <?php
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 class AMP_Render_Post_Test extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
+
 	/**
 	 * @expectedDeprecated amp_render_post
 	 */
@@ -26,7 +31,7 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 
 		$output = get_echo( 'amp_render_post', [ $post_id ] );
 
-		$this->assertContains( '<html amp', $output, 'Response does not include html tag with amp attribute.' );
+		$this->assertStringContains( '<html amp', $output, 'Response does not include html tag with amp attribute.' );
 		$this->assertEquals( 1, did_action( 'pre_amp_render_post', 'pre_amp_render_post action fire either did not fire or fired too many times.' ) );
 	}
 
@@ -62,7 +67,7 @@ class AMP_Render_Post_Test extends WP_UnitTestCase {
 		$this->was_amp_endpoint = false;
 
 		$output = get_echo( 'amp_render_post', [ $post_id ] );
-		$this->assertContains( '<html amp', $output );
+		$this->assertStringContains( '<html amp', $output );
 
 		$after_is_amp_endpoint = is_amp_endpoint();
 

--- a/tests/php/test-amp-script-sanitizer.php
+++ b/tests/php/test-amp-script-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\Dom\Document;
 
 /**
@@ -13,6 +14,8 @@ use AmpProject\Dom\Document;
  * @covers AMP_Script_Sanitizer
  */
 class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Data for testing noscript handling.
@@ -111,8 +114,8 @@ class AMP_Script_Sanitizer_Test extends WP_UnitTestCase {
 		$content = $dom->saveHTML( $dom->documentElement );
 
 		$this->assertRegExp( '/<!-- Google Tag Manager -->\s*<!-- End Google Tag Manager -->/', $content );
-		$this->assertContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
-		$this->assertContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
-		$this->assertContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" data-amp-original-style="display:none;visibility:hidden" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" data-amp-original-style="display:none;visibility:hidden" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
+		$this->assertStringContains( '<noscript><style amp-boilerplate>body{-webkit-animation:none;-moz-animation:none;-ms-animation:none;animation:none}</style></noscript>', $content );
+		$this->assertStringContains( 'Has script? <!--noscript-->Nope!<!--/noscript-->', $content );
+		$this->assertStringContains( '<!--noscript--><amp-iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="400" layout="fixed-height" width="auto" sandbox="allow-scripts allow-same-origin" data-amp-original-style="display:none;visibility:hidden" class="amp-wp-b3bfe1b"><span placeholder="" class="amp-wp-iframe-placeholder"></span><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXX" height="0" width="0" data-amp-original-style="display:none;visibility:hidden" class="amp-wp-b3bfe1b"></iframe></noscript></amp-iframe><!--/noscript-->', $content );
 	}
 }

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -9,6 +9,7 @@
 
 use AmpProject\AmpWP\RemoteRequest\CachedData;
 use AmpProject\AmpWP\RemoteRequest\CachedRemoteGetRequest;
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Tests\PrivateAccess;
 use AmpProject\Exception\FailedToGetFromRemoteUrl;
@@ -18,6 +19,7 @@ use AmpProject\Exception\FailedToGetFromRemoteUrl;
  */
 class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use PrivateAccess;
 
 	/**
@@ -641,15 +643,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 			}
 
 			if ( false === strpos( $expected_stylesheet, '{' ) ) {
-				$this->assertContains( $expected_stylesheet, $actual_stylesheets[ $i ] );
+				$this->assertStringContains( $expected_stylesheet, $actual_stylesheets[ $i ] );
 			} else {
 				$this->assertEquals( $expected_stylesheet, $actual_stylesheets[ $i ] );
 			}
-			$this->assertContains( $expected_stylesheet, $sanitized_html );
+			$this->assertStringContains( $expected_stylesheet, $sanitized_html );
 		}
 
 		if ( $actual_stylesheets ) {
-			$this->assertContains( "\n\n/*# sourceURL=amp-custom.css */", $sanitized_html );
+			$this->assertStringContains( "\n\n/*# sourceURL=amp-custom.css */", $sanitized_html );
 		}
 	}
 
@@ -1200,11 +1202,11 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertEquals( [], $error_codes );
 		$actual_stylesheets = array_values( $sanitizer->get_stylesheets() );
 		$this->assertCount( 1, $actual_stylesheets );
-		$this->assertContains( 'dashicons.woff") format("woff")', $actual_stylesheets[0] );
-		$this->assertNotContains( 'data:application/font-woff;', $actual_stylesheets[0] );
-		$this->assertContains( '.dashicons{', $actual_stylesheets[0] );
-		$this->assertContains( '.dashicons-admin-appearance:before{', $actual_stylesheets[0] );
-		$this->assertNotContains( '.dashicons-format-chat:before', $actual_stylesheets[0] );
+		$this->assertStringContains( 'dashicons.woff") format("woff")', $actual_stylesheets[0] );
+		$this->assertStringNotContains( 'data:application/font-woff;', $actual_stylesheets[0] );
+		$this->assertStringContains( '.dashicons{', $actual_stylesheets[0] );
+		$this->assertStringContains( '.dashicons-admin-appearance:before{', $actual_stylesheets[0] );
+		$this->assertStringNotContains( '.dashicons-format-chat:before', $actual_stylesheets[0] );
 	}
 
 	/**
@@ -1242,26 +1244,26 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertCount( 3, $actual_stylesheets );
 
 		// Check font included in theme.
-		$this->assertContains( '@font-face{font-family:"NonBreakingSpaceOverride";', $actual_stylesheets[0] );
-		$this->assertContains( 'format("woff2")', $actual_stylesheets[0] );
-		$this->assertContains( 'format("woff")', $actual_stylesheets[0] );
-		$this->assertNotContains( 'data:', $actual_stylesheets[0] );
-		$this->assertContains( 'fonts/NonBreakingSpaceOverride.woff2', $actual_stylesheets[0] );
-		$this->assertContains( 'fonts/NonBreakingSpaceOverride.woff', $actual_stylesheets[0] );
-		$this->assertContains( 'font-display:swap', $actual_stylesheets[0] );
+		$this->assertStringContains( '@font-face{font-family:"NonBreakingSpaceOverride";', $actual_stylesheets[0] );
+		$this->assertStringContains( 'format("woff2")', $actual_stylesheets[0] );
+		$this->assertStringContains( 'format("woff")', $actual_stylesheets[0] );
+		$this->assertStringNotContains( 'data:', $actual_stylesheets[0] );
+		$this->assertStringContains( 'fonts/NonBreakingSpaceOverride.woff2', $actual_stylesheets[0] );
+		$this->assertStringContains( 'fonts/NonBreakingSpaceOverride.woff', $actual_stylesheets[0] );
+		$this->assertStringContains( 'font-display:swap', $actual_stylesheets[0] );
 
 		// Check font not included in theme, but included in plugin.
-		$this->assertContains( '@font-face{font-family:"Genericons";', $actual_stylesheets[1] );
-		$this->assertContains( 'format("woff")', $actual_stylesheets[1] );
-		$this->assertNotContains( 'data:', $actual_stylesheets[1] );
-		$this->assertContains( 'assets/fonts/genericons.woff', $actual_stylesheets[1] );
-		$this->assertContains( 'font-display:swap', $actual_stylesheets[1] );
+		$this->assertStringContains( '@font-face{font-family:"Genericons";', $actual_stylesheets[1] );
+		$this->assertStringContains( 'format("woff")', $actual_stylesheets[1] );
+		$this->assertStringNotContains( 'data:', $actual_stylesheets[1] );
+		$this->assertStringContains( 'assets/fonts/genericons.woff', $actual_stylesheets[1] );
+		$this->assertStringContains( 'font-display:swap', $actual_stylesheets[1] );
 
 		// Check font not included anywhere, so must remain inline.
-		$this->assertContains( '@font-face{font-family:"Custom";', $actual_stylesheets[2] );
-		$this->assertContains( 'url("data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAA")', $actual_stylesheets[2] );
-		$this->assertContains( 'format("woff")', $actual_stylesheets[2] );
-		$this->assertNotContains( 'font-display:swap', $actual_stylesheets[2] );
+		$this->assertStringContains( '@font-face{font-family:"Custom";', $actual_stylesheets[2] );
+		$this->assertStringContains( 'url("data:application/x-font-woff;charset=utf-8;base64,d09GRgABAAA")', $actual_stylesheets[2] );
+		$this->assertStringContains( 'format("woff")', $actual_stylesheets[2] );
+		$this->assertStringNotContains( 'font-display:swap', $actual_stylesheets[2] );
 	}
 
 	/**
@@ -1416,8 +1418,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$this->assertCount( 1, $actual_stylesheets );
 		$stylesheet = $actual_stylesheets[0];
 
-		$this->assertNotContains( '../images/spinner', $stylesheet );
-		$this->assertContains( sprintf( '.spinner{background-image:url("%s")', admin_url( 'images/spinner-2x.gif' ) ), $stylesheet );
+		$this->assertStringNotContains( '../images/spinner', $stylesheet );
+		$this->assertStringContains( sprintf( '.spinner{background-image:url("%s")', admin_url( 'images/spinner-2x.gif' ) ), $stylesheet );
 	}
 
 	/**
@@ -1958,7 +1960,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 		$stylesheets = array_values( $sanitizer->get_stylesheets() );
 
-		$this->assertContains( $expected, $stylesheets[0] );
+		$this->assertStringContains( $expected, $stylesheets[0] );
 	}
 
 	/**
@@ -2122,7 +2124,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 					$previous = -1;
 					foreach ( $expected_order as $i => $expected ) {
-						$test->assertContains( $expected, $stylesheet, "Did not see $expected at position $i." );
+						$test->assertStringContains( $expected, $stylesheet, "Did not see $expected at position $i." );
 						$position = strpos( $stylesheet, $expected );
 						$test->assertGreaterThan( $previous, $position, "Expected $expected to be after previous (at position $i)." );
 						$previous = $position;
@@ -2156,7 +2158,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 						'remote-finally-does-not-exist.css',
 					];
 					foreach ( $expected_absent as $expected ) {
-						$test->assertNotContains( $expected, $stylesheet, "Expected to not see $expected." );
+						$test->assertStringNotContains( $expected, $stylesheet, "Expected to not see $expected." );
 					}
 
 					$expected_order = [
@@ -2168,7 +2170,7 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 
 					$previous = -1;
 					foreach ( $expected_order as $i => $expected ) {
-						$test->assertContains( $expected, $stylesheet, "Did not see $expected at position $i." );
+						$test->assertStringContains( $expected, $stylesheet, "Did not see $expected at position $i." );
 						$position = strpos( $stylesheet, $expected );
 						$test->assertGreaterThan( $previous, $position, "Expected $expected to be after previous (at position $i)." );
 						$previous = $position;
@@ -2371,8 +2373,8 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 		$original_html  = trim( ob_get_clean() );
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html );
 
-		$this->assertContains( ".dashicons-admin-customizer:before{content:\"\xEF\x95\x80\"}", $sanitized_html );
-		$this->assertContains( 'span::after{content:"⚡️"}', $sanitized_html );
+		$this->assertStringContains( ".dashicons-admin-customizer:before{content:\"\xEF\x95\x80\"}", $sanitized_html );
+		$this->assertStringContains( 'span::after{content:"⚡️"}', $sanitized_html );
 	}
 
 	/**
@@ -2501,15 +2503,15 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 					 */
 					$this->assertInstanceOf( 'DOMElement', $original_dom->getElementById( 'wpadminbar' ), 'Expected admin bar element to be present originally.' );
 					$this->assertInstanceOf( 'DOMElement', $original_dom->getElementById( 'admin-bar-css' ), 'Expected admin bar CSS to be present originally.' );
-					$this->assertContains( 'admin-bar', $original_dom->body->getAttribute( 'class' ) );
-					$this->assertContains( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
+					$this->assertStringContains( 'admin-bar', $original_dom->body->getAttribute( 'class' ) );
+					$this->assertStringContains( 'earlyprintstyle', $original_source, 'Expected early print style to not be present.' );
 
-					$this->assertContains( '.is-style-outline .wp-block-button__link', $amphtml_source, 'Expected block-library/style.css' );
-					$this->assertContains( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
-					$this->assertContains( 'amp-img.amp-wp-enforced-sizes', $amphtml_source, 'Expected amp-default.css' );
-					$this->assertContains( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to still be present.' );
-					$this->assertNotContains( 'earlyprintstyle', $amphtml_source, 'Expected early print style to not be present.' );
-					$this->assertContains( 'admin-bar', $amphtml_dom->body->getAttribute( 'class' ) );
+					$this->assertStringContains( '.is-style-outline .wp-block-button__link', $amphtml_source, 'Expected block-library/style.css' );
+					$this->assertStringContains( '[class^="wp-block-"]:not(.wp-block-gallery) figcaption', $amphtml_source, 'Expected twentyten/blocks.css' );
+					$this->assertStringContains( 'amp-img.amp-wp-enforced-sizes', $amphtml_source, 'Expected amp-default.css' );
+					$this->assertStringContains( 'ab-empty-item', $amphtml_source, 'Expected admin-bar.css to still be present.' );
+					$this->assertStringNotContains( 'earlyprintstyle', $amphtml_source, 'Expected early print style to not be present.' );
+					$this->assertStringContains( 'admin-bar', $amphtml_dom->body->getAttribute( 'class' ) );
 					$this->assertInstanceOf( 'DOMElement', $amphtml_dom->getElementById( 'wpadminbar' ) );
 				},
 			],

--- a/tests/php/test-class-amp-cli-validation-command.php
+++ b/tests/php/test-class-amp-cli-validation-command.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\PrivateAccess;
 
 /**
@@ -14,6 +15,7 @@ use AmpProject\AmpWP\Tests\PrivateAccess;
  */
 class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use PrivateAccess;
 
 	/**
@@ -374,7 +376,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		$year = gmdate( 'Y' );
 
 		// Normally, this should return the date page, unless the user has opted out of that template.
-		$this->assertContains( $year, $this->call_private_method( $this->validation, 'get_date_page' ) );
+		$this->assertStringContains( $year, $this->call_private_method( $this->validation, 'get_date_page' ) );
 
 		// If $include_conditionals is set and does not have is_date, this should not return a URL.
 		$this->validation->include_conditionals = [ 'is_search' ];
@@ -383,7 +385,7 @@ class Test_AMP_CLI_Validation_Command extends \WP_UnitTestCase {
 		// If $include_conditionals has is_date, this should return a URL.
 		$this->validation->include_conditionals = [ 'is_date' ];
 		$parsed_page_url                        = wp_parse_url( $this->call_private_method( $this->validation, 'get_date_page' ) );
-		$this->assertContains( $year, $parsed_page_url['query'] );
+		$this->assertStringContains( $year, $parsed_page_url['query'] );
 		$this->validation->include_conditionals = [];
 	}
 

--- a/tests/php/test-class-amp-comments-sanitizer.php
+++ b/tests/php/test-class-amp-comments-sanitizer.php
@@ -5,8 +5,9 @@
  * @package AMP
  */
 
-use AmpProject\Dom\Document;
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\PrivateAccess;
+use AmpProject\Dom\Document;
 
 /**
  * Tests for AMP_Comments_Sanitizer class.
@@ -15,6 +16,7 @@ use AmpProject\AmpWP\Tests\PrivateAccess;
  */
 class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use PrivateAccess;
 
 	/**
@@ -46,10 +48,10 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 		$form = $this->create_form( 'incorrect-action.php' );
 		$instance->sanitize();
 		$on = $form->getAttribute( 'on' );
-		$this->assertNotContains( 'submit:AMP.setState(', $on );
-		$this->assertNotContains( 'submit-error:AMP.setState(', $on );
+		$this->assertStringNotContains( 'submit:AMP.setState(', $on );
+		$this->assertStringNotContains( 'submit-error:AMP.setState(', $on );
 		foreach ( $this->get_form_element_names() as $name ) {
-			$this->assertNotContains( $name, $on );
+			$this->assertStringNotContains( $name, $on );
 		}
 	}
 
@@ -65,10 +67,10 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 		$form = $this->create_form( '/wp-comments-post.php' );
 		$instance->sanitize();
 		$on = $form->getAttribute( 'on' );
-		$this->assertContains( 'submit:AMP.setState(', $on );
-		$this->assertContains( 'submit-error:AMP.setState(', $on );
+		$this->assertStringContains( 'submit:AMP.setState(', $on );
+		$this->assertStringContains( 'submit-error:AMP.setState(', $on );
 		foreach ( $this->get_form_element_names() as $name ) {
-			$this->assertContains( $name, $on );
+			$this->assertStringContains( $name, $on );
 		}
 	}
 
@@ -86,15 +88,15 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 		$on        = $form->getAttribute( 'on' );
 		$amp_state = $this->dom->getElementsByTagName( 'amp-state' )->item( 0 );
 
-		$this->assertContains( 'submit:AMP.setState(', $on );
-		$this->assertContains( 'submit-error:AMP.setState(', $on );
-		$this->assertContains( 'submit-success:AMP.setState(', $on );
-		$this->assertContains( strval( $GLOBALS['post']->ID ), $on );
+		$this->assertStringContains( 'submit:AMP.setState(', $on );
+		$this->assertStringContains( 'submit-error:AMP.setState(', $on );
+		$this->assertStringContains( 'submit-success:AMP.setState(', $on );
+		$this->assertStringContains( strval( $GLOBALS['post']->ID ), $on );
 		$this->assertEquals( 'script', $amp_state->firstChild->nodeName );
 
 		foreach ( $this->get_form_element_names() as $name ) {
-			$this->assertContains( $name, $on );
-			$this->assertContains( $name, $amp_state->nodeValue );
+			$this->assertStringContains( $name, $on );
+			$this->assertStringContains( $name, $amp_state->nodeValue );
 		}
 		foreach ( $form->getElementsByTagName( 'input' ) as $input ) {
 			/**
@@ -103,8 +105,8 @@ class Test_AMP_Comments_Sanitizer extends WP_UnitTestCase {
 			 * @var DOMElement $input
 			 */
 			$on = $input->getAttribute( 'on' );
-			$this->assertContains( 'change:AMP.setState(', $on );
-			$this->assertContains( strval( $GLOBALS['post']->ID ), $on );
+			$this->assertStringContains( 'change:AMP.setState(', $on );
+			$this->assertStringContains( strval( $GLOBALS['post']->ID ), $on );
 		}
 	}
 

--- a/tests/php/test-class-amp-core-block-handler.php
+++ b/tests/php/test-class-amp-core-block-handler.php
@@ -6,6 +6,8 @@
  * @since 1.0
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_Core_Block_Handler.
  *
@@ -13,6 +15,8 @@
  * @covers AMP_Core_Block_Handler
  */
 class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Set up.
@@ -71,26 +75,26 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 
 		$handler->register_embed();
 		$rendered = do_blocks( $categories_block );
-		$this->assertContains( '<select', $rendered );
-		$this->assertNotContains( 'onchange', $rendered );
-		$this->assertContains( 'on="change', $rendered );
+		$this->assertStringContains( '<select', $rendered );
+		$this->assertStringNotContains( 'onchange', $rendered );
+		$this->assertStringContains( 'on="change', $rendered );
 		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/archives' ) ) {
 			$rendered = do_blocks( $archives_block );
-			$this->assertContains( '<select', $rendered );
-			$this->assertNotContains( 'onchange', $rendered );
-			$this->assertContains( 'on="change', $rendered );
+			$this->assertStringContains( '<select', $rendered );
+			$this->assertStringNotContains( 'onchange', $rendered );
+			$this->assertStringContains( 'on="change', $rendered );
 		}
 
 		$handler->unregister_embed();
 		$rendered = do_blocks( $categories_block );
-		$this->assertContains( '<select', $rendered );
-		$this->assertContains( 'onchange', $rendered );
-		$this->assertNotContains( 'on="change', $rendered );
+		$this->assertStringContains( '<select', $rendered );
+		$this->assertStringContains( 'onchange', $rendered );
+		$this->assertStringNotContains( 'on="change', $rendered );
 		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/archives' ) ) {
 			$rendered = do_blocks( $archives_block );
-			$this->assertContains( '<select', $rendered );
-			$this->assertContains( 'onchange', $rendered );
-			$this->assertNotContains( 'on="change', $rendered );
+			$this->assertStringContains( '<select', $rendered );
+			$this->assertStringContains( 'onchange', $rendered );
+			$this->assertStringNotContains( 'on="change', $rendered );
 		}
 	}
 
@@ -140,7 +144,7 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 
 		$content = apply_filters( 'the_content', get_post( $post_id )->post_content );
 
-		$this->assertContains( '<video width="560" height="320" ', $content );
+		$this->assertStringContains( '<video width="560" height="320" ', $content );
 	}
 
 	/**
@@ -169,8 +173,8 @@ class Test_AMP_Core_Block_Handler extends WP_UnitTestCase {
 
 		$content = apply_filters( 'the_content', get_post( $post_id )->post_content );
 
-		$this->assertContains( '<video layout="fill" object-fit="cover"', $content );
-		$this->assertNotContains( 'width=', $content );
-		$this->assertNotContains( 'height=', $content );
+		$this->assertStringContains( '<video layout="fill" object-fit="cover"', $content );
+		$this->assertStringNotContains( 'width=', $content );
+		$this->assertStringNotContains( 'height=', $content );
 	}
 }

--- a/tests/php/test-class-amp-core-theme-sanitizer.php
+++ b/tests/php/test-class-amp-core-theme-sanitizer.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\Dom\Document;
 use AmpProject\AmpWP\Tests\PrivateAccess;
 
@@ -13,6 +14,7 @@ use AmpProject\AmpWP\Tests\PrivateAccess;
  */
 class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use PrivateAccess;
 
 	/**
@@ -270,11 +272,6 @@ class AMP_Core_Theme_Sanitizer_Test extends WP_UnitTestCase {
 
 		$needle = '.site-logo amp-img { width: 3.000000rem; } @media (min-width: 700px) { .site-logo amp-img { width: 4.500000rem; } }';
 
-		// @todo Make use of AssertContainsCompatibility trait.
-		if ( method_exists( $this, 'assertStringContainsString' ) ) {
-			$this->assertStringContainsString( $needle, $logo );
-		} else {
-			$this->assertContains( $needle, $logo );
-		}
+		$this->assertStringContains( $needle, $logo );
 	}
 }

--- a/tests/php/test-class-amp-dom-utils.php
+++ b/tests/php/test-class-amp-dom-utils.php
@@ -1,5 +1,6 @@
 <?php
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\Dom\Document;
 
 /**
@@ -12,6 +13,8 @@ use AmpProject\Dom\Document;
  * @method void assertFalse( bool $expectsFalse, string $errorMessage=null )
  */
 class AMP_DOM_Utils_Test extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Test UTF-8 content.
@@ -255,10 +258,10 @@ class AMP_DOM_Utils_Test extends WP_UnitTestCase {
 
 		$serialized_html = $dom->saveHTML( $dom->documentElement );
 
-		$this->assertContains( '<a href="{{href}}" title="Hello {{name}}">', $serialized_html );
-		$this->assertContains( '<img src="{{src}}">', $serialized_html );
-		$this->assertContains( '<blockquote cite="{{cite}}">', $serialized_html );
-		$this->assertContains( '"block_attrs":{"layout":"column-1"}}', $serialized_html );
+		$this->assertStringContains( '<a href="{{href}}" title="Hello {{name}}">', $serialized_html );
+		$this->assertStringContains( '<img src="{{src}}">', $serialized_html );
+		$this->assertStringContains( '<blockquote cite="{{cite}}">', $serialized_html );
+		$this->assertStringContains( '"block_attrs":{"layout":"column-1"}}', $serialized_html );
 	}
 
 	/**

--- a/tests/php/test-class-amp-http.php
+++ b/tests/php/test-class-amp-http.php
@@ -6,12 +6,16 @@
  * @since 1.0
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_HTTP.
  *
  * @covers AMP_HTTP
  */
 class Test_AMP_HTTP extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Set up before class.
@@ -156,8 +160,8 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		foreach ( $all_query_vars as $key => $value ) {
 			$this->assertArrayHasKey( $key, $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$this->assertArrayHasKey( $key, $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$this->assertContains( "$key=$value", $_SERVER['QUERY_STRING'] );
-			$this->assertContains( "$key=$value", $_SERVER['REQUEST_URI'] );
+			$this->assertStringContains( "$key=$value", $_SERVER['QUERY_STRING'] );
+			$this->assertStringContains( "$key=$value", $_SERVER['REQUEST_URI'] );
 		}
 
 		AMP_HTTP::$purged_amp_query_vars = [];
@@ -167,14 +171,14 @@ class Test_AMP_HTTP extends WP_UnitTestCase {
 		foreach ( $bad_query_vars as $key => $value ) {
 			$this->assertArrayNotHasKey( $key, $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$this->assertArrayNotHasKey( $key, $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$this->assertNotContains( "$key=$value", $_SERVER['QUERY_STRING'] );
-			$this->assertNotContains( "$key=$value", $_SERVER['REQUEST_URI'] );
+			$this->assertStringNotContains( "$key=$value", $_SERVER['QUERY_STRING'] );
+			$this->assertStringNotContains( "$key=$value", $_SERVER['REQUEST_URI'] );
 		}
 		foreach ( $ok_query_vars as $key => $value ) {
 			$this->assertArrayHasKey( $key, $_GET ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$this->assertArrayHasKey( $key, $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$this->assertContains( "$key=$value", $_SERVER['QUERY_STRING'] );
-			$this->assertContains( "$key=$value", $_SERVER['REQUEST_URI'] );
+			$this->assertStringContains( "$key=$value", $_SERVER['QUERY_STRING'] );
+			$this->assertStringContains( "$key=$value", $_SERVER['REQUEST_URI'] );
 		}
 		// phpcs:enable WordPress.CSRF.NonceVerification.NoNonceVerification
 	}

--- a/tests/php/test-class-amp-link-sanitizer.php
+++ b/tests/php/test-class-amp-link-sanitizer.php
@@ -5,10 +5,14 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Class AMP_Link_Sanitizer_Test
  */
 class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Data for test_amp_to_amp_navigation.
@@ -184,9 +188,9 @@ class AMP_Link_Sanitizer_Test extends WP_UnitTestCase {
 			}
 
 			if ( $paired && $link_data['expected_amp'] ) {
-				$this->assertContains( '?' . amp_get_slug(), $element->getAttribute( 'href' ) );
+				$this->assertStringContains( '?' . amp_get_slug(), $element->getAttribute( 'href' ) );
 			} elseif ( ! $paired || ! $link_data['expected_amp'] ) {
-				$this->assertNotContains( '?' . amp_get_slug(), $element->getAttribute( 'href' ) );
+				$this->assertStringNotContains( '?' . amp_get_slug(), $element->getAttribute( 'href' ) );
 			}
 		}
 

--- a/tests/php/test-class-amp-meta-box.php
+++ b/tests/php/test-class-amp-meta-box.php
@@ -5,10 +5,14 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_Post_Meta_Box.
  */
 class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Instance of AMP_Post_Meta_Box
@@ -188,28 +192,28 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		// This is not in AMP 'canonical mode' but rather reader or transitional mode.
 		remove_theme_support( AMP_Theme_Support::SLUG );
 		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
-		$this->assertContains( $amp_status_markup, $output );
-		$this->assertContains( $checkbox_enabled, $output );
+		$this->assertStringContains( $amp_status_markup, $output );
+		$this->assertStringContains( $checkbox_enabled, $output );
 
 		// This is in AMP-first mode with a template that can be rendered.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
-		$this->assertContains( $amp_status_markup, $output );
-		$this->assertContains( $checkbox_enabled, $output );
+		$this->assertStringContains( $amp_status_markup, $output );
+		$this->assertStringContains( $checkbox_enabled, $output );
 
 		// Post type no longer supports AMP, so no status input.
 		remove_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
-		$this->assertContains( 'post type does not support it', $output );
-		$this->assertNotContains( $checkbox_enabled, $output );
+		$this->assertStringContains( 'post type does not support it', $output );
+		$this->assertStringNotContains( $checkbox_enabled, $output );
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
 
 		// No template is available to render the post.
 		add_filter( 'amp_supportable_templates', '__return_empty_array' );
 		AMP_Options_Manager::update_option( 'all_templates_supported', false );
 		$output = get_echo( [ $this->instance, 'render_status' ], [ $post ] );
-		$this->assertContains( 'no supported templates to display this in AMP.', wp_strip_all_tags( $output ) );
-		$this->assertNotContains( $checkbox_enabled, $output );
+		$this->assertStringContains( 'no supported templates to display this in AMP.', wp_strip_all_tags( $output ) );
+		$this->assertStringNotContains( $checkbox_enabled, $output );
 
 		// User doesn't have the capability to display the metabox.
 		add_post_type_support( 'post', AMP_Post_Type_Support::SLUG );
@@ -290,8 +294,8 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		);
 
 		$messages = $this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'template_unsupported' ] );
-		$this->assertContains( 'There are no', $messages[0] );
-		$this->assertContains( 'page=amp-options', $messages[0] );
+		$this->assertStringContains( 'There are no', $messages[0] );
+		$this->assertStringContains( 'page=amp-options', $messages[0] );
 
 		$this->assertEquals(
 			[ 'AMP cannot be enabled on password protected posts.' ],
@@ -299,8 +303,8 @@ class Test_AMP_Post_Meta_Box extends WP_UnitTestCase {
 		);
 
 		$messages = $this->instance->get_error_messages( AMP_Post_Meta_Box::DISABLED_STATUS, [ 'post-type-support' ] );
-		$this->assertContains( 'AMP cannot be enabled because this', $messages[0] );
-		$this->assertContains( 'page=amp-options', $messages[0] );
+		$this->assertStringContains( 'AMP cannot be enabled because this', $messages[0] );
+		$this->assertStringContains( 'page=amp-options', $messages[0] );
 
 		$this->assertEquals(
 			[

--- a/tests/php/test-class-amp-options-manager.php
+++ b/tests/php/test-class-amp-options-manager.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_Options_Manager.
  *
  * @covers AMP_Options_Manager
  */
 class Test_AMP_Options_Manager extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Set up.
@@ -419,9 +423,9 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		// This is the correct page, and the notice has not been dismissed, so it should display.
 		delete_user_meta( get_current_user_id(), 'dismissed_wp_pointers' );
 		$output = get_echo( [ 'AMP_Options_Manager', 'render_welcome_notice' ] );
-		$this->assertContains( 'Welcome to AMP for WordPress', $output );
-		$this->assertContains( 'Bring the speed and features of the open source AMP project to your site, complete with the tools to support content authoring and website development.', $output );
-		$this->assertContains( $id, $output );
+		$this->assertStringContains( 'Welcome to AMP for WordPress', $output );
+		$this->assertStringContains( 'Bring the speed and features of the open source AMP project to your site, complete with the tools to support content authoring and website development.', $output );
+		$this->assertStringContains( $id, $output );
 	}
 
 	/**
@@ -441,7 +445,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$amp_settings_errors = get_settings_errors( AMP_Options_Manager::OPTION_NAME );
 		$new_error           = end( $amp_settings_errors );
 		$this->assertStringStartsWith( 'Reader mode activated!', $new_error['message'] );
-		$this->assertContains( esc_url( amp_get_permalink( $page_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a page since it is the only post type supported.' );
+		$this->assertStringContains( esc_url( amp_get_permalink( $page_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a page since it is the only post type supported.' );
 		$this->assertCount( 0, get_posts( [ 'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG ] ) );
 	}
 
@@ -477,7 +481,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$amp_settings_errors = get_settings_errors( AMP_Options_Manager::OPTION_NAME );
 		$new_error           = end( $amp_settings_errors );
 		$this->assertStringStartsWith( 'Standard mode activated!', $new_error['message'] );
-		$this->assertContains( esc_url( amp_get_permalink( $post_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a post since it is the only post type supported.' );
+		$this->assertStringContains( esc_url( amp_get_permalink( $post_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a post since it is the only post type supported.' );
 		$invalid_url_posts = get_posts(
 			[
 				'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
@@ -486,8 +490,8 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		);
 		$this->assertEquals( 'updated', $new_error['type'] );
 		$this->assertCount( 1, $invalid_url_posts );
-		$this->assertContains( 'review 1 issue', $new_error['message'] );
-		$this->assertContains( esc_url( get_edit_post_link( $invalid_url_posts[0], 'raw' ) ), $new_error['message'], 'Expect edit post link for the invalid URL post to be present.' );
+		$this->assertStringContains( 'review 1 issue', $new_error['message'] );
+		$this->assertStringContains( esc_url( get_edit_post_link( $invalid_url_posts[0], 'raw' ) ), $new_error['message'], 'Expect edit post link for the invalid URL post to be present.' );
 	}
 
 	/**
@@ -561,7 +565,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		$amp_settings_errors = get_settings_errors( AMP_Options_Manager::OPTION_NAME );
 		$new_error           = end( $amp_settings_errors );
 		$this->assertStringStartsWith( 'Transitional mode activated!', $new_error['message'] );
-		$this->assertContains( esc_url( amp_get_permalink( $post_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a post since it is the only post type supported.' );
+		$this->assertStringContains( esc_url( amp_get_permalink( $post_id ) ), $new_error['message'], 'Expect amp_admin_get_preview_permalink() to return a post since it is the only post type supported.' );
 		$invalid_url_posts = get_posts(
 			[
 				'post_type' => AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
@@ -570,7 +574,7 @@ class Test_AMP_Options_Manager extends WP_UnitTestCase {
 		);
 		$this->assertEquals( 'updated', $new_error['type'] );
 		$this->assertCount( 1, $invalid_url_posts );
-		$this->assertContains( 'review 2 issues', $new_error['message'] );
-		$this->assertContains( esc_url( get_edit_post_link( $invalid_url_posts[0], 'raw' ) ), $new_error['message'], 'Expect edit post link for the invalid URL post to be present.' );
+		$this->assertStringContains( 'review 2 issues', $new_error['message'] );
+		$this->assertStringContains( esc_url( get_edit_post_link( $invalid_url_posts[0], 'raw' ) ), $new_error['message'], 'Expect edit post link for the invalid URL post to be present.' );
 	}
 }

--- a/tests/php/test-class-amp-options-menu.php
+++ b/tests/php/test-class-amp-options-menu.php
@@ -5,10 +5,14 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_Options_Menu.
  */
 class Test_AMP_Options_Menu extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Instance of AMP_Options_Menu
@@ -101,6 +105,6 @@ class Test_AMP_Options_Menu extends WP_UnitTestCase {
 
 		ob_start();
 		$this->instance->render_screen();
-		$this->assertContains( '<div class="wrap">', ob_get_clean() );
+		$this->assertStringContains( '<div class="wrap">', ob_get_clean() );
 	}
 }

--- a/tests/php/test-class-amp-playlist-embed-handler.php
+++ b/tests/php/test-class-amp-playlist-embed-handler.php
@@ -6,6 +6,8 @@
  * @since 0.7
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_Playlist_Embed_Handler.
  *
@@ -13,6 +15,8 @@
  * @covers AMP_Playlist_Embed_Handler
  */
 class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Instance of the tested class.
@@ -116,10 +120,10 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 	public function test_shortcode() {
 		$attr     = $this->get_attributes( 'video' );
 		$playlist = $this->instance->shortcode( $attr );
-		$this->assertContains( '<amp-video', $playlist );
-		$this->assertContains( '<amp-state', $playlist );
-		$this->assertContains( $this->file_1, $playlist );
-		$this->assertContains( $this->file_2, $playlist );
+		$this->assertStringContains( '<amp-video', $playlist );
+		$this->assertStringContains( '<amp-state', $playlist );
+		$this->assertStringContains( $this->file_1, $playlist );
+		$this->assertStringContains( $this->file_2, $playlist );
 	}
 
 	/**
@@ -131,12 +135,12 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$attr     = $this->get_attributes( 'video' );
 		$data     = $this->instance->get_data( $attr );
 		$playlist = $this->instance->video_playlist( $data );
-		$this->assertContains( '<amp-video', $playlist );
-		$this->assertContains( '<amp-state', $playlist );
-		$this->assertContains( $this->file_1, $playlist );
-		$this->assertContains( $this->file_2, $playlist );
-		$this->assertContains( '[src]="wpPlaylist1[wpPlaylist1.selectedIndex].videoUrl"', $playlist );
-		$this->assertContains( 'on="tap:AMP.setState({&quot;wpPlaylist1&quot;:{&quot;selectedIndex&quot;:0}})"', $playlist );
+		$this->assertStringContains( '<amp-video', $playlist );
+		$this->assertStringContains( '<amp-state', $playlist );
+		$this->assertStringContains( $this->file_1, $playlist );
+		$this->assertStringContains( $this->file_2, $playlist );
+		$this->assertStringContains( '[src]="wpPlaylist1[wpPlaylist1.selectedIndex].videoUrl"', $playlist );
+		$this->assertStringContains( 'on="tap:AMP.setState({&quot;wpPlaylist1&quot;:{&quot;selectedIndex&quot;:0}})"', $playlist );
 	}
 
 	/**
@@ -212,11 +216,11 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 
 		$data     = $this->instance->get_data( $attr );
 		$playlist = $this->instance->audio_playlist( $data );
-		$this->assertContains( '<amp-carousel', $playlist );
-		$this->assertContains( '<amp-audio', $playlist );
-		$this->assertContains( $this->file_1, $playlist );
-		$this->assertContains( $this->file_2, $playlist );
-		$this->assertContains( 'tap:AMP.setState({&quot;wpPlaylist1&quot;:{&quot;selectedIndex&quot;:0}})"', $playlist );
+		$this->assertStringContains( '<amp-carousel', $playlist );
+		$this->assertStringContains( '<amp-audio', $playlist );
+		$this->assertStringContains( $this->file_1, $playlist );
+		$this->assertStringContains( $this->file_2, $playlist );
+		$this->assertStringContains( 'tap:AMP.setState({&quot;wpPlaylist1&quot;:{&quot;selectedIndex&quot;:0}})"', $playlist );
 	}
 
 	/**
@@ -232,16 +236,16 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$expected_on = 'tap:AMP.setState({&quot;' . $state_id . '&quot;:{&quot;selectedIndex&quot;:0}})';
 
 		$tracks = get_echo( [ $this->instance, 'print_tracks' ], [ $state_id, $data['tracks'] ] );
-		$this->assertContains( '<div class="wp-playlist-tracks">', $tracks );
-		$this->assertContains( $state_id, $tracks );
-		$this->assertContains( $expected_on, $tracks );
+		$this->assertStringContains( '<div class="wp-playlist-tracks">', $tracks );
+		$this->assertStringContains( $state_id, $tracks );
+		$this->assertStringContains( $expected_on, $tracks );
 
 		$attr        = $this->get_attributes( $type );
 		$data        = $this->instance->get_data( $attr );
 		$expected_on = 'tap:AMP.setState({&quot;' . $state_id . '&quot;:{&quot;selectedIndex&quot;:0}})';
 
 		$tracks = get_echo( [ $this->instance, 'print_tracks' ], [ $state_id, $data['tracks'] ] );
-		$this->assertContains( $expected_on, $tracks );
+		$this->assertStringContains( $expected_on, $tracks );
 	}
 
 	/**
@@ -253,8 +257,8 @@ class Test_AMP_Playlist_Embed_Handler extends WP_UnitTestCase {
 		$type = 'audio';
 		$data = $this->instance->get_data( $this->get_attributes( $type ) );
 		$this->assertEquals( $type, $data['type'] );
-		$this->assertContains( $this->file_1, $data['tracks'][0]['src'] );
-		$this->assertContains( $this->file_2, $data['tracks'][1]['src'] );
+		$this->assertStringContains( $this->file_1, $data['tracks'][0]['src'] );
+		$this->assertStringContains( $this->file_2, $data['tracks'][1]['src'] );
 	}
 
 	/**

--- a/tests/php/test-class-amp-service-worker.php
+++ b/tests/php/test-class-amp-service-worker.php
@@ -6,12 +6,16 @@
  * @since 1.1
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_Service_Worker.
  *
  * @covers AMP_Service_Worker
  */
 class Test_AMP_Service_Worker extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Set up.
@@ -211,7 +215,7 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 	public function test_install_service_worker() {
 		$output = get_echo( [ 'AMP_Service_Worker', 'install_service_worker' ] );
 
-		$this->assertContains( '<amp-install-serviceworker', $output );
+		$this->assertStringContains( '<amp-install-serviceworker', $output );
 	}
 
 	/**
@@ -243,7 +247,7 @@ class Test_AMP_Service_Worker extends WP_UnitTestCase {
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 'exited', $exception->getMessage() );
 		$output = ob_get_clean();
-		$this->assertContains( '<script>navigator.serviceWorker.register', $output );
+		$this->assertStringContains( '<script>navigator.serviceWorker.register', $output );
 
 		// Go back home to clean up 🤷!
 		$this->go_to( home_url() );

--- a/tests/php/test-class-amp-theme-support.php
+++ b/tests/php/test-class-amp-theme-support.php
@@ -7,6 +7,7 @@
  */
 
 use AmpProject\AmpWP\ConfigurationArgument;
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\PrivateAccess;
 use AmpProject\Dom\Document;
 use org\bovigo\vfs;
@@ -18,6 +19,7 @@ use org\bovigo\vfs;
  */
 class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use PrivateAccess;
 
 	/**
@@ -393,7 +395,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$e = $exception;
 		}
 		$this->assertTrue( isset( $e ) ); // wp_safe_redirect() modifies the headers, and causes an error.
-		$this->assertContains( 'headers already sent', $e->getMessage() );
+		$this->assertStringContains( 'headers already sent', $e->getMessage() );
 		$e = null;
 
 		// Endpoint.
@@ -405,7 +407,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		} catch ( Exception $exception ) {
 			$e = $exception;
 		}
-		$this->assertContains( 'headers already sent', $e->getMessage() );
+		$this->assertStringContains( 'headers already sent', $e->getMessage() );
 		$e = null;
 	}
 
@@ -437,7 +439,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		} catch ( Exception $exception ) {
 			$e = $exception;
 		}
-		$this->assertContains( 'headers already sent', $e->getMessage() );
+		$this->assertStringContains( 'headers already sent', $e->getMessage() );
 	}
 
 	/**
@@ -467,7 +469,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$e = $exception;
 		}
 		$this->assertTrue( isset( $e ) );
-		$this->assertContains( 'headers already sent', $e->getMessage() );
+		$this->assertStringContains( 'headers already sent', $e->getMessage() );
 		$this->assertSame( 302, $redirect_status_code );
 		$e = null;
 
@@ -480,7 +482,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$e = $exception;
 		}
 		$this->assertTrue( isset( $e ) ); // wp_safe_redirect() modifies the headers, and causes an error.
-		$this->assertContains( 'headers already sent', $e->getMessage() );
+		$this->assertStringContains( 'headers already sent', $e->getMessage() );
 		$this->assertSame( 301, $redirect_status_code );
 		$e = null;
 
@@ -619,13 +621,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html );
 
 		// Insufficient viewport tag was not left in.
-		$this->assertNotContains( '<meta name="viewport" content="maximum-scale=1.0">', $sanitized_html );
+		$this->assertStringNotContains( '<meta name="viewport" content="maximum-scale=1.0">', $sanitized_html );
 
 		// Viewport tag was modified to include all requirements.
-		$this->assertContains( '<meta name="viewport" content="maximum-scale=1.0,width=device-width">', $sanitized_html );
+		$this->assertStringContains( '<meta name="viewport" content="maximum-scale=1.0,width=device-width">', $sanitized_html );
 
 		// MathML script was added.
-		$this->assertContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-0.1.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		$this->assertStringContains( '<script type="text/javascript" src="https://cdn.ampproject.org/v0/amp-mathml-0.1.js" async custom-element="amp-mathml"></script>', $sanitized_html ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript
 	}
 
 	/**
@@ -1124,7 +1126,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$this->assertTrue( amp_is_canonical() );
 		$output = get_echo( [ 'AMP_Theme_Support', 'amend_comment_form' ] );
-		$this->assertNotContains( '<input type="hidden" name="redirect_to"', $output );
+		$this->assertStringNotContains( '<input type="hidden" name="redirect_to"', $output );
 
 		// Test transitional AMP.
 		add_theme_support(
@@ -1135,7 +1137,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		);
 		$this->assertFalse( amp_is_canonical() );
 		$output = get_echo( [ 'AMP_Theme_Support', 'amend_comment_form' ] );
-		$this->assertContains( '<input type="hidden" name="redirect_to"', $output );
+		$this->assertStringContains( '<input type="hidden" name="redirect_to"', $output );
 	}
 
 	/**
@@ -1217,9 +1219,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 				'title_reply_before'  => '',
 			]
 		);
-		$this->assertContains( AMP_Theme_Support::get_comment_form_state_id( get_the_ID() ), $defaults['title_reply_before'] );
-		$this->assertContains( 'replyToName ?', $defaults['title_reply_before'] );
-		$this->assertContains( '</span>', $defaults['cancel_reply_before'] );
+		$this->assertStringContains( AMP_Theme_Support::get_comment_form_state_id( get_the_ID() ), $defaults['title_reply_before'] );
+		$this->assertStringContains( 'replyToName ?', $defaults['title_reply_before'] );
+		$this->assertStringContains( '</span>', $defaults['cancel_reply_before'] );
 	}
 
 	/**
@@ -1248,13 +1250,13 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$filtered_link = AMP_Theme_Support::filter_comment_reply_link( $link, $args, $comment );
 		$this->assertStringStartsWith( $before, $filtered_link );
 		$this->assertStringEndsWith( $after, $filtered_link );
-		$this->assertContains( AMP_Theme_Support::get_comment_form_state_id( get_the_ID() ), $filtered_link );
-		$this->assertContains( $comment->comment_author, $filtered_link );
-		$this->assertContains( $comment->comment_ID, $filtered_link );
-		$this->assertContains( 'tap:AMP.setState', $filtered_link );
-		$this->assertContains( $reply_text, $filtered_link );
-		$this->assertContains( $reply_to_text, $filtered_link );
-		$this->assertContains( $respond_id, $filtered_link );
+		$this->assertStringContains( AMP_Theme_Support::get_comment_form_state_id( get_the_ID() ), $filtered_link );
+		$this->assertStringContains( $comment->comment_author, $filtered_link );
+		$this->assertStringContains( $comment->comment_ID, $filtered_link );
+		$this->assertStringContains( 'tap:AMP.setState', $filtered_link );
+		$this->assertStringContains( $reply_text, $filtered_link );
+		$this->assertStringContains( $reply_to_text, $filtered_link );
+		$this->assertStringContains( $respond_id, $filtered_link );
 	}
 
 	/**
@@ -1272,14 +1274,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$link           = remove_query_arg( 'replytocom' );
 		$text           = 'Cancel your reply';
 		$filtered_link  = AMP_Theme_Support::filter_cancel_comment_reply_link( $formatted_link, $link, $text );
-		$this->assertContains( $url, $filtered_link );
-		$this->assertContains( $text, $filtered_link );
-		$this->assertContains( '<a id="cancel-comment-reply-link"', $filtered_link );
-		$this->assertContains( '.values.comment_parent ==', $filtered_link );
-		$this->assertContains( 'tap:AMP.setState(', $filtered_link );
+		$this->assertStringContains( $url, $filtered_link );
+		$this->assertStringContains( $text, $filtered_link );
+		$this->assertStringContains( '<a id="cancel-comment-reply-link"', $filtered_link );
+		$this->assertStringContains( '.values.comment_parent ==', $filtered_link );
+		$this->assertStringContains( 'tap:AMP.setState(', $filtered_link );
 
 		$filtered_link_no_text_passed = AMP_Theme_Support::filter_cancel_comment_reply_link( $formatted_link, $link, '' );
-		$this->assertContains( 'Click here to cancel reply.', $filtered_link_no_text_passed );
+		$this->assertStringContains( 'Click here to cancel reply.', $filtered_link_no_text_passed );
 	}
 
 	/**
@@ -1325,12 +1327,12 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		wp_print_styles();
 		wp_print_scripts();
 		$output = ob_get_clean();
-		$this->assertContains( '<style id=\'admin-bar-inline-css\' type=\'text/css\'>', $output ); // Note: data-ampdevmode attribute will be added by AMP_Dev_Mode_Sanitizer.
-		$this->assertNotContains( '<link rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'example-admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertContains( 'html { margin-top: 64px !important; }', $output );
+		$this->assertStringContains( '<style id=\'admin-bar-inline-css\' type=\'text/css\'>', $output ); // Note: data-ampdevmode attribute will be added by AMP_Dev_Mode_Sanitizer.
+		$this->assertStringNotContains( '<link rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'example-admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( 'html { margin-top: 64px !important; }', $output );
 		$this->assertRegExp( '/' . implode( '', [ '<script ', 'data-ampdevmode [^>]+admin-bar\.js' ] ) . '/', $output );
 		$this->assertRegExp( '/' . implode( '', [ '<script ', 'data-ampdevmode [^>]+example-admin-bar\.js' ] ) . '/', $output );
 
@@ -1619,9 +1621,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		wp_print_styles();
 		$output = ob_get_clean();
 
-		$this->assertContains( '<link rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertNotContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringNotContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 	}
 
 	/**
@@ -1645,9 +1647,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		wp_print_styles();
 		$output = ob_get_clean();
 
-		$this->assertContains( '<link rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertNotContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
-		$this->assertContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringNotContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'dashicons-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
+		$this->assertStringContains( '<link data-ampdevmode rel=\'stylesheet\' id=\'admin-bar-css\'', $output ); // phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedStylesheet
 	}
 
 	/**
@@ -1913,11 +1915,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertEquals( 1, ob_get_level() );
 
-		$this->assertContains( '<html amp', $output );
-		$this->assertContains( 'foo', $output );
-		$this->assertContains( 'BAR', $output );
-		$this->assertContains( '<amp-img src="test.png"', $output );
-		$this->assertNotContains( '<script data-test', $output );
+		$this->assertStringContains( '<html amp', $output );
+		$this->assertStringContains( 'foo', $output );
+		$this->assertStringContains( 'BAR', $output );
+		$this->assertStringContains( '<amp-img src="test.png"', $output );
+		$this->assertStringNotContains( '<script data-test', $output );
 
 	}
 
@@ -1935,9 +1937,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$partial = '<img src="test.png"><script data-head>document.write(\'Illegal\');</script>';
 		$output  = AMP_Theme_Support::filter_customize_partial_render( $partial );
-		$this->assertContains( '<amp-img src="test.png"', $output );
-		$this->assertNotContains( '<script', $output );
-		$this->assertNotContains( '<html', $output );
+		$this->assertStringContains( '<amp-img src="test.png"', $output );
+		$this->assertStringNotContains( '<script', $output );
+		$this->assertStringNotContains( '<html', $output );
 	}
 
 	/**
@@ -1972,7 +1974,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$sanitized_html = $call_prepare_response();
 
-		$this->assertNotContains( 'handle=', $sanitized_html );
+		$this->assertStringNotContains( 'handle=', $sanitized_html );
 		$this->assertEquals( 2, substr_count( $sanitized_html, '<!-- wp_print_scripts -->' ) );
 
 		$ordered_contains = [
@@ -2028,11 +2030,11 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			$prev_ordered_contain = $ordered_contain;
 		}
 
-		$this->assertContains( '<noscript><img', $sanitized_html );
-		$this->assertContains( '<amp-img', $sanitized_html );
+		$this->assertStringContains( '<noscript><img', $sanitized_html );
+		$this->assertStringContains( '<amp-img', $sanitized_html );
 
-		$this->assertContains( '<noscript><audio', $sanitized_html );
-		$this->assertContains( '<amp-audio', $sanitized_html );
+		$this->assertStringContains( '<noscript><audio', $sanitized_html );
+		$this->assertStringContains( '<amp-audio', $sanitized_html );
 
 		$removed_nodes = [];
 		foreach ( AMP_Validation_Manager::$validation_results as $result ) {
@@ -2045,7 +2047,7 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 			}
 		}
 
-		$this->assertContains( '<button>no-onclick</button>', $sanitized_html );
+		$this->assertStringContains( '<button>no-onclick</button>', $sanitized_html );
 		$this->assertCount( 5, AMP_Validation_Manager::$validation_results );
 		$this->assertEquals(
 			[
@@ -2074,9 +2076,9 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 
 		$sanitized_html = AMP_Theme_Support::prepare_response( $original_html, [ ConfigurationArgument::ENABLE_OPTIMIZER => false ] );
 
-		$this->assertContains( '<html>', $sanitized_html, 'The AMP attribute is removed from the HTML element' );
-		$this->assertContains( '<button onclick="alert', $sanitized_html, 'Invalid AMP is present in the response.' );
-		$this->assertContains( 'document.write = function', $sanitized_html, 'Override of document.write() is present.' );
+		$this->assertStringContains( '<html>', $sanitized_html, 'The AMP attribute is removed from the HTML element' );
+		$this->assertStringContains( '<button onclick="alert', $sanitized_html, 'Invalid AMP is present in the response.' );
+		$this->assertStringContains( 'document.write = function', $sanitized_html, 'Override of document.write() is present.' );
 	}
 
 	/**
@@ -2252,14 +2254,14 @@ class Test_AMP_Theme_Support extends WP_UnitTestCase {
 		// HTML, but very stripped down.
 		$input  = '<html><head></head>Hello</html>';
 		$output = AMP_Theme_Support::prepare_response( $input );
-		$this->assertContains( '<html amp', $output );
-		$this->assertContains( '<meta charset="utf-8">', $output );
+		$this->assertStringContains( '<html amp', $output );
+		$this->assertStringContains( '<meta charset="utf-8">', $output );
 
 		// HTML with doctype, comments, and whitespace before head.
 		$input  = "   <!--\nHello world!\n-->\n\n<!DOCTYPE html>  <html\n\n>\n<head profile='http://www.acme.com/profiles/core'></head><body>Hello</body></html>";
 		$output = AMP_Theme_Support::prepare_response( $input );
-		$this->assertContains( '<html amp', $output );
-		$this->assertContains( '<meta charset="utf-8">', $output );
+		$this->assertStringContains( '<html amp', $output );
+		$this->assertStringContains( '<meta charset="utf-8">', $output );
 	}
 
 	/**

--- a/tests/php/test-class-amp-widget-archives.php
+++ b/tests/php/test-class-amp-widget-archives.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for class AMP_Widget_Archives.
  *
  * @package AMP
  */
 class Test_AMP_Widget_Archives extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Instance of the widget.
@@ -77,8 +81,8 @@ class Test_AMP_Widget_Archives extends WP_UnitTestCase {
 		];
 		$output    = get_echo( [ $this->widget, 'widget' ], [ $arguments, $instance ] );
 
-		$this->assertContains( 'on="change:AMP.navigateTo(url=event.value)"', $output );
-		$this->assertNotContains( 'onchange=', $output );
+		$this->assertStringContains( 'on="change:AMP.navigateTo(url=event.value)"', $output );
+		$this->assertStringNotContains( 'onchange=', $output );
 	}
 
 }

--- a/tests/php/test-class-amp-widget-categories.php
+++ b/tests/php/test-class-amp-widget-categories.php
@@ -5,12 +5,16 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for class AMP_Widget_Categories.
  *
  * @package AMP
  */
 class Test_AMP_Widget_Categories extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Instance of the widget.
@@ -77,8 +81,8 @@ class Test_AMP_Widget_Categories extends WP_UnitTestCase {
 		];
 		$output    = get_echo( [ $this->widget, 'widget' ], [ $arguments, $instance ] );
 
-		$this->assertContains( 'on="change:', $output );
-		$this->assertNotContains( '<script type=', $output );
+		$this->assertStringContains( 'on="change:', $output );
+		$this->assertStringNotContains( '<script type=', $output );
 	}
 
 }

--- a/tests/php/test-class-amp-wordpress-tv-embed-handler.php
+++ b/tests/php/test-class-amp-wordpress-tv-embed-handler.php
@@ -6,6 +6,8 @@
  * @since 1.4
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_WordPress_TV_Embed_Handler.
  *
@@ -13,6 +15,8 @@
  * @covers AMP_WordPress_TV_Embed_Handler
  */
 class Test_AMP_WordPress_TV_Embed_Handler extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	/**
 	 * Set up.
@@ -72,9 +76,9 @@ class Test_AMP_WordPress_TV_Embed_Handler extends WP_UnitTestCase {
 
 		$handler->register_embed();
 		$rendered = apply_filters( 'the_content', $wordpress_tv_block );
-		$this->assertContains( '<iframe', $rendered );
-		$this->assertContains( 'videopress.com/embed', $rendered );
-		$this->assertNotContains( '<script', $rendered );
+		$this->assertStringContains( '<iframe', $rendered );
+		$this->assertStringContains( 'videopress.com/embed', $rendered );
+		$this->assertStringNotContains( '<script', $rendered );
 	}
 
 	/**

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -6,12 +6,16 @@
  * @since 0.7
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+
 /**
  * Tests for AMP_YouTube_Embed_Handler.
  *
  * @covers AMP_YouTube_Embed_Handler
  */
 class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
+
+	use AssertContainsCompatibility;
 
 	protected $youtube_video_id = 'kfVsfOSbJY0';
 
@@ -105,8 +109,8 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 		];
 
 		$youtube_shortcode = $this->handler->video_override( '', $attr_youtube );
-		$this->assertContains( '<amp-youtube', $youtube_shortcode );
-		$this->assertContains( $youtube_id, $youtube_shortcode );
+		$this->assertStringContains( '<amp-youtube', $youtube_shortcode );
+		$this->assertStringContains( $youtube_id, $youtube_shortcode );
 
 		$vimeo_id        = '64086087';
 		$vimeo_src       = 'https://vimeo.com/' . $vimeo_id;

--- a/tests/php/validation/test-class-amp-validated-url-post-type.php
+++ b/tests/php/validation/test-class-amp-validated-url-post-type.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\HandleValidation;
 
 // phpcs:disable WordPress.Variables.GlobalVariables.OverrideProhibited
@@ -16,6 +17,7 @@ use AmpProject\AmpWP\Tests\HandleValidation;
  */
 class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use HandleValidation;
 
 	const TESTED_CLASS = 'AMP_Validated_URL_Post_Type';
@@ -145,7 +147,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		AMP_Validated_URL_Post_Type::add_admin_menu_new_invalid_url_count();
 
-		$this->assertContains( '<span class="awaiting-mod"><span class="new-validation-error-urls-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
+		$this->assertStringContains( '<span class="awaiting-mod"><span class="new-validation-error-urls-count">1</span></span>', $submenu[ AMP_Options_Manager::OPTION_NAME ][2][0] );
 	}
 
 	/**
@@ -227,8 +229,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertEquals( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_NEW_REJECTED_STATUS, $error['term_status'] );
 
 		$summary = get_echo( [ 'AMP_Validated_URL_Post_Type', 'display_invalid_url_validation_error_counts_summary' ], [ $invalid_url_post_id ] );
-		$this->assertContains( 'Invalid markup kept: 2', $summary );
-		$this->assertContains( 'Invalid markup removed: 2', $summary );
+		$this->assertStringContains( 'Invalid markup kept: 2', $summary );
+		$this->assertStringContains( 'Invalid markup removed: 2', $summary );
 	}
 
 	/**
@@ -646,7 +648,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$invalid_url_post_id = AMP_Validated_URL_Post_Type::store_validation_errors( $errors, home_url( '/' ) );
 
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'output_custom_column' ], [ $column_name, $invalid_url_post_id ] );
-		$this->assertContains( $expected_value, $output );
+		$this->assertStringContains( $expected_value, $output );
 	}
 
 	/**
@@ -690,13 +692,13 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		// If there is a 'core' source, it should appear in the column output.
 		$error_summary['sources_with_invalid_output']['core'] = [];
 		$sources_column                                       = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
-		$this->assertContains( '<strong><span class="dashicons dashicons-wordpress-alt"></span>Other (0)</strong>', $sources_column );
+		$this->assertStringContains( '<strong><span class="dashicons dashicons-wordpress-alt"></span>Other (0)</strong>', $sources_column );
 
 		// Even if there is a hook in the sources, it should not appear in the column if there is any other source.
 		$hook_name = 'wp_header';
 		$error_summary['sources_with_invalid_output']['hook'] = [ $hook_name ];
 		$sources_column                                       = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_sources_column' ], [ $error_summary['sources_with_invalid_output'], $post_id ] );
-		$this->assertNotContains( $hook_name, $sources_column );
+		$this->assertStringNotContains( $hook_name, $sources_column );
 
 		// If a hook is the only source, it should appear in the column.
 		$error_summary['sources_with_invalid_output'] = [ 'hook' => $hook_name ];
@@ -807,7 +809,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 				];
 			}
 		);
-		$this->assertContains(
+		$this->assertStringContains(
 			'amp_validate_error=',
 			AMP_Validated_URL_Post_Type::handle_bulk_action( $initial_redirect, AMP_Validated_URL_Post_Type::BULK_VALIDATE_ACTION, $items )
 		);
@@ -837,24 +839,24 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$_GET[ AMP_Validated_URL_Post_Type::REMAINING_ERRORS ] = '1';
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ]      = '1';
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
-		$this->assertContains( 'The rechecked URL still has remaining invalid markup kept.', $output );
+		$this->assertStringContains( 'The rechecked URL still has remaining invalid markup kept.', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = '2';
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
-		$this->assertContains( 'The rechecked URLs still have remaining invalid markup kept.', $output );
+		$this->assertStringContains( 'The rechecked URLs still have remaining invalid markup kept.', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::REMAINING_ERRORS ] = '0';
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
-		$this->assertContains( 'The rechecked URLs are free of non-removed invalid markup.', $output );
+		$this->assertStringContains( 'The rechecked URLs are free of non-removed invalid markup.', $output );
 
 		$_GET[ AMP_Validated_URL_Post_Type::URLS_TESTED ] = '1';
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
-		$this->assertContains( 'The rechecked URL is free of non-removed invalid markup.', $output );
+		$this->assertStringContains( 'The rechecked URL is free of non-removed invalid markup.', $output );
 
 		$error_message              = 'Something <code>bad</code> happened!';
 		$_GET['amp_validate_error'] = AMP_Validation_Manager::serialize_validation_error_messages( [ $error_message ] );
 		$output                     = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_admin_notice' ] );
-		$this->assertContains( $error_message, $output );
+		$this->assertStringContains( $error_message, $output );
 
 		unset( $GLOBALS['current_screen'] );
 	}
@@ -921,7 +923,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertContains(
+		$this->assertStringContains(
 			'/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
@@ -932,7 +934,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception    = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertContains(
+		$this->assertStringContains(
 			'/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
@@ -943,7 +945,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception    = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertContains(
+		$this->assertStringContains(
 			'/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
@@ -954,7 +956,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception    = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertContains(
+		$this->assertStringContains(
 			sprintf( 'post.php?post=%s&action=edit&amp_urls_tested=', $post_id ),
 			$exception->getMessage()
 		);
@@ -985,7 +987,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$exception   = $handle_validate_request();
 		$this->assertInstanceOf( 'Exception', $exception );
 		$this->assertEquals( 302, $exception->getCode() );
-		$this->assertContains(
+		$this->assertStringContains(
 			'wp-admin/edit.php?post_type=amp_validated_url&amp_validate_error=',
 			$exception->getMessage()
 		);
@@ -1155,7 +1157,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		set_current_screen( 'edit.php' );
 		$current_screen->post_type = AMP_Validated_URL_Post_Type::POST_TYPE_SLUG;
 		$output                    = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_link_to_error_index_screen' ] );
-		$this->assertContains( 'View Error Index', $output );
+		$this->assertStringContains( 'View Error Index', $output );
 	}
 
 	/**
@@ -1263,11 +1265,11 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_status_meta_box' ], [ get_post( $invalid_url_post_id ) ] );
 
-		$this->assertContains( date_i18n( 'M j, Y @ H:i', strtotime( $post_storing_error->post_date ) ), $output );
-		$this->assertContains( 'Last checked:', $output );
-		$this->assertContains( 'Forget', $output );
-		$this->assertContains( esc_url( get_delete_post_link( $post_storing_error->ID, '', true ) ), $output );
-		$this->assertContains( 'misc-pub-section', $output );
+		$this->assertStringContains( date_i18n( 'M j, Y @ H:i', strtotime( $post_storing_error->post_date ) ), $output );
+		$this->assertStringContains( 'Last checked:', $output );
+		$this->assertStringContains( 'Forget', $output );
+		$this->assertStringContains( esc_url( get_delete_post_link( $post_storing_error->ID, '', true ) ), $output );
+		$this->assertStringContains( 'misc-pub-section', $output );
 	}
 
 	/**
@@ -1290,10 +1292,10 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		// Now that the current user has permissions, this should output the correct markup.
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_single_url_list_table' ], [ $post_correct_post_type ] );
-		$this->assertContains( '<form class="search-form wp-clearfix" method="get">', $output );
-		$this->assertContains( '<div id="accept-reject-buttons" class="hidden">', $output );
-		$this->assertContains( '<button type="button" class="button action accept">', $output );
-		$this->assertContains( '<button type="button" class="button action reject">', $output );
+		$this->assertStringContains( '<form class="search-form wp-clearfix" method="get">', $output );
+		$this->assertStringContains( '<div id="accept-reject-buttons" class="hidden">', $output );
+		$this->assertStringContains( '<button type="button" class="button action accept">', $output );
+		$this->assertStringContains( '<button type="button" class="button action reject">', $output );
 	}
 
 	/**
@@ -1325,8 +1327,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			]
 		);
 		$output                 = get_echo( [ 'AMP_Validated_URL_Post_Type', 'print_url_as_title' ], [ $post_correct_post_type ] );
-		$this->assertContains( '<h2 class="amp-validated-url">', $output );
-		$this->assertContains( home_url(), $output );
+		$this->assertStringContains( '<h2 class="amp-validated-url">', $output );
+		$this->assertStringContains( home_url(), $output );
 	}
 
 	/**
@@ -1423,15 +1425,15 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		// This is now on the invalid URL post type edit.php screen, so it should output a <select> element.
 		$output = get_echo( [ 'AMP_Validated_URL_Post_Type', 'render_post_filters' ], [ $correct_post_type, $correct_which_second_argument ] );
-		$this->assertContains(
+		$this->assertStringContains(
 			sprintf( 'With new errors <span class="count">(%d)</span>', $number_of_new_errors ),
 			$output
 		);
-		$this->assertContains(
+		$this->assertStringContains(
 			sprintf( 'With kept markup <span class="count">(%d)</span>', $number_of_rejected ),
 			$output
 		);
-		$this->assertContains(
+		$this->assertStringContains(
 			sprintf( 'With removed markup <span class="count">(%d)</span>', $number_of_accepted ),
 			$output
 		);
@@ -1447,8 +1449,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$post_id = AMP_Validated_URL_Post_Type::store_validation_errors( $this->get_mock_errors(), home_url( '/' ) );
 		$link    = AMP_Validated_URL_Post_Type::get_recheck_url( get_post( $post_id ) );
-		$this->assertContains( AMP_Validated_URL_Post_Type::VALIDATE_ACTION, $link );
-		$this->assertContains( wp_create_nonce( AMP_Validated_URL_Post_Type::NONCE_ACTION ), $link );
+		$this->assertStringContains( AMP_Validated_URL_Post_Type::VALIDATE_ACTION, $link );
+		$this->assertStringContains( wp_create_nonce( AMP_Validated_URL_Post_Type::NONCE_ACTION ), $link );
 	}
 
 	/**
@@ -1472,9 +1474,9 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 			get_permalink( $post_id )
 		);
 		$items = AMP_Validated_URL_Post_Type::filter_dashboard_glance_items( [] );
-		$this->assertContains( '1 URL w/ new AMP errors', $items[0] );
-		$this->assertContains( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, $items[0] );
-		$this->assertContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $items[0] );
+		$this->assertStringContains( '1 URL w/ new AMP errors', $items[0] );
+		$this->assertStringContains( AMP_Validated_URL_Post_Type::POST_TYPE_SLUG, $items[0] );
+		$this->assertStringContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $items[0] );
 	}
 
 	/**
@@ -1561,8 +1563,8 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 		$this->assertArrayHasKey( AMP_Validated_URL_Post_Type::VALIDATE_ACTION, $actions );
 		$this->assertArrayNotHasKey( 'trash', $actions );
 		$this->assertArrayHasKey( 'delete', $actions );
-		$this->assertNotContains( 'Trash', $actions['delete'] );
-		$this->assertContains( 'Forget', $actions['delete'] );
+		$this->assertStringNotContains( 'Trash', $actions['delete'] );
+		$this->assertStringContains( 'Forget', $actions['delete'] );
 
 		$this->assertEquals( [], AMP_Validated_URL_Post_Type::filter_post_row_actions( [], null ) );
 
@@ -1582,7 +1584,7 @@ class Test_AMP_Validated_URL_Post_Type extends WP_UnitTestCase {
 
 		$this->assertArrayNotHasKey( 'trash', $filtered_actions );
 		$this->assertArrayHasKey( 'delete', $filtered_actions );
-		$this->assertContains( 'Forget</a>', $filtered_actions['delete'] );
+		$this->assertStringContains( 'Forget</a>', $filtered_actions['delete'] );
 
 	}
 

--- a/tests/php/validation/test-class-amp-validation-error-taxonomy.php
+++ b/tests/php/validation/test-class-amp-validation-error-taxonomy.php
@@ -5,6 +5,7 @@
  * @package AMP
  */
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\HandleValidation;
 
 /**
@@ -14,6 +15,7 @@ use AmpProject\AmpWP\Tests\HandleValidation;
  */
 class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use HandleValidation;
 
 	/**
@@ -473,20 +475,20 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$error_status = 1;
 		$wp_query->set( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_STATUS_QUERY_VAR, $error_status );
 		$filtered_where = AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query );
-		$this->assertContains( 'SELECT 1', $filtered_where );
-		$this->assertContains( 'INNER JOIN', $filtered_where );
-		$this->assertContains( $wpdb->term_relationships, $filtered_where );
-		$this->assertContains( $wpdb->term_taxonomy, $filtered_where );
-		$this->assertContains( strval( $error_status ), $filtered_where );
+		$this->assertStringContains( 'SELECT 1', $filtered_where );
+		$this->assertStringContains( 'INNER JOIN', $filtered_where );
+		$this->assertStringContains( $wpdb->term_relationships, $filtered_where );
+		$this->assertStringContains( $wpdb->term_taxonomy, $filtered_where );
+		$this->assertStringContains( strval( $error_status ), $filtered_where );
 
 		// Now that there is a query var for error type, that should also appear in the filtered WHERE clause.
 		$error_type         = 'js_error';
 		$escaped_error_type = 'js\\\\_error';
 		$wp_query->set( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_TYPE_QUERY_VAR, $error_type );
 		$filtered_where = AMP_Validation_Error_Taxonomy::filter_posts_where_for_validation_error_status( $initial_where, $wp_query );
-		$this->assertContains( 'SELECT 1', $filtered_where );
-		$this->assertContains( strval( $error_status ), $filtered_where );
-		$this->assertContains( $escaped_error_type, $filtered_where );
+		$this->assertStringContains( 'SELECT 1', $filtered_where );
+		$this->assertStringContains( strval( $error_status ), $filtered_where );
+		$this->assertStringContains( $escaped_error_type, $filtered_where );
 	}
 
 	/**
@@ -703,8 +705,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// Assert that the filter works as expected.
 		$filtered_clauses = apply_filters( $tested_filter, $initial_clauses, $taxonomies );
-		$this->assertContains( $initial_where, $filtered_clauses['where'] );
-		$this->assertContains( 'AND tt.description LIKE', $filtered_clauses['where'] );
+		$this->assertStringContains( $initial_where, $filtered_clauses['where'] );
+		$this->assertStringContains( 'AND tt.description LIKE', $filtered_clauses['where'] );
 
 		// If $taxonomies does not have the AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG, the filter should return the clauses unchanged.
 		$taxonomies = [ 'post_tag' ];
@@ -743,7 +745,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		);
 		ob_start();
 		AMP_Validation_Error_Taxonomy::render_taxonomy_filters( AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG );
-		$this->assertContains( 'New errors <span class="count">(2)</span>', ob_get_clean() );
+		$this->assertStringContains( 'New errors <span class="count">(2)</span>', ob_get_clean() );
 	}
 
 	/**
@@ -760,8 +762,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// When passing the correct taxonomy, this should render the link.
 		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_link_to_invalid_urls_screen' ], [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] );
-		$this->assertContains( 'View Validated URLs', $output );
-		$this->assertContains(
+		$this->assertStringContains( 'View Validated URLs', $output );
+		$this->assertStringContains(
 			add_query_arg(
 				'post_type',
 				AMP_Validated_URL_Post_Type::POST_TYPE_SLUG,
@@ -806,7 +808,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// When there are 10 accepted errors, the <option> element for it should end with (10).
 		$output = get_echo( [ 'AMP_Validation_Error_Taxonomy', 'render_error_status_filter' ] );
-		$this->assertContains(
+		$this->assertStringContains(
 			sprintf(
 				'With new errors <span class="count">(%d)</span>',
 				$number_of_errors
@@ -857,17 +859,17 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		];
 
 		foreach ( $expected_to_contain as $expected ) {
-			$this->assertContains( $expected, $markup );
+			$this->assertStringContains( $expected, $markup );
 		}
 
 		// On the edit-tags.php page, the <option> text should not have 'With', like 'With JS Errors'.
-		$this->assertNotContains( 'With', $markup );
+		$this->assertStringNotContains( 'With', $markup );
 
 		// On the edit.php page (Errors by URL), the <option> text should have 'With', like 'With JS Errors'.
 		set_current_screen( 'edit.php' );
 		ob_start();
 		AMP_Validation_Error_Taxonomy::render_error_type_filter();
-		$this->assertContains( 'With', ob_get_clean() );
+		$this->assertStringContains( 'With', ob_get_clean() );
 	}
 
 	/**
@@ -885,7 +887,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		wp_delete_post( $post_id, true );
 		AMP_Validation_Error_Taxonomy::render_clear_empty_button();
 		$output = ob_get_clean();
-		$this->assertContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_CLEAR_EMPTY_ACTION, $output );
+		$this->assertStringContains( AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_CLEAR_EMPTY_ACTION, $output );
 	}
 
 	/**
@@ -931,8 +933,8 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 
 		// The conditional should be true, so test the preg_replace() call for $clauses['where'].
 		$clauses = AMP_Validation_Error_Taxonomy::filter_terms_clauses_for_description_search( $clauses, [ AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ], $args );
-		$this->assertContains( '(tt.description LIKE ', $clauses['where'] );
-		$this->assertContains( $wpdb->esc_like( $args['search'] ), $clauses['where'] );
+		$this->assertStringContains( '(tt.description LIKE ', $clauses['where'] );
+		$this->assertStringContains( $wpdb->esc_like( $args['search'] ), $clauses['where'] );
 	}
 
 	/**
@@ -995,10 +997,10 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$filtered_actions   = AMP_Validation_Error_Taxonomy::filter_tag_row_actions( $initial_actions, $term_this_taxonomy );
 		$reject_action      = $filtered_actions[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_REJECT_ACTION ];
 		$accept_action      = $filtered_actions[ AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACCEPT_ACTION ];
-		$this->assertContains( strval( $term_this_taxonomy->term_id ), $reject_action );
-		$this->assertContains( strval( $term_this_taxonomy->term_id ), $accept_action );
-		$this->assertContains( 'Keep', $reject_action );
-		$this->assertContains( 'Confirm removed', $accept_action );
+		$this->assertStringContains( strval( $term_this_taxonomy->term_id ), $reject_action );
+		$this->assertStringContains( strval( $term_this_taxonomy->term_id ), $accept_action );
+		$this->assertStringContains( 'Keep', $reject_action );
+		$this->assertStringContains( 'Confirm removed', $accept_action );
 	}
 
 	/**
@@ -1109,27 +1111,27 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		// Test the 'status' block in the switch for the error taxonomy page.
 		$GLOBALS['pagenow'] = 'edit-tags.php';
 		$filtered_content   = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'status', $term_id );
-		$this->assertContains( '<span class="status-text rejected">Kept</span>', $filtered_content );
+		$this->assertStringContains( '<span class="status-text rejected">Kept</span>', $filtered_content );
 
 		// Test the 'status' block switch for the single error page.
 		$GLOBALS['pagenow'] = 'post.php';
 		$filtered_content   = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'status', $term_id );
-		$this->assertContains( '<select class="amp-validation-error-status" id="amp_validation_error_term_status', $filtered_content );
+		$this->assertStringContains( '<select class="amp-validation-error-status" id="amp_validation_error_term_status', $filtered_content );
 
 		// Test the 'created_date_gmt' block in the switch.
 		$date = current_time( 'mysql', true );
 		update_term_meta( $term_id, 'created_date_gmt', $date );
 		$filtered_content = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'created_date_gmt', $term_id );
-		$this->assertContains( '<time datetime=', $filtered_content );
-		$this->assertContains( '<abbr title=', $filtered_content );
+		$this->assertStringContains( '<time datetime=', $filtered_content );
+		$this->assertStringContains( '<abbr title=', $filtered_content );
 
 		// Test the 'details' block in the switch.
 		$filtered_content = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'details', $term_id );
-		$this->assertContains( '<details open class="details-attributes"><summary class="details-attributes__summary"', $filtered_content );
+		$this->assertStringContains( '<details open class="details-attributes"><summary class="details-attributes__summary"', $filtered_content );
 
 		// Test the 'error_type' block in the switch.
 		$filtered_content = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'error_type', $term_id );
-		$this->assertContains( 'CSS', $filtered_content );
+		$this->assertStringContains( 'CSS', $filtered_content );
 	}
 
 	/**
@@ -1193,7 +1195,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$filtered_content   = AMP_Validation_Error_Taxonomy::filter_manage_custom_columns( $initial_content, 'error_code', $term_id );
 
 		$this->assertStringStartsWith( $initial_content . '<button type="button" aria-label="Toggle error details"', $filtered_content );
-		$this->assertContains( $expected_error_message, $filtered_content );
+		$this->assertStringContains( $expected_error_message, $filtered_content );
 	}
 
 	/**
@@ -1235,7 +1237,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 		$validation_error['code'] = AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG;
 		$term                     = self::factory()->term->create_and_get( [ 'taxonomy' => AMP_Validation_Error_Taxonomy::TAXONOMY_SLUG ] );
 		$html                     = AMP_Validation_Error_Taxonomy::render_single_url_error_details( $validation_error, $term );
-		$this->assertContains( '<dl class="detailed">', $html );
+		$this->assertStringContains( '<dl class="detailed">', $html );
 	}
 
 	/**
@@ -1309,7 +1311,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			$e = $exception;
 		}
 
-		$this->assertContains( 'Cannot modify header information', $e->getMessage() );
+		$this->assertStringContains( 'Cannot modify header information', $e->getMessage() );
 		$this->assertEquals( get_term( $error_term->term_id )->term_group, AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_ACCEPTED_STATUS );
 
 		// When the action is to 'reject' the error, this should update the status of the error to 'rejected'.
@@ -1320,7 +1322,7 @@ class Test_AMP_Validation_Error_Taxonomy extends WP_UnitTestCase {
 			$e = $exception;
 		}
 
-		$this->assertContains( 'Cannot modify header information', $e->getMessage() );
+		$this->assertStringContains( 'Cannot modify header information', $e->getMessage() );
 		$this->assertEquals( get_term( $error_term->term_id )->term_group, AMP_Validation_Error_Taxonomy::VALIDATION_ERROR_ACK_REJECTED_STATUS );
 	}
 

--- a/tests/php/validation/test-class-amp-validation-manager.php
+++ b/tests/php/validation/test-class-amp-validation-manager.php
@@ -7,6 +7,7 @@
 
 // phpcs:disable Generic.Formatting.MultipleStatementAlignment.NotSameWarning
 
+use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 use AmpProject\AmpWP\Tests\HandleValidation;
 use AmpProject\AmpWP\Tests\PrivateAccess;
 use AmpProject\Dom\Document;
@@ -19,6 +20,7 @@ use AmpProject\Dom\Document;
  */
 class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
+	use AssertContainsCompatibility;
 	use HandleValidation;
 	use PrivateAccess;
 
@@ -320,7 +322,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
 		$this->assertInternalType( 'object', $node );
-		$this->assertContains( 'action=amp_validate', $node->href );
+		$this->assertStringContains( 'action=amp_validate', $node->href );
 		$this->assertNull( $admin_bar->get_node( 'amp-view' ) );
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
 
@@ -361,7 +363,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::add_admin_bar_menu_items( $admin_bar );
 		$node = $admin_bar->get_node( 'amp' );
 		$this->assertInternalType( 'object', $node );
-		$this->assertContains( 'action=amp_validate', $node->href );
+		$this->assertStringContains( 'action=amp_validate', $node->href );
 		$this->assertNull( $admin_bar->get_node( 'amp-view' ) );
 		$this->assertInternalType( 'object', $admin_bar->get_node( 'amp-validity' ) );
 	}
@@ -749,7 +751,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$post   = self::factory()->post->create_and_get();
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
 
-		$this->assertNotContains( 'notice notice-warning', $output );
+		$this->assertStringNotContains( 'notice notice-warning', $output );
 
 		$validation_errors = [
 			[
@@ -772,14 +774,14 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		// When sanitization is accepted by default.
 		$this->accept_sanitization_by_default( true );
 		$expected_notice_non_accepted_errors = 'There is content which fails AMP validation. You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.';
-		$this->assertContains( 'notice notice-warning', $output );
-		$this->assertContains( '<code>script</code>', $output );
-		$this->assertContains( $expected_notice_non_accepted_errors, $output );
+		$this->assertStringContains( 'notice notice-warning', $output );
+		$this->assertStringContains( '<code>script</code>', $output );
+		$this->assertStringContains( $expected_notice_non_accepted_errors, $output );
 
 		// When auto-accepting validation errors, if there are unaccepted validation errors, there should be a notice because this will block serving an AMP document.
 		add_theme_support( AMP_Theme_Support::SLUG );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
-		$this->assertContains( 'There is content which fails AMP validation. You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.', $output );
+		$this->assertStringContains( 'There is content which fails AMP validation. You will have to remove the invalid markup (or allow the plugin to remove it) to serve AMP.', $output );
 
 		/*
 		 * When there are 'Rejected' or 'New Rejected' errors, there should be a message that explains that this will serve a non-AMP URL.
@@ -791,7 +793,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validated_URL_Post_Type::store_validation_errors( $validation_errors, get_permalink( $post->ID ) );
 		$this->accept_sanitization_by_default( false );
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_edit_form_validation_status' ], [ $post ] );
-		$this->assertContains( $expected_notice_non_accepted_errors, $output );
+		$this->assertStringContains( $expected_notice_non_accepted_errors, $output );
 	}
 
 	/**
@@ -1444,24 +1446,24 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_function_callback );
 		$output = ob_get_clean();
-		$this->assertContains( '<div class="notice notice-error">', $output );
-		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
-		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( '<div class="notice notice-error">', $output );
+		$this->assertStringContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
 
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_no_argument );
 		$output = ob_get_clean();
-		$this->assertContains( '<div></div>', $output );
-		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
-		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( '<div></div>', $output );
+		$this->assertStringContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
 
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_one_argument, $notice );
 		$output = ob_get_clean();
-		$this->assertContains( $notice, $output );
-		$this->assertContains( sprintf( '<div class="notice notice-warning"><p>%s</p></div>', $notice ), $output );
-		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
-		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( $notice, $output );
+		$this->assertStringContains( sprintf( '<div class="notice notice-warning"><p>%s</p></div>', $notice ), $output );
+		$this->assertStringContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
 
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_two_arguments, $notice, get_the_ID() );
@@ -1469,30 +1471,30 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Theme_Support::start_output_buffering();
 		self::output_message( $notice, get_the_ID() );
 		$expected_output = ob_get_clean();
-		$this->assertContains( $expected_output, $output );
-		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
-		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( $expected_output, $output );
+		$this->assertStringContains( '<!--amp-source-stack {"type":"plugin","name":"amp"', $output );
+		$this->assertStringContains( '<!--/amp-source-stack {"type":"plugin","name":"amp"', $output );
 
 		// This action's callback doesn't output any HTML tags, so no HTML should be present.
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_no_tag_output );
 		$output = ob_get_clean();
-		$this->assertNotContains( '<!--amp-source-stack ', $output );
-		$this->assertNotContains( '<!--/amp-source-stack ', $output );
+		$this->assertStringNotContains( '<!--amp-source-stack ', $output );
+		$this->assertStringNotContains( '<!--/amp-source-stack ', $output );
 
 		// This action's callback comes from core.
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_core_output );
 		$output = ob_get_clean();
-		$this->assertContains( '<!--amp-source-stack {"type":"core","name":"wp-includes"', $output );
-		$this->assertContains( '<!--/amp-source-stack {"type":"core","name":"wp-includes"', $output );
+		$this->assertStringContains( '<!--amp-source-stack {"type":"core","name":"wp-includes"', $output );
+		$this->assertStringContains( '<!--/amp-source-stack {"type":"core","name":"wp-includes"', $output );
 
 		// This action's callback doesn't echo any markup, so it shouldn't be wrapped in comments.
 		AMP_Theme_Support::start_output_buffering();
 		do_action( $action_no_output );
 		$output = ob_get_clean();
-		$this->assertNotContains( '<!--amp-source-stack ', $output );
-		$this->assertNotContains( '<!--/amp-source-stack ', $output );
+		$this->assertStringNotContains( '<!--amp-source-stack ', $output );
+		$this->assertStringNotContains( '<!--/amp-source-stack ', $output );
 
 		$handle_inner_action = null;
 		$handle_outer_action = null;
@@ -1874,9 +1876,9 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertInstanceOf( '\\AMP_Validation_Callback_Wrapper', $wrapped_callback );
-		$this->assertContains( $test_string, $output );
-		$this->assertContains( '<!--amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
-		$this->assertContains( '<!--/amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
+		$this->assertStringContains( $test_string, $output );
+		$this->assertStringContains( '<!--amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
+		$this->assertStringContains( '<!--/amp-source-stack {"type":"plugin","name":"amp","hook":"bar"}', $output );
 
 		$action_callback = [
 			'function'      => [ $this, 'get_string' ],
@@ -1916,11 +1918,11 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 		AMP_Validation_Manager::$hook_source_stack[] = $latest_source;
 
 		$wrapped_content = AMP_Validation_Manager::wrap_buffer_with_source_comments( $initial_content );
-		$this->assertContains( $initial_content, $wrapped_content );
-		$this->assertContains( '<!--amp-source-stack', $wrapped_content );
-		$this->assertContains( '<!--/amp-source-stack', $wrapped_content );
-		$this->assertContains( wp_json_encode( $latest_source ), $wrapped_content );
-		$this->assertNotContains( wp_json_encode( $earliest_source ), $wrapped_content );
+		$this->assertStringContains( $initial_content, $wrapped_content );
+		$this->assertStringContains( '<!--amp-source-stack', $wrapped_content );
+		$this->assertStringContains( '<!--/amp-source-stack', $wrapped_content );
+		$this->assertStringContains( wp_json_encode( $latest_source ), $wrapped_content );
+		$this->assertStringNotContains( wp_json_encode( $earliest_source ), $wrapped_content );
 	}
 
 	/**
@@ -2013,7 +2015,7 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 
 		AMP_Validation_Manager::remove_illegal_source_stack_comments( $dom );
 
-		$this->assertNotContains( 'amp-source-stack', $dom->saveHTML() );
+		$this->assertStringNotContains( 'amp-source-stack', $dom->saveHTML() );
 		$this->assertEquals( '{"foo":"bar <b>foo<\/b>"}', $dom->getElementById( 'first' )->textContent );
 		$this->assertEquals( 'body { color: blue; }body { color: red; }body { color: white; }', $dom->getElementById( 'second' )->textContent );
 		$this->assertEquals( '/* start custom scripts! */document.write("hello!")/* end custom scripts! */', $dom->getElementById( 'third' )->textContent );
@@ -2233,10 +2235,10 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			]
 		);
 		$output = get_echo( [ 'AMP_Validation_Manager', 'print_plugin_notice' ] );
-		$this->assertContains( 'Warning: The following plugin may be incompatible with AMP', $output );
-		$this->assertContains( 'Foo Bar', $output );
-		$this->assertContains( 'More details', $output );
-		$this->assertContains( admin_url( 'edit.php' ), $output );
+		$this->assertStringContains( 'Warning: The following plugin may be incompatible with AMP', $output );
+		$this->assertStringContains( 'Foo Bar', $output );
+		$this->assertStringContains( 'More details', $output );
+		$this->assertStringContains( admin_url( 'edit.php' ), $output );
 
 		if ( $cache_plugins_backup ) {
 			wp_cache_set( 'plugins', $cache_plugins_backup, 'plugins' );
@@ -2274,12 +2276,12 @@ class Test_AMP_Validation_Manager extends WP_UnitTestCase {
 			'wp-polyfill',
 		];
 
-		$this->assertContains( 'js/amp-block-validation.js', $script->src );
+		$this->assertStringContains( 'js/amp-block-validation.js', $script->src );
 		$this->assertEqualSets( $expected_dependencies, $script->deps );
 		$this->assertContains( $slug, wp_scripts()->queue );
 
 		$style = wp_styles()->registered[ $slug ];
-		$this->assertContains( 'css/amp-block-validation-compiled.css', $style->src );
+		$this->assertStringContains( 'css/amp-block-validation-compiled.css', $style->src );
 		$this->assertEquals( AMP__VERSION, $style->ver );
 		$this->assertContains( $slug, wp_styles()->queue );
 	}


### PR DESCRIPTION
## Summary

With PHPUnit 7+, using `assertContains()` to do substring matching is deprecated, and will not be supported anymore from PHPUnit 9 onwards.

To avoid throwing deprecation notices or even stop working, this PR:
- introduces the `AmpProject\AmpWP\Tests\AssertContainsCompatibility` trait with two methods: `assertStringContains()` & `assertStringNotContains()`;
- makes use of the above two methods in all of the tests that use `assertContains` for substring matching.

Note: I've opted to use camelCase-naming for these methods so they more naturally fit within other PHPUnit asserts. This required ignoring the function/method-naming PHPCS naming rule.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).