### PR TITLE
Omit node_type from validation error details

### DIFF
--- a/includes/validation/class-amp-validation-error-taxonomy.php
+++ b/includes/validation/class-amp-validation-error-taxonomy.php
@@ -2171,7 +2171,7 @@ class AMP_Validation_Error_Taxonomy {
 				if ( in_array( $key, [ 'code', 'type', 'css_property_value', 'mandatory_anyof_attrs', 'meta_property_value', 'meta_property_required_value', 'mandatory_oneof_attrs' ], true ) ) {
 					continue; // Handled above.
 				}
-				if ( in_array( $key, [ 'spec_name', 'tag_spec', 'spec_names' ], true ) ) {
+				if ( in_array( $key, [ 'spec_name', 'tag_spec', 'spec_names', 'node_type' ], true ) ) {
 					continue;
 				}
 				?>


### PR DESCRIPTION
## Summary

Fixes regression introduced in #4449.

### Before

<img width="1190" alt="Screen Shot 2020-03-30 at 11 55 23" src="https://user-images.githubusercontent.com/134745/77950562-89681680-727d-11ea-971d-28f0e0c94816.png">

### After

<img width="1185" alt="Screen Shot 2020-03-30 at 11 55 44" src="https://user-images.githubusercontent.com/134745/77950586-8f5df780-727d-11ea-93e6-0ba929e0a1ac.png">

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [ ] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
