### PR TITLE
Update hostname used for WordPress TV embeds to fix external HTTP requests

### DIFF
--- a/tests/php/test-class-amp-wordpress-tv-embed-handler.php
+++ b/tests/php/test-class-amp-wordpress-tv-embed-handler.php
@@ -44,7 +44,7 @@ class Test_AMP_WordPress_TV_Embed_Handler extends WP_UnitTestCase {
 		}
 		unset( $r );
 		return [
-			'body'          => '{"type":"video","version":"1.0","title":null,"width":500,"height":281,"html":"<iframe width=\'500\' height=\'281\' src=\'https:\\/\\/videopress.com\\/embed\\/yFCmLMGL?hd=0\' frameborder=\'0\' allowfullscreen><\\/iframe><script src=\'https:\\/\\/v0.wordpress.com\\/js\\/next\\/videopress-iframe.js?m=1435166243\'></script>"}', // phpcs:ignore
+			'body'          => '{"type":"video","version":"1.0","title":null,"width":500,"height":281,"html":"<iframe width=\'500\' height=\'281\' src=\'https:\\/\\/video.wordpress.com\\/embed\\/yFCmLMGL?hd=0\' frameborder=\'0\' allowfullscreen><\\/iframe><script src=\'https:\\/\\/v0.wordpress.com\\/js\\/next\\/videopress-iframe.js?m=1435166243\'></script>"}', // phpcs:ignore
 			'headers'       => [],
 			'response'      => [
 				'code'    => 200,
@@ -77,7 +77,7 @@ class Test_AMP_WordPress_TV_Embed_Handler extends WP_UnitTestCase {
 		$handler->register_embed();
 		$rendered = apply_filters( 'the_content', $wordpress_tv_block );
 		$this->assertStringContains( '<iframe', $rendered );
-		$this->assertStringContains( 'videopress.com/embed', $rendered );
+		$this->assertStringContains( 'video.wordpress.com/embed', $rendered );
 		$this->assertStringNotContains( '<script', $rendered );
 	}
 


### PR DESCRIPTION
## Summary

WordPress TV changed the hostname from `videopress.com` to `video.wordpress.com`. This fixes failures in the external HTTP tests.

## Checklist

- [ ] My pull request is addressing an [open issue](https://github.com/ampproject/amp-wp/contributing/project-management.md#life-of-an-issue) (please create one otherwise).
- [x] My code is tested and passes existing [tests](https://github.com/ampproject/amp-wp/contributing/engineering.md#tests).
- [x] My code follows the [Engineering Guidelines](https://github.com/ampproject/amp-wp/contributing/engineering.md) (updates are often made to the guidelines, check it out periodically).
