### PR TITLE
Only move meta tags to the head when required and add processing for meta[http-equiv]

### DIFF
--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -87,7 +87,7 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 				array_filter(
 					AMP_Allowed_Tags_Generated::get_allowed_tag( 'meta' ),
 					static function ( $spec ) {
-						return isset( $spec['tag_spec']['spec_name'] ) && 'meta name= and content=' === $spec['tag_spec']['spec_name'];
+						return isset( $spec['tag_spec']['spec_name'] ) && self::BODY_ANCESTOR_META_TAG_SPEC_NAME === $spec['tag_spec']['spec_name'];
 					}
 				)
 			);

--- a/includes/sanitizers/class-amp-meta-sanitizer.php
+++ b/includes/sanitizers/class-amp-meta-sanitizer.php
@@ -34,6 +34,7 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 	 * Tags array keys.
 	 */
 	const TAG_CHARSET        = 'charset';
+	const TAG_HTTP_EQUIV     = 'http-equiv';
 	const TAG_VIEWPORT       = 'viewport';
 	const TAG_AMP_SCRIPT_SRC = 'amp_script_src';
 	const TAG_OTHER          = 'other';
@@ -54,6 +55,7 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 	 */
 	protected $meta_tags = [
 		self::TAG_CHARSET        => [],
+		self::TAG_HTTP_EQUIV     => [],
 		self::TAG_VIEWPORT       => [],
 		self::TAG_AMP_SCRIPT_SRC => [],
 		self::TAG_OTHER          => [],
@@ -119,6 +121,8 @@ class AMP_Meta_Sanitizer extends AMP_Base_Sanitizer {
 			 */
 			if ( $meta_element->hasAttribute( Attribute::CHARSET ) ) {
 				$this->meta_tags[ self::TAG_CHARSET ][] = $meta_element->parentNode->removeChild( $meta_element );
+			} elseif ( $meta_element->hasAttribute( Attribute::HTTP_EQUIV ) ) {
+				$this->meta_tags[ self::TAG_HTTP_EQUIV ][] = $meta_element->parentNode->removeChild( $meta_element );
 			} elseif ( Attribute::VIEWPORT === $meta_element->getAttribute( Attribute::NAME ) ) {
 				$this->meta_tags[ self::TAG_VIEWPORT ][] = $meta_element->parentNode->removeChild( $meta_element );
 			} elseif ( Attribute::AMP_SCRIPT_SRC === $meta_element->getAttribute( Attribute::NAME ) ) {

--- a/tests/php/test-class-amp-meta-sanitizer.php
+++ b/tests/php/test-class-amp-meta-sanitizer.php
@@ -65,6 +65,11 @@ class Test_AMP_Meta_Sanitizer extends WP_UnitTestCase {
 				'<!DOCTYPE html><html><head><meta name="amp-script-src" content="' . esc_attr( $script1_hash ) . '"><meta charset="utf-8"><meta name="amp-script-src" content="' . esc_attr( $script2_hash ) . '"><meta name="viewport" content="width=device-width"><meta name="amp-script-src" content="' . esc_attr( $script3_hash ) . '">' . $amp_boilerplate . '</head><body><meta name="amp-script-src" content="' . esc_attr( $script4_hash ) . '"></body></html>',
 				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="amp-script-src" content="' . esc_attr( $script1_hash ) . ' ' . esc_attr( $script2_hash ) . ' ' . esc_attr( $script3_hash ) . ' ' . esc_attr( $script4_hash ) . '">' . $amp_boilerplate . '</head><body></body></html>',
 			],
+
+			'Ignore generic meta tags'                    => [
+				'<!DOCTYPE html><html><head>' . $amp_boilerplate . '</head><body><meta itemprop="datePublished" content="2020-03-24T18:05:15+05:30"><meta itemprop="width" content="1280"><meta itemprop="height" content="720"></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">' . $amp_boilerplate . '</head><body><meta itemprop="datePublished" content="2020-03-24T18:05:15+05:30"><meta itemprop="width" content="1280"><meta itemprop="height" content="720"></body></html>',
+			],
 		];
 	}
 

--- a/tests/php/test-class-amp-meta-sanitizer.php
+++ b/tests/php/test-class-amp-meta-sanitizer.php
@@ -155,7 +155,10 @@ class Test_AMP_Meta_Sanitizer extends WP_UnitTestCase {
 		$sanitizer = new AMP_Meta_Sanitizer( $dom );
 		$sanitizer->sanitize();
 
-		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer( $dom );
+		$sanitizer = new AMP_Tag_And_Attribute_Sanitizer(
+			$dom,
+			[ 'use_document_element' => true ]
+		);
 		$sanitizer->sanitize();
 
 		$this->assertEqualMarkup( $expected_content, $dom->saveHTML() );

--- a/tests/php/test-class-amp-meta-sanitizer.php
+++ b/tests/php/test-class-amp-meta-sanitizer.php
@@ -98,6 +98,11 @@ class Test_AMP_Meta_Sanitizer extends WP_UnitTestCase {
 				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><meta name="amp-script-src" content="' . esc_attr( $script1_hash ) . ' ' . esc_attr( $script2_hash ) . ' ' . esc_attr( $script3_hash ) . ' ' . esc_attr( $script4_hash ) . '">' . $amp_boilerplate . '</head><body></body></html>',
 			],
 
+			'Make sure http-equiv meta tags are moved'    => [
+				'<!DOCTYPE html><html><head><meta charset="utf-8">' . $amp_boilerplate . '</head><body><meta http-equiv="imagetoolbar" content="false"></body></html>',
+				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta http-equiv="imagetoolbar" content="false"><meta name="viewport" content="width=device-width">' . $amp_boilerplate . '</head><body></body></html>',
+			],
+
 			'Ignore generic meta tags'                    => [
 				'<!DOCTYPE html><html><head>' . $amp_boilerplate . '</head><body>' . $html5_microdata . '</body></html>',
 				'<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width">' . $amp_boilerplate . '</head><body>' . $html5_microdata . '</body></html>',

--- a/tests/php/test-class-amp-meta-sanitizer.php
+++ b/tests/php/test-class-amp-meta-sanitizer.php
@@ -58,6 +58,8 @@ class Test_AMP_Meta_Sanitizer extends WP_UnitTestCase {
 			</div>
 			<meta id="foo">
 			<meta name="greeting" content="Hello!">
+			<meta name="keywords" content="Meta Tags, Metadata" scheme="ISBN">
+			<meta content="This is a basic text" property="og:title">
 		';
 
 		return [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -2975,6 +2975,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				null,
 				[ 'amp-subscriptions' ],
 			],
+			'bad http-equiv meta tag'                 => [
+				'<html><head><meta charset="utf-8"><meta http-equiv="Content-Script-Type" content="text/vbscript"></head><body></body></html>',
+				'<html><head><meta charset="utf-8"><meta content="text/vbscript"></head><body></body></html>',
+				[],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_ATTR ],
+			],
 		];
 
 		$bad_dev_mode_document = sprintf(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR addresses. -->
Fixes #4502.

* Only move `meta` tags to the `head` when they are required to be moved; allow other tags to be in the `body` (in particular HTML5 Microdata tags).
* Add explicit recognition for `meta[http-equiv]` tags.
* Add tests for all discretely-recognized `meta` tags.
* Add tests to assert the contents of the validator spec to catch unexpected changes.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
