### PR TITLE
Add CSS monitoring time series to Site Health debugging info

### DIFF
--- a/src/Admin/SiteHealth.php
+++ b/src/Admin/SiteHealth.php
@@ -354,6 +354,11 @@ final class SiteHealth {
 							'value'   => MonitorCssTransientCaching::query_css_transient_count(),
 							'private' => false,
 						],
+						'amp_css_transient_caching_time_series' => [
+							'label'   => esc_html__( 'Calculated time series for monitoring the stylesheet caching', 'amp' ),
+							'value'   => MonitorCssTransientCaching::get_time_series(),
+							'private' => false,
+						],
 					],
 				],
 			]

--- a/src/BackgroundTask/MonitorCssTransientCaching.php
+++ b/src/BackgroundTask/MonitorCssTransientCaching.php
@@ -109,7 +109,7 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 		}
 
 		$date_string = $date->format( 'Ymd' );
-		$time_series = $this->get_time_series();
+		$time_series = self::get_time_series();
 
 		$time_series[ $date_string ] = $transient_count;
 		ksort( $time_series );
@@ -172,7 +172,7 @@ final class MonitorCssTransientCaching extends CronBasedBackgroundTask {
 	 *
 	 * @return int[] Time series with the count of transients per day.
 	 */
-	private function get_time_series() {
+	public static function get_time_series() {
 		return (array) get_option( self::TIME_SERIES_OPTION_KEY, [] );
 	}
 


### PR DESCRIPTION
## Summary

Add the CSS monitoring time series that were calculated and stored in transients to the Site Health debugging info.

This helps with detecting issues where the monitoring misfires.

![Image 2020-04-03 at 9 10 33 AM](https://user-images.githubusercontent.com/83631/78334094-6befc100-758b-11ea-8755-5abcb29af02f.png)

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [ ] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
