### PR TITLE
Fix block editor crash when editor.MediaUpload is a functional component

### DIFF
--- a/assets/src/block-editor/components/with-media-library-notice.js
+++ b/assets/src/block-editor/components/with-media-library-notice.js
@@ -145,6 +145,17 @@ export default (InitialMediaUpload, minImageDimensions) => {
 		});
 	};
 
+	// If the component is not a class (e.g. a functional or arrow function component
+	// returned by another plugin's filter), it cannot be extended via `class extends`.
+	// In that case, return it as-is to avoid crashing the editor with:
+	// "TypeError: Class extends value ... is not a constructor or null"
+	if (
+		!InitialMediaUpload.prototype ||
+		!InitialMediaUpload.prototype.isReactComponent
+	) {
+		return InitialMediaUpload;
+	}
+
 	/**
 	 * Extends the MediaUpload component to display a notice for small images.
 	 */


### PR DESCRIPTION
Fixes #8167

## Summary

The `with-media-library-notice` wrapper uses `class extends InitialMediaUpload` to override `buildAndSetFeatureImageFrame`. This crashes the entire block editor when another plugin returns a functional (arrow function) component from the `editor.MediaUpload` filter, because arrow functions have no `[[Construct]]` internal method and cannot be used as a base class.

**Error:**
```
TypeError: Class extends value l=>{...} is not a constructor or null
    at p (amp-block-editor.js:3:1219)
```

All blocks on the page display "This block has encountered an error and cannot be previewed", making the editor completely unusable.

## Fix

Add a guard that checks `prototype.isReactComponent` before attempting class inheritance. When the incoming component is not a class (e.g. a functional component from another plugin's HOC), return it as-is so the editor remains functional.

This is a minimal, safe change — the class extension path is unchanged for class components; only functional components skip it.

## Testing

1. Install a plugin that wraps `editor.MediaUpload` with a functional component HOC (e.g. one using `createHigherOrderComponent` that returns an arrow function)
2. Activate the AMP plugin
3. **Before fix:** Open any post/page in the block editor — all blocks crash
4. **After fix:** Editor loads normally, blocks render correctly
5. Without the conflicting plugin, verify AMP's featured image dimension enforcement still works as before