### PR TITLE
Fix securing multi-line mustache templates

### DIFF
--- a/lib/common/src/Dom/Document.php
+++ b/lib/common/src/Dom/Document.php
@@ -897,7 +897,7 @@ final class Document extends DOMDocument
     private function secureMustacheScriptTemplates($html)
     {
         return preg_replace(
-            '#<script(\s[^>]*?template=(["\']?)amp-mustache\2[^>]*)>(.*?)</script\s*?>#i',
+            '#<script(\s[^>]*?template=(["\']?)amp-mustache\2[^>]*)>(.*?)</script\s*?>#is',
             '<tmp-script$1>$3</tmp-script>',
             $html
         );

--- a/lib/common/tests/Dom/DocumentTest.php
+++ b/lib/common/tests/Dom/DocumentTest.php
@@ -307,6 +307,39 @@ class DocumentTest extends TestCase
                 '<!DOCTYPE html><html>' . $head . '<body><script template="amp-mustache" type="text/plain" id="foo"><table><tr>{{#example}}<td></td>{{/example}}</tr></table></script><script type="text/plain" template="amp-mustache" id="example"><p>{{#baz}}This is inside a template{{/baz}}</p></script></body></html>',
                 '<!DOCTYPE html><html>' . $head . '<body><script template="amp-mustache" type="text/plain" id="foo"><table><tr>{{#example}}<td></td>{{/example}}</tr></table></script><script type="text/plain" template="amp-mustache" id="example"><p>{{#baz}}This is inside a template{{/baz}}</p></script></body></html>',
             ],
+            'multiline_mustache_templates_appear'      => [
+                'utf-8',
+                '
+                <!DOCTYPE html>
+                <html>
+                    <head><meta charset="utf-8"></head>
+                    <body>
+                    <script type="text/plain" template="amp-mustache">
+                      <table>
+                        <tr>
+                    {{#foo}}<td></td>{{/foo}}
+                        </tr>
+                      </table>
+                    </script>
+                    </body>
+                </html>
+                ',
+                '
+                <!DOCTYPE html>
+                <html>
+                    <head><meta charset="utf-8"></head>
+                    <body>
+                    <script type="text/plain" template="amp-mustache">
+                      <table>
+                        <tr>
+                    {{#foo}}<td></td>{{/foo}}
+                        </tr>
+                      </table>
+                    </script>
+                    </body>
+                </html>
+                ',
+            ],
         ];
     }
 

--- a/tests/php/test-amp-style-sanitizer.php
+++ b/tests/php/test-amp-style-sanitizer.php
@@ -627,6 +627,30 @@ class AMP_Style_Sanitizer_Test extends WP_UnitTestCase {
 				],
 				[],
 			],
+			'classes_in_mustache_template' => [
+				'
+				<html>
+					<head>
+					</head>
+					<body>
+						<style>
+							h2.one { color: green }
+							h2.two { color: red }
+						</style>
+						<template type="amp-mustache">
+							<h2 class="one">One</h2>
+						</template>
+						<script type="text/plain" template="amp-mustache">
+							<h2 class="two">Two</h2>
+						</script>
+					</body>
+				</html>
+				',
+				[
+					'h2.one{color:green}h2.two{color:red}',
+				],
+				[],
+			],
 		];
 	}
 


### PR DESCRIPTION
## Summary

The regex missed the all-important flag `s` which resulted in `.` not matching newlines.

Fixes #4254
Fixes #4276

## Checklist

- [x] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
