### PR TITLE
Account for more YouTube URL formats

### DIFF
--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -83,7 +83,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	public function filter_embed_oembed_html( $cache, $url ) {
 		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( ! in_array( $host, [ 'youtu.be', 'youtube.com', 'www.youtube.com' ], true ) ) {
+		if ( ! in_array( $host, [ 'youtu.be', 'youtube.com', 'www.youtube.com', 'youtube-nocookie.com', 'www.youtube-nocookie.com' ], true ) ) {
 			return $cache;
 		}
 

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -187,7 +187,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 
 		if ( isset( $parsed_url['path'] ) ) {
 			$segments = explode( '/', trim( $parsed_url['path'], '/' ) );
-			if ( 1 === count( $segments ) ) {
+			if ( 1 === count( $segments ) && ! in_array( $segments[0], [ 'playlist', 'account' ], true ) ) {
 				return $segments[0]; // e.g. https://youtu.be/XOY3ZUO6P0k.
 			} elseif ( count( $segments ) > 1 ) {
 				if ( in_array( $segments[0], [ 'embed', 'v', 'e', 'vi' ], true ) ) {

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -183,7 +183,13 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 */
 	private function get_video_id_from_url( $url ) {
 		$parsed_url = wp_parse_url( $url );
-		if ( ! isset( $parsed_url['host'] ) || ! in_array( $parsed_url['host'], [ 'youtu.be', 'youtube.com', 'www.youtube.com', 'youtube-nocookie.com', 'www.youtube-nocookie.com' ], true ) ) {
+
+		if ( ! isset( $parsed_url['host'] ) ) {
+			return false;
+		}
+
+		$domain = implode( '.', array_slice( explode( '.', $parsed_url['host'] ), -2 ) );
+		if ( ! in_array( $domain, [ 'youtu.be', 'youtube.com', 'youtube-nocookie.com' ], true ) ) {
 			return false;
 		}
 

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -174,7 +174,7 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return integer|false Video ID, or false if none could be retrieved.
 	 */
 	private function get_video_id_from_url( $url ) {
-		if ( preg_match( '/(?:watch\?v=|embed\/|youtu.be\/)(?P<id>\w*)/', $url, $match ) ) {
+		if ( preg_match( '/(?:watch\?v=|embed\/|youtu.be\/)(?P<id>[\w_-]*)/', $url, $match ) ) {
 			return $match['id'];
 		}
 

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -12,9 +12,22 @@
  */
 class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 
-	// Only handling single videos. Playlists are handled elsewhere.
+	/**
+	 * URL pattern to match YouTube videos.
+	 *
+	 * Only handling single videos. Playlists are handled elsewhere.
+	 *
+	 * @deprecated No longer used.
+	 * @var string
+	 */
 	const URL_PATTERN = '#https?://(?:www\.)?(?:youtube.com/(?:v/|e/|embed/|watch[/\#?])|youtu\.be/).*#i';
-	const RATIO       = 0.5625;
+
+	/**
+	 * Ratio for calculating the default height from the content width.
+	 *
+	 * @param float
+	 */
+	const RATIO = 0.5625;
 
 	/**
 	 * Default width.

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -82,11 +82,6 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * @return string Embed.
 	 */
 	public function filter_embed_oembed_html( $cache, $url ) {
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( ! in_array( $host, [ 'youtu.be', 'youtube.com', 'www.youtube.com', 'youtube-nocookie.com', 'www.youtube-nocookie.com' ], true ) ) {
-			return $cache;
-		}
-
 		$id = $this->get_video_id_from_url( $url );
 		if ( ! $id ) {
 			return $cache;

--- a/includes/embeds/class-amp-youtube-embed-handler.php
+++ b/includes/embeds/class-amp-youtube-embed-handler.php
@@ -184,10 +184,14 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 	 * Determine the video ID from the URL.
 	 *
 	 * @param string $url URL.
-	 * @return integer|false Video ID, or false if none could be retrieved.
+	 * @return int|false Video ID, or false if none could be retrieved.
 	 */
 	private function get_video_id_from_url( $url ) {
 		$parsed_url = wp_parse_url( $url );
+		if ( ! isset( $parsed_url['host'] ) || ! in_array( $parsed_url['host'], [ 'youtu.be', 'youtube.com', 'www.youtube.com', 'youtube-nocookie.com', 'www.youtube-nocookie.com' ], true ) ) {
+			return false;
+		}
+
 		$query_vars = [];
 		if ( isset( $parsed_url['query'] ) ) {
 			wp_parse_str( $parsed_url['query'], $query_vars );
@@ -226,15 +230,11 @@ class AMP_YouTube_Embed_Handler extends AMP_Base_Embed_Handler {
 		if ( ! isset( $attr['src'] ) ) {
 			return $html;
 		}
-		$src             = $attr['src'];
-		$youtube_pattern = '#^https?://(?:www\.)?(?:youtube\.com/watch|youtu\.be/)#';
-		if ( 1 !== preg_match( $youtube_pattern, $src ) ) {
+		$video_id = $this->get_video_id_from_url( $attr['src'] );
+		if ( ! $video_id ) {
 			return $html;
 		}
 
-		$url      = ltrim( $src, '=' );
-		$video_id = $this->get_video_id_from_url( $url );
-
-		return $this->render( compact( 'video_id' ), $url );
+		return $this->render( compact( 'video_id' ), $attr['src'] );
 	}
 }

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -253,6 +253,18 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'//www.youtube-nocookie.com/embed/XOY3ZUO6P0k?rel=0',
 				'XOY3ZUO6P0k',
 			],
+			'account_url'                      => [
+				'https://www.youtube.com/account',
+				false,
+			],
+			'account_url_followed_by_segment'  => [
+				'https://www.youtube.com/account/johnsmith',
+				false,
+			],
+			'playlist_url'                     => [
+				'https://www.youtube.com/playlist?list=PLCra4VPr-3frJzAd-lVYo3-34wu0Eax_u',
+				false,
+			],
 			'false_because_no_id'              => [
 				'http://youtube.com/?wrong=XOY3ZUO6P0k',
 				false,

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -214,12 +214,40 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'CMrv_D78oxY',
 			],
 			'url_with_hyphen'                  => [
-				'https://www.youtube.com/watch?v=xo68-iWaKv8' . PHP_EOL,
+				'https://www.youtube.com/watch?v=xo68-iWaKv8',
 				'xo68-iWaKv8',
 			],
 			'url_with_hyphen_and_query_string' => [
-				'https://www.youtube.com/watch?v=xo68-iWaKv8&w=800&h=400' . PHP_EOL,
+				'https://www.youtube.com/watch?v=xo68-iWaKv8&w=800&h=400',
 				'xo68-iWaKv8',
+			],
+			'url_with_hyphen_and_query_string_dimensions_before_id' => [
+				'https://www.youtube.com/watch?w=800&h=400&v=xo68-iWaKv8',
+				'xo68-iWaKv8',
+			],
+			'embed_url'                        => [
+				'http://www.youtube.com/embed/XOY3ZUO6P0k?rel=0',
+				'XOY3ZUO6P0k',
+			],
+			'v_segment_url'                    => [
+				'http://youtube.com/v/XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'e_segment_url'                    => [
+				'http://youtube.com/e/XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'vi_segment_url'                   => [
+				'http://youtube.com/vi/XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'vi_query_param_url'               => [
+				'http://youtube.com/?vi=XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'false_because_no_id'              => [
+				'http://youtube.com/?wrong=XOY3ZUO6P0k',
+				false,
 			],
 		];
 	}
@@ -230,8 +258,8 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	 * @dataProvider get_video_id_data
 	 * @covers AMP_YouTube_Embed_Handler::get_video_id_from_url()
 	 *
-	 * @param string $url      The URL to test.
-	 * @param string $expected The expected result.
+	 * @param string       $url      The URL to test.
+	 * @param string|false $expected The expected result.
 	 * @throws ReflectionException If a reflection of the object is not possible.
 	 */
 	public function test_get_video_id_from_url( $url, $expected ) {

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -7,6 +7,7 @@
  */
 
 use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
+use AmpProject\AmpWP\Tests\PrivateAccess;
 
 /**
  * Tests for AMP_YouTube_Embed_Handler.
@@ -16,6 +17,7 @@ use AmpProject\AmpWP\Tests\AssertContainsCompatibility;
 class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 
 	use AssertContainsCompatibility;
+	use PrivateAccess;
 
 	protected $youtube_video_id = 'kfVsfOSbJY0';
 
@@ -157,30 +159,6 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="500" height="281"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0&amp;hl=en&amp;fs=1&amp;w=425&amp;h=349"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
 			],
 
-			'url_with_underscore'              => [
-				'https://www.youtube.com/watch?v=CMrv_D78oxY' . PHP_EOL,
-				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281"><a placeholder href="https://www.youtube.com/watch?v=CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
-			],
-
-			'short_url_with_underscore'        => [
-				'https://youtu.be/CMrv_D78oxY' . PHP_EOL,
-				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://youtu.be/CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281"><a placeholder href="https://youtu.be/CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
-			],
-
-			'url_with_hyphen'                  => [
-				'https://www.youtube.com/watch?v=xo68-iWaKv8' . PHP_EOL,
-				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
-			],
-
-			'url_with_hyphen_and_query_string' => [
-				'https://www.youtube.com/watch?v=xo68-iWaKv8&w=800&h=400' . PHP_EOL,
-				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8&amp;w=800&amp;h=400"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
-				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8&amp;w=800&amp;h=400"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
-			],
-
 			// Several reports of invalid URLs that have multiple `?` in the URL.
 			'url_with_querystring_and_extra_?' => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0?hl=en&fs=1&w=425&h=349' . PHP_EOL,
@@ -210,6 +188,57 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 		} else {
 			$this->assertEquals( $expected, $filtered_content );
 		}
+	}
+
+	/**
+	 * Gets the test data for test_get_video_id_from_url().
+	 *
+	 * @return array The test data.
+	 */
+	public function get_url_id_data() {
+		return [
+			'basic_url'                        => [
+				'https://www.youtube.com/watch?v=XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'short_url'                        => [
+				'https://youtu.be/XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'url_with_underscore'              => [
+				'https://www.youtube.com/watch?v=CMrv_D78oxY',
+				'CMrv_D78oxY',
+			],
+			'short_url_with_underscore'        => [
+				'https://youtu.be/CMrv_D78oxY',
+				'CMrv_D78oxY',
+			],
+			'url_with_hyphen'                  => [
+				'https://www.youtube.com/watch?v=xo68-iWaKv8' . PHP_EOL,
+				'xo68-iWaKv8',
+			],
+			'url_with_hyphen_and_query_string' => [
+				'https://www.youtube.com/watch?v=xo68-iWaKv8&w=800&h=400' . PHP_EOL,
+				'xo68-iWaKv8',
+			],
+		];
+	}
+
+	/**
+	 * Tests get_video_id_from_url.
+	 *
+	 * @dataProvider get_url_id_data
+	 * @covers AMP_YouTube_Embed_Handler::get_video_id_from_url()
+	 *
+	 * @param string $url The URL to test.
+	 * @param string $expected The expected result.
+	 * @throws ReflectionException If a reflection of the object is not possible.
+	 */
+	public function test_get_video_id_from_url( $url, $expected ) {
+		$this->assertEquals(
+			$expected,
+			$this->call_private_method( $this->handler, 'get_video_id_from_url', [ $url ] )
+		);
 	}
 
 	public function get_scripts_data() {

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -226,6 +226,10 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'xo68-iWaKv8',
 			],
 			'embed_url'                        => [
+				'http://www.youtube.com/embed/XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
+			'embed_url_ending_in_query_param'  => [
 				'http://www.youtube.com/embed/XOY3ZUO6P0k?rel=0',
 				'XOY3ZUO6P0k',
 			],

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -249,6 +249,10 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'http://youtube.com/?vi=XOY3ZUO6P0k',
 				'XOY3ZUO6P0k',
 			],
+			'nocookie_url'                     => [
+				'//www.youtube-nocookie.com/embed/XOY3ZUO6P0k?rel=0',
+				'XOY3ZUO6P0k',
+			],
 			'false_because_no_id'              => [
 				'http://youtube.com/?wrong=XOY3ZUO6P0k',
 				false,

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -230,7 +230,7 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	 * @dataProvider get_url_id_data
 	 * @covers AMP_YouTube_Embed_Handler::get_video_id_from_url()
 	 *
-	 * @param string $url The URL to test.
+	 * @param string $url      The URL to test.
 	 * @param string $expected The expected result.
 	 * @throws ReflectionException If a reflection of the object is not possible.
 	 */

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -201,6 +201,10 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'https://www.youtube.com/watch?v=XOY3ZUO6P0k',
 				'XOY3ZUO6P0k',
 			],
+			'mobile_url'                       => [
+				'https://m.youtube.com/watch?v=XOY3ZUO6P0k',
+				'XOY3ZUO6P0k',
+			],
 			'short_url'                        => [
 				'https://youtu.be/XOY3ZUO6P0k',
 				'XOY3ZUO6P0k',

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -195,7 +195,7 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	 *
 	 * @return array The test data.
 	 */
-	public function get_url_id_data() {
+	public function get_video_id_data() {
 		return [
 			'basic_url'                        => [
 				'https://www.youtube.com/watch?v=XOY3ZUO6P0k',
@@ -227,7 +227,7 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 	/**
 	 * Tests get_video_id_from_url.
 	 *
-	 * @dataProvider get_url_id_data
+	 * @dataProvider get_video_id_data
 	 * @covers AMP_YouTube_Embed_Handler::get_video_id_from_url()
 	 *
 	 * @param string $url      The URL to test.

--- a/tests/php/test-class-amp-youtube-embed-handler.php
+++ b/tests/php/test-class-amp-youtube-embed-handler.php
@@ -157,6 +157,30 @@ class Test_AMP_YouTube_Embed_Handler extends WP_UnitTestCase {
 				'<p><amp-youtube data-videoid="kfVsfOSbJY0" layout="responsive" width="500" height="281"><a placeholder href="http://www.youtube.com/watch?v=kfVsfOSbJY0&amp;hl=en&amp;fs=1&amp;w=425&amp;h=349"><img src="https://i.ytimg.com/vi/kfVsfOSbJY0/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
 			],
 
+			'url_with_underscore'              => [
+				'https://www.youtube.com/watch?v=CMrv_D78oxY' . PHP_EOL,
+				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281"><a placeholder href="https://www.youtube.com/watch?v=CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
+			],
+
+			'short_url_with_underscore'        => [
+				'https://youtu.be/CMrv_D78oxY' . PHP_EOL,
+				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://youtu.be/CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube data-videoid="CMrv_D78oxY" layout="responsive" width="500" height="281"><a placeholder href="https://youtu.be/CMrv_D78oxY"><img src="https://i.ytimg.com/vi/CMrv_D78oxY/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
+			],
+
+			'url_with_hyphen'                  => [
+				'https://www.youtube.com/watch?v=xo68-iWaKv8' . PHP_EOL,
+				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
+			],
+
+			'url_with_hyphen_and_query_string' => [
+				'https://www.youtube.com/watch?v=xo68-iWaKv8&w=800&h=400' . PHP_EOL,
+				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281" title="Rebecca Black - Friday"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8&amp;w=800&amp;h=400"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover" alt="Rebecca Black - Friday"></img></a></amp-youtube></p>' . PHP_EOL,
+				'<p><amp-youtube data-videoid="xo68-iWaKv8" layout="responsive" width="500" height="281"><a placeholder href="https://www.youtube.com/watch?v=xo68-iWaKv8&amp;w=800&amp;h=400"><img src="https://i.ytimg.com/vi/xo68-iWaKv8/hqdefault.jpg" layout="fill" object-fit="cover"></img></a></amp-youtube></p>' . PHP_EOL,
+			],
+
 			// Several reports of invalid URLs that have multiple `?` in the URL.
 			'url_with_querystring_and_extra_?' => [
 				'http://www.youtube.com/watch?v=kfVsfOSbJY0?hl=en&fs=1&w=425&h=349' . PHP_EOL,


### PR DESCRIPTION
## Summary
A YouTube embed URL can now include a hyphen or underscore, like:
https://www.youtube.com/watch?v=xo68-iWaKv8
https://youtu.be/CMrv_D78oxY
<!-- Please reference the issue this PR addresses. -->
Fixes #4504 

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
