### PR TITLE
Raise default threshold for disabling CSS caching

### DIFF
--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -162,7 +162,7 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 	 */
 	public function handle_plugin_update( $old_version ) {
 		// Reset the disabling of the CSS caching subsystem when updating from versions 1.5.0 or 1.5.1.
-		if ( version_compare( $old_version, '1.5.0', '>=' ) || version_compare( $old_version, '1.5.2', '<' ) ) {
+		if ( version_compare( $old_version, '1.5.0', '>=' ) && version_compare( $old_version, '1.5.2', '<' ) ) {
 			AMP_Options_Manager::update_option( Option::DISABLE_CSS_TRANSIENT_CACHING, false );
 		}
 	}

--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -39,8 +39,8 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 	/**
 	 * Default threshold to use for problem detection in number of transients per day.
 	 *
-     * This is set high to avoid false positives and only trigger on high-traffic sites that exhibit serious problems.
-     *
+	 * This is set high to avoid false positives and only trigger on high-traffic sites that exhibit serious problems.
+	 *
 	 * @var float
 	 */
 	const DEFAULT_THRESHOLD = 5000.0;
@@ -51,6 +51,16 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 	 * @var int
 	 */
 	const DEFAULT_SAMPLING_RANGE = 14;
+
+	/**
+	 * Register the service with the system.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		add_action( 'amp_plugin_update', [ $this, 'handle_plugin_update' ] );
+		parent::register();
+	}
 
 	/**
 	 * Get the interval to use for the event.
@@ -143,6 +153,18 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 		return (int) $wpdb->get_var(
 			"SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '_transient_amp-parsed-stylesheet%'"
 		);
+	}
+
+	/**
+	 * Handle update to plugin.
+	 *
+	 * @param string $old_version Old version.
+	 */
+	public function handle_plugin_update( $old_version ) {
+		// Reset the disabling of the CSS caching subsystem when updating from versions 1.5.0 or 1.5.1.
+		if ( version_compare( $old_version, '1.5.0', '>=' ) || version_compare( $old_version, '1.5.2', '<' ) ) {
+			AMP_Options_Manager::update_option( Option::DISABLE_CSS_TRANSIENT_CACHING, false );
+		}
 	}
 
 	/**

--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -39,9 +39,11 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 	/**
 	 * Default threshold to use for problem detection in number of transients per day.
 	 *
+     * This is set high to avoid false positives and only trigger on high-traffic sites that exhibit serious problems.
+     *
 	 * @var float
 	 */
-	const DEFAULT_THRESHOLD = 50.0;
+	const DEFAULT_THRESHOLD = 5000.0;
 
 	/**
 	 * Sampling range in days to calculate the moving average from.


### PR DESCRIPTION
## Summary

Raises the default threshold for disabling the CSS caching system from 50 to 5000.

See https://wordpress.org/support/topic/1-5-1-slow-causes-high-request-time/ for more contextual information about the problem this solves.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).