### PR TITLE
Only use LIBXML_HTML_NODEFDTD is available

### DIFF
--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -390,6 +390,17 @@ final class Document extends DOMDocument
 
         $libxml_previous_state = libxml_use_internal_errors(true);
 
+        $options |= LIBXML_COMPACT;
+
+        /*
+         * LIBXML_HTML_NODEFDTD is only available for libxml 2.7.8+.
+         * This should be the case for PHP 5.4+, but some systems seem to compile against a custom libxml version that
+         * is lower than expected.
+         */
+        if (defined('LIBXML_HTML_NODEFDTD')) {
+            $options |= constant('LIBXML_HTML_NODEFDTD');
+        }
+
         $success = parent::loadHTML($source, $options | LIBXML_COMPACT | LIBXML_HTML_NODEFDTD);
 
         libxml_clear_errors();

--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -401,7 +401,7 @@ final class Document extends DOMDocument
             $options |= constant('LIBXML_HTML_NODEFDTD');
         }
 
-        $success = parent::loadHTML($source, $options | LIBXML_COMPACT | LIBXML_HTML_NODEFDTD);
+        $success = parent::loadHTML($source, $options);
 
         libxml_clear_errors();
         libxml_use_internal_errors($libxml_previous_state);


### PR DESCRIPTION
## Summary

This PR adds a conditional wrapper around the use of `LIBXML_HTML_NODEFDTD` to ensure it is only being used when available.

However, while teting, I couldn't make a single test case fail when just omitting the constant altogether. I assume that through the extensive use of normalization, we ended up not needing this constant at all in the current form of the `Dom\Document` abstraction.

Fixes #4485

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).