### PR TITLE
Cast i-amphtml-intrinsic-sizer dimensions to integers to prevent AMP validation errors

### DIFF
--- a/lib/optimizer/src/Transformer/ServerSideRendering.php
+++ b/lib/optimizer/src/Transformer/ServerSideRendering.php
@@ -526,7 +526,15 @@ final class ServerSideRendering implements Transformer
         $sizer_img->setAttribute(Attribute::ARIA_HIDDEN, 'true');
         $sizer_img->setAttribute(Attribute::CLASS_, Amp::INTRINSIC_SIZER_ELEMENT);
         $sizer_img->setAttribute(Attribute::ROLE, 'presentation');
-        $sizer_img->setAttribute(Attribute::SRC, "data:image/svg+xml;charset=utf-8,<svg height=&quot;{$height->getNumeral()}&quot; width=&quot;{$width->getNumeral()}&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>");
+
+        // Temporarily cast decimal dimensions to integers. Can be reverted when/if the AMP Validator allows decimals.
+        // Note that the floor value is used because two elements with width=99.5 in a container 199px-wide will not fit
+        // on the same line if rounding is used.
+        // @todo Revisit after <https://github.com/ampproject/amphtml/issues/27528>.
+        $height_int = (int) $height->getNumeral();
+        $width_int  = (int) $width->getNumeral();
+
+        $sizer_img->setAttribute(Attribute::SRC, "data:image/svg+xml;charset=utf-8,<svg height=&quot;{$height_int}&quot; width=&quot;{$width_int}&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>");
 
         $sizer->appendChild($sizer_img);
 

--- a/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
+++ b/lib/optimizer/tests/Transformer/ServerSideRenderingTest.php
@@ -161,6 +161,18 @@ final class ServerSideRenderingTest extends TestCase
                 $expectWithBoilerplate('<amp-img height="300" layout="responsive" sizes="(min-width: 320px) 320px, 100vw" src="https://acme.org/image1.png" width="400" class="i-amphtml-layout-responsive i-amphtml-layout-size-defined" i-amphtml-layout="responsive"><i-amphtml-sizer style="display:block;padding-top:75.0000%;"></i-amphtml-sizer></amp-img>'),
                 [Error\CannotRemoveBoilerplate::class],
             ],
+
+            // @todo Remove floor when ampproject/amphtml#27528 is resolved.
+            'decimal dimensions intrinsic closer to floor' => [
+                $input('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic"></amp-img>'),
+                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.2" width="200.4" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;100&quot; width=&quot;200&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>"></i-amphtml-sizer></amp-img>'),
+            ],
+
+            // @todo Remove floor when ampproject/amphtml#27528 is resolved.
+            'decimal dimensions intrinsic closer to ceiling' => [
+                $input('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic"></amp-img>'),
+                $expectWithoutBoilerplate('<amp-img src="https://blog.amp.dev/wp-content/uploads/2020/03/AMP_camp_Blog.png" alt="" height="100.6" width="200.8" layout="intrinsic" class="i-amphtml-layout-intrinsic i-amphtml-layout-size-defined" i-amphtml-layout="intrinsic"><i-amphtml-sizer class="i-amphtml-sizer"><img alt="" aria-hidden="true" class="i-amphtml-intrinsic-sizer" role="presentation" src="data:image/svg+xml;charset=utf-8,<svg height=&quot;100&quot; width=&quot;200&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; version=&quot;1.1&quot;/>"></i-amphtml-sizer></amp-img>'),
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary

Until https://github.com/ampproject/amphtml/issues/27528 is resolved, decimal dimensions are not valid in the `i-amphtml-intrinsic-sizer` element. The quick fix to prevent requiring users to disable the Optimizer is to cast the dimensions to integers.

Note that casting to integers (aka flooring or rounding down) is being done to prevent a situation where two elements `99.5px`-wide are displayed inline inside of a container that is `199px` wide. If rounding were performed, then the two elements would no longer fit on the same line. This is worse than the alternative when rounding down, which is the presence of a 1px gap.

Note that browsers support sub-pixel rendering, so decimal dimensions are not rounded (at least in Chrome, Safari, and Firefox): https://codepen.io/westonruter/pen/abOxNaq

Fixes #4493

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
