### PR TITLE
Fix processing of element child sanitization loop when invalid elements are replaced with children

### DIFF
--- a/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
+++ b/includes/sanitizers/class-amp-tag-and-attribute-sanitizer.php
@@ -338,6 +338,7 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 		// ancestor nodes in AMP_Tag_And_Attribute_Sanitizer::remove_node().
 		$this_child = $element->firstChild;
 		while ( $this_child && $element->parentNode ) {
+			$prev_child = $this_child->previousSibling;
 			$next_child = $this_child->nextSibling;
 			if ( $this_child instanceof DOMElement ) {
 				$result = $this->sanitize_element( $this_child );
@@ -350,7 +351,13 @@ class AMP_Tag_And_Attribute_Sanitizer extends AMP_Base_Sanitizer {
 			} elseif ( $this_child instanceof DOMProcessingInstruction ) {
 				$this->remove_invalid_child( $this_child, [ 'code' => self::DISALLOWED_PROCESSING_INSTRUCTION ] );
 			}
-			$this_child = $next_child;
+
+			if ( ! $this_child->parentNode ) {
+				// Handle case where this child is replaced with children.
+				$this_child = $prev_child ? $prev_child->nextSibling : $element->firstChild;
+			} else {
+				$this_child = $next_child;
+			}
 		}
 
 		// If the element is still in the tree, process it.

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -732,13 +732,12 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-form' ],
 			],
 
-			'invalid-amp-form'                             => [
+			'scripts-gathered-from-invalid-parents'        => [
 				'
 				<ancestor-unknown>
-					<b>ok</b>
+					<amp-audio src="https://example.com/foo.mp3" width="100" height="200"></amp-audio>
 					<parent-unknown>
 						<amp-form>
-							<bogus></bogus>
 							<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
 								<unrecognized>who are you?</unrecognized>
 								<input type=text value="test" name="hello">
@@ -749,15 +748,15 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				</ancestor-unknown>
 				',
 				'
-				<b>ok</b>
+				<amp-audio src="https://example.com/foo.mp3" width="100" height="200"></amp-audio>
 				<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
 					who are you?
 					<input type="text" value="test" name="hello">
 				</form>
 				<amp-video src="https://example.com/foo.mp4" width="100" height="200"></amp-video>
 				',
-				[ 'amp-form', 'amp-video' ],
-				array_fill( 0, 5, AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ),
+				[ 'amp-audio', 'amp-form', 'amp-video' ],
+				array_fill( 0, 4, AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ),
 			],
 
 			'form-visible-when-invalid'                    => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -734,19 +734,30 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 
 			'invalid-amp-form'                             => [
 				'
-				<amp-form>
-					<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
-						<input type=text value="test" name="hello">
-					</form>
-				</amp-form>
+				<ancestor-unknown>
+					<b>ok</b>
+					<parent-unknown>
+						<amp-form>
+							<bogus></bogus>
+							<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
+								<unrecognized>who are you?</unrecognized>
+								<input type=text value="test" name="hello">
+							</form>
+						</amp-form>
+					</parent-unknown>
+					<amp-video src="https://example.com/foo.mp4" width="100" height="200"></amp-video>
+				</ancestor-unknown>
 				',
 				'
+				<b>ok</b>
 				<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
+					who are you?
 					<input type="text" value="test" name="hello">
 				</form>
+				<amp-video src="https://example.com/foo.mp4" width="100" height="200"></amp-video>
 				',
-				[ 'amp-form' ],
-				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
+				[ 'amp-form', 'amp-video' ],
+				array_fill( 0, 5, AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ),
 			],
 
 			'form-visible-when-invalid'                    => [

--- a/tests/php/test-tag-and-attribute-sanitizer.php
+++ b/tests/php/test-tag-and-attribute-sanitizer.php
@@ -732,6 +732,23 @@ class AMP_Tag_And_Attribute_Sanitizer_Test extends WP_UnitTestCase {
 				[ 'amp-form' ],
 			],
 
+			'invalid-amp-form'                             => [
+				'
+				<amp-form>
+					<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
+						<input type=text value="test" name="hello">
+					</form>
+				</amp-form>
+				',
+				'
+				<form method="GET" id="a_string" class="a_string" action="https://example.com" target="_blank">
+					<input type="text" value="test" name="hello">
+				</form>
+				',
+				[ 'amp-form' ],
+				[ AMP_Tag_And_Attribute_Sanitizer::DISALLOWED_TAG ],
+			],
+
 			'form-visible-when-invalid'                    => [
 				'
 				<form method="post"


### PR DESCRIPTION
## Summary

Fixes #4511.

When an unrecognized element is encountered, it is replaced with its children. This process wasn't accounted for when looping over the children of an element to sanitize. This PR ensures that when a child element is removed, the next loop iteration will pick up with the first valid descendant node that was in the now-removed child.

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
