### PR TITLE
Prevent tree-shaking selectors for  amp-x-* attributes when amp-experiment is used

### DIFF
--- a/includes/sanitizers/class-amp-style-sanitizer.php
+++ b/includes/sanitizers/class-amp-style-sanitizer.php
@@ -766,6 +766,14 @@ class AMP_Style_Sanitizer extends AMP_Base_Sanitizer {
 				continue;
 			}
 
+			// Attributes for amp-experiment begin with 'amp-x-', see <https://amp.dev/documentation/examples/components/amp-experiment/>.
+			if ( 'amp-x-' === substr( $attribute_name, 0, 6 ) ) {
+				if ( ! $this->has_used_tag_names( [ 'amp-experiment' ] ) ) {
+					return false;
+				}
+				continue;
+			}
+
 			if ( ! $this->used_attributes[ $attribute_name ] ) {
 				return false;
 			}

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -581,6 +581,52 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				[],
 				[],
 			],
+			'amp_experiment' => [
+				'
+					<html amp>
+					<head>
+						<style>
+							body[amp-x-button-color-experiment="0"] .button-color-experiment {
+								color: red;
+							}
+						</style>
+						<style>
+							body[amp-x-button-color-experiment="1"] .button-color-experiment {
+								color: green;
+							}
+						</style>
+						<style>
+							body[amp-x-button-color-experiment="2"] .button-color-experiment {
+								color: blue;
+							}
+						</style>
+					</head>
+					<body>
+						<amp-experiment>
+							<script type="application/json">
+								{
+									"button-color-experiment": {
+										"variants": {
+											"0": 30,
+											"1": 30,
+											"2": 30
+										}
+									}
+								}
+							</script>
+						</amp-experiment>
+
+						<button class="button-color-experiment">Click here</button>
+					</body>
+					</html>
+				',
+				[
+					'body[amp-x-button-color-experiment="0"] .button-color-experiment{color:red}',
+					'body[amp-x-button-color-experiment="1"] .button-color-experiment{color:green}',
+					'body[amp-x-button-color-experiment="2"] .button-color-experiment{color:blue}',
+				],
+				[],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Fixes #4437

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
